### PR TITLE
Move from AMD and CommonJS to ES6 modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-runtime"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 
 /node_modules/
 /dist/
-/nbproject/
+/lib/

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
+dist/
 src/

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "itowns2",
   "version": "1.0.0",
   "description": "A JS/WebGL framework for 3D geospatial data visualization",
-  "main": "dist/itowns2.js",
+  "main": "lib/Main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack -p",
-    "start": "webpack-dev-server -d --inline --hot"
+    "start": "webpack-dev-server -d --inline --hot",
+    "prepublish": "babel -d lib/ src/"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,12 @@
     "when": "^1.7.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.5.1",
+    "babel-core": "^6.5.1",
+    "babel-loader": "^6.2.2",
+    "babel-plugin-transform-runtime": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-runtime": "^6.5.0",
     "js-beautify": "^1.6.2",
     "raw-loader": "^0.5.1",
     "webpack": "^1.12.12",

--- a/src/Core/Commander/Command.js
+++ b/src/Core/Commander/Command.js
@@ -4,37 +4,33 @@
  * Description: Cette object contient une commande à executer. Elle porte également les buffers résultants.
  */
 
-define('Core/Commander/Command', [], function() {
+function Command() {
+    //Constructor
 
+    this.name = null;
+    this.priority = 0.0; //Math.floor((Math.random()*100));
+    this.state = null;
+    this.inParallel = null;
+    this.inBuffers = null;
+    this.outBuffers = null;
+    this.paramsFunction = [];
+    this.processFunction = null;
+    this.async = null;
+    this.force = null;
+    this.type = null;
+    this.addInHistory = null;
+    this.source = null;
+    this.requester = null;
 
-    function Command() {
-        //Constructor
+}
 
-        this.name = null;
-        this.priority = 0.0; //Math.floor((Math.random()*100));
-        this.state = null;
-        this.inParallel = null;
-        this.inBuffers = null;
-        this.outBuffers = null;
-        this.paramsFunction = [];
-        this.processFunction = null;
-        this.async = null;
-        this.force = null;
-        this.type = null;
-        this.addInHistory = null;
-        this.source = null;
-        this.requester = null;
+Command.prototype.constructor = Command;
 
-    }
+/**
+ */
+Command.prototype.instance = function() {
+    //TODO: Implement Me 
 
-    Command.prototype.constructor = Command;
+};
 
-    /**
-     */
-    Command.prototype.instance = function() {
-        //TODO: Implement Me 
-
-    };
-
-    return Command;
-});
+export default Command;

--- a/src/Core/Commander/History.js
+++ b/src/Core/Commander/History.js
@@ -48,6 +48,6 @@ History.prototype.delete = function(id) {
 
 
 
-module.exports = {
-    History: History
+export {
+    History
 };

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -4,61 +4,60 @@
  * Description: Cette Classe construit une commande. Cette Command ensuite pousser dans une file d'attente.
  */
 
-define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', 'Core/Commander/Command'], function(ManagerCommands, Command) {
+import ManagerCommands from 'Core/Commander/ManagerCommands';
+import Command from 'Core/Commander/Command';
 
-    function InterfaceCommander(type, param) {
-        //Constructor
+function InterfaceCommander(type, param) {
+    //Constructor
 
-        this.managerCommands = ManagerCommands();
-        this.type = type;
+    this.managerCommands = ManagerCommands();
+    this.type = type;
 
-        this.managerCommands.createProvider(this.type, param);
+    this.managerCommands.createProvider(this.type, param);
 
-    }
+}
 
-    InterfaceCommander.prototype.constructor = InterfaceCommander;
+InterfaceCommander.prototype.constructor = InterfaceCommander;
 
-    /**
-     * @param com {[object Object]} 
-     */
-    InterfaceCommander.prototype.request = function(com) {
-        //TODO: Implement Me 
+/**
+ * @param com {[object Object]} 
+ */
+InterfaceCommander.prototype.request = function(com) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    /**
-     * @return  {[object Object]} 
-     */
-    InterfaceCommander.prototype.buildCommand = function() {
-        //TODO: Implement Me 
-        this._builderCommand();
-    };
+/**
+ * @return  {[object Object]} 
+ */
+InterfaceCommander.prototype.buildCommand = function() {
+    //TODO: Implement Me 
+    this._builderCommand();
+};
 
-    InterfaceCommander.prototype.getTextureBil = function(coWMTS) {
-        //TODO: Implement Me 
-        return this.managerCommands.getTextureBil(coWMTS);
-    };
+InterfaceCommander.prototype.getTextureBil = function(coWMTS) {
+    //TODO: Implement Me 
+    return this.managerCommands.getTextureBil(coWMTS);
+};
 
-    InterfaceCommander.prototype.getTextureOrtho = function(coWMTS) {
-        //TODO: Implement Me 
-        return this.managerCommands.getTextureOrtho(coWMTS);
-    };
+InterfaceCommander.prototype.getTextureOrtho = function(coWMTS) {
+    //TODO: Implement Me 
+    return this.managerCommands.getTextureOrtho(coWMTS);
+};
 
-    InterfaceCommander.prototype.getTile = function(bbox, parent) {
+InterfaceCommander.prototype.getTile = function(bbox, parent) {
 
-        var command = new Command();
-        command.type = this.type;
-        command.requester = parent;
-        command.paramsFunction.push(bbox);
+    var command = new Command();
+    command.type = this.type;
+    command.requester = parent;
+    command.paramsFunction.push(bbox);
 
-        //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;
+    //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;
 
-        command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible && parent.material.visible ? parent.sse * parent.sse * 100000 : 1.0);
+    command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible && parent.material.visible ? parent.sse * parent.sse * 100000 : 1.0);
 
-        this.managerCommands.addCommand(command);
-    };
+    this.managerCommands.addCommand(command);
+};
 
 
-    return InterfaceCommander;
-
-});
+export default InterfaceCommander;

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -1,62 +1,61 @@
 /**
  * Generated On: 2015-10-5
  * Class: ApiGlobe
- * Description: Classe faÃ§ade pour attaquer les fonctionnalitÃ©s du code.
+ * Description: Classe façade pour attaquer les fonctionnalités du code.
  */
 
 
-define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', ['Core/Commander/Interfaces/EventsManager', 'Scene/Scene'], function(EventsManager, Scene) {
+import EventsManager from 'Core/Commander/Interfaces/EventsManager';
+import Scene from 'Scene/Scene';
 
-    function ApiGlobe() {
-        //Constructor
+function ApiGlobe() {
+    //Constructor
 
-        this.scene = null;
-        this.commandsTree = null;
+    this.scene = null;
+    this.commandsTree = null;
 
-    };
+};
 
-    ApiGlobe.prototype = new EventsManager();
+ApiGlobe.prototype = new EventsManager();
 
-    /**
-     * @param Command
-     */
-    ApiGlobe.prototype.add = function(Command) {
-        //TODO: Implement Me 
+/**
+ * @param Command
+ */
+ApiGlobe.prototype.add = function(Command) {
+    //TODO: Implement Me 
 
-    };
+};
 
 
-    /**
-     * @param commandTemplate
-     */
-    ApiGlobe.prototype.createCommand = function(commandTemplate) {
-        //TODO: Implement Me 
+/**
+ * @param commandTemplate
+ */
+ApiGlobe.prototype.createCommand = function(commandTemplate) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    /**
-     */
-    ApiGlobe.prototype.execute = function() {
-        //TODO: Implement Me 
+/**
+ */
+ApiGlobe.prototype.execute = function() {
+    //TODO: Implement Me 
 
-    };
+};
 
-    ApiGlobe.createSceneGlobe = function(pos) {
-        //TODO: Normalement la creation de scene ne doit pas etre ici....
-        // Aï¿½ deplacer plus tard
+ApiGlobe.createSceneGlobe = function(pos) {
+    //TODO: Normalement la creation de scene ne doit pas etre ici....
+    // A  deplacer plus tard
 
-        this.scene = Scene();
-        this.scene.init(pos);
+    this.scene = Scene();
+    this.scene.init(pos);
 
-        return this.scene;
+    return this.scene;
 
-    };
+};
 
-    ApiGlobe.showClouds = function(value) {
+ApiGlobe.showClouds = function(value) {
 
-        this.scene.layers[0].showClouds(value);
-    };
+    this.scene.layers[0].showClouds(value);
+};
 
-    return ApiGlobe;
-
-});
+export default ApiGlobe;

--- a/src/Core/Commander/Interfaces/Event.js
+++ b/src/Core/Commander/Interfaces/Event.js
@@ -29,6 +29,6 @@ Event.prototype.xmlToEvents = function() {
 
 
 
-module.exports = {
-    Event: Event
+export {
+    Event
 };

--- a/src/Core/Commander/Interfaces/EventsManager.js
+++ b/src/Core/Commander/Interfaces/EventsManager.js
@@ -6,42 +6,38 @@
 
 
 
-define('Core/Commander/Interfaces/EventsManager', [], function() {
+function EventsManager() {
+    //Constructor
 
-    function EventsManager() {
-        //Constructor
-
-        this.commands = null;
-        this.events = null;
-        this.timer = null;
+    this.commands = null;
+    this.events = null;
+    this.timer = null;
 
 
+}
+
+/**
+ * @param pevent {[object Object]} 
+ * @param com {[object Object]} 
+ */
+EventsManager.prototype.connect = function(pevent, com) {
+    //TODO: Implement Me 
+
+};
+
+EventsManager.prototype.command = function() {
+
+};
+
+EventsManager.prototype.wait = function() {
+    var waitTime = 250;
+    if (this.timer === null) {
+        this.timer = window.setTimeout(this.command, waitTime);
+    } else {
+        window.clearInterval(this.timer);
+        this.timer = window.setTimeout(this.command, waitTime);
     }
 
-    /**
-     * @param pevent {[object Object]} 
-     * @param com {[object Object]} 
-     */
-    EventsManager.prototype.connect = function(pevent, com) {
-        //TODO: Implement Me 
+};
 
-    };
-
-    EventsManager.prototype.command = function() {
-
-    };
-
-    EventsManager.prototype.wait = function() {
-        var waitTime = 250;
-        if (this.timer === null) {
-            this.timer = window.setTimeout(this.command, waitTime);
-        } else {
-            window.clearInterval(this.timer);
-            this.timer = window.setTimeout(this.command, waitTime);
-        }
-
-    };
-
-    return EventsManager;
-
-});
+export default EventsManager;

--- a/src/Core/Commander/Interfaces/KeyboardEvent.js
+++ b/src/Core/Commander/Interfaces/KeyboardEvent.js
@@ -4,7 +4,7 @@
  * Description: Evènement clavier
  */
 
-var Event = require('Event');
+import Event from 'Event';
 
 function KeyboardEvent() {
     //Constructor
@@ -15,6 +15,6 @@ function KeyboardEvent() {
 KeyboardEvent.prototype = new Event();
 
 
-module.exports = {
-    KeyboardEvent: KeyboardEvent
+export {
+    KeyboardEvent
 };

--- a/src/Core/Commander/Interfaces/MouseEvent.js
+++ b/src/Core/Commander/Interfaces/MouseEvent.js
@@ -4,7 +4,7 @@
  * Description: Evènement souris
  */
 
-var Event = require('Event');
+import Event from 'Event';
 
 function MouseEvent() {
     //Constructor
@@ -15,6 +15,6 @@ function MouseEvent() {
 MouseEvent.prototype = new Event();
 
 
-module.exports = {
-    MouseEvent: MouseEvent
+export {
+    MouseEvent
 };

--- a/src/Core/Commander/Interfaces/Times/Timeline.js
+++ b/src/Core/Commander/Interfaces/Times/Timeline.js
@@ -3,7 +3,7 @@
  * Class: Timeline
  */
 
-var EventsManager = require('EventsManager');
+import EventsManager from 'EventsManager';
 
 function Timeline() {
     //Constructor
@@ -26,6 +26,6 @@ Timeline.prototype.update = function() {
 
 
 
-module.exports = {
-    Timeline: Timeline
+export {
+    Timeline
 };

--- a/src/Core/Commander/Interfaces/Times/Timer.js
+++ b/src/Core/Commander/Interfaces/Times/Timer.js
@@ -44,6 +44,6 @@ Timer.prototype.pause = function() {
 
 
 
-module.exports = {
-    Timer: Timer
+export {
+    Timer
 };

--- a/src/Core/Commander/Interfaces/Times/Trigger.js
+++ b/src/Core/Commander/Interfaces/Times/Trigger.js
@@ -23,6 +23,6 @@ Trigger.prototype.executeChildrenCommand = function() {
 
 
 
-module.exports = {
-    Trigger: Trigger
+export {
+    Trigger
 };

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -15,144 +15,131 @@
  * @param {type} THREE
  * @returns {Function}
  */
-define('Core/Commander/ManagerCommands', [
-        'Core/Commander/Providers/tileGlobeProvider',
-        'Core/Commander/Interfaces/EventsManager',
-        'PriorityQueue',
-        'when',
-        'Globe/EllipsoidTileMesh',
-        'Core/Geographic/CoordCarto',
-        'THREE'
-    ],
-    function(
-        tileGlobeProvider,
-        EventsManager,
-        PriorityQueue,
-        when,
-        EllipsoidTileMesh,
-        CoordCarto,
-        THREE
-    ) {
+import tileGlobeProvider from 'Core/Commander/Providers/tileGlobeProvider';
+import EventsManager from 'Core/Commander/Interfaces/EventsManager';
+import PriorityQueue from 'PriorityQueue';
+import when from 'when';
+import EllipsoidTileMesh from 'Globe/EllipsoidTileMesh';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import THREE from 'THREE';
 
-        var instanceCommandManager = null;
+var instanceCommandManager = null;
 
-        function ManagerCommands() {
-            //Constructor
-            if (instanceCommandManager !== null) {
-                throw new Error("Cannot instantiate more than one ManagerCommands");
-            }
+function ManagerCommands() {
+    //Constructor
+    if (instanceCommandManager !== null) {
+        throw new Error("Cannot instantiate more than one ManagerCommands");
+    }
 
-            this.queueAsync = new PriorityQueue({
-                comparator: function(a, b) {
-                    return b.priority - a.priority;
-                }
-            });
-            this.queueSync = null;
-            this.loadQueue = [];
-            this.providers = [];
-            this.history = null;
-            this.eventsManager = new EventsManager();
-            this.scene = undefined;
-
+    this.queueAsync = new PriorityQueue({
+        comparator: function(a, b) {
+            return b.priority - a.priority;
         }
-
-        ManagerCommands.prototype.constructor = ManagerCommands;
-
-        ManagerCommands.prototype.addCommand = function(command) {
-            this.queueAsync.queue(command);
-        };
-
-        ManagerCommands.prototype.init = function(scene) {
-            this.scene = scene;
-        };
-
-        ManagerCommands.prototype.createProvider = function(type, param) {
-            if (type === EllipsoidTileMesh) {
-                this.providers.push(new tileGlobeProvider(param));
-            }
-        };
-
-        ManagerCommands.prototype.runAllCommands = function() {
-            if (this.queueAsync.length === 0)
-                return when(0);
-
-            return when.all(this.arrayDeQueue(16))
-                .then(function() {
-                    return this.runAllCommands();
-                }.bind(this));
-
-        };
-
-        ManagerCommands.prototype.arrayDeQueue = function(number) {
-            var nT = number === undefined ? this.queueAsync.length : number;
-
-            var arrayTasks = [];
-
-            while (this.queueAsync.length > 0 && arrayTasks.length < nT) {
-                arrayTasks.push(this.providers[0].get(this.deQueue()));
-            }
-
-            return arrayTasks;
-        };
-
-        /**
-         */
-        ManagerCommands.prototype.deQueue = function() {
-
-            while (this.queueAsync.length > 0) {
-                var com = this.queueAsync.peek();
-                var parent = com.requester;
-
-                if (parent.visible === false && parent.level >= 2) {
-
-                    while (parent.children.length > 0) {
-                        var child = parent.children[0];
-                        child.dispose();
-                        parent.remove(child);
-                    }
-                    parent.wait = false;
-                    parent.false = false;
-                    this.queueAsync.dequeue();
-                } else
-                    return this.queueAsync.dequeue();
-
-            }
-
-            return undefined;
-        };
-
-        /**
-         */
-        ManagerCommands.prototype.removeCanceled = function() {
-            //TODO: Implement Me 
-
-        };
-
-        /**
-         */
-        ManagerCommands.prototype.wait = function() {
-            //TODO: Implement Me 
-            this.eventsManager.wait();
-        };
-
-        /**
-         */
-        ManagerCommands.prototype.forecast = function() {
-            //TODO: Implement Me 
-
-        };
-
-        /**
-         * @param object
-         */
-        ManagerCommands.prototype.addInHistory = function(object) {
-            //TODO: Implement Me 
-
-        };
-
-        return function() {
-            instanceCommandManager = instanceCommandManager || new ManagerCommands();
-            return instanceCommandManager;
-        };
-
     });
+    this.queueSync = null;
+    this.loadQueue = [];
+    this.providers = [];
+    this.history = null;
+    this.eventsManager = new EventsManager();
+    this.scene = undefined;
+
+}
+
+ManagerCommands.prototype.constructor = ManagerCommands;
+
+ManagerCommands.prototype.addCommand = function(command) {
+    this.queueAsync.queue(command);
+};
+
+ManagerCommands.prototype.init = function(scene) {
+    this.scene = scene;
+};
+
+ManagerCommands.prototype.createProvider = function(type, param) {
+    if (type === EllipsoidTileMesh) {
+        this.providers.push(new tileGlobeProvider(param));
+    }
+};
+
+ManagerCommands.prototype.runAllCommands = function() {
+    if (this.queueAsync.length === 0)
+        return when(0);
+
+    return when.all(this.arrayDeQueue(16))
+        .then(function() {
+            return this.runAllCommands();
+        }.bind(this));
+
+};
+
+ManagerCommands.prototype.arrayDeQueue = function(number) {
+    var nT = number === undefined ? this.queueAsync.length : number;
+
+    var arrayTasks = [];
+
+    while (this.queueAsync.length > 0 && arrayTasks.length < nT) {
+        arrayTasks.push(this.providers[0].get(this.deQueue()));
+    }
+
+    return arrayTasks;
+};
+
+/**
+ */
+ManagerCommands.prototype.deQueue = function() {
+
+    while (this.queueAsync.length > 0) {
+        var com = this.queueAsync.peek();
+        var parent = com.requester;
+
+        if (parent.visible === false && parent.level >= 2) {
+
+            while (parent.children.length > 0) {
+                var child = parent.children[0];
+                child.dispose();
+                parent.remove(child);
+            }
+            parent.wait = false;
+            parent.false = false;
+            this.queueAsync.dequeue();
+        } else
+            return this.queueAsync.dequeue();
+
+    }
+
+    return undefined;
+};
+
+/**
+ */
+ManagerCommands.prototype.removeCanceled = function() {
+    //TODO: Implement Me 
+
+};
+
+/**
+ */
+ManagerCommands.prototype.wait = function() {
+    //TODO: Implement Me 
+    this.eventsManager.wait();
+};
+
+/**
+ */
+ManagerCommands.prototype.forecast = function() {
+    //TODO: Implement Me 
+
+};
+
+/**
+ * @param object
+ */
+ManagerCommands.prototype.addInHistory = function(object) {
+    //TODO: Implement Me 
+
+};
+
+export default function() {
+    instanceCommandManager = instanceCommandManager || new ManagerCommands();
+    return instanceCommandManager;
+};

--- a/src/Core/Commander/Memento.js
+++ b/src/Core/Commander/Memento.js
@@ -23,6 +23,6 @@ Memento.prototype.memento = function(object) {
 
 
 
-module.exports = {
-    Memento: Memento
+export {
+    Memento
 };

--- a/src/Core/Commander/Providers/CacheRessource.js
+++ b/src/Core/Commander/Providers/CacheRessource.js
@@ -4,47 +4,43 @@
  * Description: Cette classe singleton est un cache des ressources et services
  */
 
-define('Core/Commander/Providers/CacheRessource', [], function() {
+var instanceCache = null;
 
-    var instanceCache = null;
+function CacheRessource() {
+    //Constructor
 
-    function CacheRessource() {
-        //Constructor
+    this.cacheObjects = [];
+    this._maximumSize = null;
 
-        this.cacheObjects = [];
-        this._maximumSize = null;
+}
 
-    }
+/**
+ * @param url
+ */
+CacheRessource.prototype.getRessource = function(url) {
+    //TODO: Implement Me 
 
-    /**
-     * @param url
-     */
-    CacheRessource.prototype.getRessource = function(url) {
-        //TODO: Implement Me 
+    return undefined;
+    return this.cacheObjects[url];
 
-        return undefined;
-        return this.cacheObjects[url];
+};
 
-    };
+CacheRessource.prototype.addRessource = function(url, ressource) {
 
-    CacheRessource.prototype.addRessource = function(url, ressource) {
+    this.cacheObjects[url] = ressource;
 
-        this.cacheObjects[url] = ressource;
-
-    };
+};
 
 
-    /**
-     * @param id
-     */
-    CacheRessource.prototype.getRessourceByID = function(id) {
-        //TODO: Implement Me 
+/**
+ * @param id
+ */
+CacheRessource.prototype.getRessourceByID = function(id) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    return function() {
-        instanceCache = instanceCache || new CacheRessource();
-        return instanceCache;
-    };
-
-});
+export default function() {
+    instanceCache = instanceCache || new CacheRessource();
+    return instanceCache;
+};

--- a/src/Core/Commander/Providers/IoDriver.js
+++ b/src/Core/Commander/Providers/IoDriver.js
@@ -5,54 +5,49 @@
  */
 
 
-define('Core/Commander/Providers/IoDriver', [], function() {
+function IoDriver() {
+    //Constructor
 
 
-    function IoDriver() {
-        //Constructor
+}
+
+IoDriver.prototype.constructor = IoDriver;
 
 
-    }
+/**
+ * @param url
+ */
+IoDriver.prototype.load = function(url) {
+    //TODO: Implement Me 
 
-    IoDriver.prototype.constructor = IoDriver;
-
-
-    /**
-     * @param url
-     */
-    IoDriver.prototype.load = function(url) {
-        //TODO: Implement Me 
-
-    };
+};
 
 
-    /**
-     * @param url
-     * @param inputObject {Object} 
-     */
-    IoDriver.prototype.write = function(url, inputObject) {
-        //TODO: Implement Me 
+/**
+ * @param url
+ * @param inputObject {Object} 
+ */
+IoDriver.prototype.write = function(url, inputObject) {
+    //TODO: Implement Me 
 
-    };
-
-
-    /**
-     * @param url
-     */
-    IoDriver.prototype.readAsync = function(url) {
-        //TODO: Implement Me 
-
-    };
+};
 
 
-    /**
-     * @param url
-     */
-    IoDriver.prototype.writeAsync = function(url) {
-        //TODO: Implement Me 
+/**
+ * @param url
+ */
+IoDriver.prototype.readAsync = function(url) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    return IoDriver;
 
-});
+/**
+ * @param url
+ */
+IoDriver.prototype.writeAsync = function(url) {
+    //TODO: Implement Me 
+
+};
+
+export default IoDriver;

--- a/src/Core/Commander/Providers/IoDriverBati3D.js
+++ b/src/Core/Commander/Providers/IoDriverBati3D.js
@@ -3,7 +3,7 @@
  * Class: IoDriverBati3D
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverBati3D() {
     //Constructor
@@ -14,6 +14,6 @@ function IoDriverBati3D() {
 IoDriverBati3D.prototype = new IoDriver();
 
 
-module.exports = {
-    IoDriverBati3D: IoDriverBati3D
+export {
+    IoDriverBati3D
 };

--- a/src/Core/Commander/Providers/IoDriverCameraStereoPolis.js
+++ b/src/Core/Commander/Providers/IoDriverCameraStereoPolis.js
@@ -3,7 +3,7 @@
  * Class: IoDriverCameraStereoPolis
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverCameraStereoPolis() {
     //Constructor
@@ -14,6 +14,6 @@ function IoDriverCameraStereoPolis() {
 IoDriverCameraStereoPolis.prototype = new IoDriver();
 
 
-module.exports = {
-    IoDriverCameraStereoPolis: IoDriverCameraStereoPolis
+export {
+    IoDriverCameraStereoPolis
 };

--- a/src/Core/Commander/Providers/IoDriverFloatImage.js
+++ b/src/Core/Commander/Providers/IoDriverFloatImage.js
@@ -3,7 +3,7 @@
  * Class: IoDriverFloatImage
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverFloatImage() {
     //Constructor
@@ -14,6 +14,6 @@ function IoDriverFloatImage() {
 IoDriverFloatImage.prototype = new IoDriver();
 
 
-module.exports = {
-    IoDriverFloatImage: IoDriverFloatImage
+export {
+    IoDriverFloatImage
 };

--- a/src/Core/Commander/Providers/IoDriverLydarCloud.js
+++ b/src/Core/Commander/Providers/IoDriverLydarCloud.js
@@ -3,7 +3,7 @@
  * Class: IoDriverLydarCloud
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverLydarCloud() {
     //Constructor
@@ -14,6 +14,6 @@ function IoDriverLydarCloud() {
 IoDriverLydarCloud.prototype = new IoDriver();
 
 
-module.exports = {
-    IoDriverLydarCloud: IoDriverLydarCloud
+export {
+    IoDriverLydarCloud
 };

--- a/src/Core/Commander/Providers/IoDriverMicmac.js
+++ b/src/Core/Commander/Providers/IoDriverMicmac.js
@@ -3,7 +3,7 @@
  * Class: IoDriverMicmac
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverMicmac() {
     //Constructor
@@ -22,6 +22,6 @@ IoDriverMicmac.prototype.loadOrientation = function() {
 
 
 
-module.exports = {
-    IoDriverMicmac: IoDriverMicmac
+export {
+    IoDriverMicmac
 };

--- a/src/Core/Commander/Providers/IoDriverPly.js
+++ b/src/Core/Commander/Providers/IoDriverPly.js
@@ -3,7 +3,7 @@
  * Class: IoDriverPly
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverPly() {
     //Constructor
@@ -14,6 +14,6 @@ function IoDriverPly() {
 IoDriverPly.prototype = new IoDriver();
 
 
-module.exports = {
-    IoDriverPly: IoDriverPly
+export {
+    IoDriverPly
 };

--- a/src/Core/Commander/Providers/IoDriverXML.js
+++ b/src/Core/Commander/Providers/IoDriverXML.js
@@ -5,49 +5,48 @@
  */
 
 
-define('Core/Commander/Providers/IoDriverXML', ['Core/Commander/Providers/IoDriver', 'when'], function(IoDriver, when) {
+import IoDriver from 'Core/Commander/Providers/IoDriver';
+import when from 'when';
 
 
-    function IoDriverXML() {
-        //Constructor
-        IoDriver.call(this);
+function IoDriverXML() {
+    //Constructor
+    IoDriver.call(this);
 
-    }
+}
 
-    IoDriverXML.prototype = Object.create(IoDriver.prototype);
+IoDriverXML.prototype = Object.create(IoDriver.prototype);
 
-    IoDriverXML.prototype.constructor = IoDriverXML;
+IoDriverXML.prototype.constructor = IoDriverXML;
 
-    IoDriverXML.prototype.read = function(url) {
+IoDriverXML.prototype.read = function(url) {
 
-        var deferred = when.defer();
+    var deferred = when.defer();
 
-        var xhr = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest();
 
-        xhr.open("GET", url, true);
+    xhr.open("GET", url, true);
 
-        xhr.responseType = "document";
+    xhr.responseType = "document";
 
-        xhr.crossOrigin = '';
+    xhr.crossOrigin = '';
 
-        xhr.onload = function() {
-            deferred.resolve(this.response);
-
-        };
-
-        xhr.onerror = function() {
-
-            deferred.reject(Error("Error IoDriverXML"));
-
-        };
-
-        xhr.send(null);
-
-        return deferred;
-
+    xhr.onload = function() {
+        deferred.resolve(this.response);
 
     };
 
-    return IoDriverXML;
+    xhr.onerror = function() {
 
-});
+        deferred.reject(Error("Error IoDriverXML"));
+
+    };
+
+    xhr.send(null);
+
+    return deferred;
+
+
+};
+
+export default IoDriverXML;

--- a/src/Core/Commander/Providers/IoDriver_Image.js
+++ b/src/Core/Commander/Providers/IoDriver_Image.js
@@ -4,51 +4,50 @@
  */
 
 
-define('Core/Commander/Providers/IoDriver_Image', ['Core/Commander/Providers/IoDriver', 'when'], function(IoDriver, when) {
+import IoDriver from 'Core/Commander/Providers/IoDriver';
+import when from 'when';
 
 
-    function IoDriver_Image() {
-        //Constructor
-        IoDriver.call(this);
+function IoDriver_Image() {
+    //Constructor
+    IoDriver.call(this);
 
-    }
+}
 
-    IoDriver_Image.prototype = Object.create(IoDriver.prototype);
+IoDriver_Image.prototype = Object.create(IoDriver.prototype);
 
-    IoDriver_Image.prototype.constructor = IoDriver_Image;
+IoDriver_Image.prototype.constructor = IoDriver_Image;
 
-    IoDriver_Image.prototype.read = function(url) {
+IoDriver_Image.prototype.read = function(url) {
 
-        var deferred = when.defer();
-        var image = new Image();
+    var deferred = when.defer();
+    var image = new Image();
 
-        image.addEventListener('load', function(event) {
+    image.addEventListener('load', function(event) {
 
-            deferred.resolve(this);
+        deferred.resolve(this);
 
-        }, false);
+    }, false);
 
-        image.addEventListener('progress', function(event) {
+    image.addEventListener('progress', function(event) {
 
-        }, false);
-
-
-        image.addEventListener('error', function(event) {
+    }, false);
 
 
-            //TODO bug il faut tester quand l'image n'existe pas 
-            deferred.resolve(this);
-            //deferred.reject(Error("Error IoDriver_Image"));        
+    image.addEventListener('error', function(event) {
 
-        }, false);
 
-        image.crossOrigin = '';
-        image.src = url;
+        //TODO bug il faut tester quand l'image n'existe pas 
+        deferred.resolve(this);
+        //deferred.reject(Error("Error IoDriver_Image"));        
 
-        return deferred;
+    }, false);
 
-    };
+    image.crossOrigin = '';
+    image.src = url;
 
-    return IoDriver_Image;
+    return deferred;
 
-});
+};
+
+export default IoDriver_Image;

--- a/src/Core/Commander/Providers/IoDriver_XBIL.js
+++ b/src/Core/Commander/Providers/IoDriver_XBIL.js
@@ -4,89 +4,88 @@
  */
 
 
-define('Core/Commander/Providers/IoDriver_XBIL', ['Core/Commander/Providers/IoDriver', 'when'], function(IoDriver, when) {
+import IoDriver from 'Core/Commander/Providers/IoDriver';
+import when from 'when';
 
 
-    var portableXBIL = function(buffer) {
-        this.floatArray = new Float32Array(buffer);
-        this.max = -1000000;
-        this.min = 1000000;
-        this.texture = -1;
-    };
+var portableXBIL = function(buffer) {
+    this.floatArray = new Float32Array(buffer);
+    this.max = -1000000;
+    this.min = 1000000;
+    this.texture = -1;
+};
 
 
-    function IoDriver_XBIL() {
-        //Constructor
-        IoDriver.call(this);
+function IoDriver_XBIL() {
+    //Constructor
+    IoDriver.call(this);
 
-    }
+}
 
-    IoDriver_XBIL.prototype = Object.create(IoDriver.prototype);
+IoDriver_XBIL.prototype = Object.create(IoDriver.prototype);
 
-    IoDriver_XBIL.prototype.constructor = IoDriver_XBIL;
+IoDriver_XBIL.prototype.constructor = IoDriver_XBIL;
 
-    IoDriver_XBIL.prototype.read = function(url) {
+IoDriver_XBIL.prototype.read = function(url) {
 
-        var deferred = when.defer();
+    var deferred = when.defer();
 
-        var xhr = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest();
 
-        xhr.open("GET", url, true);
+    xhr.open("GET", url, true);
 
-        xhr.responseType = "arraybuffer";
-        xhr.crossOrigin = '';
+    xhr.responseType = "arraybuffer";
+    xhr.crossOrigin = '';
 
-        xhr.onload = function() {
+    xhr.onload = function() {
 
-            var arrayBuffer = this.response;
+        var arrayBuffer = this.response;
 
-            if (arrayBuffer) {
+        if (arrayBuffer) {
 
-                //                var floatArray = new Float32Array(arrayBuffer);                
-                //                var max = - 1000000;
-                //                var min =   1000000;
+            //                var floatArray = new Float32Array(arrayBuffer);                
+            //                var max = - 1000000;
+            //                var min =   1000000;
 
-                var result = new portableXBIL(arrayBuffer);
+            var result = new portableXBIL(arrayBuffer);
 
-                var mcolor = 0.0;
-                //var mcolor  = Math.random();
+            var mcolor = 0.0;
+            //var mcolor  = Math.random();
 
 
-                for (var i = 0; i < result.floatArray.byteLength; i++) {
-                    var val = result.floatArray[i];
-                    //  TODO debug a voir avec le geoportail
-                    //if(val === -99999.0 || val === undefined )                        
-                    if (val < -10.0 || val === undefined)
-                        result.floatArray[i] = mcolor;
-                    else {
-                        result.max = Math.max(result.max, val);
-                        result.min = Math.min(result.min, val);
-                    }
+            for (var i = 0; i < result.floatArray.byteLength; i++) {
+                var val = result.floatArray[i];
+                //  TODO debug a voir avec le geoportail
+                //if(val === -99999.0 || val === undefined )                        
+                if (val < -10.0 || val === undefined)
+                    result.floatArray[i] = mcolor;
+                else {
+                    result.max = Math.max(result.max, val);
+                    result.min = Math.min(result.min, val);
                 }
-
-                if (result.min === 1000000)
-                    return deferred.resolve(undefined);
-
-                deferred.resolve(result);
             }
-        };
 
-        xhr.onerror = function() {
+            if (result.min === 1000000)
+                return deferred.resolve(undefined);
 
-            //console.log('error bil');
-            deferred.resolve(undefined);
-            //deferred.reject(Error("Error IoDriver_XBIL"));
+            deferred.resolve(result);
+        }
+    };
 
-        };
+    xhr.onerror = function() {
 
-        xhr.send(null);
-
-        return deferred;
-
+        //console.log('error bil');
+        deferred.resolve(undefined);
+        //deferred.reject(Error("Error IoDriver_XBIL"));
 
     };
 
+    xhr.send(null);
 
-    return IoDriver_XBIL;
+    return deferred;
 
-});
+
+};
+
+
+export default IoDriver_XBIL;

--- a/src/Core/Commander/Providers/IoDriverglTF.js
+++ b/src/Core/Commander/Providers/IoDriverglTF.js
@@ -3,7 +3,7 @@
  * Class: IoDriverglTF
  */
 
-var IoDriver = require('IoDriver');
+import IoDriver from 'IoDriver';
 
 function IoDriverglTF() {
     //Constructor
@@ -14,6 +14,6 @@ function IoDriverglTF() {
 IoDriverglTF.prototype = new IoDriver();
 
 
-module.exports = {
-    IoDriverglTF: IoDriverglTF
+export {
+    IoDriverglTF
 };

--- a/src/Core/Commander/Providers/ItineraryService.js
+++ b/src/Core/Commander/Providers/ItineraryService.js
@@ -4,7 +4,7 @@
  * Description: Service de calcul d'itinéraire
  */
 
-var Service = require('Service');
+import Service from 'Service';
 
 function ItineraryService() {
     //Constructor
@@ -15,6 +15,6 @@ function ItineraryService() {
 ItineraryService.prototype = new Service();
 
 
-module.exports = {
-    ItineraryService: ItineraryService
+export {
+    ItineraryService
 };

--- a/src/Core/Commander/Providers/NodeMeshProvider.js
+++ b/src/Core/Commander/Providers/NodeMeshProvider.js
@@ -4,7 +4,7 @@
  * Description: Factory/Provider NodeMesh
  */
 
-var NodeProvider = require('NodeProvider');
+import NodeProvider from 'NodeProvider';
 
 function NodeMeshProvider() {
     //Constructor
@@ -15,6 +15,6 @@ function NodeMeshProvider() {
 NodeMeshProvider.prototype = new NodeProvider();
 
 
-module.exports = {
-    NodeMeshProvider: NodeMeshProvider
+export {
+    NodeMeshProvider
 };

--- a/src/Core/Commander/Providers/Provider.js
+++ b/src/Core/Commander/Providers/Provider.js
@@ -4,36 +4,31 @@
  * Description: Generic class to serve data, local or distant, nodes and services.
  */
 
-define('Core/Commander/Providers/Provider', [], function() {
+function Provider(iodriver) {
+    //Constructor
+
+    this.type = null;
+    this._IoDriver = iodriver;
+
+}
+
+Provider.prototype.constructor = Provider;
+
+/**
+ * @param url
+ */
+Provider.prototype.get = function(url) {
+    //TODO: Implement Me 
+
+};
 
 
-    function Provider(iodriver) {
-        //Constructor
+/**
+ * @param url
+ */
+Provider.prototype.getInCache = function(url) {
+    //TODO: Implement Me 
 
-        this.type = null;
-        this._IoDriver = iodriver;
+};
 
-    }
-
-    Provider.prototype.constructor = Provider;
-
-    /**
-     * @param url
-     */
-    Provider.prototype.get = function(url) {
-        //TODO: Implement Me 
-
-    };
-
-
-    /**
-     * @param url
-     */
-    Provider.prototype.getInCache = function(url) {
-        //TODO: Implement Me 
-
-    };
-
-    return Provider;
-
-});
+export default Provider;

--- a/src/Core/Commander/Providers/Service.js
+++ b/src/Core/Commander/Providers/Service.js
@@ -4,7 +4,7 @@
  * Description: Service distant ou locaux.
  */
 
-var Provider = require('Provider');
+import Provider from 'Provider';
 
 function Service() {
     //Constructor
@@ -15,6 +15,6 @@ function Service() {
 Service.prototype = new Provider();
 
 
-module.exports = {
-    Service: Service
+export {
+    Service
 };

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -5,129 +5,116 @@
  */
 
 
-define('Core/Commander/Providers/WMS_Provider', [
-        'Core/Commander/Providers/Provider',
-        'Core/Commander/Providers/IoDriver_XBIL',
-        'Core/Commander/Providers/IoDriver_Image',
-        'Core/Commander/Providers/IoDriverXML',
-        'when',
-        'Core/defaultValue',
-        'THREE',
-        'Core/Commander/Providers/CacheRessource'
-    ],
-    function(
-        Provider,
-        IoDriver_XBIL,
-        IoDriver_Image,
-        IoDriverXML,
-        when,
-        defaultValue,
-        THREE,
-        CacheRessource) {
+import Provider from 'Core/Commander/Providers/Provider';
+import IoDriver_XBIL from 'Core/Commander/Providers/IoDriver_XBIL';
+import IoDriver_Image from 'Core/Commander/Providers/IoDriver_Image';
+import IoDriverXML from 'Core/Commander/Providers/IoDriverXML';
+import when from 'when';
+import defaultValue from 'Core/defaultValue';
+import THREE from 'THREE';
+import CacheRessource from 'Core/Commander/Providers/CacheRessource';
 
-        /**
-         * Return url wmts MNT
-         * @param {String} options.url: service base url
-         * @param {String} options.layer: requested data layer
-         * @param {String} options.format: image format (default: format/jpeg)
-         * @returns {Object@call;create.url.url|String}
-         */
-        function WMS_Provider(options) {
-            //Constructor
+/**
+ * Return url wmts MNT
+ * @param {String} options.url: service base url
+ * @param {String} options.layer: requested data layer
+ * @param {String} options.format: image format (default: format/jpeg)
+ * @returns {Object@call;create.url.url|String}
+ */
+function WMS_Provider(options) {
+    //Constructor
 
-            Provider.call(this, new IoDriver_XBIL());
-            this.cache = CacheRessource();
-            this.ioDriverImage = new IoDriver_Image();
-            this.ioDriverXML = new IoDriverXML();
+    Provider.call(this, new IoDriver_XBIL());
+    this.cache = CacheRessource();
+    this.ioDriverImage = new IoDriver_Image();
+    this.ioDriverXML = new IoDriverXML();
 
-            this.baseUrl = options.url || "";
-            this.layer = options.layer || "";
-            this.format = defaultValue(options.format, "image/jpeg");
-            this.srs = options.srs || "";;
-            this.width = defaultValue(options.width, 256);
-            this.height = defaultValue(options.height, 256);
-        }
+    this.baseUrl = options.url || "";
+    this.layer = options.layer || "";
+    this.format = defaultValue(options.format, "image/jpeg");
+    this.srs = options.srs || "";;
+    this.width = defaultValue(options.width, 256);
+    this.height = defaultValue(options.height, 256);
+}
 
-        WMS_Provider.prototype = Object.create(Provider.prototype);
+WMS_Provider.prototype = Object.create(Provider.prototype);
 
-        WMS_Provider.prototype.constructor = WMS_Provider;
+WMS_Provider.prototype.constructor = WMS_Provider;
 
 
-        /**
-         * Returns the url for a WMS query with the specified bounding box
-         * @param {BoundingBox} bbox: requested bounding box
-         * @returns {Object@call;create.url.url|String}
-         */
-        WMS_Provider.prototype.url = function(bbox) {
-            var url = this.baseUrl + "?LAYERS=" + this.layer + "&FORMAT=" + this.format +
-                "&SERVICE=WMS&VERSION=1.1.1" + "&REQUEST=GetMap&BBOX=" +
-                bbox.minCarto.longitude + "," + bbox.minCarto.latitude + "," +
-                bbox.maxCarto.longitude + "," + bbox.maxCarto.latitude +
-                "&WIDTH=" + this.width + "&HEIGHT=" + this.height + "&SRS=" + this.srs;
-            return url;
-        };
+/**
+ * Returns the url for a WMS query with the specified bounding box
+ * @param {BoundingBox} bbox: requested bounding box
+ * @returns {Object@call;create.url.url|String}
+ */
+WMS_Provider.prototype.url = function(bbox) {
+    var url = this.baseUrl + "?LAYERS=" + this.layer + "&FORMAT=" + this.format +
+        "&SERVICE=WMS&VERSION=1.1.1" + "&REQUEST=GetMap&BBOX=" +
+        bbox.minCarto.longitude + "," + bbox.minCarto.latitude + "," +
+        bbox.maxCarto.longitude + "," + bbox.maxCarto.latitude +
+        "&WIDTH=" + this.width + "&HEIGHT=" + this.height + "&SRS=" + this.srs;
+    return url;
+};
 
 
-        /**
-         * Return url wms IR coverage
-         * ex url: http://realearth.ssec.wisc.edu/api/image?products=globalir&bounds=-85,-178,85,178&width=1024&height=512
-         * We can also specify time of coverage image like &time=2016-02-12+10:42
-         * @param {type} coWMS
-         * @returns {Object@call;create.urlOrtho.url|String}
-         */
-        WMS_Provider.prototype.urlGlobalIR = function(coWMS) {
-            var latBound = coWMS.latBound || new THREE.Vector2(-85, 85);
-            var longBound = coWMS.longBound || new THREE.Vector2(-178, 178);
+/**
+ * Return url wms IR coverage
+ * ex url: http://realearth.ssec.wisc.edu/api/image?products=globalir&bounds=-85,-178,85,178&width=1024&height=512
+ * We can also specify time of coverage image like &time=2016-02-12+10:42
+ * @param {type} coWMS
+ * @returns {Object@call;create.urlOrtho.url|String}
+ */
+WMS_Provider.prototype.urlGlobalIR = function(coWMS) {
+    var latBound = coWMS.latBound || new THREE.Vector2(-85, 85);
+    var longBound = coWMS.longBound || new THREE.Vector2(-178, 178);
 
-            var width = coWMS.width || 1024;
-            var height = coWMS.height || 512;
+    var width = coWMS.width || 1024;
+    var height = coWMS.height || 512;
 
-            var urlBaseService = "http://realearth.ssec.wisc.edu/api/image?products=globalir&bounds=";
+    var urlBaseService = "http://realearth.ssec.wisc.edu/api/image?products=globalir&bounds=";
 
-            // URL for all globe  IR imagery   
-            var url = urlBaseService + latBound.x + "," + longBound.x + "," + latBound.y + "," + longBound.y +
-                "&width=" + width + "&height=" + height;
-
-
-            //"http://realearth.ssec.wisc.edu/api/image?products=globalir_20160212_080000&"+
-            //"x="+coWMS.col+"&y="+coWMS.row+"&z=" + coWMS.zoom;
-            return url;
+    // URL for all globe  IR imagery   
+    var url = urlBaseService + latBound.x + "," + longBound.x + "," + latBound.y + "," + longBound.y +
+        "&width=" + width + "&height=" + height;
 
 
-        };
+    //"http://realearth.ssec.wisc.edu/api/image?products=globalir_20160212_080000&"+
+    //"x="+coWMS.col+"&y="+coWMS.row+"&z=" + coWMS.zoom;
+    return url;
+
+
+};
 
 
 
-        /**
-         * Returns a texture from the WMS stream with the specified bounding box 
-         * @param {BoundingBox} bbox: requested bounding box
-         * @returns {WMS_Provider_L15.WMS_Provider.prototype@pro;_IoDriver@call;read@call;then}
-         */
-        WMS_Provider.prototype.getTexture = function(bbox) {
+/**
+ * Returns a texture from the WMS stream with the specified bounding box 
+ * @param {BoundingBox} bbox: requested bounding box
+ * @returns {WMS_Provider_L15.WMS_Provider.prototype@pro;_IoDriver@call;read@call;then}
+ */
+WMS_Provider.prototype.getTexture = function(bbox) {
 
-            if (bbox === undefined)
-                return when(-2);
+    if (bbox === undefined)
+        return when(-2);
 
-            var url = this.url(bbox);
+    var url = this.url(bbox);
 
-            var textureCache = this.cache.getRessource(url);
+    var textureCache = this.cache.getRessource(url);
 
-            if (textureCache !== undefined)
-                return when(textureCache);
-            return this.ioDriverImage.read(url).then(function(image) {
-                var result = {};
-                result.texture = new THREE.Texture(image);
-                result.texture.generateMipmaps = false;
-                result.texture.magFilter = THREE.LinearFilter;
-                result.texture.minFilter = THREE.LinearFilter;
-                result.texture.anisotropy = 16;
+    if (textureCache !== undefined)
+        return when(textureCache);
+    return this.ioDriverImage.read(url).then(function(image) {
+        var result = {};
+        result.texture = new THREE.Texture(image);
+        result.texture.generateMipmaps = false;
+        result.texture.magFilter = THREE.LinearFilter;
+        result.texture.minFilter = THREE.LinearFilter;
+        result.texture.anisotropy = 16;
 
-                this.cache.addRessource(url, result.texture);
-                return result.texture;
+        this.cache.addRessource(url, result.texture);
+        return result.texture;
 
-            }.bind(this));
-        };
+    }.bind(this));
+};
 
-        return WMS_Provider;
-
-    });
+export default WMS_Provider;

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -5,150 +5,138 @@
  */
 
 
-define('Core/Commander/Providers/WMTS_Provider', [
-        'Core/Commander/Providers/Provider',
-        'Core/Commander/Providers/IoDriver_XBIL',
-        'Core/Commander/Providers/IoDriver_Image',
-        'Core/Commander/Providers/IoDriverXML',
-        'when',
-        'THREE',
-        'Core/Commander/Providers/CacheRessource'
-    ],
-    function(
-        Provider,
-        IoDriver_XBIL,
-        IoDriver_Image,
-        IoDriverXML,
-        when,
-        THREE,
-        CacheRessource) {
+import Provider from 'Core/Commander/Providers/Provider';
+import IoDriver_XBIL from 'Core/Commander/Providers/IoDriver_XBIL';
+import IoDriver_Image from 'Core/Commander/Providers/IoDriver_Image';
+import IoDriverXML from 'Core/Commander/Providers/IoDriverXML';
+import when from 'when';
+import THREE from 'THREE';
+import CacheRessource from 'Core/Commander/Providers/CacheRessource';
 
 
-        function WMTS_Provider() {
-            //Constructor
+function WMTS_Provider() {
+    //Constructor
 
-            Provider.call(this, new IoDriver_XBIL());
-            this.cache = CacheRessource();
-            this.ioDriverImage = new IoDriver_Image();
-            this.ioDriverXML = new IoDriverXML();
+    Provider.call(this, new IoDriver_XBIL());
+    this.cache = CacheRessource();
+    this.ioDriverImage = new IoDriver_Image();
+    this.ioDriverXML = new IoDriverXML();
 
+}
+
+WMTS_Provider.prototype = Object.create(Provider.prototype);
+
+WMTS_Provider.prototype.constructor = WMTS_Provider;
+
+
+/**
+ * Return url wmts MNT
+ * @param {type} coWMTS : coord WMTS
+ * @returns {Object@call;create.url.url|String}
+ */
+WMTS_Provider.prototype.url = function(coWMTS) {
+    var key = "va5orxd0pgzvq3jxutqfuy0b";
+    var layer = coWMTS.zoom > 11 ? "ELEVATION.ELEVATIONGRIDCOVERAGE.HIGHRES" : "ELEVATION.ELEVATIONGRIDCOVERAGE";
+
+    var url = "http://wxs.ign.fr/" + key + "/geoportail/wmts?LAYER=" + layer +
+        "&FORMAT=image/x-bil;bits=32&SERVICE=WMTS&VERSION=1.0.0" +
+        "&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM" +
+        "&TILEMATRIX=" + coWMTS.zoom + "&TILEROW=" + coWMTS.row + "&TILECOL=" + coWMTS.col;
+    return url;
+};
+
+/**
+ * Return url wmts orthophoto
+ * @param {type} coWMTS
+ * @returns {Object@call;create.urlOrtho.url|String}
+ */
+WMTS_Provider.prototype.urlOrtho = function(coWMTS) {
+
+    var key = "va5orxd0pgzvq3jxutqfuy0b";
+    var layer = "ORTHOIMAGERY.ORTHOPHOTOS";
+    //layer  = "GEOGRAPHICALGRIDSYSTEMS.MAPS";
+
+    var url = "http://wxs.ign.fr/" + key + "/geoportail/wmts?LAYER=" + layer +
+        "&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0" +
+        "&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM" +
+        "&TILEMATRIX=" + coWMTS.zoom + "&TILEROW=" + coWMTS.row + "&TILECOL=" + coWMTS.col;
+    return url;
+};
+
+/**
+ * return texture float alpha THREE.js of MNT 
+ * @param {type} coWMTS : coord WMTS
+ * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
+ */
+WMTS_Provider.prototype.getTextureBil = function(coWMTS) {
+
+    if (coWMTS === undefined)
+        return when(-2);
+
+    var url = this.url(coWMTS);
+
+    var textureCache = this.cache.getRessource(url);
+
+    if (textureCache !== undefined)
+        return when(textureCache);
+
+    if (coWMTS.zoom <= 2) {
+        var texture = -1;
+        this.cache.addRessource(url, texture);
+        return when(texture);
+    }
+
+    return this._IoDriver.read(url).then(function(result) {
+        if (result !== undefined) {
+            result.texture = new THREE.DataTexture(result.floatArray, 256, 256, THREE.AlphaFormat, THREE.FloatType);
+            result.texture.generateMipmaps = false;
+            result.texture.magFilter = THREE.LinearFilter;
+            result.texture.minFilter = THREE.LinearFilter;
+            this.cache.addRessource(url, result);
+            return result;
+        } else {
+            var texture = -1;
+            this.cache.addRessource(url, texture);
+            return texture;
         }
+    }.bind(this));
+};
 
-        WMTS_Provider.prototype = Object.create(Provider.prototype);
+/**
+ * Return texture RGBA THREE.js of orthophoto
+ * TODO : RGBA --> RGB remove alpha canal
+ * @param {type} coWMTS
+ * @param {type} id
+ * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;ioDriverImage@call;read@call;then}
+ */
+WMTS_Provider.prototype.getTextureOrtho = function(coWMTS, id) {
 
-        WMTS_Provider.prototype.constructor = WMTS_Provider;
+    var pack = function(i) {
+        this.texture;
+        this.id = i;
+    };
 
+    var result = new pack(id);
 
-        /**
-         * Return url wmts MNT
-         * @param {type} coWMTS : coord WMTS
-         * @returns {Object@call;create.url.url|String}
-         */
-        WMTS_Provider.prototype.url = function(coWMTS) {
-            var key = "va5orxd0pgzvq3jxutqfuy0b";
-            var layer = coWMTS.zoom > 11 ? "ELEVATION.ELEVATIONGRIDCOVERAGE.HIGHRES" : "ELEVATION.ELEVATIONGRIDCOVERAGE";
+    var url = this.urlOrtho(coWMTS);
+    result.texture = this.cache.getRessource(url);
 
-            var url = "http://wxs.ign.fr/" + key + "/geoportail/wmts?LAYER=" + layer +
-                "&FORMAT=image/x-bil;bits=32&SERVICE=WMTS&VERSION=1.0.0" +
-                "&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM" +
-                "&TILEMATRIX=" + coWMTS.zoom + "&TILEROW=" + coWMTS.row + "&TILECOL=" + coWMTS.col;
-            return url;
-        };
+    if (result.texture !== undefined) {
+        return when(result);
+    }
+    return this.ioDriverImage.read(url).then(function(image) {
 
-        /**
-         * Return url wmts orthophoto
-         * @param {type} coWMTS
-         * @returns {Object@call;create.urlOrtho.url|String}
-         */
-        WMTS_Provider.prototype.urlOrtho = function(coWMTS) {
+        result.texture = new THREE.Texture(image);
+        result.texture.generateMipmaps = false;
+        result.texture.magFilter = THREE.LinearFilter;
+        result.texture.minFilter = THREE.LinearFilter;
+        result.texture.anisotropy = 16;
 
-            var key = "va5orxd0pgzvq3jxutqfuy0b";
-            var layer = "ORTHOIMAGERY.ORTHOPHOTOS";
-            //layer  = "GEOGRAPHICALGRIDSYSTEMS.MAPS";
+        this.cache.addRessource(url, result.texture);
+        return result;
 
-            var url = "http://wxs.ign.fr/" + key + "/geoportail/wmts?LAYER=" + layer +
-                "&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0" +
-                "&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM" +
-                "&TILEMATRIX=" + coWMTS.zoom + "&TILEROW=" + coWMTS.row + "&TILECOL=" + coWMTS.col;
-            return url;
-        };
+    }.bind(this));
 
-        /**
-         * return texture float alpha THREE.js of MNT 
-         * @param {type} coWMTS : coord WMTS
-         * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
-         */
-        WMTS_Provider.prototype.getTextureBil = function(coWMTS) {
+};
 
-            if (coWMTS === undefined)
-                return when(-2);
-
-            var url = this.url(coWMTS);
-
-            var textureCache = this.cache.getRessource(url);
-
-            if (textureCache !== undefined)
-                return when(textureCache);
-
-            if (coWMTS.zoom <= 2) {
-                var texture = -1;
-                this.cache.addRessource(url, texture);
-                return when(texture);
-            }
-
-            return this._IoDriver.read(url).then(function(result) {
-                if (result !== undefined) {
-                    result.texture = new THREE.DataTexture(result.floatArray, 256, 256, THREE.AlphaFormat, THREE.FloatType);
-                    result.texture.generateMipmaps = false;
-                    result.texture.magFilter = THREE.LinearFilter;
-                    result.texture.minFilter = THREE.LinearFilter;
-                    this.cache.addRessource(url, result);
-                    return result;
-                } else {
-                    var texture = -1;
-                    this.cache.addRessource(url, texture);
-                    return texture;
-                }
-            }.bind(this));
-        };
-
-        /**
-         * Return texture RGBA THREE.js of orthophoto
-         * TODO : RGBA --> RGB remove alpha canal
-         * @param {type} coWMTS
-         * @param {type} id
-         * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;ioDriverImage@call;read@call;then}
-         */
-        WMTS_Provider.prototype.getTextureOrtho = function(coWMTS, id) {
-
-            var pack = function(i) {
-                this.texture;
-                this.id = i;
-            };
-
-            var result = new pack(id);
-
-            var url = this.urlOrtho(coWMTS);
-            result.texture = this.cache.getRessource(url);
-
-            if (result.texture !== undefined) {
-                return when(result);
-            }
-            return this.ioDriverImage.read(url).then(function(image) {
-
-                result.texture = new THREE.Texture(image);
-                result.texture.generateMipmaps = false;
-                result.texture.magFilter = THREE.LinearFilter;
-                result.texture.minFilter = THREE.LinearFilter;
-                result.texture.anisotropy = 16;
-
-                this.cache.addRessource(url, result.texture);
-                return result;
-
-            }.bind(this));
-
-        };
-
-        return WMTS_Provider;
-
-    });
+export default WMTS_Provider;

--- a/src/Core/Commander/Providers/tileGlobeProvider.js
+++ b/src/Core/Commander/Providers/tileGlobeProvider.js
@@ -15,153 +15,137 @@
 
 
 
-define('Core/Commander/Providers/tileGlobeProvider', [
-        'when',
-        'Core/Geographic/Projection',
-        'Core/Commander/Providers/WMTS_Provider',
-        'Core/Commander/Providers/KML_Provider',
-        'Globe/EllipsoidTileGeometry',
-        'Core/Geographic/CoordWMTS',
-        'Core/Math/Ellipsoid',
-        'Core/defaultValue',
-        'Scene/BoundingBox',
-        'three'
-    ],
-    function(
-        when,
-        Projection,
-        WMTS_Provider,
-        KML_Provider,
-        EllipsoidTileGeometry,
-        CoordWMTS,
-        Ellipsoid,
-        defaultValue,
-        BoundingBox,
-        THREE
-    ) {
+import when from 'when';
+import Projection from 'Core/Geographic/Projection';
+import WMTS_Provider from 'Core/Commander/Providers/WMTS_Provider';
+import KML_Provider from 'Core/Commander/Providers/KML_Provider';
+import EllipsoidTileGeometry from 'Globe/EllipsoidTileGeometry';
+import CoordWMTS from 'Core/Geographic/CoordWMTS';
+import Ellipsoid from 'Core/Math/Ellipsoid';
+import defaultValue from 'Core/defaultValue';
+import BoundingBox from 'Scene/BoundingBox';
+import THREE from 'three';
 
-        function tileGlobeProvider(size) {
-            //Constructor
+function tileGlobeProvider(size) {
+    //Constructor
 
-            this.projection = new Projection();
-            this.providerWMTS = new WMTS_Provider();
-            //this.providerWMS     = new WMS_Provider();
-            this.ellipsoid = new Ellipsoid(size);
-            this.providerKML = new KML_Provider(this.ellipsoid);
-            this.cacheGeometry = [];
-            this.tree = null;
-            this.nNode = 0;
+    this.projection = new Projection();
+    this.providerWMTS = new WMTS_Provider();
+    //this.providerWMS     = new WMS_Provider();
+    this.ellipsoid = new Ellipsoid(size);
+    this.providerKML = new KML_Provider(this.ellipsoid);
+    this.cacheGeometry = [];
+    this.tree = null;
+    this.nNode = 0;
 
-        }
+}
 
-        tileGlobeProvider.prototype.constructor = tileGlobeProvider;
+tileGlobeProvider.prototype.constructor = tileGlobeProvider;
 
-        tileGlobeProvider.prototype.getGeometry = function(bbox, cooWMTS) {
-            var geometry = undefined;
-            var n = Math.pow(2, cooWMTS.zoom + 1);
-            var part = Math.PI * 2.0 / n;
+tileGlobeProvider.prototype.getGeometry = function(bbox, cooWMTS) {
+    var geometry = undefined;
+    var n = Math.pow(2, cooWMTS.zoom + 1);
+    var part = Math.PI * 2.0 / n;
 
-            if (this.cacheGeometry[cooWMTS.zoom] !== undefined && this.cacheGeometry[cooWMTS.zoom][cooWMTS.row] !== undefined) {
-                geometry = this.cacheGeometry[cooWMTS.zoom][cooWMTS.row];
-            } else {
-                if (this.cacheGeometry[cooWMTS.zoom] === undefined)
-                    this.cacheGeometry[cooWMTS.zoom] = new Array();
+    if (this.cacheGeometry[cooWMTS.zoom] !== undefined && this.cacheGeometry[cooWMTS.zoom][cooWMTS.row] !== undefined) {
+        geometry = this.cacheGeometry[cooWMTS.zoom][cooWMTS.row];
+    } else {
+        if (this.cacheGeometry[cooWMTS.zoom] === undefined)
+            this.cacheGeometry[cooWMTS.zoom] = new Array();
 
-                var precision = 16;
-                var rootBBox = new BoundingBox(0, part + part * 0.01, bbox.minCarto.latitude, bbox.maxCarto.latitude);
+        var precision = 16;
+        var rootBBox = new BoundingBox(0, part + part * 0.01, bbox.minCarto.latitude, bbox.maxCarto.latitude);
 
-                geometry = new EllipsoidTileGeometry(rootBBox, precision, this.ellipsoid, cooWMTS.zoom);
-                this.cacheGeometry[cooWMTS.zoom][cooWMTS.row] = geometry;
+        geometry = new EllipsoidTileGeometry(rootBBox, precision, this.ellipsoid, cooWMTS.zoom);
+        this.cacheGeometry[cooWMTS.zoom][cooWMTS.row] = geometry;
 
-            }
+    }
 
-            return geometry;
-        };
+    return geometry;
+};
 
-        tileGlobeProvider.prototype.get = function(command) {
+tileGlobeProvider.prototype.get = function(command) {
 
-            if (command === undefined)
-                return when();
+    if (command === undefined)
+        return when();
 
-            var bbox = command.paramsFunction[0];
-            var cooWMTS = this.projection.WGS84toWMTS(bbox);
-            var parent = command.requester;
-            var geometry = undefined; //getGeometry(bbox,cooWMTS);       
-            var tile = new command.type(bbox, cooWMTS, this.ellipsoid, this.nNode++, geometry);
+    var bbox = command.paramsFunction[0];
+    var cooWMTS = this.projection.WGS84toWMTS(bbox);
+    var parent = command.requester;
+    var geometry = undefined; //getGeometry(bbox,cooWMTS);       
+    var tile = new command.type(bbox, cooWMTS, this.ellipsoid, this.nNode++, geometry);
 
-            if (geometry) {
-                tile.rotation.set(0, (cooWMTS.col % 2) * (Math.PI * 2.0 / Math.pow(2, cooWMTS.zoom + 1)), 0);
-                tile.updateMatrixWorld();
-            }
+    if (geometry) {
+        tile.rotation.set(0, (cooWMTS.col % 2) * (Math.PI * 2.0 / Math.pow(2, cooWMTS.zoom + 1)), 0);
+        tile.updateMatrixWorld();
+    }
 
-            var translate = new THREE.Vector3();
+    var translate = new THREE.Vector3();
 
-            if (parent.worldToLocal)
-                translate = parent.worldToLocal(tile.absoluteCenter.clone());
+    if (parent.worldToLocal)
+        translate = parent.worldToLocal(tile.absoluteCenter.clone());
 
-            tile.position.copy(translate);
-            tile.updateMatrixWorld();
+    tile.position.copy(translate);
+    tile.updateMatrixWorld();
 
-            tile.setVisibility(false);
+    tile.setVisibility(false);
 
-            tile.link = parent.link;
+    tile.link = parent.link;
 
-            parent.add(tile);
+    parent.add(tile);
 
-            return this.providerWMTS.getTextureBil(tile.useParent() ? undefined : cooWMTS).then(function(terrain) {
-                this.setTerrain(terrain);
+    return this.providerWMTS.getTextureBil(tile.useParent() ? undefined : cooWMTS).then(function(terrain) {
+        this.setTerrain(terrain);
 
-                return this;
+        return this;
 
-            }.bind(tile)).then(function(tile) {
-                if (cooWMTS.zoom >= 2)
-                    this.getOrthoImages(tile);
-                else
-                    tile.checkOrtho();
+    }.bind(tile)).then(function(tile) {
+        if (cooWMTS.zoom >= 2)
+            this.getOrthoImages(tile);
+        else
+            tile.checkOrtho();
 
-                return tile;
+        return tile;
 
-            }.bind(this)).then(function(tile) {
+    }.bind(this)).then(function(tile) {
 
-                //            if(tile.level  === 16  )
-                //            {
-                //                var longitude   = tile.bbox.center.x / Math.PI * 180 - 180;
-                //                var latitude    = tile.bbox.center.y / Math.PI * 180;
-                //
-                //                this.providerKML.loadKMZ(longitude, latitude).then(function (collada){
-                //                    
-                //                    
-                //                    if(collada && tile.link.children.indexOf(collada) === -1)
-                //                    {                                 
-                //                        tile.link.add(collada);
-                //                        tile.content = collada;
-                //                    }
-                //                }.bind(this));
-                //                
-                //            }
+        //            if(tile.level  === 16  )
+        //            {
+        //                var longitude   = tile.bbox.center.x / Math.PI * 180 - 180;
+        //                var latitude    = tile.bbox.center.y / Math.PI * 180;
+        //
+        //                this.providerKML.loadKMZ(longitude, latitude).then(function (collada){
+        //                    
+        //                    
+        //                    if(collada && tile.link.children.indexOf(collada) === -1)
+        //                    {         
+        //                        tile.link.add(collada);
+        //                        tile.content = collada;
+        //                    }
+        //                }.bind(this));
+        //                
+        //            }
 
-            }.bind(this));
-        };
+    }.bind(this));
+};
 
-        tileGlobeProvider.prototype.getOrthoImages = function(tile) {
-            var box = this.projection.WMTS_WGS84ToWMTS_PM(tile.cooWMTS, tile.bbox); // 
-            var id = 0;
-            var col = box[0].col;
-            tile.orthoNeed = box[1].row + 1 - box[0].row;
+tileGlobeProvider.prototype.getOrthoImages = function(tile) {
+    var box = this.projection.WMTS_WGS84ToWMTS_PM(tile.cooWMTS, tile.bbox); // 
+    var id = 0;
+    var col = box[0].col;
+    tile.orthoNeed = box[1].row + 1 - box[0].row;
 
-            for (var row = box[0].row; row < box[1].row + 1; row++) {
-                this.providerWMTS.getTextureOrtho(new CoordWMTS(box[0].zoom, row, col), id).then(
-                    function(result) {
-                        this.setTextureOrtho(result.texture, result.id);
+    for (var row = box[0].row; row < box[1].row + 1; row++) {
+        this.providerWMTS.getTextureOrtho(new CoordWMTS(box[0].zoom, row, col), id).then(
+            function(result) {
+                this.setTextureOrtho(result.texture, result.id);
 
-                    }.bind(tile)
-                );
+            }.bind(tile)
+        );
 
-                id++;
-            }
+        id++;
+    }
 
-        };
+};
 
-        return tileGlobeProvider;
-
-    });
+export default tileGlobeProvider;

--- a/src/Core/Commander/Queue.js
+++ b/src/Core/Commander/Queue.js
@@ -5,124 +5,119 @@
  */
 
 
-define('Core/Commander/Queue', [],
-    function() {
+function Queue(criteria, heapType) {
+    this.criteria = criteria;
+    this.length = 0;
+    this.queue = [];
 
-        function Queue(criteria, heapType) {
-            this.criteria = criteria;
-            this.length = 0;
-            this.queue = [];
-
-            this.isMax = !!heapType;
-            if (heapType !== 0 && heapType !== 1) {
-                console.log(heapType + " not supported.");
-            }
-            /*
-            console.log(this.isMax );
+    this.isMax = !!heapType;
+    if (heapType !== 0 && heapType !== 1) {
+        console.log(heapType + " not supported.");
+    }
+    /*
+    console.log(this.isMax );
         
-            var isMax = false;
+    var isMax = false;
 
-            //Constructor
-            if (heapType===0) {
-                isMax = true;
-            } else if (heapType===1) {
-                isMax = false;
-            } else {
-                throw heapType + " not supported.";
-            }
+    //Constructor
+    if (heapType===0) {
+        isMax = true;
+    } else if (heapType===1) {
+        isMax = false;
+    } else {
+        throw heapType + " not supported.";
+    }
         
-            console.log(isMax );*/
-        }
+    console.log(isMax );*/
+}
 
-        Queue.prototype.insert = function(value) {
+Queue.prototype.insert = function(value) {
 
 
-            if (!value.hasOwnProperty(this.criteria)) {
-                console.log(value);
-                console.log("Cannot insert " + value + " because it does not have a property by the name of " + this.criteria + ".");
-            }
-            this.queue.push(value);
-            this.length++;
-            this.bubbleUp(this.length - 1);
-        };
+    if (!value.hasOwnProperty(this.criteria)) {
+        console.log(value);
+        console.log("Cannot insert " + value + " because it does not have a property by the name of " + this.criteria + ".");
+    }
+    this.queue.push(value);
+    this.length++;
+    this.bubbleUp(this.length - 1);
+};
 
-        Queue.prototype.getHighestPriorityElement = function() {
-            return this.queue[0];
-        };
-        Queue.prototype.shiftHighestPriorityElement = function() {
-            if (length < 0) {
-                console.log("There are no more elements in your priority queue");
-            }
-            var oldRoot = this.queue[0];
-            var newRoot = this.queue.pop();
-            this.length--;
-            this.queue[0] = newRoot;
-            this.swapUntilQueueIsCorrect(0);
-            return oldRoot;
-        };
-        Queue.prototype.bubbleUp = function(index) {
-            if (index === 0) {
-                return;
-            }
-            var parent = this.getParentOf(index);
+Queue.prototype.getHighestPriorityElement = function() {
+    return this.queue[0];
+};
+Queue.prototype.shiftHighestPriorityElement = function() {
+    if (length < 0) {
+        console.log("There are no more elements in your priority queue");
+    }
+    var oldRoot = this.queue[0];
+    var newRoot = this.queue.pop();
+    this.length--;
+    this.queue[0] = newRoot;
+    this.swapUntilQueueIsCorrect(0);
+    return oldRoot;
+};
+Queue.prototype.bubbleUp = function(index) {
+    if (index === 0) {
+        return;
+    }
+    var parent = this.getParentOf(index);
 
-            if (parent === -1) {
-                parent = 0;
-                console.log(this.queue);
-                console.log("-----");
-            }
+    if (parent === -1) {
+        parent = 0;
+        console.log(this.queue);
+        console.log("-----");
+    }
 
-            if (this.evaluate(index, parent)) {
-                this.swap(index, parent);
-                this.bubbleUp(parent);
-            } else {
-                return;
-            }
-        };
-        Queue.prototype.swapUntilQueueIsCorrect = function(value) {
-            var left = this.getLeftOf(value),
-                right = this.getRightOf(value);
+    if (this.evaluate(index, parent)) {
+        this.swap(index, parent);
+        this.bubbleUp(parent);
+    } else {
+        return;
+    }
+};
+Queue.prototype.swapUntilQueueIsCorrect = function(value) {
+    var left = this.getLeftOf(value),
+        right = this.getRightOf(value);
 
-            if (this.evaluate(left, value)) {
-                this.swap(value, left);
-                this.swapUntilQueueIsCorrect(left);
-            } else if (this.evaluate(right, value)) {
-                this.swap(value, right);
-                this.swapUntilQueueIsCorrect(right);
-            } else if (value === 0) {
-                return;
-            } else {
-                this.swapUntilQueueIsCorrect(0);
-            }
-        };
-        Queue.prototype.swap = function(self, target) {
-            var placeHolder = this.queue[self];
-            this.queue[self] = this.queue[target];
-            this.queue[target] = placeHolder;
-        };
-        Queue.prototype.evaluate = function(self, target) {
+    if (this.evaluate(left, value)) {
+        this.swap(value, left);
+        this.swapUntilQueueIsCorrect(left);
+    } else if (this.evaluate(right, value)) {
+        this.swap(value, right);
+        this.swapUntilQueueIsCorrect(right);
+    } else if (value === 0) {
+        return;
+    } else {
+        this.swapUntilQueueIsCorrect(0);
+    }
+};
+Queue.prototype.swap = function(self, target) {
+    var placeHolder = this.queue[self];
+    this.queue[self] = this.queue[target];
+    this.queue[target] = placeHolder;
+};
+Queue.prototype.evaluate = function(self, target) {
 
-            if (this.queue[target] === undefined || this.queue[self] === undefined) {
-                return false;
-            }
-            if (this.isMax) {
-                return (this.queue[self][this.criteria] > this.queue[target][this.criteria]);
-            } else {
-                return (this.queue[self][this.criteria] < this.queue[target][this.criteria]);
-            }
-        };
-        Queue.prototype.getParentOf = function(index) {
-            return Math.floor(index / 2) - 1;
-        };
-        Queue.prototype.getLeftOf = function(index) {
-            return index * 2 + 1;
-        };
-        Queue.prototype.getRightOf = function(index) {
-            return index * 2 + 2;
-        };
-        Queue.MAX_HEAP = 0;
-        Queue.MIN_HEAP = 1;
+    if (this.queue[target] === undefined || this.queue[self] === undefined) {
+        return false;
+    }
+    if (this.isMax) {
+        return (this.queue[self][this.criteria] > this.queue[target][this.criteria]);
+    } else {
+        return (this.queue[self][this.criteria] < this.queue[target][this.criteria]);
+    }
+};
+Queue.prototype.getParentOf = function(index) {
+    return Math.floor(index / 2) - 1;
+};
+Queue.prototype.getLeftOf = function(index) {
+    return index * 2 + 1;
+};
+Queue.prototype.getRightOf = function(index) {
+    return index * 2 + 2;
+};
+Queue.MAX_HEAP = 0;
+Queue.MIN_HEAP = 1;
 
-        return Queue;
-
-    });
+export default Queue;

--- a/src/Core/Commander/TemplatesCommand.js
+++ b/src/Core/Commander/TemplatesCommand.js
@@ -29,6 +29,6 @@ TemplatesCommand.prototype.specifiesCommand = function() {
 
 
 
-module.exports = {
-    TemplatesCommand: TemplatesCommand
+export {
+    TemplatesCommand
 };

--- a/src/Core/Commander/Worker.js
+++ b/src/Core/Commander/Worker.js
@@ -11,6 +11,6 @@ function Worker() {
 
 
 
-module.exports = {
-    Worker: Worker
+export {
+    Worker
 };

--- a/src/Core/Geographic/CoordCarto.js
+++ b/src/Core/Geographic/CoordCarto.js
@@ -8,26 +8,25 @@
  * @param {type} defaultValue
  * @returns {CoordCarto_L9.CoordCarto}
  */
-define('Core/Geographic/CoordCarto', ['Core/defaultValue'], function(defaultValue) {
+import defaultValue from 'Core/defaultValue';
 
 
-    function CoordCarto(longitude, latitude, altitude) {
-        this.longitude = defaultValue(longitude, 0);
-        this.latitude = defaultValue(latitude, 0);
-        this.altitude = defaultValue(altitude, 0);
-    }
+function CoordCarto(longitude, latitude, altitude) {
+    this.longitude = defaultValue(longitude, 0);
+    this.latitude = defaultValue(latitude, 0);
+    this.altitude = defaultValue(altitude, 0);
+}
 
-    CoordCarto.prototype.constructor = CoordCarto;
+CoordCarto.prototype.constructor = CoordCarto;
 
-    CoordCarto.prototype.setFromDegreeGeo = function(longitude, latitude, altitude) {
+CoordCarto.prototype.setFromDegreeGeo = function(longitude, latitude, altitude) {
 
 
-        this.longitude = defaultValue(latitude * Math.PI / 180, 0);
-        this.latitude = defaultValue(-longitude * Math.PI / 180 + Math.PI, 0);
-        this.altitude = defaultValue(altitude, 0);
+    this.longitude = defaultValue(latitude * Math.PI / 180, 0);
+    this.latitude = defaultValue(-longitude * Math.PI / 180 + Math.PI, 0);
+    this.altitude = defaultValue(altitude, 0);
 
-        return this;
-    };
+    return this;
+};
 
-    return CoordCarto;
-});
+export default CoordCarto;

--- a/src/Core/Geographic/CoordWMTS.js
+++ b/src/Core/Geographic/CoordWMTS.js
@@ -9,27 +9,26 @@
  * @param {type} defaultValue
  * @returns {CoordWMTS_L10.CoordWMTS}
  */
-define('Core/Geographic/CoordWMTS', ['Core/defaultValue'], function(defaultValue) {
+import defaultValue from 'Core/defaultValue';
 
 
-    /**
-     * 
-     * @param {type} zoom
-     * @param {type} row
-     * @param {type} col
-     * @returns {CoordWMTS_L12.CoordWMTS}
-     */
-    function CoordWMTS(zoom, row, col) {
-        this.zoom = defaultValue(zoom, 0);
-        this.row = defaultValue(row, 0);
-        this.col = defaultValue(col, 0);
-    }
+/**
+ * 
+ * @param {type} zoom
+ * @param {type} row
+ * @param {type} col
+ * @returns {CoordWMTS_L12.CoordWMTS}
+ */
+function CoordWMTS(zoom, row, col) {
+    this.zoom = defaultValue(zoom, 0);
+    this.row = defaultValue(row, 0);
+    this.col = defaultValue(col, 0);
+}
 
-    CoordWMTS.prototype.constructor = CoordWMTS;
+CoordWMTS.prototype.constructor = CoordWMTS;
 
-    CoordWMTS.prototype.clone = function() {
-        return new CoordWMTS(this.zoom, this.row, this.col);
-    };
+CoordWMTS.prototype.clone = function() {
+    return new CoordWMTS(this.zoom, this.row, this.col);
+};
 
-    return CoordWMTS;
-});
+export default CoordWMTS;

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -4,126 +4,125 @@
  * Description: Outils de projections cartographiques et de convertion
  */
 
-define('Core/Geographic/Projection', ['Core/Geographic/CoordWMTS', 'Core/Math/MathExtented'], function(CoordWMTS, MathExt) {
+import CoordWMTS from 'Core/Geographic/CoordWMTS';
+import MathExt from 'Core/Math/MathExtented';
 
 
-    function Projection() {
-        //Constructor
+function Projection() {
+    //Constructor
 
-    }
+}
 
-    /**
-     * @param x
-     * @param y
-     */
-    Projection.prototype.WGS84ToPM = function(x, y) {
-        //TODO: Implement Me 
+/**
+ * @param x
+ * @param y
+ */
+Projection.prototype.WGS84ToPM = function(x, y) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    Projection.prototype.WGS84ToY = function(latitude) {
+Projection.prototype.WGS84ToY = function(latitude) {
 
-        return 0.5 - Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
+    return 0.5 - Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
 
-    };
+};
 
-    Projection.prototype.WGS84LatitudeClamp = function(latitude) {
+Projection.prototype.WGS84LatitudeClamp = function(latitude) {
 
-        //var min = -68.1389  / 180 * Math.PI;
-        var min = -86 / 180 * Math.PI;
-        var max = 84 / 180 * Math.PI;
+    //var min = -68.1389  / 180 * Math.PI;
+    var min = -86 / 180 * Math.PI;
+    var max = 84 / 180 * Math.PI;
 
-        latitude = Math.max(min, latitude);
-        latitude = Math.min(max, latitude);
+    latitude = Math.max(min, latitude);
+    latitude = Math.min(max, latitude);
 
-        return latitude;
+    return latitude;
 
-    };
+};
 
-    /**
-     * 
-     * @param {type} cWMTS
-     * @param {type} bbox
-     * @returns {Array}
-     */
-    Projection.prototype.WMTS_WGS84ToWMTS_PM = function(cWMTS, bbox) {
+/**
+ * 
+ * @param {type} cWMTS
+ * @param {type} bbox
+ * @returns {Array}
+ */
+Projection.prototype.WMTS_WGS84ToWMTS_PM = function(cWMTS, bbox) {
 
-        var wmtsBox = [];
-        var level = cWMTS.zoom + 1;
-        var nbRow = Math.pow(2, level);
+    var wmtsBox = [];
+    var level = cWMTS.zoom + 1;
+    var nbRow = Math.pow(2, level);
 
-        //var sY      = this.WGS84ToY(this.WGS84LatitudeClamp(-Math.PI*0.5)) - this.WGS84ToY(this.WGS84LatitudeClamp(Math.PI*0.5));
-        var sizeRow = 1.0 / nbRow;
+    //var sY      = this.WGS84ToY(this.WGS84LatitudeClamp(-Math.PI*0.5)) - this.WGS84ToY(this.WGS84LatitudeClamp(Math.PI*0.5));
+    var sizeRow = 1.0 / nbRow;
 
-        var yMin = this.WGS84ToY(this.WGS84LatitudeClamp(bbox.maxCarto.latitude));
-        var yMax = this.WGS84ToY(this.WGS84LatitudeClamp(bbox.minCarto.latitude));
+    var yMin = this.WGS84ToY(this.WGS84LatitudeClamp(bbox.maxCarto.latitude));
+    var yMax = this.WGS84ToY(this.WGS84LatitudeClamp(bbox.minCarto.latitude));
 
-        var minRow, maxRow, min, max;
+    var minRow, maxRow, min, max;
 
-        min = yMin / sizeRow;
-        max = yMax / sizeRow;
+    min = yMin / sizeRow;
+    max = yMax / sizeRow;
 
-        minRow = Math.floor(min);
-        maxRow = Math.floor(max);
+    minRow = Math.floor(min);
+    maxRow = Math.floor(max);
 
-        if (max - maxRow === 0.0 || maxRow === nbRow)
-            maxRow--;
+    if (max - maxRow === 0.0 || maxRow === nbRow)
+        maxRow--;
 
-        var minCol = cWMTS.col;
-        var maxCol = minCol;
+    var minCol = cWMTS.col;
+    var maxCol = minCol;
 
-        wmtsBox.push(new CoordWMTS(level, minRow, minCol));
-        wmtsBox.push(new CoordWMTS(level, maxRow, maxCol));
+    wmtsBox.push(new CoordWMTS(level, minRow, minCol));
+    wmtsBox.push(new CoordWMTS(level, maxRow, maxCol));
 
-        return wmtsBox;
+    return wmtsBox;
 
-    };
+};
 
-    /**
-     * @param x
-     * @param y
-     */
-    Projection.prototype.PMToWGS84 = function(x, y) {
-        //TODO: Implement Me 
+/**
+ * @param x
+ * @param y
+ */
+Projection.prototype.PMToWGS84 = function(x, y) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    Projection.prototype.WGS84toWMTS = function(bbox) {
+Projection.prototype.WGS84toWMTS = function(bbox) {
 
-        var zoom = Math.floor(Math.log(MathExt.PI / bbox.dimension.y) / MathExt.LOG_TWO + 0.5);
+    var zoom = Math.floor(Math.log(MathExt.PI / bbox.dimension.y) / MathExt.LOG_TWO + 0.5);
 
-        var nY = Math.pow(2, zoom);
-        var nX = 2 * nY;
+    var nY = Math.pow(2, zoom);
+    var nX = 2 * nY;
 
-        var uX = MathExt.TWO_PI / nX;
-        var uY = MathExt.PI / nY;
+    var uX = MathExt.TWO_PI / nX;
+    var uY = MathExt.PI / nY;
 
-        var col = Math.floor(bbox.center.x / uX);
-        var row = Math.floor(nY - (MathExt.PI_OV_TWO + bbox.center.y) / uY);
+    var col = Math.floor(bbox.center.x / uX);
+    var row = Math.floor(nY - (MathExt.PI_OV_TWO + bbox.center.y) / uY);
 
-        return new CoordWMTS(zoom, row, col);
-    };
-
-
-    /**
-     * @param longi
-     * @param lati
-     */
-    Projection.prototype.geoToPM = function(longi, lati) {
-        //TODO: Implement Me 
-
-    };
+    return new CoordWMTS(zoom, row, col);
+};
 
 
-    /**
-     * @param longi
-     * @param lati
-     */
-    Projection.prototype.geoToWGS84 = function(longi, lati) {
-        //TODO: Implement Me 
+/**
+ * @param longi
+ * @param lati
+ */
+Projection.prototype.geoToPM = function(longi, lati) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    return Projection;
 
-});
+/**
+ * @param longi
+ * @param lati
+ */
+Projection.prototype.geoToWGS84 = function(longi, lati) {
+    //TODO: Implement Me 
+
+};
+
+export default Projection;

--- a/src/Core/Geographic/Quad.js
+++ b/src/Core/Geographic/Quad.js
@@ -4,25 +4,24 @@
  * and open the template in the editor.
  */
 
-define('Core/Geographic/Quad', ['Scene/BoundingBox'], function(BoundingBox) {
-    function Quad(bbox) {
-        this.northWest = new BoundingBox(bbox.minCarto.longitude, bbox.center.x, bbox.center.y, bbox.maxCarto.latitude, bbox.center);
-        this.northEast = new BoundingBox(bbox.center.x, bbox.maxCarto.longitude, bbox.center.y, bbox.maxCarto.latitude, bbox.center);
-        this.southWest = new BoundingBox(bbox.minCarto.longitude, bbox.center.x, bbox.minCarto.latitude, bbox.center.y, bbox.center);
-        this.southEast = new BoundingBox(bbox.center.x, bbox.maxCarto.longitude, bbox.minCarto.latitude, bbox.center.y, bbox.center);
-    }
+import BoundingBox from 'Scene/BoundingBox';
 
-    Quad.prototype.array = function() {
-        var subdiv = [];
+function Quad(bbox) {
+    this.northWest = new BoundingBox(bbox.minCarto.longitude, bbox.center.x, bbox.center.y, bbox.maxCarto.latitude, bbox.center);
+    this.northEast = new BoundingBox(bbox.center.x, bbox.maxCarto.longitude, bbox.center.y, bbox.maxCarto.latitude, bbox.center);
+    this.southWest = new BoundingBox(bbox.minCarto.longitude, bbox.center.x, bbox.minCarto.latitude, bbox.center.y, bbox.center);
+    this.southEast = new BoundingBox(bbox.center.x, bbox.maxCarto.longitude, bbox.minCarto.latitude, bbox.center.y, bbox.center);
+}
 
-        subdiv.push(this.northWest);
-        subdiv.push(this.northEast);
-        subdiv.push(this.southWest);
-        subdiv.push(this.southEast);
+Quad.prototype.array = function() {
+    var subdiv = [];
 
-        return subdiv;
-    };
+    subdiv.push(this.northWest);
+    subdiv.push(this.northEast);
+    subdiv.push(this.southWest);
+    subdiv.push(this.southEast);
 
-    return Quad;
+    return subdiv;
+};
 
-});
+export default Quad;

--- a/src/Core/Math/Box.js
+++ b/src/Core/Math/Box.js
@@ -11,6 +11,6 @@ function Box() {
 
 
 
-module.exports = {
-    Box: Box
+export {
+    Box
 };

--- a/src/Core/Math/Ellipsoid.js
+++ b/src/Core/Math/Ellipsoid.js
@@ -6,131 +6,131 @@
 
 
 
-define('Core/Math/Ellipsoid', ['Core/Math/MathExtented', 'THREE', 'Core/defaultValue'], function(MathExt, THREE, defaultValue) {
+import MathExt from 'Core/Math/MathExtented';
+import THREE from 'THREE';
+import defaultValue from 'Core/defaultValue';
 
-    function Ellipsoid(size) {
-        //Constructor
+function Ellipsoid(size) {
+    //Constructor
 
-        this.rayon_1 = size.x;
-        this.rayon_2 = size.y;
-        this.rayon_3 = size.z;
+    this.rayon_1 = size.x;
+    this.rayon_2 = size.y;
+    this.rayon_3 = size.z;
 
-        this.size = size;
+    this.size = size;
 
-        this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
+    this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
+}
+
+Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function(coordCarto) {
+
+    var longitude = coordCarto.longitude;
+    var latitude = coordCarto.latitude;
+    var cosLatitude = Math.cos(latitude);
+
+    var x = cosLatitude * Math.cos(-longitude);
+    var z = cosLatitude * Math.sin(-longitude);
+    var y = Math.sin(latitude);
+
+    var result = new THREE.Vector3(x, y, z);
+
+    return result.normalize();
+
+};
+
+Ellipsoid.prototype.setSize = function(size) {
+    this.rayon_1 = size.x;
+    this.rayon_2 = size.y;
+    this.rayon_3 = size.z;
+
+    this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
+};
+
+
+Ellipsoid.prototype.cartographicToCartesian = function(coordCarto) {
+
+    //var n;
+    var k = new THREE.Vector3();
+    var n = this.geodeticSurfaceNormalCartographic(coordCarto);
+
+    k.multiplyVectors(this._radiiSquared, n);
+
+    var gamma = Math.sqrt(n.dot(k));
+
+    k.divideScalar(gamma);
+
+    n.multiplyScalar(coordCarto.altitude);
+
+    //n.multiplyScalar(0.0);
+
+    return k.add(n);
+};
+
+Ellipsoid.prototype.cartographicToCartesianArray = function(coordCartoArray) {
+
+    var cartesianArray = [];
+    for (var i = 0; i < coordCartoArray.length; i++) {
+        cartesianArray.push(this.cartographicToCartesian(coordCartoArray[i]));
     }
 
-    Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function(coordCarto) {
+    return cartesianArray;
 
-        var longitude = coordCarto.longitude;
-        var latitude = coordCarto.latitude;
-        var cosLatitude = Math.cos(latitude);
+};
 
-        var x = cosLatitude * Math.cos(-longitude);
-        var z = cosLatitude * Math.sin(-longitude);
-        var y = Math.sin(latitude);
+Ellipsoid.prototype.intersection = function(ray) {
 
-        var result = new THREE.Vector3(x, y, z);
+    var EPSILON = 0.0001;
+    var O_C = ray.origin;
+    var dir = ray.direction;
+    //normalizeVector( dir );
 
-        return result.normalize();
+    var a =
+        ((dir.x * dir.x) / (this.size.x * this.size.x)) + ((dir.y * dir.y) / (this.size.y * this.size.y)) + ((dir.z * dir.z) / (this.size.z * this.size.z));
 
-    };
+    var b =
+        ((2 * O_C.x * dir.x) / (this.size.x * this.size.x)) + ((2 * O_C.y * dir.y) / (this.size.y * this.size.y)) + ((2 * O_C.z * dir.z) / (this.size.z * this.size.z));
+    var c =
+        ((O_C.x * O_C.x) / (this.size.x * this.size.x)) + ((O_C.y * O_C.y) / (this.size.y * this.size.y)) + ((O_C.z * O_C.z) / (this.size.z * this.size.z)) - 1;
 
-    Ellipsoid.prototype.setSize = function(size) {
-        this.rayon_1 = size.x;
-        this.rayon_2 = size.y;
-        this.rayon_3 = size.z;
+    var d = ((b * b) - (4 * a * c));
+    if (d < 0 || a === 0 || b === 0 || c === 0)
+        return false;
 
-        this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
-    };
+    d = Math.sqrt(d);
 
+    var t1 = (-b + d) / (2 * a);
+    var t2 = (-b - d) / (2 * a);
 
-    Ellipsoid.prototype.cartographicToCartesian = function(coordCarto) {
+    if (t1 <= EPSILON && t2 <= EPSILON) return false; // both intersections are behind the ray origin
+    var back = (t1 <= EPSILON || t2 <= EPSILON); // If only one intersection (t>0) then we are inside the ellipsoid and the intersection is at the back of the ellipsoid
+    var t = 0;
+    if (t1 <= EPSILON)
+        t = t2;
+    else
+    if (t2 <= EPSILON)
+        t = t1;
+    else
+        t = (t1 < t2) ? t1 : t2;
 
-        //var n;
-        var k = new THREE.Vector3();
-        var n = this.geodeticSurfaceNormalCartographic(coordCarto);
+    if (t < EPSILON) return false; // Too close to intersection
 
-        k.multiplyVectors(this._radiiSquared, n);
+    var inter = new THREE.Vector3();
 
-        var gamma = Math.sqrt(n.dot(k));
+    inter.addVectors(ray.origin, dir.clone().setLength(t));
 
-        k.divideScalar(gamma);
+    return inter;
 
-        n.multiplyScalar(coordCarto.altitude);
+    /*
+    var normal = intersection.clone();//-ellipsoid.center;
+    normal.x = 2*normal.x/(this.size.x*this.size.x);
+    normal.y = 2*normal.y/(this.size.y*this.size.y);
+    normal.z = 2*normal.z/(this.size.z*this.size.z);
 
-        //n.multiplyScalar(0.0);
-
-        return k.add(n);
-    };
-
-    Ellipsoid.prototype.cartographicToCartesianArray = function(coordCartoArray) {
-
-        var cartesianArray = [];
-        for (var i = 0; i < coordCartoArray.length; i++) {
-            cartesianArray.push(this.cartographicToCartesian(coordCartoArray[i]));
-        }
-
-        return cartesianArray;
-
-    };
-
-    Ellipsoid.prototype.intersection = function(ray) {
-
-        var EPSILON = 0.0001;
-        var O_C = ray.origin;
-        var dir = ray.direction;
-        //normalizeVector( dir );
-
-        var a =
-            ((dir.x * dir.x) / (this.size.x * this.size.x)) + ((dir.y * dir.y) / (this.size.y * this.size.y)) + ((dir.z * dir.z) / (this.size.z * this.size.z));
-
-        var b =
-            ((2 * O_C.x * dir.x) / (this.size.x * this.size.x)) + ((2 * O_C.y * dir.y) / (this.size.y * this.size.y)) + ((2 * O_C.z * dir.z) / (this.size.z * this.size.z));
-        var c =
-            ((O_C.x * O_C.x) / (this.size.x * this.size.x)) + ((O_C.y * O_C.y) / (this.size.y * this.size.y)) + ((O_C.z * O_C.z) / (this.size.z * this.size.z)) - 1;
-
-        var d = ((b * b) - (4 * a * c));
-        if (d < 0 || a === 0 || b === 0 || c === 0)
-            return false;
-
-        d = Math.sqrt(d);
-
-        var t1 = (-b + d) / (2 * a);
-        var t2 = (-b - d) / (2 * a);
-
-        if (t1 <= EPSILON && t2 <= EPSILON) return false; // both intersections are behind the ray origin
-        var back = (t1 <= EPSILON || t2 <= EPSILON); // If only one intersection (t>0) then we are inside the ellipsoid and the intersection is at the back of the ellipsoid
-        var t = 0;
-        if (t1 <= EPSILON)
-            t = t2;
-        else
-        if (t2 <= EPSILON)
-            t = t1;
-        else
-            t = (t1 < t2) ? t1 : t2;
-
-        if (t < EPSILON) return false; // Too close to intersection
-
-        var inter = new THREE.Vector3();
-
-        inter.addVectors(ray.origin, dir.clone().setLength(t));
-
-        return inter;
-
-        /*
-        var normal = intersection.clone();//-ellipsoid.center;
-        normal.x = 2*normal.x/(this.size.x*this.size.x);
-        normal.y = 2*normal.y/(this.size.y*this.size.y);
-        normal.z = 2*normal.z/(this.size.z*this.size.z);
-
-        //normal.w = 0.f;
-        normal *= (back) ? -1.f : 1.f;
-        normalizeVector(normal);
-        */
-    };
+    //normal.w = 0.f;
+    normal *= (back) ? -1.f : 1.f;
+    normalizeVector(normal);
+    */
+};
 
 
-    return Ellipsoid;
-
-});
+export default Ellipsoid;

--- a/src/Core/Math/MathExtented.js
+++ b/src/Core/Math/MathExtented.js
@@ -5,59 +5,57 @@
  */
 
 
-define('Core/Math/MathExtented', ['THREE'], function(THREE) {
+import THREE from 'THREE';
 
-    /**
-     * Math functions.
-     *
-     * @namespace
-     * @alias MathExt
-     */
-    var MathExt = {};
+/**
+ * Math functions.
+ *
+ * @namespace
+ * @alias MathExt
+ */
+var MathExt = {};
 
-    /**
-     * pi
-     *
-     * @type {Number}
-     * @constant
-     */
-    MathExt.PI = Math.PI;
-
-
-    /**
-     * pi/2
-     *
-     * @type {Number}
-     * @constant
-     */
-    MathExt.PI_OV_TWO = Math.PI * 0.5;
+/**
+ * pi
+ *
+ * @type {Number}
+ * @constant
+ */
+MathExt.PI = Math.PI;
 
 
-    MathExt.PI_OV_FOUR = Math.PI * 0.25;
+/**
+ * pi/2
+ *
+ * @type {Number}
+ * @constant
+ */
+MathExt.PI_OV_TWO = Math.PI * 0.5;
 
-    /**
-     * pi*2
-     *
-     * @type {Number}
-     * @constant
-     */
-    MathExt.TWO_PI = Math.PI * 2.0;
 
-    MathExt.INV_TWO_PI = 1.0 / MathExt.TWO_PI;
+MathExt.PI_OV_FOUR = Math.PI * 0.25;
 
-    MathExt.LOG_TWO = Math.log(2.0);
+/**
+ * pi*2
+ *
+ * @type {Number}
+ * @constant
+ */
+MathExt.TWO_PI = Math.PI * 2.0;
 
-    MathExt.divideVectors = function(u, v) {
-        var w = new THREE.Vector3(u.x / v.x, u.y / v.y, u.z / v.z);
+MathExt.INV_TWO_PI = 1.0 / MathExt.TWO_PI;
 
-        return w;
-    };
+MathExt.LOG_TWO = Math.log(2.0);
 
-    MathExt.lenghtSquared = function(u) {
+MathExt.divideVectors = function(u, v) {
+    var w = new THREE.Vector3(u.x / v.x, u.y / v.y, u.z / v.z);
 
-        return u.x * u.x + u.y * u.y + u.z * u.z;
-    };
+    return w;
+};
 
-    return MathExt;
+MathExt.lenghtSquared = function(u) {
 
-});
+    return u.x * u.x + u.y * u.y + u.z * u.z;
+};
+
+export default MathExt;

--- a/src/Core/Math/Point2D.js
+++ b/src/Core/Math/Point2D.js
@@ -5,16 +5,14 @@
  */
 
 
-define('Core/Math/Point2D', ['Core/defaultValue'], function(defaultValue) {
+import defaultValue from 'Core/defaultValue';
 
-    function Point2D(x, y) {
-        //Constructor
+function Point2D(x, y) {
+    //Constructor
 
-        this.x = defaultValue(x, 0);
-        this.y = defaultValue(y, 0);
+    this.x = defaultValue(x, 0);
+    this.y = defaultValue(y, 0);
 
-    }
+}
 
-    return Point2D;
-
-});
+export default Point2D;

--- a/src/Core/Math/Rectangle.js
+++ b/src/Core/Math/Rectangle.js
@@ -11,6 +11,6 @@ function Rectangle() {
 
 
 
-module.exports = {
-    Rectangle: Rectangle
+export {
+    Rectangle
 };

--- a/src/Core/System/Capabilities.js
+++ b/src/Core/System/Capabilities.js
@@ -3,48 +3,45 @@
  * Class: Capabilities
  */
 
-define('Core/System/Capabilities', [], function() {
+function Capabilities() {
+    //Constructor
+
+    this._systemCap = null;
+    this._gpuCap = null;
+
+}
 
 
-    function Capabilities() {
-        //Constructor
-
-        this._systemCap = null;
-        this._gpuCap = null;
-
-    }
-
-
-    /**
-     */
-    Capabilities.prototype.getSystemCapabilities = function() {
-        //TODO: Implement Me 
-        var memory = window.performance.memory;
-        console.log(memory.totalJSHeapSize / (1024 * 1024) + '/' + memory.jsHeapSizeLimit / (1024 * 1024));
-    };
+/**
+ */
+Capabilities.prototype.getSystemCapabilities = function() {
+    //TODO: Implement Me 
+    var memory = window.performance.memory;
+    console.log(memory.totalJSHeapSize / (1024 * 1024) + '/' + memory.jsHeapSizeLimit / (1024 * 1024));
+};
 
 
-    /**
-     */
-    Capabilities.prototype.getGpuCapabilities = function() {
-        //TODO: Implement Me 
+/**
+ */
+Capabilities.prototype.getGpuCapabilities = function() {
+    //TODO: Implement Me 
 
-    };
+};
 
 
-    /**
-     */
-    Capabilities.prototype.ioFile = function() {
-        //TODO: Implement Me 
+/**
+ */
+Capabilities.prototype.ioFile = function() {
+    //TODO: Implement Me 
 
-    };
+};
 
-    Capabilities.prototype.isInternetExplorer = function() {
+Capabilities.prototype.isInternetExplorer = function() {
 
-        return /*@cc_on!@*/ false || !!document.documentMode;
+    return /*@cc_on!@*/ false || !!document.documentMode;
 
-    };
-    /*
+};
+/*
     Capabilities.prototype.checkVersion = function()
     {
       var msg = "You're not using Internet Explorer.";
@@ -60,5 +57,4 @@ define('Core/System/Capabilities', [], function() {
       alert( msg );
     };
    */
-    return Capabilities;
-});
+export default Capabilities;

--- a/src/Core/System/JavaTools.js
+++ b/src/Core/System/JavaTools.js
@@ -5,24 +5,19 @@
  */
 
 
-define('Core/System/JavaTools', [], function() {
+function JavaTools() {
+    //Constructor
 
+}
 
-    function JavaTools() {
-        //Constructor
+JavaTools.prototype.constructor = JavaTools;
 
+JavaTools.prototype.freeArray = function(sourceArray) {
+    var arr = sourceArray.slice();
+
+    while (arr.length > 0) {
+        arr.pop();
     }
+};
 
-    JavaTools.prototype.constructor = JavaTools;
-
-    JavaTools.prototype.freeArray = function(sourceArray) {
-        var arr = sourceArray.slice();
-
-        while (arr.length > 0) {
-            arr.pop();
-        }
-    };
-
-    return JavaTools;
-
-});
+export default JavaTools;

--- a/src/Core/System/MessageError.js
+++ b/src/Core/System/MessageError.js
@@ -11,6 +11,6 @@ function MessageError() {
 
 
 
-module.exports = {
-    MessageError: MessageError
+export {
+    MessageError
 };

--- a/src/Core/Web/Proxy.js
+++ b/src/Core/Web/Proxy.js
@@ -12,6 +12,6 @@ function Proxy() {
 
 
 
-module.exports = {
-    Proxy: Proxy
+export {
+    Proxy
 };

--- a/src/Core/Web/Url.js
+++ b/src/Core/Web/Url.js
@@ -13,6 +13,6 @@ function Url() {
 
 
 
-module.exports = {
-    Url: Url
+export {
+    Url
 };

--- a/src/Core/Web/XMLHttpRequester.js
+++ b/src/Core/Web/XMLHttpRequester.js
@@ -12,6 +12,6 @@ function XMLHttpRequester() {
 
 
 
-module.exports = {
-    XMLHttpRequester: XMLHttpRequester
+export {
+    XMLHttpRequester
 };

--- a/src/Core/defaultValue.js
+++ b/src/Core/defaultValue.js
@@ -5,12 +5,8 @@
  */
 
 
-define('Core/defaultValue', [], function() {
+var defaultValue = function(value, def) {
+    return value === undefined ? def : value;
+};
 
-    var defaultValue = function(value, def) {
-        return value === undefined ? def : value;
-    };
-
-    return defaultValue;
-
-});
+export default defaultValue;

--- a/src/Globe/Atmosphere.js
+++ b/src/Globe/Atmosphere.js
@@ -5,69 +5,70 @@
  */
 
 
-define('Globe/Atmosphere', ['Renderer/NodeMesh', 'THREE', 'Renderer/Shader/GlowFS.glsl', 'Renderer/Shader/GlowVS.glsl'], function(NodeMesh, THREE, GlowFS, GlowVS) {
+import NodeMesh from 'Renderer/NodeMesh';
+import THREE from 'THREE';
+import GlowFS from 'Renderer/Shader/GlowFS.glsl';
+import GlowVS from 'Renderer/Shader/GlowVS.glsl';
 
-    function Atmosphere(size) {
+function Atmosphere(size) {
 
-        NodeMesh.call(this);
+    NodeMesh.call(this);
 
-        this.uniformsOut = {
-            atmoIN: {
-                type: "i",
-                value: 0
-            },
-            screenSize: {
-                type: "v2",
-                value: new THREE.Vector2(window.innerWidth, window.innerHeight)
-            } // Should be updated on screen resize...
-        };
+    this.uniformsOut = {
+        atmoIN: {
+            type: "i",
+            value: 0
+        },
+        screenSize: {
+            type: "v2",
+            value: new THREE.Vector2(window.innerWidth, window.innerHeight)
+        } // Should be updated on screen resize...
+    };
 
-        this.material = new THREE.ShaderMaterial({
+    this.material = new THREE.ShaderMaterial({
 
-            uniforms: this.uniformsOut,
-            vertexShader: GlowVS,
-            fragmentShader: GlowFS,
-            side: THREE.BackSide,
-            blending: THREE.AdditiveBlending,
-            transparent: true,
-            wireframe: false
+        uniforms: this.uniformsOut,
+        vertexShader: GlowVS,
+        fragmentShader: GlowFS,
+        side: THREE.BackSide,
+        blending: THREE.AdditiveBlending,
+        transparent: true,
+        wireframe: false
 
-        });
+    });
 
-        this.geometry = new THREE.SphereGeometry(size.x * 1.14, 128, 128);
+    this.geometry = new THREE.SphereGeometry(size.x * 1.14, 128, 128);
 
-        this.uniformsIn = {
-            atmoIN: {
-                type: "i",
-                value: 1
-            },
-            screenSize: {
-                type: "v2",
-                value: new THREE.Vector2(window.innerWidth, window.innerHeight)
-            } // Should be updated on screen resize...
-        };
+    this.uniformsIn = {
+        atmoIN: {
+            type: "i",
+            value: 1
+        },
+        screenSize: {
+            type: "v2",
+            value: new THREE.Vector2(window.innerWidth, window.innerHeight)
+        } // Should be updated on screen resize...
+    };
 
-        var materialAtmoIn = new THREE.ShaderMaterial({
+    var materialAtmoIn = new THREE.ShaderMaterial({
 
-            uniforms: this.uniformsIn,
-            vertexShader: GlowVS,
-            fragmentShader: GlowFS,
-            side: THREE.FrontSide,
-            blending: THREE.AdditiveBlending,
-            transparent: true
+        uniforms: this.uniformsIn,
+        vertexShader: GlowVS,
+        fragmentShader: GlowFS,
+        side: THREE.FrontSide,
+        blending: THREE.AdditiveBlending,
+        transparent: true
 
-        });
+    });
 
-        var atmosphereIN = new THREE.Mesh(new THREE.SphereGeometry(size.x * 1.002, 64, 64), materialAtmoIn);
+    var atmosphereIN = new THREE.Mesh(new THREE.SphereGeometry(size.x * 1.002, 64, 64), materialAtmoIn);
 
-        this.add(atmosphereIN);
+    this.add(atmosphereIN);
 
-    }
+}
 
-    Atmosphere.prototype = Object.create(NodeMesh.prototype);
+Atmosphere.prototype = Object.create(NodeMesh.prototype);
 
-    Atmosphere.prototype.constructor = Atmosphere;
+Atmosphere.prototype.constructor = Atmosphere;
 
-    return Atmosphere;
-
-});
+export default Atmosphere;

--- a/src/Globe/Clouds.js
+++ b/src/Globe/Clouds.js
@@ -5,90 +5,87 @@
  */
 
 
-define('Globe/Clouds', ['Renderer/NodeMesh',
-    'THREE',
-    'Renderer/c3DEngine',
-    'Core/Commander/Providers/WMS_Provider',
-    'Renderer/Shader/CloudsFS.glsl',
-    'Renderer/Shader/CloudsVS.glsl'
-], function(NodeMesh, THREE, gfxEngine, WMS_Provider, CloudsFS, CloudsVS) {
+import NodeMesh from 'Renderer/NodeMesh';
+import THREE from 'THREE';
+import gfxEngine from 'Renderer/c3DEngine';
+import WMS_Provider from 'Core/Commander/Providers/WMS_Provider';
+import CloudsFS from 'Renderer/Shader/CloudsFS.glsl';
+import CloudsVS from 'Renderer/Shader/CloudsVS.glsl';
 
-    function Clouds(size) {
+function Clouds(size) {
 
-        NodeMesh.call(this);
+    NodeMesh.call(this);
 
-        this.providerWMS = new WMS_Provider({});
-        this.loader = new THREE.TextureLoader();
-        this.loader.crossOrigin = '';
-        this.live = false;
+    this.providerWMS = new WMS_Provider({});
+    this.loader = new THREE.TextureLoader();
+    this.loader.crossOrigin = '';
+    this.live = false;
 
-        this.geometry = new THREE.SphereGeometry(6400000, 96, 96);
+    this.geometry = new THREE.SphereGeometry(6400000, 96, 96);
 
-        this.uniforms = {
-            diffuse: {
-                type: "t",
-                value: this.loader.load("http://realearth.ssec.wisc.edu/api/image?products=globalir&bounds=-85,-178,85,178&width=256&height=128")
-            },
-            time: {
-                type: "f",
-                value: 0.
-            }
-        };
-
-
-        this.material = new THREE.ShaderMaterial({
-
-            uniforms: this.uniforms,
-            vertexShader: CloudsVS,
-            fragmentShader: CloudsFS,
-            //   blending        : THREE.AdditiveBlending,
-            transparent: true,
-            wireframe: false
-
-        });
-
-        this.rotation.y += Math.PI;
-
-        //this.generate();
-
-        this.visible = false;
-
-
-    }
-
-    Clouds.prototype = Object.create(NodeMesh.prototype);
-
-    Clouds.prototype.constructor = Clouds;
-
-
-    Clouds.prototype.generate = function() {
-
-        this.live = true;
-        var coWMS = {
-            latBound: new THREE.Vector2(-85, 85),
-            longBound: new THREE.Vector2(-178, 178),
-            width: 2048,
-            height: 1024
-        };
-
-
-        var url = this.providerWMS.urlGlobalIR(coWMS, 0);
-        this.loader.load(url, function(texture) {
-            this.material.uniforms.diffuse.value = texture;
-            this.material.uniforms.diffuse.needsUpdate = true;
-            this.animate();
-        }.bind(this));
-
-
-
+    this.uniforms = {
+        diffuse: {
+            type: "t",
+            value: this.loader.load("http://realearth.ssec.wisc.edu/api/image?products=globalir&bounds=-85,-178,85,178&width=256&height=128")
+        },
+        time: {
+            type: "f",
+            value: 0.
+        }
     };
 
-    Clouds.prototype.animate = function() {
 
-        this.material.uniforms.time.value += 0.01;
-        requestAnimationFrame(this.animate.bind(this));
+    this.material = new THREE.ShaderMaterial({
+
+        uniforms: this.uniforms,
+        vertexShader: CloudsVS,
+        fragmentShader: CloudsFS,
+        //   blending        : THREE.AdditiveBlending,
+        transparent: true,
+        wireframe: false
+
+    });
+
+    this.rotation.y += Math.PI;
+
+    //this.generate();
+
+    this.visible = false;
+
+
+}
+
+Clouds.prototype = Object.create(NodeMesh.prototype);
+
+Clouds.prototype.constructor = Clouds;
+
+
+Clouds.prototype.generate = function() {
+
+    this.live = true;
+    var coWMS = {
+        latBound: new THREE.Vector2(-85, 85),
+        longBound: new THREE.Vector2(-178, 178),
+        width: 2048,
+        height: 1024
     };
 
-    return Clouds;
 
-});
+    var url = this.providerWMS.urlGlobalIR(coWMS, 0);
+    this.loader.load(url, function(texture) {
+        this.material.uniforms.diffuse.value = texture;
+        this.material.uniforms.diffuse.needsUpdate = true;
+        this.animate();
+    }.bind(this));
+
+
+
+};
+
+Clouds.prototype.animate = function() {
+
+    this.material.uniforms.time.value += 0.01;
+    requestAnimationFrame(this.animate.bind(this));
+};
+
+export default Clouds;

--- a/src/Globe/CollisionGlobe.js
+++ b/src/Globe/CollisionGlobe.js
@@ -5,7 +5,7 @@
  * 
  */
 
-var NodeProcess = require('NodeProcess');
+import NodeProcess from 'NodeProcess';
 
 function CollisionGlobe() {
     //Constructor
@@ -25,6 +25,6 @@ CollisionGlobe.prototype.update = function(camera) {
 
 
 
-module.exports = {
-    CollisionGlobe: CollisionGlobe
+export {
+    CollisionGlobe
 };

--- a/src/Globe/EllipsoidTileGeometry.js
+++ b/src/Globe/EllipsoidTileGeometry.js
@@ -6,270 +6,259 @@
  * Description: Tuile géométrique. Buffer des vertex et des faces
  */
 
-define('Globe/EllipsoidTileGeometry', [
-    'THREE',
-    'Core/defaultValue',
-    'Scene/BoundingBox',
-    'Core/Math/Ellipsoid',
-    'Core/Geographic/CoordCarto',
-    'Core/Math/MathExtented',
-    'Core/System/JavaTools'
-], function(
-    THREE,
-    defaultValue,
-    BoundingBox,
-    Ellipsoid,
-    CoordCarto,
-    MathExt,
-    JavaTools) {
+import THREE from 'THREE';
+import defaultValue from 'Core/defaultValue';
+import BoundingBox from 'Scene/BoundingBox';
+import Ellipsoid from 'Core/Math/Ellipsoid';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import MathExt from 'Core/Math/MathExtented';
+import JavaTools from 'Core/System/JavaTools';
 
-    function EllipsoidTileGeometry(bbox, segment, pellipsoid, zoom) {
-        //Constructor
-        THREE.BufferGeometry.call(this);
+function EllipsoidTileGeometry(bbox, segment, pellipsoid, zoom) {
+    //Constructor
+    THREE.BufferGeometry.call(this);
 
-        var javToo = new JavaTools();
+    var javToo = new JavaTools();
 
-        var nbRow = Math.pow(2.0, zoom + 1.0);
+    var nbRow = Math.pow(2.0, zoom + 1.0);
 
-        bbox = defaultValue(bbox, new BoundingBox());
+    bbox = defaultValue(bbox, new BoundingBox());
 
-        var ellipsoid = defaultValue(pellipsoid, new Ellipsoid(6378137, 6356752.3142451793, 6378137));
+    var ellipsoid = defaultValue(pellipsoid, new Ellipsoid(6378137, 6356752.3142451793, 6378137));
 
-        var nSeg = defaultValue(segment, 32);
-        var nVertex = (nSeg + 1) * (nSeg + 1) + 8 * (nSeg - 1); // correct pour uniquement les vertex
-        var triangles = (nSeg) * (nSeg) + 16 * (nSeg - 1); // correct pour uniquement les vertex
+    var nSeg = defaultValue(segment, 32);
+    var nVertex = (nSeg + 1) * (nSeg + 1) + 8 * (nSeg - 1); // correct pour uniquement les vertex
+    var triangles = (nSeg) * (nSeg) + 16 * (nSeg - 1); // correct pour uniquement les vertex
 
-        var widthSegments = nSeg;
-        var heightSegments = nSeg;
+    var widthSegments = nSeg;
+    var heightSegments = nSeg;
 
-        var bufferVertex = new Float32Array(nVertex * 3);
-        var bufferIndex = new Uint32Array(triangles * 3 * 2);
-        var bufferNormal = new Float32Array(nVertex * 3);
-        var bufferUV = new Float32Array(nVertex * 2);
-        var bufferUV2 = new Float32Array(nVertex);
+    var bufferVertex = new Float32Array(nVertex * 3);
+    var bufferIndex = new Uint32Array(triangles * 3 * 2);
+    var bufferNormal = new Float32Array(nVertex * 3);
+    var bufferUV = new Float32Array(nVertex * 2);
+    var bufferUV2 = new Float32Array(nVertex);
 
-        widthSegments = Math.max(2, Math.floor(widthSegments) || 2);
-        heightSegments = Math.max(2, Math.floor(heightSegments) || 2);
+    widthSegments = Math.max(2, Math.floor(widthSegments) || 2);
+    heightSegments = Math.max(2, Math.floor(heightSegments) || 2);
 
-        var phiStart = bbox.minCarto.longitude;
-        var phiLength = bbox.dimension.x;
+    var phiStart = bbox.minCarto.longitude;
+    var phiLength = bbox.dimension.x;
 
-        this.cLongi = bbox.center.x;
+    this.cLongi = bbox.center.x;
 
-        var thetaStart = bbox.minCarto.latitude;
-        var thetaLength = bbox.dimension.y;
+    var thetaStart = bbox.minCarto.latitude;
+    var thetaLength = bbox.dimension.y;
 
-        this.carto2Normal = function(phi, theta) {
-            return ellipsoid.geodeticSurfaceNormalCartographic(new CoordCarto(phi, theta, 0));
-        };
+    this.carto2Normal = function(phi, theta) {
+        return ellipsoid.geodeticSurfaceNormalCartographic(new CoordCarto(phi, theta, 0));
+    };
 
-        //        this.tops        = [];
-        //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart, thetaStart,0)));
-        //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength, thetaStart+ thetaLength,0)));
-        //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart, thetaStart+ thetaLength,0)));
-        //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength, thetaStart,0)));   
-        //
-        //        this.normals        = [];
-        //
-        //        this.normals.push(this.carto2Normal(phiStart, thetaStart));
-        //        this.normals.push(this.carto2Normal(phiStart + phiLength, thetaStart+ thetaLength));
-        //        this.normals.push(this.carto2Normal(phiStart, thetaStart+ thetaLength));
-        //        this.normals.push(this.carto2Normal(phiStart + phiLength, thetaStart));        
+    //        this.tops        = [];
+    //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart, thetaStart,0)));
+    //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength, thetaStart+ thetaLength,0)));
+    //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart, thetaStart+ thetaLength,0)));
+    //        this.tops.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength, thetaStart,0)));   
+    //
+    //        this.normals        = [];
+    //
+    //        this.normals.push(this.carto2Normal(phiStart, thetaStart));
+    //        this.normals.push(this.carto2Normal(phiStart + phiLength, thetaStart+ thetaLength));
+    //        this.normals.push(this.carto2Normal(phiStart, thetaStart+ thetaLength));
+    //        this.normals.push(this.carto2Normal(phiStart + phiLength, thetaStart));        
 
-        //        this.HeightPoints    = [];                
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart                        , thetaStart    ,0)));
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + bbox.halfDimension.x , thetaStart    ,0)));
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength            , thetaStart    ,0)));
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength            , thetaStart + bbox.halfDimension.y,0)));        
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength            , thetaStart + thetaLength  ,0)));
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + bbox.halfDimension.x , thetaStart + thetaLength  ,0)));        
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart                        , thetaStart + thetaLength  ,0)));
-        //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart                        , thetaStart + bbox.halfDimension.y,0)));        
+    //        this.HeightPoints    = [];                
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart                        , thetaStart    ,0)));
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + bbox.halfDimension.x , thetaStart    ,0)));
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength            , thetaStart    ,0)));
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength            , thetaStart + bbox.halfDimension.y,0)));        
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + phiLength            , thetaStart + thetaLength  ,0)));
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart + bbox.halfDimension.x , thetaStart + thetaLength  ,0)));        
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart                        , thetaStart + thetaLength  ,0)));
+    //        this.HeightPoints.push(ellipsoid.cartographicToCartesian(new CoordCarto(phiStart                        , thetaStart + bbox.halfDimension.y,0)));        
 
-        var ccarto = new CoordCarto(bbox.center.x, bbox.center.y, 0);
-        this.center = ellipsoid.cartographicToCartesian(ccarto);
+    var ccarto = new CoordCarto(bbox.center.x, bbox.center.y, 0);
+    this.center = ellipsoid.cartographicToCartesian(ccarto);
 
-        this.OBB = bbox.get3DBBox(ellipsoid, this.center);
+    this.OBB = bbox.get3DBBox(ellipsoid, this.center);
 
-        var idVertex = 0;
-        var x, y, vertices = [],
-            skirt = [],
-            skirtEnd = [];
+    var idVertex = 0;
+    var x, y, vertices = [],
+        skirt = [],
+        skirtEnd = [];
 
-        var st1 = 0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + thetaStart * 0.5)) * MathExt.INV_TWO_PI;
+    var st1 = 0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + thetaStart * 0.5)) * MathExt.INV_TWO_PI;
 
-        if (!isFinite(st1))
-            st1 = 0;
+    if (!isFinite(st1))
+        st1 = 0;
 
-        var sizeTexture = 1.0 / nbRow;
+    var sizeTexture = 1.0 / nbRow;
 
-        var start = (st1 % (sizeTexture));
+    var start = (st1 % (sizeTexture));
 
-        var st = st1 - start;
+    var st = st1 - start;
 
-        for (y = 0; y <= heightSegments; y++) {
+    for (y = 0; y <= heightSegments; y++) {
 
-            var verticesRow = [];
+        var verticesRow = [];
 
-            var v = y / heightSegments;
-            var lati = thetaStart + v * thetaLength;
-            var t = ((0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + lati * 0.5)) * MathExt.INV_TWO_PI) - st) * nbRow;
+        var v = y / heightSegments;
+        var lati = thetaStart + v * thetaLength;
+        var t = ((0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + lati * 0.5)) * MathExt.INV_TWO_PI) - st) * nbRow;
 
-            if (!isFinite(t))
-                t = 0;
+        if (!isFinite(t))
+            t = 0;
 
-            for (x = 0; x <= widthSegments; x++) {
+        for (x = 0; x <= widthSegments; x++) {
 
-                var u = x / widthSegments;
+            var u = x / widthSegments;
 
-                var longi = phiStart + u * phiLength;
+            var longi = phiStart + u * phiLength;
 
-                var vertex = ellipsoid.cartographicToCartesian(new CoordCarto(longi, lati, 0));
+            var vertex = ellipsoid.cartographicToCartesian(new CoordCarto(longi, lati, 0));
 
-                var id3 = idVertex * 3;
-                //                    
-                bufferVertex[id3 + 0] = vertex.x - this.center.x;
-                bufferVertex[id3 + 1] = vertex.y - this.center.y;
-                bufferVertex[id3 + 2] = vertex.z - this.center.z;
-
-
-                //                    bufferVertex[id3+ 0] = vertex.x ;
-                //                    bufferVertex[id3+ 1] = vertex.y ;
-                //                    bufferVertex[id3+ 2] = vertex.z ;
-
-                var normal = vertex.clone().normalize();
-
-                bufferNormal[id3 + 0] = normal.x;
-                bufferNormal[id3 + 1] = normal.y;
-                bufferNormal[id3 + 2] = normal.z;
-
-                bufferUV[idVertex * 2 + 0] = u;
-                bufferUV[idVertex * 2 + 1] = 1 - v;
-
-                bufferUV2[idVertex] = t;
-
-                if (y !== 0 && y !== heightSegments)
-                    if (x === widthSegments)
-                        skirt.push(idVertex);
-                    else if (x === 0)
-                    skirtEnd.push(idVertex);
-
-                verticesRow.push(idVertex);
-
-                idVertex++;
-
-            }
-
-            vertices.push(verticesRow);
-
-            if (y === 0)
-                skirt = skirt.concat(verticesRow);
-            else if (y === heightSegments)
-                skirt = skirt.concat(verticesRow.slice().reverse());
-
-        }
-
-        skirt = skirt.concat(skirtEnd.reverse());
-
-        function bufferize(va, vb, vc, idVertex) {
-            bufferIndex[idVertex + 0] = va;
-            bufferIndex[idVertex + 1] = vb;
-            bufferIndex[idVertex + 2] = vc;
-        }
-
-        var idVertex2 = 0;
-
-        for (y = 0; y < heightSegments; y++) {
-
-            for (x = 0; x < widthSegments; x++) {
-
-                var v1 = vertices[y][x + 1];
-                var v2 = vertices[y][x];
-                var v3 = vertices[y + 1][x];
-                var v4 = vertices[y + 1][x + 1];
-
-                bufferize(v4, v2, v1, idVertex2);
-
-                idVertex2 += 3;
-
-                bufferize(v4, v3, v2, idVertex2);
-
-                idVertex2 += 3;
-            }
-        }
-
-        var start = idVertex;
-        var rmax = 5000;
-        var r = Math.max(rmax, Math.pow(rmax, 1 / zoom));
-
-        r = isFinite(r) ? r : rmax;
-
-        for (i = 0; i < skirt.length; i++) {
-
-            var id = skirt[i];
             var id3 = idVertex * 3;
-            var id23 = id * 3;
+            //                    
+            bufferVertex[id3 + 0] = vertex.x - this.center.x;
+            bufferVertex[id3 + 1] = vertex.y - this.center.y;
+            bufferVertex[id3 + 2] = vertex.z - this.center.z;
 
-            bufferVertex[id3 + 0] = bufferVertex[id23 + 0] - bufferNormal[id23 + 0] * r;
-            bufferVertex[id3 + 1] = bufferVertex[id23 + 1] - bufferNormal[id23 + 1] * r;
-            bufferVertex[id3 + 2] = bufferVertex[id23 + 2] - bufferNormal[id23 + 2] * r;
 
-            bufferNormal[id3 + 0] = bufferNormal[id23 + 0];
-            bufferNormal[id3 + 1] = bufferNormal[id23 + 1];
-            bufferNormal[id3 + 2] = bufferNormal[id23 + 2];
+            //                    bufferVertex[id3+ 0] = vertex.x ;
+            //                    bufferVertex[id3+ 1] = vertex.y ;
+            //                    bufferVertex[id3+ 2] = vertex.z ;
 
-            bufferUV[idVertex * 2 + 0] = bufferUV[id * 2 + 0];
-            bufferUV[idVertex * 2 + 1] = bufferUV[id * 2 + 1];
-            bufferUV2[idVertex] = bufferUV2[id];
+            var normal = vertex.clone().normalize();
 
-            var idf = (i + 1) % skirt.length;
+            bufferNormal[id3 + 0] = normal.x;
+            bufferNormal[id3 + 1] = normal.y;
+            bufferNormal[id3 + 2] = normal.z;
 
-            var v1 = id;
-            var v2 = idVertex;
-            var v3 = idVertex + 1;
-            var v4 = skirt[idf];
+            bufferUV[idVertex * 2 + 0] = u;
+            bufferUV[idVertex * 2 + 1] = 1 - v;
 
-            if (idf === 0)
-                v3 = start;
+            bufferUV2[idVertex] = t;
 
-            bufferize(v1, v2, v3, idVertex2);
+            if (y !== 0 && y !== heightSegments)
+                if (x === widthSegments)
+                    skirt.push(idVertex);
+                else if (x === 0)
+                skirtEnd.push(idVertex);
 
-            idVertex2 += 3;
-
-            bufferize(v1, v3, v4, idVertex2);
-
-            idVertex2 += 3;
+            verticesRow.push(idVertex);
 
             idVertex++;
 
         }
 
-        // TODO : free array
+        vertices.push(verticesRow);
 
-        this.setIndex(new THREE.BufferAttribute(bufferIndex, 1));
-        this.addAttribute('position', new THREE.BufferAttribute(bufferVertex, 3));
-        this.addAttribute('normal', new THREE.BufferAttribute(bufferNormal, 3));
-        this.addAttribute('uv', new THREE.BufferAttribute(bufferUV, 2));
-        this.addAttribute('uv1', new THREE.BufferAttribute(bufferUV2, 1));
-
-        // ---> for SSE
-        this.computeBoundingSphere();
-
-        javToo.freeArray(vertices);
-
-        // TODO how free typedArray
-        bufferVertex = null;
-        bufferIndex = null;
-        bufferNormal = null;
-        bufferUV = null;
-        bufferUV2 = null;
+        if (y === 0)
+            skirt = skirt.concat(verticesRow);
+        else if (y === heightSegments)
+            skirt = skirt.concat(verticesRow.slice().reverse());
 
     }
 
-    EllipsoidTileGeometry.prototype = Object.create(THREE.BufferGeometry.prototype);
+    skirt = skirt.concat(skirtEnd.reverse());
 
-    EllipsoidTileGeometry.prototype.constructor = EllipsoidTileGeometry;
+    function bufferize(va, vb, vc, idVertex) {
+        bufferIndex[idVertex + 0] = va;
+        bufferIndex[idVertex + 1] = vb;
+        bufferIndex[idVertex + 2] = vc;
+    }
 
-    return EllipsoidTileGeometry;
+    var idVertex2 = 0;
 
-});
+    for (y = 0; y < heightSegments; y++) {
+
+        for (x = 0; x < widthSegments; x++) {
+
+            var v1 = vertices[y][x + 1];
+            var v2 = vertices[y][x];
+            var v3 = vertices[y + 1][x];
+            var v4 = vertices[y + 1][x + 1];
+
+            bufferize(v4, v2, v1, idVertex2);
+
+            idVertex2 += 3;
+
+            bufferize(v4, v3, v2, idVertex2);
+
+            idVertex2 += 3;
+        }
+    }
+
+    var start = idVertex;
+    var rmax = 5000;
+    var r = Math.max(rmax, Math.pow(rmax, 1 / zoom));
+
+    r = isFinite(r) ? r : rmax;
+
+    for (var i = 0; i < skirt.length; i++) {
+
+        var id = skirt[i];
+        var id3 = idVertex * 3;
+        var id23 = id * 3;
+
+        bufferVertex[id3 + 0] = bufferVertex[id23 + 0] - bufferNormal[id23 + 0] * r;
+        bufferVertex[id3 + 1] = bufferVertex[id23 + 1] - bufferNormal[id23 + 1] * r;
+        bufferVertex[id3 + 2] = bufferVertex[id23 + 2] - bufferNormal[id23 + 2] * r;
+
+        bufferNormal[id3 + 0] = bufferNormal[id23 + 0];
+        bufferNormal[id3 + 1] = bufferNormal[id23 + 1];
+        bufferNormal[id3 + 2] = bufferNormal[id23 + 2];
+
+        bufferUV[idVertex * 2 + 0] = bufferUV[id * 2 + 0];
+        bufferUV[idVertex * 2 + 1] = bufferUV[id * 2 + 1];
+        bufferUV2[idVertex] = bufferUV2[id];
+
+        var idf = (i + 1) % skirt.length;
+
+        var v1 = id;
+        var v2 = idVertex;
+        var v3 = idVertex + 1;
+        var v4 = skirt[idf];
+
+        if (idf === 0)
+            v3 = start;
+
+        bufferize(v1, v2, v3, idVertex2);
+
+        idVertex2 += 3;
+
+        bufferize(v1, v3, v4, idVertex2);
+
+        idVertex2 += 3;
+
+        idVertex++;
+
+    }
+
+    // TODO : free array
+
+    this.setIndex(new THREE.BufferAttribute(bufferIndex, 1));
+    this.addAttribute('position', new THREE.BufferAttribute(bufferVertex, 3));
+    this.addAttribute('normal', new THREE.BufferAttribute(bufferNormal, 3));
+    this.addAttribute('uv', new THREE.BufferAttribute(bufferUV, 2));
+    this.addAttribute('uv1', new THREE.BufferAttribute(bufferUV2, 1));
+
+    // ---> for SSE
+    this.computeBoundingSphere();
+
+    javToo.freeArray(vertices);
+
+    // TODO how free typedArray
+    bufferVertex = null;
+    bufferIndex = null;
+    bufferNormal = null;
+    bufferUV = null;
+    bufferUV2 = null;
+
+}
+
+EllipsoidTileGeometry.prototype = Object.create(THREE.BufferGeometry.prototype);
+
+EllipsoidTileGeometry.prototype.constructor = EllipsoidTileGeometry;
+
+export default EllipsoidTileGeometry;

--- a/src/Globe/EllipsoidTileMesh.js
+++ b/src/Globe/EllipsoidTileMesh.js
@@ -14,223 +14,219 @@
  * @param {type} Material
  * @returns {EllipsoidTileMesh_L10.EllipsoidTileMesh}
  */
-define('Globe/EllipsoidTileMesh', [
-    'Renderer/NodeMesh',
-    'Globe/EllipsoidTileGeometry',
-    'Scene/BoundingBox',
-    'Core/defaultValue',
-    'THREE',
-    'Renderer/GlobeMaterial',
-    'Core/Geographic/CoordCarto',
-    'OBBHelper',
-    'SphereHelper'
-], function(NodeMesh, EllipsoidTileGeometry, BoundingBox, defaultValue, THREE, GlobeMaterial, CoordCarto, OBBHelper, SphereHelper) {
+import NodeMesh from 'Renderer/NodeMesh';
+import EllipsoidTileGeometry from 'Globe/EllipsoidTileGeometry';
+import BoundingBox from 'Scene/BoundingBox';
+import defaultValue from 'Core/defaultValue';
+import THREE from 'THREE';
+import GlobeMaterial from 'Renderer/GlobeMaterial';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import OBBHelper from 'OBBHelper';
+import SphereHelper from 'SphereHelper';
 
-    function EllipsoidTileMesh(bbox, cooWMTS, ellipsoid, id, geometryCache) {
-        //Constructor
-        NodeMesh.call(this);
+function EllipsoidTileMesh(bbox, cooWMTS, ellipsoid, id, geometryCache) {
+    //Constructor
+    NodeMesh.call(this);
 
 
-        this.level = cooWMTS.zoom;
-        this.cooWMTS = cooWMTS;
-        this.bbox = defaultValue(bbox, new BoundingBox());
-        this.id = id;
+    this.level = cooWMTS.zoom;
+    this.cooWMTS = cooWMTS;
+    this.bbox = defaultValue(bbox, new BoundingBox());
+    this.id = id;
 
-        var precision = 16;
-        var levelMax = 18;
+    var precision = 16;
+    var levelMax = 18;
 
-        this.geometricError = Math.pow(2, (levelMax - this.level));
-        this.geometry = defaultValue(geometryCache, new EllipsoidTileGeometry(bbox, precision, ellipsoid, this.level));
-        var ccarto = new CoordCarto(bbox.center.x, bbox.center.y, 0);
+    this.geometricError = Math.pow(2, (levelMax - this.level));
+    this.geometry = defaultValue(geometryCache, new EllipsoidTileGeometry(bbox, precision, ellipsoid, this.level));
+    var ccarto = new CoordCarto(bbox.center.x, bbox.center.y, 0);
 
-        // TODO modif ver world coord de three.js 
-        this.absoluteCenter = ellipsoid.cartographicToCartesian(ccarto);
+    // TODO modif ver world coord de three.js 
+    this.absoluteCenter = ellipsoid.cartographicToCartesian(ccarto);
 
-        // TODO ??? 
-        this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, this.absoluteCenter);
-        this.orthoNeed = 0;
-        this.material = new GlobeMaterial(bbox, id);
-        this.dot = 0;
-        this.frustumCulled = false;
-        this.maxChildren = 4;
+    // TODO ??? 
+    this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, this.absoluteCenter);
+    this.orthoNeed = 0;
+    this.material = new GlobeMaterial(bbox, id);
+    this.dot = 0;
+    this.frustumCulled = false;
+    this.maxChildren = 4;
 
-        var groupTerrain = [14, 11, 7, 3];
-        this.levelTerrain = this.level;
+    var groupTerrain = [14, 11, 7, 3];
+    this.levelTerrain = this.level;
 
-        for (var i = 0; i < groupTerrain.length; i++) {
-            var gLev = groupTerrain[i];
-            if (this.level >= gLev) {
-                this.levelTerrain = gLev;
-                break;
-            }
+    for (var i = 0; i < groupTerrain.length; i++) {
+        var gLev = groupTerrain[i];
+        if (this.level >= gLev) {
+            this.levelTerrain = gLev;
+            break;
         }
-
-
-        //  TODO : Attention ne marche plus car les helpers ne sont plus ajouter à la scene
-        /*
-        var showHelper = true;
-        showHelper = false;
-
-        if (showHelper && this.level >= 2) {
-
-            //this.helper  = new THREE.SphereHelper(this.geometry.boundingSphere.radius);
-
-            //var text = 'z(' + this.level.toString() + '),r(' + cooWMTS.row + '),c(' + cooWMTS.col + ')';
-            var text = (this.level + 1).toString();
-
-            this.helper = new THREE.OBBHelper(this.geometry.OBB, text);
-
-            if (this.helper instanceof THREE.SphereHelper)
-
-                this.helper.position.add(this.absoluteCenter);
-
-            else if (this.helper instanceof THREE.OBBHelper)
-
-                this.helper.translateZ(this.absoluteCenter.length());
-
-        }
-        */
     }
 
-    EllipsoidTileMesh.prototype = Object.create(NodeMesh.prototype);
 
-    EllipsoidTileMesh.prototype.constructor = EllipsoidTileMesh;
+    //  TODO : Attention ne marche plus car les helpers ne sont plus ajouter à la scene
+    /*
+    var showHelper = true;
+    showHelper = false;
 
-    EllipsoidTileMesh.prototype.dispose = function() {
-        // TODO à mettre dans node mesh
-        this.material.dispose();
-        this.geometry.dispose();
-        this.geometry = null;
-        this.material = null;
-    };
+    if (showHelper && this.level >= 2) {
 
-    /**
-    * 
+        //this.helper  = new THREE.SphereHelper(this.geometry.boundingSphere.radius);
 
-     * @returns {undefined}     */
-    EllipsoidTileMesh.prototype.disposeChildren = function() {
-        while (this.children.length > 0) {
-            var child = this.children[0];
-            this.remove(child);
-            child.dispose();
-        }
-        this.material.visible = true;
-    };
+        //var text = 'z(' + this.level.toString() + '),r(' + cooWMTS.row + '),c(' + cooWMTS.col + ')';
+        var text = (this.level + 1).toString();
 
-    EllipsoidTileMesh.prototype.useParent = function() {
-        return this.level !== this.levelTerrain;
-    };
+        this.helper = new THREE.OBBHelper(this.geometry.OBB, text);
 
-    EllipsoidTileMesh.prototype.enableRTC = function(enable) {
-        this.material.enableRTC(enable);
-    };
+        if (this.helper instanceof THREE.SphereHelper)
 
-    EllipsoidTileMesh.prototype.enablePickingRender = function(enable) {
-        this.material.enablePickingRender(enable);
-    };
+            this.helper.position.add(this.absoluteCenter);
 
-    EllipsoidTileMesh.prototype.setFog = function(fog) {
-        this.material.setFogDistance(fog);
-    };
+        else if (this.helper instanceof THREE.OBBHelper)
 
-    EllipsoidTileMesh.prototype.setMatrixRTC = function(rtc) {
-        this.material.setMatrixRTC(rtc);
-    };
-
-    EllipsoidTileMesh.prototype.setDebug = function(enable) {
-        this.material.setDebug(enable);
-    };
-
-    EllipsoidTileMesh.prototype.setSelected = function(select) {
-        this.material.setSelected(select);
-    };
-
-    EllipsoidTileMesh.prototype.setTerrain = function(terrain) {
-        var texture;
-        var pitScale;
-
-        if (terrain === -1)
-            texture = -1;
-        else if (terrain === -2) {
-            var parentBil = this.getParentLevel(this.levelTerrain);
-            pitScale = parentBil.bbox.pitScale(this.bbox);
-            texture = parentBil.material.Textures_00[0];
-
-            this.setAltitude(parentBil.bbox.minCarto.altitude, parentBil.bbox.maxCarto.altitude);
-
-        } else {
-            texture = terrain.texture;
-            this.setAltitude(terrain.min, terrain.max);
-        }
-
-        this.material.setTexture(texture, 0, 0, pitScale);
-    };
-
-    EllipsoidTileMesh.prototype.setAltitude = function(min, max) {
-        this.bbox.setAltitude(min, max);
-        var delta = this.geometry.OBB.addHeight(this.bbox);
-        var trans = this.absoluteCenter.clone().setLength(delta.y);
-
-        var radius = this.geometry.boundingSphere.radius;
-
-        this.geometry.boundingSphere.radius = Math.sqrt(delta.x * delta.x + radius * radius);
-        this.centerSphere.add(trans);
-
-        if (this.helper instanceof THREE.OBBHelper) {
-            this.helper.update(this.geometry.OBB);
             this.helper.translateZ(this.absoluteCenter.length());
-        } else if (this.helper instanceof THREE.SphereHelper) {
-            this.helper.update(this.geometry.boundingSphere.radius);
-            this.helper.position.add(trans);
+
+    }
+    */
+}
+
+EllipsoidTileMesh.prototype = Object.create(NodeMesh.prototype);
+
+EllipsoidTileMesh.prototype.constructor = EllipsoidTileMesh;
+
+EllipsoidTileMesh.prototype.dispose = function() {
+    // TODO à mettre dans node mesh
+    this.material.dispose();
+    this.geometry.dispose();
+    this.geometry = null;
+    this.material = null;
+};
+
+/**
+* 
+
+ * @returns {undefined}     */
+EllipsoidTileMesh.prototype.disposeChildren = function() {
+    while (this.children.length > 0) {
+        var child = this.children[0];
+        this.remove(child);
+        child.dispose();
+    }
+    this.material.visible = true;
+};
+
+EllipsoidTileMesh.prototype.useParent = function() {
+    return this.level !== this.levelTerrain;
+};
+
+EllipsoidTileMesh.prototype.enableRTC = function(enable) {
+    this.material.enableRTC(enable);
+};
+
+EllipsoidTileMesh.prototype.enablePickingRender = function(enable) {
+    this.material.enablePickingRender(enable);
+};
+
+EllipsoidTileMesh.prototype.setFog = function(fog) {
+    this.material.setFogDistance(fog);
+};
+
+EllipsoidTileMesh.prototype.setMatrixRTC = function(rtc) {
+    this.material.setMatrixRTC(rtc);
+};
+
+EllipsoidTileMesh.prototype.setDebug = function(enable) {
+    this.material.setDebug(enable);
+};
+
+EllipsoidTileMesh.prototype.setSelected = function(select) {
+    this.material.setSelected(select);
+};
+
+EllipsoidTileMesh.prototype.setTerrain = function(terrain) {
+    var texture;
+    var pitScale;
+
+    if (terrain === -1)
+        texture = -1;
+    else if (terrain === -2) {
+        var parentBil = this.getParentLevel(this.levelTerrain);
+        pitScale = parentBil.bbox.pitScale(this.bbox);
+        texture = parentBil.material.Textures_00[0];
+
+        this.setAltitude(parentBil.bbox.minCarto.altitude, parentBil.bbox.maxCarto.altitude);
+
+    } else {
+        texture = terrain.texture;
+        this.setAltitude(terrain.min, terrain.max);
+    }
+
+    this.material.setTexture(texture, 0, 0, pitScale);
+};
+
+EllipsoidTileMesh.prototype.setAltitude = function(min, max) {
+    this.bbox.setAltitude(min, max);
+    var delta = this.geometry.OBB.addHeight(this.bbox);
+    var trans = this.absoluteCenter.clone().setLength(delta.y);
+
+    var radius = this.geometry.boundingSphere.radius;
+
+    this.geometry.boundingSphere.radius = Math.sqrt(delta.x * delta.x + radius * radius);
+    this.centerSphere.add(trans);
+
+    if (this.helper instanceof THREE.OBBHelper) {
+        this.helper.update(this.geometry.OBB);
+        this.helper.translateZ(this.absoluteCenter.length());
+    } else if (this.helper instanceof THREE.SphereHelper) {
+        this.helper.update(this.geometry.boundingSphere.radius);
+        this.helper.position.add(trans);
+    }
+};
+
+EllipsoidTileMesh.prototype.setTextureOrtho = function(texture, id) {
+    id = id === undefined ? 0 : id;
+    this.material.setTexture(texture, 1, id);
+    this.checkOrtho();
+    //  if(this.material.nbTextures === this.material.Textures_01.length)
+    //   this.visible = false;
+};
+
+EllipsoidTileMesh.prototype.normals = function() {
+    return this.geometry.normals;
+};
+
+EllipsoidTileMesh.prototype.fourCorners = function() {
+    return this.geometry.fourCorners;
+};
+
+EllipsoidTileMesh.prototype.normal = function() {
+    return this.geometry.normal;
+};
+
+EllipsoidTileMesh.prototype.center = function() {
+    return this.geometry.center;
+};
+
+EllipsoidTileMesh.prototype.OBB = function() {
+    return this.geometry.OBB;
+};
+
+EllipsoidTileMesh.prototype.checkOrtho = function() {
+
+
+    if (this.orthoNeed + 1 === this.material.nbTextures || this.level < 2)
+
+    {
+
+        this.loaded = true;
+        this.material.update();
+
+        var parent = this.parent;
+
+        if (parent !== null && parent.childrenLoaded()) {
+            parent.wait = false;
         }
-    };
+    }
+};
 
-    EllipsoidTileMesh.prototype.setTextureOrtho = function(texture, id) {
-        id = id === undefined ? 0 : id;
-        this.material.setTexture(texture, 1, id);
-        this.checkOrtho();
-        //  if(this.material.nbTextures === this.material.Textures_01.length)
-        //   this.visible = false;
-    };
-
-    EllipsoidTileMesh.prototype.normals = function() {
-        return this.geometry.normals;
-    };
-
-    EllipsoidTileMesh.prototype.fourCorners = function() {
-        return this.geometry.fourCorners;
-    };
-
-    EllipsoidTileMesh.prototype.normal = function() {
-        return this.geometry.normal;
-    };
-
-    EllipsoidTileMesh.prototype.center = function() {
-        return this.geometry.center;
-    };
-
-    EllipsoidTileMesh.prototype.OBB = function() {
-        return this.geometry.OBB;
-    };
-
-    EllipsoidTileMesh.prototype.checkOrtho = function() {
-
-
-        if (this.orthoNeed + 1 === this.material.nbTextures || this.level < 2)
-
-        {
-
-            this.loaded = true;
-            this.material.update();
-
-            var parent = this.parent;
-
-            if (parent !== null && parent.childrenLoaded()) {
-                parent.wait = false;
-            }
-        }
-    };
-
-    return EllipsoidTileMesh;
-
-});
+export default EllipsoidTileMesh;

--- a/src/Globe/Globe.js
+++ b/src/Globe/Globe.js
@@ -4,118 +4,111 @@
  * Description: Le globe est le noeud du globe (node) principale.
  */
 
-define('Globe/Globe', [
-    'Core/defaultValue',
-    'Scene/Layer',
-    'Scene/Quadtree',
-    'Scene/SchemeTile',
-    'Core/Math/MathExtented',
-    'Globe/EllipsoidTileMesh',
-    'Globe/Atmosphere',
-    'Globe/Clouds',
-    'Core/System/Capabilities',
-    'Core/Geographic/CoordCarto',
-    'Renderer/BasicMaterial',
-    'THREE'
-], function(defaultValue, Layer, Quadtree, SchemeTile, MathExt,
-    EllipsoidTileMesh, Atmosphere, Clouds, Capabilities,
-    CoordCarto, BasicMaterial, THREE) {
+import defaultValue from 'Core/defaultValue';
+import Layer from 'Scene/Layer';
+import Quadtree from 'Scene/Quadtree';
+import SchemeTile from 'Scene/SchemeTile';
+import MathExt from 'Core/Math/MathExtented';
+import EllipsoidTileMesh from 'Globe/EllipsoidTileMesh';
+import Atmosphere from 'Globe/Atmosphere';
+import Clouds from 'Globe/Clouds';
+import Capabilities from 'Core/System/Capabilities';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import BasicMaterial from 'Renderer/BasicMaterial';
+import THREE from 'THREE';
 
-    function Globe(scale) {
-        //Constructor
 
-        Layer.call(this);
+function Globe(scale) {
+    //Constructor
 
-        scale = defaultValue(scale, 1.0);
-        var caps = new Capabilities();
-        this.NOIE = !caps.isInternetExplorer();
+    Layer.call(this);
 
-        this.size = new THREE.Vector3(6378137, 6356752.3142451793, 6378137).multiplyScalar(scale);
-        this.batiments = new Layer();
+    scale = defaultValue(scale, 1.0);
+    var caps = new Capabilities();
+    this.NOIE = !caps.isInternetExplorer();
 
-        var kml = new THREE.Mesh();
-        this.batiments.add(kml);
+    this.size = new THREE.Vector3(6378137, 6356752.3142451793, 6378137).multiplyScalar(scale);
+    this.batiments = new Layer();
 
-        this.terrain = new Quadtree(EllipsoidTileMesh, this.SchemeTileWMTS(2), this.size, kml);
-        this.atmosphere = this.NOIE ? new Atmosphere(this.size) : undefined;
-        this.clouds = new Clouds();
+    var kml = new THREE.Mesh();
+    this.batiments.add(kml);
 
-        var material = new BasicMaterial(new THREE.Color(1, 0, 0));
-        var geometry = new THREE.SphereGeometry(200);
-        var batiment = new THREE.Mesh(geometry, material);
-        var position = this.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(48.87, 0, 200));
-        batiment.frustumCulled = false;
-        //material.wireframe      = true;
-        batiment.position.copy(position);
+    this.terrain = new Quadtree(EllipsoidTileMesh, this.SchemeTileWMTS(2), this.size, kml);
+    this.atmosphere = this.NOIE ? new Atmosphere(this.size) : undefined;
+    this.clouds = new Clouds();
 
-        var material2 = new BasicMaterial(new THREE.Color(1, 0.5, 1));
-        material2.visible = false;
-        var batiment2 = new THREE.Mesh(geometry, material2);
-        var position2 = this.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(48.87, 0.001, 100));
-        batiment2.frustumCulled = false;
-        material2.wireframe = true;
-        batiment2.position.copy(position2);
+    var material = new BasicMaterial(new THREE.Color(1, 0, 0));
+    var geometry = new THREE.SphereGeometry(200);
+    var batiment = new THREE.Mesh(geometry, material);
+    var position = this.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(48.87, 0, 200));
+    batiment.frustumCulled = false;
+    //material.wireframe      = true;
+    batiment.position.copy(position);
 
-        //this.batiments.add( batiment );        
-        //this.batiments.add( batiment2 );
+    var material2 = new BasicMaterial(new THREE.Color(1, 0.5, 1));
+    material2.visible = false;
+    var batiment2 = new THREE.Mesh(geometry, material2);
+    var position2 = this.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(48.87, 0.001, 100));
+    batiment2.frustumCulled = false;
+    material2.wireframe = true;
+    batiment2.position.copy(position2);
 
-        this.add(this.terrain);
-        this.add(this.batiments);
+    //this.batiments.add( batiment );        
+    //this.batiments.add( batiment2 );
 
-        if (this.atmosphere !== undefined) {
-            this.atmosphere.add(this.clouds);
-            this.add(this.atmosphere);
-        }
+    this.add(this.terrain);
+    this.add(this.batiments);
 
-        //this.add(new THREE.Object3D().add());
-
+    if (this.atmosphere !== undefined) {
+        this.atmosphere.add(this.clouds);
+        this.add(this.atmosphere);
     }
 
-    Globe.prototype = Object.create(Layer.prototype);
+    //this.add(new THREE.Object3D().add());
 
-    Globe.prototype.constructor = Globe;
+}
 
-    /**
-     * @documentation: Rafrachi les matï¿½riaux en fonction du quadTree ORTHO
-     *
-     */
-    Globe.prototype.QuadTreeToMaterial = function() {
-        //TODO: Implement Me 
+Globe.prototype = Object.create(Layer.prototype);
 
-    };
+Globe.prototype.constructor = Globe;
 
-    Globe.prototype.SchemeTileWMTS = function(type) {
-        //TODO: Implement Me 
-        if (type === 2) {
-            var schemeT = new SchemeTile();
-            schemeT.add(0, MathExt.PI, -MathExt.PI_OV_TWO, MathExt.PI_OV_TWO);
-            schemeT.add(MathExt.PI, MathExt.TWO_PI, -MathExt.PI_OV_TWO, MathExt.PI_OV_TWO);
-            return schemeT;
-        }
+/**
+ * @documentation: Rafrachi les matériaux en fonction du quadTree ORTHO
+ *
+ */
+Globe.prototype.QuadTreeToMaterial = function() {
+    //TODO: Implement Me 
 
-    };
+};
 
-    Globe.prototype.showAtmosphere = function(show) {
-        if (this.atmosphere !== undefined)
-            this.atmosphere.visible = show;
+Globe.prototype.SchemeTileWMTS = function(type) {
+    //TODO: Implement Me 
+    if (type === 2) {
+        var schemeT = new SchemeTile();
+        schemeT.add(0, MathExt.PI, -MathExt.PI_OV_TWO, MathExt.PI_OV_TWO);
+        schemeT.add(MathExt.PI, MathExt.TWO_PI, -MathExt.PI_OV_TWO, MathExt.PI_OV_TWO);
+        return schemeT;
+    }
 
-    };
+};
 
-    Globe.prototype.showClouds = function(show) {
+Globe.prototype.showAtmosphere = function(show) {
+    if (this.atmosphere !== undefined)
+        this.atmosphere.visible = show;
 
-        if (this.clouds.live === false && show) {
-            this.clouds.generate();
-        }
-        this.clouds.visible = show;
+};
 
-    };
+Globe.prototype.showClouds = function(show) {
 
+    if (this.clouds.live === false && show) {
+        this.clouds.generate();
+    }
+    this.clouds.visible = show;
 
-    Globe.prototype.ellipsoid = function() {
-        return this.terrain.interCommand.managerCommands.providers[0].ellipsoid;
-    };
+};
 
+Globe.prototype.ellipsoid = function() {
+    return this.terrain.interCommand.managerCommands.providers[0].ellipsoid;
+};
 
-    return Globe;
-
-});
+export default Globe;

--- a/src/Globe/HorizonCulling.js
+++ b/src/Globe/HorizonCulling.js
@@ -4,7 +4,7 @@
  * Description: Determine les NodeMeshs cachés par l'horizon du Globe.
  */
 
-var NodeProcess = require('NodeProcess');
+import NodeProcess from 'NodeProcess';
 
 function HorizonCulling() {
     //Constructor
@@ -15,6 +15,6 @@ function HorizonCulling() {
 HorizonCulling.prototype = new NodeProcess();
 
 
-module.exports = {
-    HorizonCulling: HorizonCulling
+export {
+    HorizonCulling
 };

--- a/src/Globe/SSE.js
+++ b/src/Globe/SSE.js
@@ -4,7 +4,7 @@
  * Description: Calcul screen space error d'un NodeMesh
  */
 
-var NodeProcess = require('NodeProcess');
+import NodeProcess from 'NodeProcess';
 
 function SSE() {
     //Constructor
@@ -15,6 +15,6 @@ function SSE() {
 SSE.prototype = new NodeProcess();
 
 
-module.exports = {
-    SSE: SSE
+export {
+    SSE
 };

--- a/src/Globe/Star.js
+++ b/src/Globe/Star.js
@@ -5,29 +5,29 @@
  */
 
 
-define('Globe/Star', ['Renderer/NodeMesh', 'StarGeometry', 'three'], function(NodeMesh, StarGeometry, THREE) {
+import NodeMesh from 'Renderer/NodeMesh';
+import StarGeometry from 'StarGeometry';
+import THREE from 'three';
 
 
 
-    var Star = function() {
+var Star = function() {
 
 
-        NodeMesh.call(this);
+    NodeMesh.call(this);
 
-        var geom = new THREE.StarGeometry();
+    var geom = new THREE.StarGeometry();
 
-        var particles = new THREE.Points(geom, new THREE.PointsMaterial({
-            color: 0xAAAACC
-        }));
-        this.add(particles);
+    var particles = new THREE.Points(geom, new THREE.PointsMaterial({
+        color: 0xAAAACC
+    }));
+    this.add(particles);
 
-    };
+};
 
-    Star.prototype = Object.create(NodeMesh.prototype);
+Star.prototype = Object.create(NodeMesh.prototype);
 
-    Star.prototype.constructor = Star;
+Star.prototype.constructor = Star;
 
 
-    return Star;
-
-});
+export default Star;

--- a/src/Main.js
+++ b/src/Main.js
@@ -4,15 +4,13 @@
  * and open the template in the editor.
  */
 
-define(['Core/Commander/Interfaces/ApiInterface/ApiGlobe'],
-    function(ApiGlobe) {
-        // browser execution or not ?
-        var scope = typeof window !== "undefined" ? window : {};
-        var itowns = scope.itowns || {
-            viewer: ApiGlobe
-        };
-        scope.itowns = itowns;
-        return scope.itowns;
+import ApiGlobe from 'Core/Commander/Interfaces/ApiInterface/ApiGlobe';
 
-    }
-);
+// browser execution or not ?
+var scope = typeof window !== "undefined" ? window : {};
+var itowns = scope.itowns || {
+    viewer: ApiGlobe
+};
+scope.itowns = itowns;
+
+export default scope.itowns;

--- a/src/Renderer/BasicMaterial.js
+++ b/src/Renderer/BasicMaterial.js
@@ -5,83 +5,76 @@
  */
 
 
-define('Renderer/BasicMaterial', ['THREE',
-    'Core/defaultValue',
-    'Renderer/Shader/SimpleVS.glsl',
-    'Renderer/Shader/SimpleFS.glsl'
-], function(
-    THREE,
-    defaultValue,
-    SimpleVS,
-    SimpleFS) {
+import THREE from 'THREE';
+import defaultValue from 'Core/defaultValue';
+import SimpleVS from 'Renderer/Shader/SimpleVS.glsl';
+import SimpleFS from 'Renderer/Shader/SimpleFS.glsl';
 
-    function BasicMaterial(color) {
-        //Constructor
+function BasicMaterial(color) {
+    //Constructor
 
-        THREE.ShaderMaterial.call(this);
+    THREE.ShaderMaterial.call(this);
 
-        this.vertexShader = SimpleVS;
-        this.fragmentShader = SimpleFS;
+    this.vertexShader = SimpleVS;
+    this.fragmentShader = SimpleFS;
 
-        this.uniforms = {
-            diffuseColor: {
-                type: "c",
-                value: defaultValue(color, new THREE.Color())
-            },
-            RTC: {
-                type: "i",
-                value: 1
-            },
-            mVPMatRTC: {
-                type: "m4",
-                value: new THREE.Matrix4()
-            },
-            distanceFog: {
-                type: "f",
-                value: 1000000000.0
-            },
-            uuid: {
-                type: "i",
-                value: 0
-            },
-            debug: {
-                type: "i",
-                value: false
-            },
-            selected: {
-                type: "i",
-                value: false
-            }
+    this.uniforms = {
+        diffuseColor: {
+            type: "c",
+            value: defaultValue(color, new THREE.Color())
+        },
+        RTC: {
+            type: "i",
+            value: 1
+        },
+        mVPMatRTC: {
+            type: "m4",
+            value: new THREE.Matrix4()
+        },
+        distanceFog: {
+            type: "f",
+            value: 1000000000.0
+        },
+        uuid: {
+            type: "i",
+            value: 0
+        },
+        debug: {
+            type: "i",
+            value: false
+        },
+        selected: {
+            type: "i",
+            value: false
+        }
 
-        };
-    }
-
-    BasicMaterial.prototype = Object.create(THREE.ShaderMaterial.prototype);
-    BasicMaterial.prototype.constructor = BasicMaterial;
-
-    BasicMaterial.prototype.enableRTC = function(enable) {
-        this.uniforms.RTC.value = enable === true ? 1 : 0;
     };
+}
 
-    BasicMaterial.prototype.setDebug = function(debug_value) {
-        this.uniforms.debug.value = debug_value;
-    };
+BasicMaterial.prototype = Object.create(THREE.ShaderMaterial.prototype);
+BasicMaterial.prototype.constructor = BasicMaterial;
 
-    BasicMaterial.prototype.setMatrixRTC = function(rtc) {
-        this.uniforms.mVPMatRTC.value = rtc;
-    };
-    BasicMaterial.prototype.setUuid = function(uuid) {
-        this.uniforms.uuid.value = uuid;
-    };
+BasicMaterial.prototype.enableRTC = function(enable) {
+    this.uniforms.RTC.value = enable === true ? 1 : 0;
+};
 
-    BasicMaterial.prototype.setFogDistance = function(df) {
-        this.uniforms.distanceFog.value = df;
-    };
+BasicMaterial.prototype.setDebug = function(debug_value) {
+    this.uniforms.debug.value = debug_value;
+};
 
-    BasicMaterial.prototype.setSelected = function(selected) {
-        this.uniforms.selected.value = selected;
-    };
+BasicMaterial.prototype.setMatrixRTC = function(rtc) {
+    this.uniforms.mVPMatRTC.value = rtc;
+};
+BasicMaterial.prototype.setUuid = function(uuid) {
+    this.uniforms.uuid.value = uuid;
+};
 
-    return BasicMaterial;
+BasicMaterial.prototype.setFogDistance = function(df) {
+    this.uniforms.distanceFog.value = df;
+};
 
-});
+BasicMaterial.prototype.setSelected = function(selected) {
+    this.uniforms.selected.value = selected;
+};
+
+export default BasicMaterial;

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -5,124 +5,123 @@
  */
 
 
-define('Renderer/Camera', ['Scene/Node', 'THREE'], function(Node, THREE) {
+import Node from 'Scene/Node';
+import THREE from 'THREE';
 
-    function Camera(width, height, debug) {
-        //Constructor
+function Camera(width, height, debug) {
+    //Constructor
 
-        Node.call(this);
+    Node.call(this);
 
-        this.ratio = width / height;
-        this.FOV = 30;
+    this.ratio = width / height;
+    this.FOV = 30;
 
-        this.camera3D = new THREE.PerspectiveCamera(30, this.ratio);
-        this.camera3D.matrixAutoUpdate = false;
-        this.camera3D.rotationAutoUpdate = false;
+    this.camera3D = new THREE.PerspectiveCamera(30, this.ratio);
+    this.camera3D.matrixAutoUpdate = false;
+    this.camera3D.rotationAutoUpdate = false;
 
-        this.direction = new THREE.Vector3();
-        this.frustum = new THREE.Frustum();
-        this.width = width;
-        this.height = height;
-        this.Hypotenuse = Math.sqrt(this.width * this.width + this.height * this.height);
+    this.direction = new THREE.Vector3();
+    this.frustum = new THREE.Frustum();
+    this.width = width;
+    this.height = height;
+    this.Hypotenuse = Math.sqrt(this.width * this.width + this.height * this.height);
 
-        var radAngle = this.FOV * Math.PI / 180;
-        this.HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / this.ratio); // TODO surement faux               
-        this.HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * this.Hypotenuse / this.width);
-        this.preSSE = this.Hypotenuse * (2.0 * Math.tan(this.HYFOV * 0.5));
+    var radAngle = this.FOV * Math.PI / 180;
+    this.HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / this.ratio); // TODO surement faux               
+    this.HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * this.Hypotenuse / this.width);
+    this.preSSE = this.Hypotenuse * (2.0 * Math.tan(this.HYFOV * 0.5));
 
-        this.cameraHelper = undefined; //debug  ? new THREE.CameraHelper( this.camera3D ) : undefined;
-    }
+    this.cameraHelper = undefined; //debug  ? new THREE.CameraHelper( this.camera3D ) : undefined;
+}
 
-    Camera.prototype = Object.create(Node.prototype);
+Camera.prototype = Object.create(Node.prototype);
 
-    Camera.prototype.constructor = Camera;
+Camera.prototype.constructor = Camera;
 
-    /**
-     */
-    Camera.prototype.position = function() {
+/**
+ */
+Camera.prototype.position = function() {
 
-        return this.camera3D.position;
+    return this.camera3D.position;
 
-    };
+};
 
-    Camera.prototype.camHelper = function() {
+Camera.prototype.camHelper = function() {
 
-        return this.cameraHelper;
+    return this.cameraHelper;
 
-    };
+};
 
-    Camera.prototype.createCamHelper = function() {
+Camera.prototype.createCamHelper = function() {
 
-        this.cameraHelper = new THREE.CameraHelper(this.camera3D);
+    this.cameraHelper = new THREE.CameraHelper(this.camera3D);
 
-    };
+};
 
-    Camera.prototype.matrixWorldInverse = function() {
+Camera.prototype.matrixWorldInverse = function() {
 
-        return this.camera3D.matrixWorldInverse;
-    };
+    return this.camera3D.matrixWorldInverse;
+};
 
-    Camera.prototype.resize = function(width, height) {
+Camera.prototype.resize = function(width, height) {
 
-        this.width = width;
-        this.height = height;
-        this.ratio = width / height;
+    this.width = width;
+    this.height = height;
+    this.ratio = width / height;
 
-        this.Hypotenuse = Math.sqrt(this.width * this.width + this.height * this.height);
+    this.Hypotenuse = Math.sqrt(this.width * this.width + this.height * this.height);
 
-        var radAngle = this.FOV * Math.PI / 180;
+    var radAngle = this.FOV * Math.PI / 180;
 
-        this.HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * this.Hypotenuse / this.width);
+    this.HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * this.Hypotenuse / this.width);
 
-        this.preSSE = this.Hypotenuse * (2.0 * Math.tan(this.HYFOV * 0.5));
+    this.preSSE = this.Hypotenuse * (2.0 * Math.tan(this.HYFOV * 0.5));
 
-        this.camera3D.aspect = this.ratio;
+    this.camera3D.aspect = this.ratio;
 
-        this.camera3D.updateProjectionMatrix();
+    this.camera3D.updateProjectionMatrix();
 
-    };
+};
 
-    Camera.prototype.SSE = function(node) {
+Camera.prototype.SSE = function(node) {
 
-        var boundingSphere = node.geometry.boundingSphere;
+    var boundingSphere = node.geometry.boundingSphere;
 
-        var distance = Math.max(0.0, (this.camera3D.position.distanceTo(node.centerSphere) - boundingSphere.radius));
+    var distance = Math.max(0.0, (this.camera3D.position.distanceTo(node.centerSphere) - boundingSphere.radius));
 
-        var SSE = this.preSSE * (node.geometricError / distance);
+    var SSE = this.preSSE * (node.geometricError / distance);
 
-        node.sse = SSE;
+    node.sse = SSE;
 
-        return SSE;
+    return SSE;
 
-    };
+};
 
-    Camera.prototype.update = function() {
-        var vector = new THREE.Vector3(0, 0, 1);
+Camera.prototype.update = function() {
+    var vector = new THREE.Vector3(0, 0, 1);
 
-        this.direction = vector.applyQuaternion(this.camera3D.quaternion);
+    this.direction = vector.applyQuaternion(this.camera3D.quaternion);
 
-        this.frustum.setFromMatrix(new THREE.Matrix4().multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse));
+    this.frustum.setFromMatrix(new THREE.Matrix4().multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse));
 
-    };
+};
 
-    Camera.prototype.setPosition = function(position) {
-        this.camera3D.position.copy(position);
-    };
+Camera.prototype.setPosition = function(position) {
+    this.camera3D.position.copy(position);
+};
 
-    Camera.prototype.setRotation = function(rotation) {
-        this.camera3D.quaternion.copy(rotation);
-    };
+Camera.prototype.setRotation = function(rotation) {
+    this.camera3D.quaternion.copy(rotation);
+};
 
-    Camera.prototype.getFrustum = function() {
+Camera.prototype.getFrustum = function() {
 
-        this.camera3D.updateMatrix();
-        this.camera3D.updateMatrixWorld();
-        this.camera3D.matrixWorldInverse.getInverse(this.camera3D.matrixWorld);
-        this.frustum.setFromMatrix(new THREE.Matrix4().multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse));
+    this.camera3D.updateMatrix();
+    this.camera3D.updateMatrixWorld();
+    this.camera3D.matrixWorldInverse.getInverse(this.camera3D.matrixWorld);
+    this.frustum.setFromMatrix(new THREE.Matrix4().multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse));
 
-        return this.frustum;
-    };
+    return this.frustum;
+};
 
-    return Camera;
-
-});
+export default Camera;

--- a/src/Renderer/DepthMaterial.js
+++ b/src/Renderer/DepthMaterial.js
@@ -5,32 +5,25 @@
  */
 
 
-define('Renderer/DepthMaterial', ['THREE',
-    'Renderer/BasicMaterial',
-    'Core/System/JavaTools',
-    'Renderer/Shader/DepthVS.glsl',
-    'Renderer/Shader/DepthFS.glsl'
-], function(
-    THREE,
-    BasicMaterial,
-    JavaTools,
-    DepthVS,
-    DepthFS) {
+import THREE from 'THREE';
+import BasicMaterial from 'Renderer/BasicMaterial';
+import JavaTools from 'Core/System/JavaTools';
+import DepthVS from 'Renderer/Shader/DepthVS.glsl';
+import DepthFS from 'Renderer/Shader/DepthFS.glsl';
 
-    var DepthMaterial = function() {
+var DepthMaterial = function() {
 
-        BasicMaterial.call(this);
+    BasicMaterial.call(this);
 
-        this.vertexShader = DepthVS;
-        this.fragmentShader = DepthFS;
+    this.vertexShader = DepthVS;
+    this.fragmentShader = DepthFS;
 
-        this.wireframe = false;
-        //this.wireframe = true;
+    this.wireframe = false;
+    //this.wireframe = true;
 
-    };
+};
 
-    DepthMaterial.prototype = Object.create(BasicMaterial.prototype);
-    DepthMaterial.prototype.constructor = DepthMaterial;
+DepthMaterial.prototype = Object.create(BasicMaterial.prototype);
+DepthMaterial.prototype.constructor = DepthMaterial;
 
-    return DepthMaterial;
-});
+export default DepthMaterial;

--- a/src/Renderer/GlobeMaterial.js
+++ b/src/Renderer/GlobeMaterial.js
@@ -5,136 +5,129 @@
  */
 
 
-define('Renderer/GlobeMaterial', ['THREE',
-    'Renderer/BasicMaterial',
-    'Core/System/JavaTools',
-    'Renderer/Shader/GlobeVS.glsl',
-    'Renderer/Shader/GlobeFS.glsl'
-], function(
-    THREE,
-    BasicMaterial,
-    JavaTools,
-    GlobeVS,
-    GlobeFS) {
+import THREE from 'THREE';
+import BasicMaterial from 'Renderer/BasicMaterial';
+import JavaTools from 'Core/System/JavaTools';
+import GlobeVS from 'Renderer/Shader/GlobeVS.glsl';
+import GlobeFS from 'Renderer/Shader/GlobeFS.glsl';
 
-    var GlobeMaterial = function(bbox, id) {
+var GlobeMaterial = function(bbox, id) {
 
-        BasicMaterial.call(this);
+    BasicMaterial.call(this);
 
-        this.Textures_00 = [];
-        this.Textures_00.push(new THREE.Texture());
-        this.Textures_01 = [];
+    this.Textures_00 = [];
+    this.Textures_00.push(new THREE.Texture());
+    this.Textures_01 = [];
 
-        this.vertexShader = GlobeVS;
-        this.fragmentShader = GlobeFS;
+    this.vertexShader = GlobeVS;
+    this.fragmentShader = GlobeFS;
 
-        this.uniforms.dTextures_00 = {
-            type: "tv",
-            value: this.Textures_00
-        };
-        this.uniforms.dTextures_01 = {
-            type: "tv",
-            value: this.Textures_01
-        };
-        this.uniforms.nbTextures_00 = {
-            type: "i",
-            value: 0
-        };
-        this.uniforms.nbTextures_01 = {
-            type: "i",
-            value: 0
-        };
-        this.uniforms.pitScale = {
-            type: "v3",
-            value: new THREE.Vector3(0.0, 0.0, 1.0)
-        };
-        this.uniforms.pickingRender = {
-            type: "i",
-            value: 0
-        };
-
-        this.setUuid(id);
-        this.nbTextures = 0;
-        this.wireframe = false;
-        //this.wireframe = true;
-
+    this.uniforms.dTextures_00 = {
+        type: "tv",
+        value: this.Textures_00
+    };
+    this.uniforms.dTextures_01 = {
+        type: "tv",
+        value: this.Textures_01
+    };
+    this.uniforms.nbTextures_00 = {
+        type: "i",
+        value: 0
+    };
+    this.uniforms.nbTextures_01 = {
+        type: "i",
+        value: 0
+    };
+    this.uniforms.pitScale = {
+        type: "v3",
+        value: new THREE.Vector3(0.0, 0.0, 1.0)
+    };
+    this.uniforms.pickingRender = {
+        type: "i",
+        value: 0
     };
 
-    GlobeMaterial.prototype = Object.create(BasicMaterial.prototype);
-    GlobeMaterial.prototype.constructor = GlobeMaterial;
+    this.setUuid(id);
+    this.nbTextures = 0;
+    this.wireframe = false;
+    //this.wireframe = true;
 
-    GlobeMaterial.prototype.dispose = function() {
+};
 
-        this.dispatchEvent({
-            type: 'dispose'
-        });
+GlobeMaterial.prototype = Object.create(BasicMaterial.prototype);
+GlobeMaterial.prototype.constructor = GlobeMaterial;
 
-        for (var i = 0, max = this.Textures_00.length; i < max; i++) {
-            if (this.Textures_00[i] instanceof THREE.Texture)
-                this.Textures_00[i].dispose();
+GlobeMaterial.prototype.dispose = function() {
+
+    this.dispatchEvent({
+        type: 'dispose'
+    });
+
+    for (var i = 0, max = this.Textures_00.length; i < max; i++) {
+        if (this.Textures_00[i] instanceof THREE.Texture)
+            this.Textures_00[i].dispose();
+    }
+
+    for (var i = 0, max = this.Textures_01.length; i < max; i++) {
+        if (this.Textures_01[i] instanceof THREE.Texture)
+            this.Textures_01[i].dispose();
+    }
+
+    var jT = new JavaTools();
+
+    jT.freeArray(this.Textures_00);
+    jT.freeArray(this.Textures_01);
+
+    jT.freeArray(this.uniforms.dTextures_00.value);
+    jT.freeArray(this.uniforms.dTextures_01.value);
+    this.nbTextures = 0;
+};
+
+GlobeMaterial.prototype.setTexture = function(texture, layer, id, pitScale) {
+    if (layer === 0 && texture !== -1) {
+        this.Textures_00[0] = texture;
+        this.nbTextures++;
+
+        if (pitScale)
+            this.uniforms.pitScale.value = pitScale;
+    } else {
+        this.Textures_01[id] = texture; // BEWARE: array [] -> size: 0; array [10]="wao" -> size: 11            
+        this.nbTextures++;
+    }
+};
+
+GlobeMaterial.prototype.update = function() {
+    // Elevation
+    for (var i = 0, max = this.Textures_00.length; i < max; i++)
+        if (this.Textures_00[i].image !== undefined)
+            this.Textures_00[i].needsUpdate = true;
+
+    this.uniforms.dTextures_00.value = this.Textures_00;
+    this.uniforms.nbTextures_00.value = 1.0;
+
+    // Image texture (ortho, carto...)
+    for (var i = 0, max = this.Textures_01.length; i < max; i++)
+        if (this.Textures_01[i] && this.Textures_01[i].image !== undefined)
+            this.Textures_01[i].needsUpdate = true;
+
+    this.uniforms.dTextures_01.value = this.Textures_01; // Re-affect all the array each time a new texture is received -> NOT GOOD
+    this.uniforms.nbTextures_01.value = this.Textures_01.length;; //this.nbTextures;// this.Textures_01.length;
+
+};
+
+GlobeMaterial.prototype.CheekNeedsUpdate = function() {
+    for (var i = 0, max = this.Textures_01.length; i < max; i++)
+        if (this.Textures_01[i] && this.Textures_01[i].image !== undefined) {
+            if (this.Textures_01[i].needsUpdate === true)
+                return false;
         }
 
-        for (var i = 0, max = this.Textures_01.length; i < max; i++) {
-            if (this.Textures_01[i] instanceof THREE.Texture)
-                this.Textures_01[i].dispose();
-        }
+    return true;
+};
 
-        var jT = new JavaTools();
+GlobeMaterial.prototype.enablePickingRender = function(enable) {
+    this.uniforms.pickingRender.value = enable === true ? 1 : 0;
 
-        jT.freeArray(this.Textures_00);
-        jT.freeArray(this.Textures_01);
+};
 
-        jT.freeArray(this.uniforms.dTextures_00.value);
-        jT.freeArray(this.uniforms.dTextures_01.value);
-        this.nbTextures = 0;
-    };
-
-    GlobeMaterial.prototype.setTexture = function(texture, layer, id, pitScale) {
-        if (layer === 0 && texture !== -1) {
-            this.Textures_00[0] = texture;
-            this.nbTextures++;
-
-            if (pitScale)
-                this.uniforms.pitScale.value = pitScale;
-        } else {
-            this.Textures_01[id] = texture; // BEWARE: array [] -> size: 0; array [10]="wao" -> size: 11            
-            this.nbTextures++;
-        }
-    };
-
-    GlobeMaterial.prototype.update = function() {
-        // Elevation
-        for (var i = 0, max = this.Textures_00.length; i < max; i++)
-            if (this.Textures_00[i].image !== undefined)
-                this.Textures_00[i].needsUpdate = true;
-
-        this.uniforms.dTextures_00.value = this.Textures_00;
-        this.uniforms.nbTextures_00.value = 1.0;
-
-        // Image texture (ortho, carto...)
-        for (var i = 0, max = this.Textures_01.length; i < max; i++)
-            if (this.Textures_01[i] && this.Textures_01[i].image !== undefined)
-                this.Textures_01[i].needsUpdate = true;
-
-        this.uniforms.dTextures_01.value = this.Textures_01; // Re-affect all the array each time a new texture is received -> NOT GOOD
-        this.uniforms.nbTextures_01.value = this.Textures_01.length;; //this.nbTextures;// this.Textures_01.length;
-
-    };
-
-    GlobeMaterial.prototype.CheekNeedsUpdate = function() {
-        for (var i = 0, max = this.Textures_01.length; i < max; i++)
-            if (this.Textures_01[i] && this.Textures_01[i].image !== undefined) {
-                if (this.Textures_01[i].needsUpdate === true)
-                    return false;
-            }
-
-        return true;
-    };
-
-    GlobeMaterial.prototype.enablePickingRender = function(enable) {
-        this.uniforms.pickingRender.value = enable === true ? 1 : 0;
-
-    };
-
-    return GlobeMaterial;
-});
+export default GlobeMaterial;

--- a/src/Renderer/ManagerMaterial.js
+++ b/src/Renderer/ManagerMaterial.js
@@ -14,6 +14,6 @@ function ManagerMaterial() {
 
 
 
-module.exports = {
-    ManagerMaterial: ManagerMaterial
+export {
+    ManagerMaterial
 };

--- a/src/Renderer/NodeMesh.js
+++ b/src/Renderer/NodeMesh.js
@@ -6,57 +6,56 @@
 
 
 
-define('Renderer/NodeMesh', ['Scene/Node', 'THREE'], function(Node, THREE) {
+import Node from 'Scene/Node';
+import THREE from 'THREE';
 
 
-    var NodeMesh = function() {
-        //Constructor
+var NodeMesh = function() {
+    //Constructor
 
-        Node.call(this);
-        THREE.Mesh.call(this);
+    Node.call(this);
+    THREE.Mesh.call(this);
 
-        this.sse = 0.0;
-        this.wait = false;
-        this.helper = undefined;
+    this.sse = 0.0;
+    this.wait = false;
+    this.helper = undefined;
 
-    };
+};
 
-    NodeMesh.prototype = Object.create(THREE.Mesh.prototype);
+NodeMesh.prototype = Object.create(THREE.Mesh.prototype);
 
-    NodeMesh.prototype.constructor = NodeMesh;
+NodeMesh.prototype.constructor = NodeMesh;
 
-    NodeMesh.prototype.showHelper = function(show) {
-        if (this.helper !== undefined)
-            this.helper.visible = show;
-    };
+NodeMesh.prototype.showHelper = function(show) {
+    if (this.helper !== undefined)
+        this.helper.visible = show;
+};
 
-    NodeMesh.prototype.setVisibility = function(show) {
-        this.visible = show;
-        this.showHelper(show);
+NodeMesh.prototype.setVisibility = function(show) {
+    this.visible = show;
+    this.showHelper(show);
 
-        if (this.content !== null)
-            this.content.visible = show;
+    if (this.content !== null)
+        this.content.visible = show;
 
-        return show;
-    };
+    return show;
+};
 
-    NodeMesh.prototype.setMaterialVisibility = function(show) {
-        this.material.visible = show;
-        if (this.helper !== undefined)
-            this.helper.setMaterialVisibility(show);
+NodeMesh.prototype.setMaterialVisibility = function(show) {
+    this.material.visible = show;
+    if (this.helper !== undefined)
+        this.helper.setMaterialVisibility(show);
 
-        if (this.content !== null && show)
-            this.content.visible = true;
+    if (this.content !== null && show)
+        this.content.visible = true;
 
-    };
+};
 
-    NodeMesh.prototype.setChildrenVisibility = function(show) {
-        for (var i = 0; i < this.children.length; i++)
-            this.children[i].setVisibility(show);
-    };
+NodeMesh.prototype.setChildrenVisibility = function(show) {
+    for (var i = 0; i < this.children.length; i++)
+        this.children[i].setVisibility(show);
+};
 
-    Node.extend(NodeMesh);
+Node.extend(NodeMesh);
 
-    return NodeMesh;
-
-});
+export default NodeMesh;

--- a/src/Renderer/Object3DProvider.js
+++ b/src/Renderer/Object3DProvider.js
@@ -3,7 +3,7 @@
  * Class: Object3DProvider
  */
 
-var NodeProvider = require('NodeProvider');
+import NodeProvider from 'NodeProvider';
 
 function Object3DProvider() {
     //Constructor
@@ -12,6 +12,6 @@ function Object3DProvider() {
 Object3DProvider.prototype = new NodeProvider();
 
 
-module.exports = {
-    Object3DProvider: Object3DProvider
+export {
+    Object3DProvider
 };

--- a/src/Renderer/ThreeExtented/FrustrumCulling.js
+++ b/src/Renderer/ThreeExtented/FrustrumCulling.js
@@ -4,7 +4,7 @@
  * Description: Détermine les NodeMeshs contenues dans le frustrum de la caméra.
  */
 
-var NodeProcess = require('NodeProcess');
+import NodeProcess from 'NodeProcess';
 
 function FrustrumCulling() {
     //Constructor
@@ -15,6 +15,6 @@ function FrustrumCulling() {
 FrustrumCulling.prototype = new NodeProcess();
 
 
-module.exports = {
-    FrustrumCulling: FrustrumCulling
+export {
+    FrustrumCulling
 };

--- a/src/Renderer/ThreeExtented/GlobeControls.js
+++ b/src/Renderer/ThreeExtented/GlobeControls.js
@@ -6,7 +6,7 @@
 //    Zoom - middle mouse, or mousewheel / touch: two finger spread or squish
 //    Pan - right mouse, or arrow keys / touch: three finter swipe
 
-var THREE = require('three');
+import THREE from 'three';
 
 THREE.GlobeControls = function(object, domElement, engine) {
 

--- a/src/Renderer/ThreeExtented/KMZLoader.js
+++ b/src/Renderer/ThreeExtented/KMZLoader.js
@@ -5,89 +5,79 @@
 /* global THREE */
 
 //var JSZip = require("C:/Users/vcoindet/Documents/NetBeansProjects/itownsV1/src/Renderer/ThreeExtented/jszip.min");
-define('Renderer/ThreeExtented/KMZLoader', ['Renderer/ThreeExtented/jszip.min',
-        'THREE',
-        'Renderer/ThreeExtented/ColladaLoader',
-        'Core/Commander/Providers/IoDriverXML',
-        'Core/Geographic/CoordCarto',
-        'when'
-    ],
-    function(
-        JSZip,
-        THREE,
-        ColladaLoader,
-        IoDriverXML,
-        CoordCarto,
-        when) {
+import JSZip from 'Renderer/ThreeExtented/jszip.min';
+import THREE from 'THREE';
+import ColladaLoader from 'Renderer/ThreeExtented/ColladaLoader';
+import IoDriverXML from 'Core/Commander/Providers/IoDriverXML';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import when from 'when';
 
-        function KMZLoader() {
+function KMZLoader() {
 
-            this.colladaLoader = new THREE.ColladaLoader();
-            this.colladaLoader.options.convertUpAxis = true;
-            this.ioDriverXML = new IoDriverXML();
-            this.cache = [];
-        };
+    this.colladaLoader = new THREE.ColladaLoader();
+    this.colladaLoader.options.convertUpAxis = true;
+    this.ioDriverXML = new IoDriverXML();
+    this.cache = [];
+};
 
-        KMZLoader.prototype = Object.create(KMZLoader.prototype);
+KMZLoader.prototype = Object.create(KMZLoader.prototype);
 
-        KMZLoader.prototype.constructor = KMZLoader;
+KMZLoader.prototype.constructor = KMZLoader;
 
-        KMZLoader.prototype.load = function(url) {
+KMZLoader.prototype.load = function(url) {
 
 
-            var deferred = when.defer();
+    var deferred = when.defer();
 
-            var xhr = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest();
 
-            xhr.open("GET", url, true);
+    xhr.open("GET", url, true);
 
-            xhr.responseType = "arraybuffer";
+    xhr.responseType = "arraybuffer";
 
-            xhr.crossOrigin = '';
+    xhr.crossOrigin = '';
 
-            var scopeLoader = this.colladaLoader;
+    var scopeLoader = this.colladaLoader;
 
-            xhr.onload = function() {
+    xhr.onload = function() {
 
-                var zip = new JSZip(this.response);
-                var collada = undefined;
-                var coordCarto = undefined;
-                for (var name in zip.files) {
-                    //console.log(name);
-                    if (name.toLowerCase().substr(-4) === '.dae') {
-                        collada = scopeLoader.parse(zip.file(name).asText());
-                    } else if (name.toLowerCase().substr(-4) === '.kml') {
+        var zip = new JSZip(this.response);
+        var collada = undefined;
+        var coordCarto = undefined;
+        for (var name in zip.files) {
+            //console.log(name);
+            if (name.toLowerCase().substr(-4) === '.dae') {
+                collada = scopeLoader.parse(zip.file(name).asText());
+            } else if (name.toLowerCase().substr(-4) === '.kml') {
 
-                        var parser = new DOMParser();
-                        var doc = parser.parseFromString(zip.file(name).asText(), "text/xml");
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(zip.file(name).asText(), "text/xml");
 
-                        var longitude = Number(doc.getElementsByTagName("longitude")[0].childNodes[0].nodeValue);
-                        var latitude = Number(doc.getElementsByTagName("latitude")[0].childNodes[0].nodeValue);
-                        var altitude = Number(doc.getElementsByTagName("altitude")[0].childNodes[0].nodeValue);
+                var longitude = Number(doc.getElementsByTagName("longitude")[0].childNodes[0].nodeValue);
+                var latitude = Number(doc.getElementsByTagName("latitude")[0].childNodes[0].nodeValue);
+                var altitude = Number(doc.getElementsByTagName("altitude")[0].childNodes[0].nodeValue);
 
-                        coordCarto = new CoordCarto().setFromDegreeGeo(latitude, longitude, altitude);
+                coordCarto = new CoordCarto().setFromDegreeGeo(latitude, longitude, altitude);
 
-                    }
-                }
+            }
+        }
 
-                collada.coorCarto = coordCarto;
+        collada.coorCarto = coordCarto;
 
-                deferred.resolve(collada);
+        deferred.resolve(collada);
 
-            };
+    };
 
-            xhr.onerror = function() {
+    xhr.onerror = function() {
 
-                deferred.reject(Error("Error KMZLoader"));
+        deferred.reject(Error("Error KMZLoader"));
 
-            };
+    };
 
-            xhr.send(null);
+    xhr.send(null);
 
-            return deferred;
+    return deferred;
 
-        };
+};
 
-        return KMZLoader;
-
-    });
+export default KMZLoader;

--- a/src/Renderer/ThreeExtented/OBB.js
+++ b/src/Renderer/ThreeExtented/OBB.js
@@ -5,7 +5,7 @@
  */
 
 
-var THREE = require('three');
+import THREE from 'three';
 
 THREE.OBB = function(min, max) {
     THREE.Object3D.call(this);

--- a/src/Renderer/ThreeExtented/OBBHelper.js
+++ b/src/Renderer/ThreeExtented/OBBHelper.js
@@ -5,9 +5,9 @@
  */
 
 
-var THREE = require('three');
-require('three/examples/js/utils/FontUtils');
-require('Renderer/Three/optimer_regular');
+import THREE from 'three';
+import 'three/examples/js/utils/FontUtils';
+import 'Renderer/Three/optimer_regular';
 
 THREE.OBBHelper = function(OBB, text) {
     var indices = new Uint16Array([0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4, 1, 5, 2, 6, 3, 7]);

--- a/src/Renderer/ThreeExtented/SphereHelper.js
+++ b/src/Renderer/ThreeExtented/SphereHelper.js
@@ -5,7 +5,7 @@
  */
 
 
-var THREE = require('three');
+import THREE from 'three';
 
 THREE.SphereHelper = function(radius) {
     THREE.Mesh.call(this);

--- a/src/Renderer/ThreeExtented/StarGeometry.js
+++ b/src/Renderer/ThreeExtented/StarGeometry.js
@@ -5,7 +5,7 @@
  */
 
 
-var THREE = require('three');
+import THREE from 'three';
 
 THREE.StarGeometry = function() {
     THREE.Geometry.call(this);

--- a/src/Renderer/Utils.js
+++ b/src/Renderer/Utils.js
@@ -1,4 +1,4 @@
-// var Cartography = require('Cartogaphy');
+// import Cartography from 'Cartogaphy';
 
 /**
  * Tools used by iTOWNS modules

--- a/src/Renderer/Utils.js
+++ b/src/Renderer/Utils.js
@@ -1,1373 +1,1370 @@
 // var Cartography = require('Cartogaphy');
 
-define([], function() {
+/**
+ * Tools used by iTOWNS modules
+ * @exports Utils
+ * @author Mathieu Benard IGN
+ */
 
+//--------- Ray casting---------------
+var _tp = [];
+_P = function(x, y) {
+    this.x = x;
+    this.y = y;
+    this.flag = false;
+}
+_P.prototype.toString = function() {
+    return "Point [" + this.x + ", " + this.y + "]";
+}
+_P.dist = function(a, b) {
+        var dx = b.x - a.x;
+        var dy = b.y - a.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+    //--------------------------------------
+var Utils = {
+
+
+    snd: null, // Sound player (for fun)
+    snd2: null, // When mixing another sound
     /**
-     * Tools used by iTOWNS modules
-     * @exports Utils
-     * @author Mathieu Benard IGN
+     * Return the hexadecimal reprensentation of an integer (expressed in base 10)
      */
 
-    //--------- Ray casting---------------
-    var _tp = [];
-    _P = function(x, y) {
-        this.x = x;
-        this.y = y;
-        this.flag = false;
-    }
-    _P.prototype.toString = function() {
-        return "Point [" + this.x + ", " + this.y + "]";
-    }
-    _P.dist = function(a, b) {
-            var dx = b.x - a.x;
-            var dy = b.y - a.y;
-            return Math.sqrt(dx * dx + dy * dy);
+
+    toHex: function(number, min) {
+        var hexes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
+        var hex = '';
+        var min = min || 2;
+        var nibble;
+
+        do {
+            nibble = number & 0x0f;
+            number = number >> 4;
+            hex = hexes[nibble] + hex;
+        } while (number);
+
+        if (hex.length < min) {
+            hex = new Array(min - hex.length + 1).join('0') + hex;
         }
-        //--------------------------------------
-    var Utils = {
+
+        return '0x' + hex;
+    },
+
+    /**
+     * Get the total offset (top, left) of DOM element, including his parents offset
+     * 
+     * @param {Object} element The DOM element 
+     * @return : {Object} Object with properties top and left (calculated offset)
+     */
+    getOffset: function(element) {
+        var top = 0,
+            left = 0;
+        do {
+            top += element.offsetTop;
+            left += element.offsetLeft;
+        } while (element = element.offsetParent);
+
+        return {
+            top: top,
+            left: left
+        };
+    },
+
+    rad2Deg: function(rad) {
+        return (180 * rad / Math.PI) % 360;
+    },
+
+    deg2Rad: function(deg) {
+        return (Math.PI * deg / 180) % (2 * Math.PI);
+    },
+
+    /**
+     * @return {Number} absolute difference between the two given angles wich must be in radian and belong
+     * to [0,2π[
+     */
+    angleDiff: function(angle1, angle2) {
+        var dif = angle1 - angle2;
+
+        if (dif < -Math.PI) {
+            dif += 2 * Math.PI;
+        } else if (dif > Math.PI) {
+            dif -= 2 * Math.PI;
+        }
+
+        return Math.abs(dif);
+    },
+
+    parseParams: function() {
+        var params = {};
+
+        var tmp = window.location.search.substr(1).split("&"); // Adresse ex: http://www.itowns.fr/viewer/laserADVIewer.html?date=2008_05_05&hour=14&seconds=350&easting=655550.2&northing=6866565.3
+        for (i = 0; i < tmp.length; i++) {
+            data = tmp[i].split("=");
+            params[data[0].toLowerCase()] = data[1];
+        }
+        //http://localhost/termob3/?easting=652630.51&northing=6861728.03&mobile=false&nc=false
+        params.panoname = params.panoname || "TerMob2-130116_0923-00-00002_0000623";
+        params.easting = params.easting || 651110;
+        params.northing = params.northing || 6861835;
+        params.heading = params.heading || 0;
+        params.duree = params.duree || "25";
+        params.particlesize = params.particlesize || "0.01";
+        params.mobile = params.mobile == "true" || false;
+        params.nc = params.nc == "true" || false; // nodecontroller to control camera from phone accelerometer
 
 
-        snd: null, // Sound player (for fun)
-        snd2: null, // When mixing another sound
-        /**
-         * Return the hexadecimal reprensentation of an integer (expressed in base 10)
-         */
+        if (typeof(params.debug) === "undefined" || params.debug !== "true") {
+            params.debug = false;
+        } else {
+            params.debug = true;
+        }
+
+        //dinhnq : to initialize Opendata Modules
+
+        // params.easting = params.easting || "655550.2";
+        // params.northing = params.northing || "6866565.3";
+        // params.altitude = params.altitude || "0.0";    
+        return params;
+    },
+
+    /**
+     * @todo Clean it (global var)
+     */
+    getInitialInfoAndLoad: function(infoArray) {
+
+        if (typeof(infoArray) === "undefined") {
+            var req = new IT.RequestGIS("php/getInfoFromName.php?panoname=" + params.panoname);
+            req.sendCommand(IT.Utils.getInitialInfoAndLoad);
+        } else {
+
+            var info = {};
+            info.easting = infoArray[0].split("=")[1];
+            info.northing = infoArray[1].split("=")[1];
+            info.altitude = infoArray[2].split("=")[1];
+            info.heading = infoArray[3].split("=")[1];
+            info.pitch = infoArray[4].split("=")[1];
+            info.roll = infoArray[5].split("=")[1];
+
+            var time = infoArray[6].split("=")[1].split(":");
+            info.hour = time[0];
+            info.second = parseInt(time[1]) * 60 + parseInt(time[2])
+            info.near_address_num = infoArray[7].split("=")[1];
+            info.near_address_name = infoArray[8].split("=")[1];
+            info.date = infoArray[9].split("=")[1].replace(/-/g, "_").trim();
+
+            var currentPanoX = pano.panoInfo.easting;
+            var currentPanoY = pano.panoInfo.altitude;
+            var currentPanoZ = pano.panoInfo.northing;
+            pano.name = params.panoname;
+            pano.url = serverInfos.url + serverInfos.iipService + "/" + params.panoname + ".jp2";
+
+            pano.panoInfo.easting = info.easting;
+            pano.panoInfo.northing = info.northing;
+            pano.panoInfo.altitude = info.altitude;
+            pano.panoInfo.pan_xml_heading_pp = info.heading;
+            pano.panoInfo.pan_xml_pitch_pp = info.pitch;
+            pano.panoInfo.pan_xml_roll_pp = info.roll;
+            pano.loadUrl(pano.url);
+
+            console.log(pano.panoInfo.easting - initialInfo['easting']);
+            pano.updateGlobalPano(new THREE.Vector3(pano.panoInfo.easting - initialInfo['easting'],
+                    pano.panoInfo.altitude - initialInfo['altitude'],
+                    pano.panoInfo.northing - initialInfo['northing']),
+                new THREE.Vector3(IT.Utils.deg2Rad(pano.panoInfo.pan_xml_roll_pp),
+                    IT.Utils.deg2Rad(pano.panoInfo.pan_xml_heading_pp),
+                    IT.Utils.deg2Rad(pano.panoInfo.pan_xml_pitch_pp)));
 
 
-        toHex: function(number, min) {
-            var hexes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
-            var hex = '';
-            var min = min || 2;
-            var nibble;
-
-            do {
-                nibble = number & 0x0f;
-                number = number >> 4;
-                hex = hexes[nibble] + hex;
-            } while (number);
-
-            if (hex.length < min) {
-                hex = new Array(min - hex.length + 1).join('0') + hex;
+            var translation = {
+                x: pano.panoInfo.easting - currentPanoX,
+                y: pano.panoInfo.altitude - currentPanoY,
+                z: pano.panoInfo.northing - currentPanoZ
             }
 
-            return '0x' + hex;
-        },
+            translatX += translation.x;
+            translatY += translation.y;
+            translatZ += translation.z;
 
-        /**
-         * Get the total offset (top, left) of DOM element, including his parents offset
-         * 
-         * @param {Object} element The DOM element 
-         * @return : {Object} Object with properties top and left (calculated offset)
-         */
-        getOffset: function(element) {
-            var top = 0,
-                left = 0;
-            do {
-                top += element.offsetTop;
-                left += element.offsetLeft;
-            } while (element = element.offsetParent);
 
-            return {
-                top: top,
-                left: left
-            };
-        },
+            camera.position.x = translatX;
+            camera.position.y = translatY;
+            camera.position.z = translatZ;
 
-        rad2Deg: function(rad) {
-            return (180 * rad / Math.PI) % 360;
-        },
-
-        deg2Rad: function(deg) {
-            return (Math.PI * deg / 180) % (2 * Math.PI);
-        },
-
-        /**
-         * @return {Number} absolute difference between the two given angles wich must be in radian and belong
-         * to [0,2π[
-         */
-        angleDiff: function(angle1, angle2) {
-            var dif = angle1 - angle2;
-
-            if (dif < -Math.PI) {
-                dif += 2 * Math.PI;
-            } else if (dif > Math.PI) {
-                dif -= 2 * Math.PI;
+            //translating the current position on the map if it has not been done yet
+            if (map) {
+                map.movePositionOnMap(translation);
             }
 
-            return Math.abs(dif);
-        },
+            IT.Utils.cameraLookAtPosition(intersectionX, intersectionY, intersectionZ, camera.position.x, camera.position.y, camera.position.z);
+            //this.cameraLookAtPosition(0,0,this.camera.position.x,this.camera.position.z);
+            //IT.Utils.getInitialInfoAndLoad
 
-        parseParams: function() {
-            var params = {};
+        }
+    },
 
-            var tmp = window.location.search.substr(1).split("&"); // Adresse ex: http://www.itowns.fr/viewer/laserADVIewer.html?date=2008_05_05&hour=14&seconds=350&easting=655550.2&northing=6866565.3
-            for (i = 0; i < tmp.length; i++) {
-                data = tmp[i].split("=");
-                params[data[0].toLowerCase()] = data[1];
-            }
-            //http://localhost/termob3/?easting=652630.51&northing=6861728.03&mobile=false&nc=false
-            params.panoname = params.panoname || "TerMob2-130116_0923-00-00002_0000623";
-            params.easting = params.easting || 651110;
-            params.northing = params.northing || 6861835;
-            params.heading = params.heading || 0;
-            params.duree = params.duree || "25";
-            params.particlesize = params.particlesize || "0.01";
-            params.mobile = params.mobile == "true" || false;
-            params.nc = params.nc == "true" || false; // nodecontroller to control camera from phone accelerometer
+    /**
+     * Function that make the cam look at a special 3D (2D) point knowing his future position. 
+     * x1,z1 target of intersection , x2 z2 position of cam after translation in center of pano.
+     * @todo : Clean it (delete global var uses)
+     */
+    cameraLookAtPosition: function(x1, y1, z1, x2, y2, z2, headingCorrection) {
 
 
-            if (typeof(params.debug) === "undefined" || params.debug !== "true") {
-                params.debug = false;
-            } else {
-                params.debug = true;
-            }
+        var alpha = Math.atan2(x1 - x2, z1 - z2);
+        var d = 100000;
+        anglecameraLon = alpha;
+        var x = -distTarget * Math.sin(anglecameraLon);
+        var z = -distTarget * Math.cos(anglecameraLon);
 
-            //dinhnq : to initialize Opendata Modules
+        var base = Math.sqrt((x1 - x2) * (x1 - x2) + (z1 - z2) * (z1 - z2));
+        var beta = Math.atan2(y1 - y2, base);
+        console.log(beta);
+        anglecameraLat = -beta;
+        var y = -distTarget * Math.sin(beta);
 
-            // params.easting = params.easting || "655550.2";
-            // params.northing = params.northing || "6866565.3";
-            // params.altitude = params.altitude || "0.0";    
-            return params;
-        },
+        camrotxwanted = x;
+        camrotywanted = y;
+        camrotzwanted = z;
+    },
 
-        /**
-         * @todo Clean it (global var)
-         */
-        getInitialInfoAndLoad: function(infoArray) {
+    outputMatrix4: function(mat) {
+        console.debug(mat.elements[0] + " " + mat.elements[4] + " " + mat.elements[8] + " " + mat.elements[12] + "\n" +
+            mat.elements[1] + " " + mat.elements[5] + " " + mat.elements[9] + " " + mat.elements[13] + "\n" +
+            mat.elements[2] + " " + mat.elements[6] + " " + mat.elements[10] + " " + mat.elements[14] + "\n" +
+            mat.elements[3] + " " + mat.elements[7] + " " + mat.elements[11] + " " + mat.elements[15]);
+    },
 
-            if (typeof(infoArray) === "undefined") {
-                var req = new IT.RequestGIS("php/getInfoFromName.php?panoname=" + params.panoname);
-                req.sendCommand(IT.Utils.getInitialInfoAndLoad);
-            } else {
+    inDivArea: function(x, y, divID) {
+        var divMap = $(divID)[0];
+        var isInDiv = false;
+        var divOffset = Utils.getOffset(divMap);
 
-                var info = {};
-                info.easting = infoArray[0].split("=")[1];
-                info.northing = infoArray[1].split("=")[1];
-                info.altitude = infoArray[2].split("=")[1];
-                info.heading = infoArray[3].split("=")[1];
-                info.pitch = infoArray[4].split("=")[1];
-                info.roll = infoArray[5].split("=")[1];
+        if (x >= divOffset.left && x <= (divOffset.left + divMap.offsetWidth) &&
+            y >= divOffset.top && y <= (divOffset.top + divMap.offsetHeight)) {
+            isInDiv = true;
+        }
+        return isInDiv;
+    },
 
-                var time = infoArray[6].split("=")[1].split(":");
-                info.hour = time[0];
-                info.second = parseInt(time[1]) * 60 + parseInt(time[2])
-                info.near_address_num = infoArray[7].split("=")[1];
-                info.near_address_name = infoArray[8].split("=")[1];
-                info.date = infoArray[9].split("=")[1].replace(/-/g, "_").trim();
+    clamp: function(val, range) {
+        if (val < range.min) {
+            val = rangemin;
+        }
 
-                var currentPanoX = pano.panoInfo.easting;
-                var currentPanoY = pano.panoInfo.altitude;
-                var currentPanoZ = pano.panoInfo.northing;
-                pano.name = params.panoname;
-                pano.url = serverInfos.url + serverInfos.iipService + "/" + params.panoname + ".jp2";
+        if (val > max) {
+            val = max;
+        }
 
-                pano.panoInfo.easting = info.easting;
-                pano.panoInfo.northing = info.northing;
-                pano.panoInfo.altitude = info.altitude;
-                pano.panoInfo.pan_xml_heading_pp = info.heading;
-                pano.panoInfo.pan_xml_pitch_pp = info.pitch;
-                pano.panoInfo.pan_xml_roll_pp = info.roll;
-                pano.loadUrl(pano.url);
+        return val;
+    },
 
-                console.log(pano.panoInfo.easting - initialInfo['easting']);
-                pano.updateGlobalPano(new THREE.Vector3(pano.panoInfo.easting - initialInfo['easting'],
-                        pano.panoInfo.altitude - initialInfo['altitude'],
-                        pano.panoInfo.northing - initialInfo['northing']),
-                    new THREE.Vector3(IT.Utils.deg2Rad(pano.panoInfo.pan_xml_roll_pp),
-                        IT.Utils.deg2Rad(pano.panoInfo.pan_xml_heading_pp),
-                        IT.Utils.deg2Rad(pano.panoInfo.pan_xml_pitch_pp)));
-
-
-                var translation = {
-                    x: pano.panoInfo.easting - currentPanoX,
-                    y: pano.panoInfo.altitude - currentPanoY,
-                    z: pano.panoInfo.northing - currentPanoZ
-                }
-
-                translatX += translation.x;
-                translatY += translation.y;
-                translatZ += translation.z;
-
-
-                camera.position.x = translatX;
-                camera.position.y = translatY;
-                camera.position.z = translatZ;
-
-                //translating the current position on the map if it has not been done yet
-                if (map) {
-                    map.movePositionOnMap(translation);
-                }
-
-                IT.Utils.cameraLookAtPosition(intersectionX, intersectionY, intersectionZ, camera.position.x, camera.position.y, camera.position.z);
-                //this.cameraLookAtPosition(0,0,this.camera.position.x,this.camera.position.z);
-                //IT.Utils.getInitialInfoAndLoad
-
-            }
-        },
-
-        /**
-         * Function that make the cam look at a special 3D (2D) point knowing his future position. 
-         * x1,z1 target of intersection , x2 z2 position of cam after translation in center of pano.
-         * @todo : Clean it (delete global var uses)
-         */
-        cameraLookAtPosition: function(x1, y1, z1, x2, y2, z2, headingCorrection) {
-
-
-            var alpha = Math.atan2(x1 - x2, z1 - z2);
-            var d = 100000;
-            anglecameraLon = alpha;
-            var x = -distTarget * Math.sin(anglecameraLon);
-            var z = -distTarget * Math.cos(anglecameraLon);
-
-            var base = Math.sqrt((x1 - x2) * (x1 - x2) + (z1 - z2) * (z1 - z2));
-            var beta = Math.atan2(y1 - y2, base);
-            console.log(beta);
-            anglecameraLat = -beta;
-            var y = -distTarget * Math.sin(beta);
-
-            camrotxwanted = x;
-            camrotywanted = y;
-            camrotzwanted = z;
-        },
-
-        outputMatrix4: function(mat) {
-            console.debug(mat.elements[0] + " " + mat.elements[4] + " " + mat.elements[8] + " " + mat.elements[12] + "\n" +
-                mat.elements[1] + " " + mat.elements[5] + " " + mat.elements[9] + " " + mat.elements[13] + "\n" +
-                mat.elements[2] + " " + mat.elements[6] + " " + mat.elements[10] + " " + mat.elements[14] + "\n" +
-                mat.elements[3] + " " + mat.elements[7] + " " + mat.elements[11] + " " + mat.elements[15]);
-        },
-
-        inDivArea: function(x, y, divID) {
-            var divMap = $(divID)[0];
-            var isInDiv = false;
-            var divOffset = Utils.getOffset(divMap);
-
-            if (x >= divOffset.left && x <= (divOffset.left + divMap.offsetWidth) &&
-                y >= divOffset.top && y <= (divOffset.top + divMap.offsetHeight)) {
-                isInDiv = true;
-            }
-            return isInDiv;
-        },
-
-        clamp: function(val, range) {
-            if (val < range.min) {
-                val = rangemin;
-            }
-
-            if (val > max) {
-                val = max;
-            }
-
+    clampMin: function(val, min) {
+        if (val < min) {
+            return min;
+        } else {
             return val;
-        },
-
-        clampMin: function(val, min) {
-            if (val < min) {
-                return min;
-            } else {
-                return val;
-            }
-        },
-
-        clampMax: function(val, max) {
-            if (val > max) {
-                return max;
-            } else {
-                return val;
-            }
-        },
-
-        /**
-         * Convert 2D coordinates from screen space ranging from [0..window.innerWidth] in x and [0..window.innerHeight]
-         * in y to Normalized Device Coordinates (NDC) ranging from [-1..1] in x and [-1..1] in y
-         * @return {Object} Converted point (x,y) 
-         */
-        toNDC: function(x, y) {
-            return {
-                x: (x / (window.innerWidth)) * 2 - 1,
-                y: -(y / (window.innerHeight)) * 2 + 1
-            };
-        },
-
-        /**
-         * toNDC inverse function (i.e convert from NDC space to screen space)
-         * @return {Object} Converted point (x,y)
-         * @see toNDC 
-         */
-        toScreenSpace: function(x, y) {
-            return {
-                x: (x + 1) / 2 * window.innerWidth,
-                y: -(y - 1) / 2 * window.innerHeigth
-            };
-        },
-
-        notYetImplemented: function() {
-            throw new Error("Not yet implented !");
-        },
-
-        noPanoramic: function() {
-            alert("No panoramic found at that position");
-        },
-
-
-
-        loadTexture: function(path) {
-
-            var texture = new THREE.Texture(texture_placeholder);
-            var material = new THREE.MeshBasicMaterial({
-                map: texture,
-                overdraw: true
-            });
-
-            var image = new Image();
-            image.onload = function() {
-
-                texture.needsUpdate = true;
-                material.map.image = this;
-
-                render();
-
-            };
-            image.src = path;
-
-            return material;
-
-        },
-
-        // SAVE Good old THREE matrix functions
-        translate: function(matrix, v) {
-
-            var te = matrix.elements;
-            var x = v.x,
-                y = v.y,
-                z = v.z;
-
-            te[12] = te[0] * x + te[4] * y + te[8] * z + te[12];
-            te[13] = te[1] * x + te[5] * y + te[9] * z + te[13];
-            te[14] = te[2] * x + te[6] * y + te[10] * z + te[14];
-            te[15] = te[3] * x + te[7] * y + te[11] * z + te[15];
-
-            return matrix;
-        },
-
-        rotateX: function(matrix, angle) {
-
-            var te = matrix.elements;
-            var m12 = te[4];
-            var m22 = te[5];
-            var m32 = te[6];
-            var m42 = te[7];
-            var m13 = te[8];
-            var m23 = te[9];
-            var m33 = te[10];
-            var m43 = te[11];
-            var c = Math.cos(angle);
-            var s = Math.sin(angle);
+        }
+    },
+
+    clampMax: function(val, max) {
+        if (val > max) {
+            return max;
+        } else {
+            return val;
+        }
+    },
+
+    /**
+     * Convert 2D coordinates from screen space ranging from [0..window.innerWidth] in x and [0..window.innerHeight]
+     * in y to Normalized Device Coordinates (NDC) ranging from [-1..1] in x and [-1..1] in y
+     * @return {Object} Converted point (x,y) 
+     */
+    toNDC: function(x, y) {
+        return {
+            x: (x / (window.innerWidth)) * 2 - 1,
+            y: -(y / (window.innerHeight)) * 2 + 1
+        };
+    },
+
+    /**
+     * toNDC inverse function (i.e convert from NDC space to screen space)
+     * @return {Object} Converted point (x,y)
+     * @see toNDC 
+     */
+    toScreenSpace: function(x, y) {
+        return {
+            x: (x + 1) / 2 * window.innerWidth,
+            y: -(y - 1) / 2 * window.innerHeigth
+        };
+    },
+
+    notYetImplemented: function() {
+        throw new Error("Not yet implented !");
+    },
+
+    noPanoramic: function() {
+        alert("No panoramic found at that position");
+    },
+
+
+
+    loadTexture: function(path) {
+
+        var texture = new THREE.Texture(texture_placeholder);
+        var material = new THREE.MeshBasicMaterial({
+            map: texture,
+            overdraw: true
+        });
+
+        var image = new Image();
+        image.onload = function() {
+
+            texture.needsUpdate = true;
+            material.map.image = this;
+
+            render();
+
+        };
+        image.src = path;
+
+        return material;
+
+    },
+
+    // SAVE Good old THREE matrix functions
+    translate: function(matrix, v) {
+
+        var te = matrix.elements;
+        var x = v.x,
+            y = v.y,
+            z = v.z;
+
+        te[12] = te[0] * x + te[4] * y + te[8] * z + te[12];
+        te[13] = te[1] * x + te[5] * y + te[9] * z + te[13];
+        te[14] = te[2] * x + te[6] * y + te[10] * z + te[14];
+        te[15] = te[3] * x + te[7] * y + te[11] * z + te[15];
+
+        return matrix;
+    },
+
+    rotateX: function(matrix, angle) {
+
+        var te = matrix.elements;
+        var m12 = te[4];
+        var m22 = te[5];
+        var m32 = te[6];
+        var m42 = te[7];
+        var m13 = te[8];
+        var m23 = te[9];
+        var m33 = te[10];
+        var m43 = te[11];
+        var c = Math.cos(angle);
+        var s = Math.sin(angle);
+
+        te[4] = c * m12 + s * m13;
+        te[5] = c * m22 + s * m23;
+        te[6] = c * m32 + s * m33;
+        te[7] = c * m42 + s * m43;
 
-            te[4] = c * m12 + s * m13;
-            te[5] = c * m22 + s * m23;
-            te[6] = c * m32 + s * m33;
-            te[7] = c * m42 + s * m43;
-
-            te[8] = c * m13 - s * m12;
-            te[9] = c * m23 - s * m22;
-            te[10] = c * m33 - s * m32;
-            te[11] = c * m43 - s * m42;
-
-            return matrix;
-
-        },
-
-        rotateY: function(matrix, angle) {
-
-            var te = matrix.elements;
-            var m11 = te[0];
-            var m21 = te[1];
-            var m31 = te[2];
-            var m41 = te[3];
-            var m13 = te[8];
-            var m23 = te[9];
-            var m33 = te[10];
-            var m43 = te[11];
-            var c = Math.cos(angle);
-            var s = Math.sin(angle);
-
-            te[0] = c * m11 - s * m13;
-            te[1] = c * m21 - s * m23;
-            te[2] = c * m31 - s * m33;
-            te[3] = c * m41 - s * m43;
-
-            te[8] = c * m13 + s * m11;
-            te[9] = c * m23 + s * m21;
-            te[10] = c * m33 + s * m31;
-            te[11] = c * m43 + s * m41;
-
-            return matrix;
-        },
-
-        rotateZ: function(matrix, angle) {
-
-            var te = matrix.elements;
-            var m11 = te[0];
-            var m21 = te[1];
-            var m31 = te[2];
-            var m41 = te[3];
-            var m12 = te[4];
-            var m22 = te[5];
-            var m32 = te[6];
-            var m42 = te[7];
-            var c = Math.cos(angle);
-            var s = Math.sin(angle);
-
-            te[0] = c * m11 + s * m12;
-            te[1] = c * m21 + s * m22;
-            te[2] = c * m31 + s * m32;
-            te[3] = c * m41 + s * m42;
-
-            te[4] = c * m12 - s * m11;
-            te[5] = c * m22 - s * m21;
-            te[6] = c * m32 - s * m31;
-            te[7] = c * m42 - s * m41;
-
-            return matrix;
-        },
-
-        rotateByAxis: function(matrix, axis, angle) {
-
-            var te = matrix.elements;
-
-            // optimize by checking axis
-
-            if (axis.x === 1 && axis.y === 0 && axis.z === 0) {
-
-                return this.rotateX(matrix, angle);
-
-            } else if (axis.x === 0 && axis.y === 1 && axis.z === 0) {
-
-                return this.rotateY(matrix, angle);
-
-            } else if (axis.x === 0 && axis.y === 0 && axis.z === 1) {
-
-                return this.rotateZ(matrix, angle);
-
-            }
-
-            var x = axis.x,
-                y = axis.y,
-                z = axis.z;
-            var n = Math.sqrt(x * x + y * y + z * z);
-
-            x /= n;
-            y /= n;
-            z /= n;
-
-            var xx = x * x,
-                yy = y * y,
-                zz = z * z;
-            var c = Math.cos(angle);
-            var s = Math.sin(angle);
-            var oneMinusCosine = 1 - c;
-            var xy = x * y * oneMinusCosine;
-            var xz = x * z * oneMinusCosine;
-            var yz = y * z * oneMinusCosine;
-            var xs = x * s;
-            var ys = y * s;
-            var zs = z * s;
-
-            var r11 = xx + (1 - xx) * c;
-            var r21 = xy + zs;
-            var r31 = xz - ys;
-            var r12 = xy - zs;
-            var r22 = yy + (1 - yy) * c;
-            var r32 = yz + xs;
-            var r13 = xz + ys;
-            var r23 = yz - xs;
-            var r33 = zz + (1 - zz) * c;
-
-            var m11 = te[0],
-                m21 = te[1],
-                m31 = te[2],
-                m41 = te[3];
-            var m12 = te[4],
-                m22 = te[5],
-                m32 = te[6],
-                m42 = te[7];
-            var m13 = te[8],
-                m23 = te[9],
-                m33 = te[10],
-                m43 = te[11];
-
-            te[0] = r11 * m11 + r21 * m12 + r31 * m13;
-            te[1] = r11 * m21 + r21 * m22 + r31 * m23;
-            te[2] = r11 * m31 + r21 * m32 + r31 * m33;
-            te[3] = r11 * m41 + r21 * m42 + r31 * m43;
-
-            te[4] = r12 * m11 + r22 * m12 + r32 * m13;
-            te[5] = r12 * m21 + r22 * m22 + r32 * m23;
-            te[6] = r12 * m31 + r22 * m32 + r32 * m33;
-            te[7] = r12 * m41 + r22 * m42 + r32 * m43;
-
-            te[8] = r13 * m11 + r23 * m12 + r33 * m13;
-            te[9] = r13 * m21 + r23 * m22 + r33 * m23;
-            te[10] = r13 * m31 + r23 * m32 + r33 * m33;
-            te[11] = r13 * m41 + r23 * m42 + r33 * m43;
-
-            return matrix;
-
-        },
-        //dinhnq-- invers matrix, need for opendata module
-        /*
-         * The inverse of a 2x2 matrix:
-            | a11 a12 |-1             |  a22 -a12 |
-            | a21 a22 |    =  1/DET * | -a21  a11 |
-            with DET  =  a11a22-a12a21
-         */
-        invMatrix2x2: function(a, b, c, d) {
-            //A = [a,b;c,d] => inv(A) = (1/detA)[d,-b;-c,a]
-            var ret = new Array(4);
-            var detA = 1 / (a * d - b * c);
-            ret[0] = detA * d;
-            ret[1] = -detA * b;
-            ret[2] = -detA * c;
-            ret[3] = detA * a;
-            return ret;
-        },
-
-        /*
-         * The inverse of a 3x3 matrix:
-        | a11 a12 a13 |-1             |   a33a22-a32a23  -(a33a12-a32a13)   a23a12-a22a13  |
-        | a21 a22 a23 |    =  1/DET * | -(a33a21-a31a23)   a33a11-a31a13  -(a23a11-a21a13) |
-        | a31 a32 a33 |               |   a32a21-a31a22  -(a32a11-a31a12)   a22a11-a21a12  |
-        with DET  =  a11(a33a22-a32a23)-a21(a33a12-a32a13)+a31(a23a12-a22a13)
-        */
-
-        invMatrix3x3: function(a11, a12, a13, a21, a22, a23, a31, a32, a33) {
-            detA = 1 / (a11(a33 * a22 - a32 * a23) - a21(a33 * a12 - a32 * a13) + a31 * (a23 * a12 - a22 * a13));
-            var ret = new Array(9);
-            ret[0] = detA * (a33 * a22 - a32 * a23);
-            ret[1] = -detA * (a33 * a12 - a32 * a13);
-            ret[2] = detA * (a23 * a12 - a22 * a13);
-            ret[3] = -detA * (a33 * a21 - a31 * a23)
-            ret[4] = detA * (a33 * a11 - a31 * a13);
-            ret[5] = -detA * (a23 * a11 - a21 * a13);
-            ret[6] = detA * (a32 * a21 - a31 * a22);
-            ret[7] = -detA * (a32 * a11 - a31 * a12);
-            ret[8] = detA * (a22 * a11 - a21 * a12);
-            return ret;
-        },
-
-        invMatrix4x4: function(matrix, result) {
-            var result = new Array(16);
-            var tmp_0 = matrix[10] * matrix[15];
-            var tmp_1 = matrix[14] * matrix[11];
-            var tmp_2 = matrix[6] * matrix[15];
-            var tmp_3 = matrix[14] * matrix[7];
-            var tmp_4 = matrix[6] * matrix[11];
-            var tmp_5 = matrix[10] * matrix[7];
-            var tmp_6 = matrix[2] * matrix[15];
-            var tmp_7 = matrix[14] * matrix[3];
-            var tmp_8 = matrix[2] * matrix[11];
-            var tmp_9 = matrix[10] * matrix[3];
-            var tmp_10 = matrix[2] * matrix[7];
-            var tmp_11 = matrix[6] * matrix[3];
-            var tmp_12 = matrix[8] * matrix[13];
-            var tmp_13 = matrix[12] * matrix[9];
-            var tmp_14 = matrix[4] * matrix[13];
-            var tmp_15 = matrix[12] * matrix[5];
-            var tmp_16 = matrix[4] * matrix[9];
-            var tmp_17 = matrix[8] * matrix[5];
-            var tmp_18 = matrix[0] * matrix[13];
-            var tmp_19 = matrix[12] * matrix[1];
-            var tmp_20 = matrix[0] * matrix[9];
-            var tmp_21 = matrix[8] * matrix[1];
-            var tmp_22 = matrix[0] * matrix[5];
-            var tmp_23 = matrix[4] * matrix[1];
-
-            var t0 = ((tmp_0 * matrix[5] + tmp_3 * matrix[9] + tmp_4 * matrix[13]) - (tmp_1 * matrix[5] + tmp_2 * matrix[9] + tmp_5 * matrix[13]));
-            var t1 = ((tmp_1 * matrix[1] + tmp_6 * matrix[9] + tmp_9 * matrix[13]) - (tmp_0 * matrix[1] + tmp_7 * matrix[9] + tmp_8 * matrix[13]));
-            var t2 = ((tmp_2 * matrix[1] + tmp_7 * matrix[5] + tmp_10 * matrix[13]) - (tmp_3 * matrix[1] + tmp_6 * matrix[5] + tmp_11 * matrix[13]));
-            var t3 = ((tmp_5 * matrix[1] + tmp_8 * matrix[5] + tmp_11 * matrix[9]) - (tmp_4 * matrix[1] + tmp_9 * matrix[5] + tmp_10 * matrix[9]));
-
-            var d1 = (matrix[0] * t0 + matrix[4] * t1 + matrix[8] * t2 + matrix[12] * t3);
-            if (Math.abs(d1) < 1e-5) {
-                console.log("Warning can't inverse matrix " + matrix);
-                if (result !== undefined) {
-                    return false;
-                } else {
-                    result = [1.0, 0.0, 0.0, 0.0,
-                        0.0, 1.0, 0.0, 0.0,
-                        0.0, 0.0, 1.0, 0.0,
-                        0.0, 0.0, 0.0, 1.0
-                    ];;
-                }
-            }
-            var d = 1.0 / d1;
-
-            var out_00 = d * t0;
-            var out_01 = d * t1;
-            var out_02 = d * t2;
-            var out_03 = d * t3;
-
-            var out_10 = d * ((tmp_1 * matrix[4] + tmp_2 * matrix[8] + tmp_5 * matrix[12]) - (tmp_0 * matrix[4] + tmp_3 * matrix[8] + tmp_4 * matrix[12]));
-            var out_11 = d * ((tmp_0 * matrix[0] + tmp_7 * matrix[8] + tmp_8 * matrix[12]) - (tmp_1 * matrix[0] + tmp_6 * matrix[8] + tmp_9 * matrix[12]));
-            var out_12 = d * ((tmp_3 * matrix[0] + tmp_6 * matrix[4] + tmp_11 * matrix[12]) - (tmp_2 * matrix[0] + tmp_7 * matrix[4] + tmp_10 * matrix[12]));
-            var out_13 = d * ((tmp_4 * matrix[0] + tmp_9 * matrix[4] + tmp_10 * matrix[8]) - (tmp_5 * matrix[0] + tmp_8 * matrix[4] + tmp_11 * matrix[8]));
-
-            var out_20 = d * ((tmp_12 * matrix[7] + tmp_15 * matrix[11] + tmp_16 * matrix[15]) - (tmp_13 * matrix[7] + tmp_14 * matrix[11] + tmp_17 * matrix[15]));
-            var out_21 = d * ((tmp_13 * matrix[3] + tmp_18 * matrix[11] + tmp_21 * matrix[15]) - (tmp_12 * matrix[3] + tmp_19 * matrix[11] + tmp_20 * matrix[15]));
-            var out_22 = d * ((tmp_14 * matrix[3] + tmp_19 * matrix[7] + tmp_22 * matrix[15]) - (tmp_15 * matrix[3] + tmp_18 * matrix[7] + tmp_23 * matrix[15]));
-            var out_23 = d * ((tmp_17 * matrix[3] + tmp_20 * matrix[7] + tmp_23 * matrix[11]) - (tmp_16 * matrix[3] + tmp_21 * matrix[7] + tmp_22 * matrix[11]));
-
-            var out_30 = d * ((tmp_14 * matrix[10] + tmp_17 * matrix[14] + tmp_13 * matrix[6]) - (tmp_16 * matrix[14] + tmp_12 * matrix[6] + tmp_15 * matrix[10]));
-            var out_31 = d * ((tmp_20 * matrix[14] + tmp_12 * matrix[2] + tmp_19 * matrix[10]) - (tmp_18 * matrix[10] + tmp_21 * matrix[14] + tmp_13 * matrix[2]));
-            var out_32 = d * ((tmp_18 * matrix[6] + tmp_23 * matrix[14] + tmp_15 * matrix[2]) - (tmp_22 * matrix[14] + tmp_14 * matrix[2] + tmp_19 * matrix[6]));
-            var out_33 = d * ((tmp_22 * matrix[10] + tmp_16 * matrix[2] + tmp_21 * matrix[6]) - (tmp_20 * matrix[6] + tmp_23 * matrix[10] + tmp_17 * matrix[2]));
-
-            result[0] = out_00;
-            result[1] = out_01;
-            result[2] = out_02;
-            result[3] = out_03;
-            result[4] = out_10;
-            result[5] = out_11;
-            result[6] = out_12;
-            result[7] = out_13;
-            result[8] = out_20;
-            result[9] = out_21;
-            result[10] = out_22;
-            result[11] = out_23;
-            result[12] = out_30;
-            result[13] = out_31;
-            result[14] = out_32;
-            result[15] = out_33;
-            return result;
-        },
-
-        //----------Ray Casting------------------
-        //modify from http://polyk.ivank.net
-        //cast a ray to edge of threejs poly linestring 
-        Raycast: function(p, la, x, y, dx, dy, isc) {
-
-            var l = p.length;
-            var a1 = new _P(0, 0),
-                a2 = new _P(0, 0),
-                b1 = new _P(0, 0),
-                b2 = new _P(0, 0),
-                c = new _P(0, 0);
-            //ray line    
-            a1.x = x;
-            a1.y = y;
-            a2.x = x + dx;
-            a2.y = y + dy;
-
-            if (isc == null) isc = {
-                dist: 0,
-                edge: 0,
-                line: {
-                    x1: 0,
-                    y1: 0,
-                    x2: 0,
-                    y2: 0
-                },
-                intersectPt: {
-                    x: 0,
-                    y: 0
-                },
-                norm: {
-                    x: 0,
-                    y: 0
-                },
-                refl: {
-                    x: 0,
-                    y: 0
-                }
-            };
-            isc.dist = Infinity;
-            var j;
-            for (var i = 0; i < l; i += 2) {
-                j = i / 2;
-                if (la[j] === la[j + 1]) {
-                    b1.x = p[i];
-                    b1.y = p[i + 1];
-                    b2.x = p[i + 2];
-                    b2.y = p[i + 3];
-                    var nisc = this.RayLineIntersection(a1, a2, b1, b2, c);
-                    if (nisc) this.updateISC(dx, dy, a1, b1, b2, c, i / 2, isc, nisc);
-                }
-            }
-
-            return (isc.dist != Infinity) ? isc : null;
-        },
-
-        //cast on threejs linestring
-        Raycast2: function(p, v1, v2) {
-
-            var l = p.length;
-            var a1 = new _P(0, 0),
-                a2 = new _P(0, 0),
-                b1 = new _P(0, 0),
-                b2 = new _P(0, 0),
-                c = new _P(0, 0);
-            //ray line    
-            a1.x = v1.x;
-            a1.y = v1.z;
-            a2.x = v2.x;
-            a2.y = v2.z;
-
-            var isc = {
-                dist: 0,
-                edge: 0,
-                line: {
-                    x1: 0,
-                    y1: 0,
-                    x2: 0,
-                    y2: 0
-                },
-                intersectPt: {
-                    x: 0,
-                    y: 0
-                },
-                norm: {
-                    x: 0,
-                    y: 0
-                },
-                refl: {
-                    x: 0,
-                    y: 0
-                }
-            };
-            isc.dist = Infinity;
-            for (var i = 0; i < l; i += 2) {
-                b1.x = p[i].x;
-                b1.y = p[i].z;
-                b2.x = p[i + 1].x;
-                b2.y = p[i + 1].z;
-                var nisc = this.RayLineIntersection(a1, a2, b1, b2, c);
-                if (nisc) this.updateISC(v2.x, v2.y, a1, b1, b2, c, i / 2, isc, nisc);
-            }
-
-            return (isc.dist != Infinity) ? isc : null;
-        },
-
-        RayLineIntersection: function(a1, a2, b1, b2, c) {
-            var dax = (a1.x - a2.x),
-                dbx = (b1.x - b2.x);
-            var day = (a1.y - a2.y),
-                dby = (b1.y - b2.y);
-
-            var Den = dax * dby - day * dbx;
-            if (Den == 0) return null; // parallel
-
-            var A = (a1.x * a2.y - a1.y * a2.x);
-            var B = (b1.x * b2.y - b1.y * b2.x);
-
-            var I = c;
-            var iDen = 1 / Den;
-            I.x = (A * dbx - dax * B) * iDen;
-            I.y = (A * dby - day * B) * iDen;
-
-            if (!this.InRect(I, b1, b2)) return null;
-            if ((day > 0 && I.y > a1.y) || (day < 0 && I.y < a1.y)) return null;
-            if ((dax > 0 && I.x > a1.x) || (dax < 0 && I.x < a1.x)) return null;
-            return I;
-        },
-
-        InRect: function(a, b, c) {
-            if (b.x == c.x) return (a.y >= Math.min(b.y, c.y) && a.y <= Math.max(b.y, c.y));
-            if (b.y == c.y) return (a.x >= Math.min(b.x, c.x) && a.x <= Math.max(b.x, c.x));
-
-            if (a.x >= Math.min(b.x, c.x) && a.x <= Math.max(b.x, c.x) && a.y >= Math.min(b.y, c.y) && a.y <= Math.max(b.y, c.y))
-                return true;
-            return false;
-        },
-        updateISC: function(dx, dy, a1, b1, b2, c, edge, isc, I) {
-            var nrl = _P.dist(a1, c);
-            if (nrl < isc.dist) {
-                var ibl = 1 / _P.dist(b1, b2);
-                var nx = -(b2.y - b1.y) * ibl;
-                var ny = (b2.x - b1.x) * ibl;
-                var ddot = 2 * (dx * nx + dy * ny);
-                isc.dist = nrl;
-                isc.norm.x = nx;
-                isc.norm.y = ny;
-                isc.refl.x = -ddot * nx + dx;
-                isc.refl.y = -ddot * ny + dy;
-                isc.edge = edge;
-                isc.line.x1 = b1.x;
-                isc.line.y1 = b1.y;
-                isc.line.x2 = b2.x;
-                isc.line.y2 = b2.y;
-                isc.intersectPt.x = I.x;
-                isc.intersectPt.y = I.y;
-            }
-        },
-
-        //project point on closest egde of poly
-        //note: p is poly linestring of threejs    
-        projectPointOnLine: function(p, pt) {
-            var l = p.length;
-            var a1 = new _P(0, 0),
-                b1 = new _P(0, 0),
-                b2 = new _P(0, 0),
-                c = new _P(0, 0);
-            a1.x = pt.x;
-            a1.y = pt.z;
-
-            var isc = {
-                dist: Infinity,
-                edge: 0,
-                line: {
-                    x1: 0,
-                    y1: 0,
-                    x2: 0,
-                    y2: 0
-                },
-                point: {
-                    x: 0,
-                    y: 0
-                },
-                norm: {
-                    x: 0,
-                    y: 0
-                }
-            };
-            //var j;
-            for (var i = 0; i < l; i += 2) {
-                b1.x = p[i].x;
-                b1.y = p[i].z;
-                b2.x = p[i + 1].x;
-                b2.y = p[i + 1].z;
-                this.pointLineDist(a1, b1, b2, i >> 1, isc);
-            }
-
-            var idst = 1 / isc.dist;
-            isc.norm.x = (pt.x - isc.point.x) * idst;
-            isc.norm.y = (pt.z - isc.point.y) * idst;
-            return isc;
-        },
-        pointLineDist: function(p, a, b, edge, isc) {
-            var x = p.x,
-                y = p.y,
-                x1 = a.x,
-                y1 = a.y,
-                x2 = b.x,
-                y2 = b.y;
-
-            var A = x - x1;
-            var B = y - y1;
-            var C = x2 - x1;
-            var D = y2 - y1;
-
-            var dot = A * C + B * D;
-            var len_sq = C * C + D * D;
-            var param = dot / len_sq;
-
-            var xx, yy;
-
-            if (param < 0 || (x1 == x2 && y1 == y2)) {
-                xx = x1;
-                yy = y1;
-            } else if (param > 1) {
-                xx = x2;
-                yy = y2;
-            } else {
-                xx = x1 + param * C;
-                yy = y1 + param * D;
-            }
-
-            var dx = x - xx;
-            var dy = y - yy;
-            var dst = Math.sqrt(dx * dx + dy * dy);
-            if (dst < isc.dist) {
-                isc.dist = dst;
-                isc.edge = edge;
-                isc.point.x = xx;
-                isc.point.y = yy;
-                isc.line.x1 = a.x;
-                isc.line.y1 = a.y;
-                isc.line.x2 = b.x;
-                isc.line.y2 = b.y;
-            }
-        },
-
-        //slice poly into two parts, used this function to delete 
-        //artifacts from OpenData line string ray casting!
-        slice: function(p, ax, ay, bx, by) {
-            if (this.ContainsPoint(p, ax, ay) || this.ContainsPoint(p, bx, by)) return [p.slice(0)];
-
-            var a = new _P(ax, ay);
-            var b = new _P(bx, by);
-            var iscs = []; // intersections
-            var ps = []; // points
-            for (var i = 0; i < p.length; i += 2) ps.push(new _P(p[i], p[i + 1]));
-
-            for (var i = 0; i < ps.length; i++) {
-                var isc = new _P(0, 0);
-                isc = this._GetLineIntersection(a, b, ps[i], ps[(i + 1) % ps.length], isc);
-
-                if (isc) {
-                    isc.flag = true;
-                    iscs.push(isc);
-                    ps.splice(i + 1, 0, isc);
-                    i++;
-                }
-            }
-            if (iscs.length == 0) return [p.slice(0)];
-            var comp = function(u, v) {
-                return _P.dist(a, u) - _P.dist(a, v);
-            }
-            iscs.sort(comp);
-
-            var pgs = [];
-            var dir = 0;
-            while (iscs.length > 0) {
-                var n = ps.length;
-                var i0 = iscs[0];
-                var i1 = iscs[1];
-                var ind0 = ps.indexOf(i0);
-                var ind1 = ps.indexOf(i1);
-                var solved = false;
-
-                if (this._firstWithFlag(ps, ind0) == ind1) solved = true;
-                else {
-                    i0 = iscs[1];
-                    i1 = iscs[0];
-                    ind0 = ps.indexOf(i0);
-                    ind1 = ps.indexOf(i1);
-                    if (this._firstWithFlag(ps, ind0) == ind1) solved = true;
-                }
-                if (solved) {
-                    dir--;
-                    var pgn = this._getPoints(ps, ind0, ind1);
-                    pgs.push(pgn);
-                    ps = this._getPoints(ps, ind1, ind0);
-                    i0.flag = i1.flag = false;
-                    iscs.splice(0, 2);
-                    if (iscs.length == 0) pgs.push(ps);
-                } else {
-                    dir++;
-                    iscs.reverse();
-                }
-                if (dir > 1) break;
-            }
-            var result = [];
-            for (var i = 0; i < pgs.length; i++) {
-                var pg = pgs[i];
-                var npg = [];
-                for (var j = 0; j < pg.length; j++) npg.push(pg[j].x, pg[j].y);
-                result.push(npg);
-            }
-            return result;
-        },
-
-        /*TODO: use this function to check if line string points are inside poly which
-         *created from Bati 3D d'OpenData. The idea is that we do ray casting with Bati 3D
-         * to detect front of building (facades), a poly is created from these facades. Finally, we
-         * check if the lines are inside the poly which permet to hide invisible lines from scene*/
-        containsPoint: function(p, px, py) {
-            var n = p.length >> 1;
-            var ax, ay, bx = p[2 * n - 2] - px,
-                by = p[2 * n - 1] - py;
-            var depth = 0;
-            for (var i = 0; i < n; i++) {
-                ax = bx;
-                ay = by;
-                bx = p[2 * i] - px;
-                by = p[2 * i + 1] - py;
-                if (ay < 0 && by < 0) continue; // both "up" or both "donw"
-                if (ay >= 0 && by >= 0) continue; // both "up" or both "donw"
-                if (ax < 0 && bx < 0) continue;
-
-                var lx = ax + (bx - ax) * (-ay) / (by - ay);
-                if (lx > 0) depth++;
-            }
-            return (depth & 1) == 1;
-        },
-
-        //px, py sont coords d'emprise du sol        
-        extractLineStringInsidePoly: function(px, py, l) {
-            var lines = [];
-            if (px.length !== py.length) {
-                console.warn("poly bounding box have wrong structure!!!");
+        te[8] = c * m13 - s * m12;
+        te[9] = c * m23 - s * m22;
+        te[10] = c * m33 - s * m32;
+        te[11] = c * m43 - s * m42;
+
+        return matrix;
+
+    },
+
+    rotateY: function(matrix, angle) {
+
+        var te = matrix.elements;
+        var m11 = te[0];
+        var m21 = te[1];
+        var m31 = te[2];
+        var m41 = te[3];
+        var m13 = te[8];
+        var m23 = te[9];
+        var m33 = te[10];
+        var m43 = te[11];
+        var c = Math.cos(angle);
+        var s = Math.sin(angle);
+
+        te[0] = c * m11 - s * m13;
+        te[1] = c * m21 - s * m23;
+        te[2] = c * m31 - s * m33;
+        te[3] = c * m41 - s * m43;
+
+        te[8] = c * m13 + s * m11;
+        te[9] = c * m23 + s * m21;
+        te[10] = c * m33 + s * m31;
+        te[11] = c * m43 + s * m41;
+
+        return matrix;
+    },
+
+    rotateZ: function(matrix, angle) {
+
+        var te = matrix.elements;
+        var m11 = te[0];
+        var m21 = te[1];
+        var m31 = te[2];
+        var m41 = te[3];
+        var m12 = te[4];
+        var m22 = te[5];
+        var m32 = te[6];
+        var m42 = te[7];
+        var c = Math.cos(angle);
+        var s = Math.sin(angle);
+
+        te[0] = c * m11 + s * m12;
+        te[1] = c * m21 + s * m22;
+        te[2] = c * m31 + s * m32;
+        te[3] = c * m41 + s * m42;
+
+        te[4] = c * m12 - s * m11;
+        te[5] = c * m22 - s * m21;
+        te[6] = c * m32 - s * m31;
+        te[7] = c * m42 - s * m41;
+
+        return matrix;
+    },
+
+    rotateByAxis: function(matrix, axis, angle) {
+
+        var te = matrix.elements;
+
+        // optimize by checking axis
+
+        if (axis.x === 1 && axis.y === 0 && axis.z === 0) {
+
+            return this.rotateX(matrix, angle);
+
+        } else if (axis.x === 0 && axis.y === 1 && axis.z === 0) {
+
+            return this.rotateY(matrix, angle);
+
+        } else if (axis.x === 0 && axis.y === 0 && axis.z === 1) {
+
+            return this.rotateZ(matrix, angle);
+
+        }
+
+        var x = axis.x,
+            y = axis.y,
+            z = axis.z;
+        var n = Math.sqrt(x * x + y * y + z * z);
+
+        x /= n;
+        y /= n;
+        z /= n;
+
+        var xx = x * x,
+            yy = y * y,
+            zz = z * z;
+        var c = Math.cos(angle);
+        var s = Math.sin(angle);
+        var oneMinusCosine = 1 - c;
+        var xy = x * y * oneMinusCosine;
+        var xz = x * z * oneMinusCosine;
+        var yz = y * z * oneMinusCosine;
+        var xs = x * s;
+        var ys = y * s;
+        var zs = z * s;
+
+        var r11 = xx + (1 - xx) * c;
+        var r21 = xy + zs;
+        var r31 = xz - ys;
+        var r12 = xy - zs;
+        var r22 = yy + (1 - yy) * c;
+        var r32 = yz + xs;
+        var r13 = xz + ys;
+        var r23 = yz - xs;
+        var r33 = zz + (1 - zz) * c;
+
+        var m11 = te[0],
+            m21 = te[1],
+            m31 = te[2],
+            m41 = te[3];
+        var m12 = te[4],
+            m22 = te[5],
+            m32 = te[6],
+            m42 = te[7];
+        var m13 = te[8],
+            m23 = te[9],
+            m33 = te[10],
+            m43 = te[11];
+
+        te[0] = r11 * m11 + r21 * m12 + r31 * m13;
+        te[1] = r11 * m21 + r21 * m22 + r31 * m23;
+        te[2] = r11 * m31 + r21 * m32 + r31 * m33;
+        te[3] = r11 * m41 + r21 * m42 + r31 * m43;
+
+        te[4] = r12 * m11 + r22 * m12 + r32 * m13;
+        te[5] = r12 * m21 + r22 * m22 + r32 * m23;
+        te[6] = r12 * m31 + r22 * m32 + r32 * m33;
+        te[7] = r12 * m41 + r22 * m42 + r32 * m43;
+
+        te[8] = r13 * m11 + r23 * m12 + r33 * m13;
+        te[9] = r13 * m21 + r23 * m22 + r33 * m23;
+        te[10] = r13 * m31 + r23 * m32 + r33 * m33;
+        te[11] = r13 * m41 + r23 * m42 + r33 * m43;
+
+        return matrix;
+
+    },
+    //dinhnq-- invers matrix, need for opendata module
+    /*
+     * The inverse of a 2x2 matrix:
+        | a11 a12 |-1             |  a22 -a12 |
+        | a21 a22 |    =  1/DET * | -a21  a11 |
+        with DET  =  a11a22-a12a21
+     */
+    invMatrix2x2: function(a, b, c, d) {
+        //A = [a,b;c,d] => inv(A) = (1/detA)[d,-b;-c,a]
+        var ret = new Array(4);
+        var detA = 1 / (a * d - b * c);
+        ret[0] = detA * d;
+        ret[1] = -detA * b;
+        ret[2] = -detA * c;
+        ret[3] = detA * a;
+        return ret;
+    },
+
+    /*
+     * The inverse of a 3x3 matrix:
+    | a11 a12 a13 |-1             |   a33a22-a32a23  -(a33a12-a32a13)   a23a12-a22a13  |
+    | a21 a22 a23 |    =  1/DET * | -(a33a21-a31a23)   a33a11-a31a13  -(a23a11-a21a13) |
+    | a31 a32 a33 |               |   a32a21-a31a22  -(a32a11-a31a12)   a22a11-a21a12  |
+    with DET  =  a11(a33a22-a32a23)-a21(a33a12-a32a13)+a31(a23a12-a22a13)
+    */
+
+    invMatrix3x3: function(a11, a12, a13, a21, a22, a23, a31, a32, a33) {
+        detA = 1 / (a11(a33 * a22 - a32 * a23) - a21(a33 * a12 - a32 * a13) + a31 * (a23 * a12 - a22 * a13));
+        var ret = new Array(9);
+        ret[0] = detA * (a33 * a22 - a32 * a23);
+        ret[1] = -detA * (a33 * a12 - a32 * a13);
+        ret[2] = detA * (a23 * a12 - a22 * a13);
+        ret[3] = -detA * (a33 * a21 - a31 * a23)
+        ret[4] = detA * (a33 * a11 - a31 * a13);
+        ret[5] = -detA * (a23 * a11 - a21 * a13);
+        ret[6] = detA * (a32 * a21 - a31 * a22);
+        ret[7] = -detA * (a32 * a11 - a31 * a12);
+        ret[8] = detA * (a22 * a11 - a21 * a12);
+        return ret;
+    },
+
+    invMatrix4x4: function(matrix, result) {
+        var result = new Array(16);
+        var tmp_0 = matrix[10] * matrix[15];
+        var tmp_1 = matrix[14] * matrix[11];
+        var tmp_2 = matrix[6] * matrix[15];
+        var tmp_3 = matrix[14] * matrix[7];
+        var tmp_4 = matrix[6] * matrix[11];
+        var tmp_5 = matrix[10] * matrix[7];
+        var tmp_6 = matrix[2] * matrix[15];
+        var tmp_7 = matrix[14] * matrix[3];
+        var tmp_8 = matrix[2] * matrix[11];
+        var tmp_9 = matrix[10] * matrix[3];
+        var tmp_10 = matrix[2] * matrix[7];
+        var tmp_11 = matrix[6] * matrix[3];
+        var tmp_12 = matrix[8] * matrix[13];
+        var tmp_13 = matrix[12] * matrix[9];
+        var tmp_14 = matrix[4] * matrix[13];
+        var tmp_15 = matrix[12] * matrix[5];
+        var tmp_16 = matrix[4] * matrix[9];
+        var tmp_17 = matrix[8] * matrix[5];
+        var tmp_18 = matrix[0] * matrix[13];
+        var tmp_19 = matrix[12] * matrix[1];
+        var tmp_20 = matrix[0] * matrix[9];
+        var tmp_21 = matrix[8] * matrix[1];
+        var tmp_22 = matrix[0] * matrix[5];
+        var tmp_23 = matrix[4] * matrix[1];
+
+        var t0 = ((tmp_0 * matrix[5] + tmp_3 * matrix[9] + tmp_4 * matrix[13]) - (tmp_1 * matrix[5] + tmp_2 * matrix[9] + tmp_5 * matrix[13]));
+        var t1 = ((tmp_1 * matrix[1] + tmp_6 * matrix[9] + tmp_9 * matrix[13]) - (tmp_0 * matrix[1] + tmp_7 * matrix[9] + tmp_8 * matrix[13]));
+        var t2 = ((tmp_2 * matrix[1] + tmp_7 * matrix[5] + tmp_10 * matrix[13]) - (tmp_3 * matrix[1] + tmp_6 * matrix[5] + tmp_11 * matrix[13]));
+        var t3 = ((tmp_5 * matrix[1] + tmp_8 * matrix[5] + tmp_11 * matrix[9]) - (tmp_4 * matrix[1] + tmp_9 * matrix[5] + tmp_10 * matrix[9]));
+
+        var d1 = (matrix[0] * t0 + matrix[4] * t1 + matrix[8] * t2 + matrix[12] * t3);
+        if (Math.abs(d1) < 1e-5) {
+            console.log("Warning can't inverse matrix " + matrix);
+            if (result !== undefined) {
                 return false;
             } else {
-                var p = [];
-                for (var i = 0; i < px.length; i++) {
-                    p.push(px[i]);
-                    p.push(py[i])
-                }
-                for (var i = 0; i < l.length - 4; i += 4) {
-                    if (this.containsPoint(p, l[i], l[i + 1]) && this.containsPoint(p, l[i + 2], l[i + 3])) {
-                        lines.push(l[i]);
-                        lines.push(l[i + 1]);
-                        lines.push(l[i + 2]);
-                        lines.push(l[i + 3]);
-                    }
-                }
-
+                result = [1.0, 0.0, 0.0, 0.0,
+                    0.0, 1.0, 0.0, 0.0,
+                    0.0, 0.0, 1.0, 0.0,
+                    0.0, 0.0, 0.0, 1.0
+                ];;
             }
-            return lines;
-        },
+        }
+        var d = 1.0 / d1;
 
-        convex: function(ax, ay, bx, by, cx, cy) {
-            return (ay - by) * (cx - bx) + (bx - ax) * (cy - by) >= 0;
-        },
+        var out_00 = d * t0;
+        var out_01 = d * t1;
+        var out_02 = d * t2;
+        var out_03 = d * t3;
 
-        polyIsConvex: function(p) {
-            if (p.length < 6) return true;
-            var l = p.length - 4;
-            for (var i = 0; i < l; i += 2)
-                if (!this.convex(p[i], p[i + 1], p[i + 2], p[i + 3], p[i + 4], p[i + 5])) return false;
-            if (!this.convex(p[l], p[l + 1], p[l + 2], p[l + 3], p[0], p[1])) return false;
-            if (!this.convex(p[l + 2], p[l + 3], p[0], p[1], p[2], p[3])) return false;
-            return true;
-        },
+        var out_10 = d * ((tmp_1 * matrix[4] + tmp_2 * matrix[8] + tmp_5 * matrix[12]) - (tmp_0 * matrix[4] + tmp_3 * matrix[8] + tmp_4 * matrix[12]));
+        var out_11 = d * ((tmp_0 * matrix[0] + tmp_7 * matrix[8] + tmp_8 * matrix[12]) - (tmp_1 * matrix[0] + tmp_6 * matrix[8] + tmp_9 * matrix[12]));
+        var out_12 = d * ((tmp_3 * matrix[0] + tmp_6 * matrix[4] + tmp_11 * matrix[12]) - (tmp_2 * matrix[0] + tmp_7 * matrix[4] + tmp_10 * matrix[12]));
+        var out_13 = d * ((tmp_4 * matrix[0] + tmp_9 * matrix[4] + tmp_10 * matrix[8]) - (tmp_5 * matrix[0] + tmp_8 * matrix[4] + tmp_11 * matrix[8]));
 
-        getLineIntersection: function(a1, a2, b1, b2, c) {
-            var dax = (a1.x - a2.x),
-                dbx = (b1.x - b2.x);
-            var day = (a1.y - a2.y),
-                dby = (b1.y - b2.y);
+        var out_20 = d * ((tmp_12 * matrix[7] + tmp_15 * matrix[11] + tmp_16 * matrix[15]) - (tmp_13 * matrix[7] + tmp_14 * matrix[11] + tmp_17 * matrix[15]));
+        var out_21 = d * ((tmp_13 * matrix[3] + tmp_18 * matrix[11] + tmp_21 * matrix[15]) - (tmp_12 * matrix[3] + tmp_19 * matrix[11] + tmp_20 * matrix[15]));
+        var out_22 = d * ((tmp_14 * matrix[3] + tmp_19 * matrix[7] + tmp_22 * matrix[15]) - (tmp_15 * matrix[3] + tmp_18 * matrix[7] + tmp_23 * matrix[15]));
+        var out_23 = d * ((tmp_17 * matrix[3] + tmp_20 * matrix[7] + tmp_23 * matrix[11]) - (tmp_16 * matrix[3] + tmp_21 * matrix[7] + tmp_22 * matrix[11]));
 
-            var Den = dax * dby - day * dbx;
-            if (Den == 0) return null; // parallel
+        var out_30 = d * ((tmp_14 * matrix[10] + tmp_17 * matrix[14] + tmp_13 * matrix[6]) - (tmp_16 * matrix[14] + tmp_12 * matrix[6] + tmp_15 * matrix[10]));
+        var out_31 = d * ((tmp_20 * matrix[14] + tmp_12 * matrix[2] + tmp_19 * matrix[10]) - (tmp_18 * matrix[10] + tmp_21 * matrix[14] + tmp_13 * matrix[2]));
+        var out_32 = d * ((tmp_18 * matrix[6] + tmp_23 * matrix[14] + tmp_15 * matrix[2]) - (tmp_22 * matrix[14] + tmp_14 * matrix[2] + tmp_19 * matrix[6]));
+        var out_33 = d * ((tmp_22 * matrix[10] + tmp_16 * matrix[2] + tmp_21 * matrix[6]) - (tmp_20 * matrix[6] + tmp_23 * matrix[10] + tmp_17 * matrix[2]));
 
-            var A = (a1.x * a2.y - a1.y * a2.x);
-            var B = (b1.x * b2.y - b1.y * b2.x);
+        result[0] = out_00;
+        result[1] = out_01;
+        result[2] = out_02;
+        result[3] = out_03;
+        result[4] = out_10;
+        result[5] = out_11;
+        result[6] = out_12;
+        result[7] = out_13;
+        result[8] = out_20;
+        result[9] = out_21;
+        result[10] = out_22;
+        result[11] = out_23;
+        result[12] = out_30;
+        result[13] = out_31;
+        result[14] = out_32;
+        result[15] = out_33;
+        return result;
+    },
 
-            var I = c;
-            I.x = (A * dbx - dax * B) / Den;
-            I.y = (A * dby - day * B) / Den;
+    //----------Ray Casting------------------
+    //modify from http://polyk.ivank.net
+    //cast a ray to edge of threejs poly linestring 
+    Raycast: function(p, la, x, y, dx, dy, isc) {
 
-            if (this.InRect(I, a1, a2) && this.InRect(I, b1, b2)) return I;
-            return null;
-        },
-        getAreaPoly: function(p) {
-            if (p.length < 6) return 0;
-            var l = p.length - 2;
-            var sum = 0;
-            for (var i = 0; i < l; i += 2)
-                sum += (p[i + 2] - p[i]) * (p[i + 1] + p[i + 3]);
-            sum += (p[0] - p[l]) * (p[l + 1] + p[1]);
-            return -sum * 0.5;
-        },
-        removDuplicateArray: function(arr) {
-            var temp = {};
-            for (var i = 0; i < arr.length; i++)
-                temp[arr[i]] = true;
-            var r = [];
-            for (var k in temp)
-                r.push(k);
-            return r;
-        },
+        var l = p.length;
+        var a1 = new _P(0, 0),
+            a2 = new _P(0, 0),
+            b1 = new _P(0, 0),
+            b2 = new _P(0, 0),
+            c = new _P(0, 0);
+        //ray line    
+        a1.x = x;
+        a1.y = y;
+        a2.x = x + dx;
+        a2.y = y + dy;
 
-        checkSign: function(a, b) {
-            return ((a * b) >= 0);
-        },
-
-        //this function returns commun point if two lines are intersected.
-        //it is different from Raycast* function where the point is located 
-        //from two vectors. 
-        getLineIntersection2: function(p1, p2, p3, p4) {
-            var x1 = p1.x,
-                y1 = p1.y,
-                x2 = p2.x,
-                y2 = p2.y,
-                x3 = p3.x,
-                y3 = p3.y,
-                x4 = p4.x,
-                y4 = p4.y;
-
-            var a1, a2, b1, b2, c1, c2;
-            var r1, r2, r3, r4;
-            var denom, offset, num;
-
-            // Compute a1, b1, c1, where line joining points 1 and 2
-            // is "a1 x + b1 y + c1 = 0".
-            a1 = y2 - y1;
-            b1 = x1 - x2;
-            c1 = (x2 * y1) - (x1 * y2);
-
-            // Compute r3 and r4.
-            r3 = ((a1 * x3) + (b1 * y3) + c1);
-            r4 = ((a1 * x4) + (b1 * y4) + c1);
-
-            // Check signs of r3 and r4. If both point 3 and point 4 lie on
-            // same side of line 1, the line segments do not intersect.
-            if ((r3 != 0) && (r4 != 0) && this.checkSign(r3, r4)) {
-                return -1;
-            }
-
-            // Compute a2, b2, c2
-            a2 = y4 - y3;
-            b2 = x3 - x4;
-            c2 = (x4 * y3) - (x3 * y4);
-
-            // Compute r1 and r2
-            r1 = (a2 * x1) + (b2 * y1) + c2;
-            r2 = (a2 * x2) + (b2 * y2) + c2;
-
-            // Check signs of r1 and r2. If both point 1 and point 2 lie
-            // on same side of second line segment, the line segments do
-            // not intersect.
-            if ((r1 != 0) && (r2 != 0) && (this.checkSign(r1, r2))) {
-                return -1;
-            }
-
-            //Line segments intersect: compute intersection point.
-            denom = (a1 * b2) - (a2 * b1);
-
-            if (denom == 0) {
-                return -1;
-            }
-
-            if (denom < 0) {
-                offset = -denom / 2;
-            } else {
-                offset = denom / 2;
-            }
-
-            // The denom/2 is to get rounding instead of truncating. It
-            // is added or subtracted to the numerator, depending upon the
-            // sign of the numerator.
-            var point = {
-                x: 0,
-                y: 0,
-                dist: 0
-            };
-            num = (b1 * c2) - (b2 * c1);
-            if (num < 0) {
-                point.x = (num - offset) / denom;
-            } else {
-                point.x = (num + offset) / denom;
-            }
-
-            num = (a2 * c1) - (a1 * c2);
-            if (num < 0) {
-                point.y = (num - offset) / denom;
-            } else {
-                point.y = (num + offset) / denom;
-            }
-            point.dist = Math.sqrt((point.x - p1.x) * (point.x - p1.x) + (point.y - p1.y) * (point.y - p1.y));
-            // lines_intersect
-            return point;
-        },
-
-        getIntersectLinePoly: function(p, pt1, pt2) {
-
-            var l = p.length;
-            var a1 = new _P(0, 0),
-                a2 = new _P(0, 0),
-                b1 = new _P(0, 0),
-                b2 = new _P(0, 0),
-                I = new _P(0, 0);
-            //ray line    
-            a1.x = pt1.x;
-            a1.y = pt1.z;
-            a2.x = pt2.x;
-            a2.y = pt2.z;
-            var min_dist = Infinity;
-            for (var i = 0; i < l; i += 2) {
-                b1.x = p[i].x;
-                b1.y = p[i].z;
-                b2.x = p[i + 1].x;
-                b2.y = p[i + 1].z;
-                var isc = this.getLineIntersection2(a1, a2, b1, b2);
-                if (isc !== -1) { //check if intersect
-                    //console.warn(nrl);
-                    if (isc.dist < min_dist) {
-                        I.x = isc.x;
-                        I.y = isc.y;
-                    }
-                    min_dist = isc.dist;
-                }
-            }
-
-            return I;
-        },
-
-        lambert93ToWGS: function(lambertCoords) {
-            var wgsLonLat = new OpenLayers.LonLat(lambertCoords.x, lambertCoords.y);
-            wgsLonLat.transform(new OpenLayers.Projection("EPSG:2154"), new OpenLayers.Projection("CRS:84"));
-            return wgsLonLat;
-        },
-
-        wgsToLambert93: function(wgsCoords) {
-            var lambertCoords = new OpenLayers.LonLat(wgsCoords.lon, wgsCoords.lat);
-            lambertCoords.transform(new OpenLayers.Projection("CRS:84"), new OpenLayers.Projection("EPSG:2154"));
-            return {
-                x: lambertCoords.lon,
-                y: lambertCoords.lat
-            };
-        },
-
-
-        // http://fr.wikipedia.org/wiki/MÃ©thode_de_Cardan  Thanks Bredif
-        cardan_cubic_roots: function(a, b, c, d) {
-
-            if (a == 0) return this.quadratic_roots(b, c, d);
-            var vt = -b / (3 * a);
-            var a2 = a * a;
-            var b2 = b * b;
-            var a3 = a * a2;
-            var b3 = b * b2;
-            var p = c / a - b2 / (3 * a2);
-            var q = b3 / (a3 * 13.5) + d / a - b * c / (3 * a2);
-            if (p == 0) {
-                var x = this.cubic_root(-q) + vt;
-                return [x, x, x];
-            }
-            var p3_4_27 = p * p * p * 4 / 27;
-            var del = q * q + p3_4_27;
-
-            if (del > 0) {
-                var sqrt_del = Math.sqrt(del);
-                var u = this.cubic_root((-q + sqrt_del) / 2);
-                var v = this.cubic_root((-q - sqrt_del) / 2);
-                return [u + v + vt];
-            } else if (del == 0) {
-                var z0 = 3 * q / p;
-                var x0 = vt + z0;
-                var x12 = vt - z0 * 0.5;
-                return [x0, x12, x12];
-            } else // (del < 0)
-            {
-                var kos = Math.acos(-q / Math.sqrt(p3_4_27));
-                var r = 2 * Math.sqrt(-p / 3)
-                return [
-                    r * Math.cos((kos) / 3) + vt,
-                    r * Math.cos((kos + Math.PI) / 3) + vt,
-                    r * Math.cos((kos + 2 * Math.PI) / 3) + vt
-                ];
-            }
-        },
-
-        quadratic_roots: function(a, b, c) {
-            var delta = b * b - 4 * a * c;
-            if (delta < 0) return [];
-            var x0 = -b / (2 * a);
-            if (delta == 0) return [x0];
-            var sqr_delta_2a = Math.sqrt(delta) / (2 * a);
-            return [x0 - sqr_delta_2a, x0 + sqr_delta_2a];
-        },
-
-        sgn: function(x) {
-            return (x > 0) - (x < 0);
-        },
-
-        cubic_root: function(x) {
-            return this.sgn(x) * Math.pow(Math.abs(x), 1 / 3);
-        },
-
-
-        // Return sun position with azimuth and altitude in rad       
-        getSunPosition: function() {
-
-            var m = Math,
-                PI = m.PI,
-                sin = m.sin,
-                cos = m.cos,
-                tan = m.tan,
-                asin = m.asin,
-                atan = m.atan2;
-
-            var rad = PI / 180,
-                dayMs = 1000 * 60 * 60 * 24,
-                J1970 = 2440588,
-                J2000 = 2451545,
-                e = rad * 23.4397; // obliquity of the Earth
-
-            function toJulian(date) {
-                return date.valueOf() / dayMs - 0.5 + J1970;
-            }
-
-            function toDays(date) {
-                return toJulian(date) - J2000;
-            }
-
-            function getRightAscension(l, b) {
-                return atan(sin(l) * cos(e) - tan(b) * sin(e), cos(l));
-            }
-
-            function getDeclination(l, b) {
-                return asin(sin(b) * cos(e) + cos(b) * sin(e) * sin(l));
-            }
-
-            function getAzimuth(H, phi, dec) {
-                return atan(sin(H), cos(H) * sin(phi) - tan(dec) * cos(phi));
-            }
-
-            function getAltitude(H, phi, dec) {
-                return asin(sin(phi) * sin(dec) + cos(phi) * cos(dec) * cos(H));
-            }
-
-            function getSiderealTime(d, lw) {
-                return rad * (280.16 + 360.9856235 * d) - lw;
-            }
-
-            function getSolarMeanAnomaly(d) {
-                return rad * (357.5291 + 0.98560028 * d);
-            }
-
-            function getEquationOfCenter(M) {
-                return rad * (1.9148 * sin(M) + 0.0200 * sin(2 * M) + 0.0003 * sin(3 * M));
-            }
-
-            function getEclipticLongitude(M, C) {
-                var P = rad * 102.9372; // perihelion of the Earth
-                return M + C + P + PI;
-            }
-
-            return function getSunPosition(date, lat, lon) {
-                var lw = rad * -lon,
-                    phi = rad * lat,
-                    d = toDays(date),
-                    M = getSolarMeanAnomaly(d),
-                    C = getEquationOfCenter(M),
-                    L = getEclipticLongitude(M, C),
-                    D = getDeclination(L, 0),
-                    A = getRightAscension(L, 0),
-                    t = getSiderealTime(d, lw),
-                    H = t - A;
-
-                return {
-                    altitude: getAltitude(H, phi, D),
-                    azimuth: getAzimuth(H, phi, D) + PI // - PI/2 // origin: north !!! not like original Mourner code but more classical ref
-                };
-            };
-
-
-        },
-
-        // Return scene coordinate ({x,y,z}) of sun
-        getSunPositionInScene: function(date, lat, lon) {
-
-            if (lat == undefined) {
-                var currentPosWGS84 = Cartography.convertCoordVec3(Cartography.getCurrentPosition(), "EPSG:2154", "CRS:84");
-                lat = currentPosWGS84.z;
-                lon = currentPosWGS84.x;
-            }
-            var sun = Utils.getSunPosition()(date, lat, lon);
-            var length = 2000; // distance of the sun from the earth
-            var direction = {
+        if (isc == null) isc = {
+            dist: 0,
+            edge: 0,
+            line: {
+                x1: 0,
+                y1: 0,
+                x2: 0,
+                y2: 0
+            },
+            intersectPt: {
                 x: 0,
                 y: 0
-            };
-            direction.x = Math.sin(sun.azimuth) * length;
-            direction.y = Math.cos(sun.azimuth) * length;
-            var realalti = Math.sin(sun.altitude) * length;
-
-            //console.log(direction, realalti);
-
-            return {
-                x: direction.x,
-                y: realalti,
-                z: direction.y
-            };
+            },
+            norm: {
+                x: 0,
+                y: 0
+            },
+            refl: {
+                x: 0,
+                y: 0
+            }
+        };
+        isc.dist = Infinity;
+        var j;
+        for (var i = 0; i < l; i += 2) {
+            j = i / 2;
+            if (la[j] === la[j + 1]) {
+                b1.x = p[i];
+                b1.y = p[i + 1];
+                b2.x = p[i + 2];
+                b2.y = p[i + 3];
+                var nisc = this.RayLineIntersection(a1, a2, b1, b2, c);
+                if (nisc) this.updateISC(dx, dy, a1, b1, b2, c, i / 2, isc, nisc);
+            }
         }
 
+        return (isc.dist != Infinity) ? isc : null;
+    },
+
+    //cast on threejs linestring
+    Raycast2: function(p, v1, v2) {
+
+        var l = p.length;
+        var a1 = new _P(0, 0),
+            a2 = new _P(0, 0),
+            b1 = new _P(0, 0),
+            b2 = new _P(0, 0),
+            c = new _P(0, 0);
+        //ray line    
+        a1.x = v1.x;
+        a1.y = v1.z;
+        a2.x = v2.x;
+        a2.y = v2.z;
+
+        var isc = {
+            dist: 0,
+            edge: 0,
+            line: {
+                x1: 0,
+                y1: 0,
+                x2: 0,
+                y2: 0
+            },
+            intersectPt: {
+                x: 0,
+                y: 0
+            },
+            norm: {
+                x: 0,
+                y: 0
+            },
+            refl: {
+                x: 0,
+                y: 0
+            }
+        };
+        isc.dist = Infinity;
+        for (var i = 0; i < l; i += 2) {
+            b1.x = p[i].x;
+            b1.y = p[i].z;
+            b2.x = p[i + 1].x;
+            b2.y = p[i + 1].z;
+            var nisc = this.RayLineIntersection(a1, a2, b1, b2, c);
+            if (nisc) this.updateISC(v2.x, v2.y, a1, b1, b2, c, i / 2, isc, nisc);
+        }
+
+        return (isc.dist != Infinity) ? isc : null;
+    },
+
+    RayLineIntersection: function(a1, a2, b1, b2, c) {
+        var dax = (a1.x - a2.x),
+            dbx = (b1.x - b2.x);
+        var day = (a1.y - a2.y),
+            dby = (b1.y - b2.y);
+
+        var Den = dax * dby - day * dbx;
+        if (Den == 0) return null; // parallel
+
+        var A = (a1.x * a2.y - a1.y * a2.x);
+        var B = (b1.x * b2.y - b1.y * b2.x);
+
+        var I = c;
+        var iDen = 1 / Den;
+        I.x = (A * dbx - dax * B) * iDen;
+        I.y = (A * dby - day * B) * iDen;
+
+        if (!this.InRect(I, b1, b2)) return null;
+        if ((day > 0 && I.y > a1.y) || (day < 0 && I.y < a1.y)) return null;
+        if ((dax > 0 && I.x > a1.x) || (dax < 0 && I.x < a1.x)) return null;
+        return I;
+    },
+
+    InRect: function(a, b, c) {
+        if (b.x == c.x) return (a.y >= Math.min(b.y, c.y) && a.y <= Math.max(b.y, c.y));
+        if (b.y == c.y) return (a.x >= Math.min(b.x, c.x) && a.x <= Math.max(b.x, c.x));
+
+        if (a.x >= Math.min(b.x, c.x) && a.x <= Math.max(b.x, c.x) && a.y >= Math.min(b.y, c.y) && a.y <= Math.max(b.y, c.y))
+            return true;
+        return false;
+    },
+    updateISC: function(dx, dy, a1, b1, b2, c, edge, isc, I) {
+        var nrl = _P.dist(a1, c);
+        if (nrl < isc.dist) {
+            var ibl = 1 / _P.dist(b1, b2);
+            var nx = -(b2.y - b1.y) * ibl;
+            var ny = (b2.x - b1.x) * ibl;
+            var ddot = 2 * (dx * nx + dy * ny);
+            isc.dist = nrl;
+            isc.norm.x = nx;
+            isc.norm.y = ny;
+            isc.refl.x = -ddot * nx + dx;
+            isc.refl.y = -ddot * ny + dy;
+            isc.edge = edge;
+            isc.line.x1 = b1.x;
+            isc.line.y1 = b1.y;
+            isc.line.x2 = b2.x;
+            isc.line.y2 = b2.y;
+            isc.intersectPt.x = I.x;
+            isc.intersectPt.y = I.y;
+        }
+    },
+
+    //project point on closest egde of poly
+    //note: p is poly linestring of threejs    
+    projectPointOnLine: function(p, pt) {
+        var l = p.length;
+        var a1 = new _P(0, 0),
+            b1 = new _P(0, 0),
+            b2 = new _P(0, 0),
+            c = new _P(0, 0);
+        a1.x = pt.x;
+        a1.y = pt.z;
+
+        var isc = {
+            dist: Infinity,
+            edge: 0,
+            line: {
+                x1: 0,
+                y1: 0,
+                x2: 0,
+                y2: 0
+            },
+            point: {
+                x: 0,
+                y: 0
+            },
+            norm: {
+                x: 0,
+                y: 0
+            }
+        };
+        //var j;
+        for (var i = 0; i < l; i += 2) {
+            b1.x = p[i].x;
+            b1.y = p[i].z;
+            b2.x = p[i + 1].x;
+            b2.y = p[i + 1].z;
+            this.pointLineDist(a1, b1, b2, i >> 1, isc);
+        }
+
+        var idst = 1 / isc.dist;
+        isc.norm.x = (pt.x - isc.point.x) * idst;
+        isc.norm.y = (pt.z - isc.point.y) * idst;
+        return isc;
+    },
+    pointLineDist: function(p, a, b, edge, isc) {
+        var x = p.x,
+            y = p.y,
+            x1 = a.x,
+            y1 = a.y,
+            x2 = b.x,
+            y2 = b.y;
+
+        var A = x - x1;
+        var B = y - y1;
+        var C = x2 - x1;
+        var D = y2 - y1;
+
+        var dot = A * C + B * D;
+        var len_sq = C * C + D * D;
+        var param = dot / len_sq;
+
+        var xx, yy;
+
+        if (param < 0 || (x1 == x2 && y1 == y2)) {
+            xx = x1;
+            yy = y1;
+        } else if (param > 1) {
+            xx = x2;
+            yy = y2;
+        } else {
+            xx = x1 + param * C;
+            yy = y1 + param * D;
+        }
+
+        var dx = x - xx;
+        var dy = y - yy;
+        var dst = Math.sqrt(dx * dx + dy * dy);
+        if (dst < isc.dist) {
+            isc.dist = dst;
+            isc.edge = edge;
+            isc.point.x = xx;
+            isc.point.y = yy;
+            isc.line.x1 = a.x;
+            isc.line.y1 = a.y;
+            isc.line.x2 = b.x;
+            isc.line.y2 = b.y;
+        }
+    },
+
+    //slice poly into two parts, used this function to delete 
+    //artifacts from OpenData line string ray casting!
+    slice: function(p, ax, ay, bx, by) {
+        if (this.ContainsPoint(p, ax, ay) || this.ContainsPoint(p, bx, by)) return [p.slice(0)];
+
+        var a = new _P(ax, ay);
+        var b = new _P(bx, by);
+        var iscs = []; // intersections
+        var ps = []; // points
+        for (var i = 0; i < p.length; i += 2) ps.push(new _P(p[i], p[i + 1]));
+
+        for (var i = 0; i < ps.length; i++) {
+            var isc = new _P(0, 0);
+            isc = this._GetLineIntersection(a, b, ps[i], ps[(i + 1) % ps.length], isc);
+
+            if (isc) {
+                isc.flag = true;
+                iscs.push(isc);
+                ps.splice(i + 1, 0, isc);
+                i++;
+            }
+        }
+        if (iscs.length == 0) return [p.slice(0)];
+        var comp = function(u, v) {
+            return _P.dist(a, u) - _P.dist(a, v);
+        }
+        iscs.sort(comp);
+
+        var pgs = [];
+        var dir = 0;
+        while (iscs.length > 0) {
+            var n = ps.length;
+            var i0 = iscs[0];
+            var i1 = iscs[1];
+            var ind0 = ps.indexOf(i0);
+            var ind1 = ps.indexOf(i1);
+            var solved = false;
+
+            if (this._firstWithFlag(ps, ind0) == ind1) solved = true;
+            else {
+                i0 = iscs[1];
+                i1 = iscs[0];
+                ind0 = ps.indexOf(i0);
+                ind1 = ps.indexOf(i1);
+                if (this._firstWithFlag(ps, ind0) == ind1) solved = true;
+            }
+            if (solved) {
+                dir--;
+                var pgn = this._getPoints(ps, ind0, ind1);
+                pgs.push(pgn);
+                ps = this._getPoints(ps, ind1, ind0);
+                i0.flag = i1.flag = false;
+                iscs.splice(0, 2);
+                if (iscs.length == 0) pgs.push(ps);
+            } else {
+                dir++;
+                iscs.reverse();
+            }
+            if (dir > 1) break;
+        }
+        var result = [];
+        for (var i = 0; i < pgs.length; i++) {
+            var pg = pgs[i];
+            var npg = [];
+            for (var j = 0; j < pg.length; j++) npg.push(pg[j].x, pg[j].y);
+            result.push(npg);
+        }
+        return result;
+    },
+
+    /*TODO: use this function to check if line string points are inside poly which
+     *created from Bati 3D d'OpenData. The idea is that we do ray casting with Bati 3D
+     * to detect front of building (facades), a poly is created from these facades. Finally, we
+     * check if the lines are inside the poly which permet to hide invisible lines from scene*/
+    containsPoint: function(p, px, py) {
+        var n = p.length >> 1;
+        var ax, ay, bx = p[2 * n - 2] - px,
+            by = p[2 * n - 1] - py;
+        var depth = 0;
+        for (var i = 0; i < n; i++) {
+            ax = bx;
+            ay = by;
+            bx = p[2 * i] - px;
+            by = p[2 * i + 1] - py;
+            if (ay < 0 && by < 0) continue; // both "up" or both "donw"
+            if (ay >= 0 && by >= 0) continue; // both "up" or both "donw"
+            if (ax < 0 && bx < 0) continue;
+
+            var lx = ax + (bx - ax) * (-ay) / (by - ay);
+            if (lx > 0) depth++;
+        }
+        return (depth & 1) == 1;
+    },
+
+    //px, py sont coords d'emprise du sol        
+    extractLineStringInsidePoly: function(px, py, l) {
+        var lines = [];
+        if (px.length !== py.length) {
+            console.warn("poly bounding box have wrong structure!!!");
+            return false;
+        } else {
+            var p = [];
+            for (var i = 0; i < px.length; i++) {
+                p.push(px[i]);
+                p.push(py[i])
+            }
+            for (var i = 0; i < l.length - 4; i += 4) {
+                if (this.containsPoint(p, l[i], l[i + 1]) && this.containsPoint(p, l[i + 2], l[i + 3])) {
+                    lines.push(l[i]);
+                    lines.push(l[i + 1]);
+                    lines.push(l[i + 2]);
+                    lines.push(l[i + 3]);
+                }
+            }
+
+        }
+        return lines;
+    },
+
+    convex: function(ax, ay, bx, by, cx, cy) {
+        return (ay - by) * (cx - bx) + (bx - ax) * (cy - by) >= 0;
+    },
+
+    polyIsConvex: function(p) {
+        if (p.length < 6) return true;
+        var l = p.length - 4;
+        for (var i = 0; i < l; i += 2)
+            if (!this.convex(p[i], p[i + 1], p[i + 2], p[i + 3], p[i + 4], p[i + 5])) return false;
+        if (!this.convex(p[l], p[l + 1], p[l + 2], p[l + 3], p[0], p[1])) return false;
+        if (!this.convex(p[l + 2], p[l + 3], p[0], p[1], p[2], p[3])) return false;
+        return true;
+    },
+
+    getLineIntersection: function(a1, a2, b1, b2, c) {
+        var dax = (a1.x - a2.x),
+            dbx = (b1.x - b2.x);
+        var day = (a1.y - a2.y),
+            dby = (b1.y - b2.y);
+
+        var Den = dax * dby - day * dbx;
+        if (Den == 0) return null; // parallel
+
+        var A = (a1.x * a2.y - a1.y * a2.x);
+        var B = (b1.x * b2.y - b1.y * b2.x);
+
+        var I = c;
+        I.x = (A * dbx - dax * B) / Den;
+        I.y = (A * dby - day * B) / Den;
+
+        if (this.InRect(I, a1, a2) && this.InRect(I, b1, b2)) return I;
+        return null;
+    },
+    getAreaPoly: function(p) {
+        if (p.length < 6) return 0;
+        var l = p.length - 2;
+        var sum = 0;
+        for (var i = 0; i < l; i += 2)
+            sum += (p[i + 2] - p[i]) * (p[i + 1] + p[i + 3]);
+        sum += (p[0] - p[l]) * (p[l + 1] + p[1]);
+        return -sum * 0.5;
+    },
+    removDuplicateArray: function(arr) {
+        var temp = {};
+        for (var i = 0; i < arr.length; i++)
+            temp[arr[i]] = true;
+        var r = [];
+        for (var k in temp)
+            r.push(k);
+        return r;
+    },
+
+    checkSign: function(a, b) {
+        return ((a * b) >= 0);
+    },
+
+    //this function returns commun point if two lines are intersected.
+    //it is different from Raycast* function where the point is located 
+    //from two vectors. 
+    getLineIntersection2: function(p1, p2, p3, p4) {
+        var x1 = p1.x,
+            y1 = p1.y,
+            x2 = p2.x,
+            y2 = p2.y,
+            x3 = p3.x,
+            y3 = p3.y,
+            x4 = p4.x,
+            y4 = p4.y;
+
+        var a1, a2, b1, b2, c1, c2;
+        var r1, r2, r3, r4;
+        var denom, offset, num;
+
+        // Compute a1, b1, c1, where line joining points 1 and 2
+        // is "a1 x + b1 y + c1 = 0".
+        a1 = y2 - y1;
+        b1 = x1 - x2;
+        c1 = (x2 * y1) - (x1 * y2);
+
+        // Compute r3 and r4.
+        r3 = ((a1 * x3) + (b1 * y3) + c1);
+        r4 = ((a1 * x4) + (b1 * y4) + c1);
+
+        // Check signs of r3 and r4. If both point 3 and point 4 lie on
+        // same side of line 1, the line segments do not intersect.
+        if ((r3 != 0) && (r4 != 0) && this.checkSign(r3, r4)) {
+            return -1;
+        }
+
+        // Compute a2, b2, c2
+        a2 = y4 - y3;
+        b2 = x3 - x4;
+        c2 = (x4 * y3) - (x3 * y4);
+
+        // Compute r1 and r2
+        r1 = (a2 * x1) + (b2 * y1) + c2;
+        r2 = (a2 * x2) + (b2 * y2) + c2;
+
+        // Check signs of r1 and r2. If both point 1 and point 2 lie
+        // on same side of second line segment, the line segments do
+        // not intersect.
+        if ((r1 != 0) && (r2 != 0) && (this.checkSign(r1, r2))) {
+            return -1;
+        }
+
+        //Line segments intersect: compute intersection point.
+        denom = (a1 * b2) - (a2 * b1);
+
+        if (denom == 0) {
+            return -1;
+        }
+
+        if (denom < 0) {
+            offset = -denom / 2;
+        } else {
+            offset = denom / 2;
+        }
+
+        // The denom/2 is to get rounding instead of truncating. It
+        // is added or subtracted to the numerator, depending upon the
+        // sign of the numerator.
+        var point = {
+            x: 0,
+            y: 0,
+            dist: 0
+        };
+        num = (b1 * c2) - (b2 * c1);
+        if (num < 0) {
+            point.x = (num - offset) / denom;
+        } else {
+            point.x = (num + offset) / denom;
+        }
+
+        num = (a2 * c1) - (a1 * c2);
+        if (num < 0) {
+            point.y = (num - offset) / denom;
+        } else {
+            point.y = (num + offset) / denom;
+        }
+        point.dist = Math.sqrt((point.x - p1.x) * (point.x - p1.x) + (point.y - p1.y) * (point.y - p1.y));
+        // lines_intersect
+        return point;
+    },
+
+    getIntersectLinePoly: function(p, pt1, pt2) {
+
+        var l = p.length;
+        var a1 = new _P(0, 0),
+            a2 = new _P(0, 0),
+            b1 = new _P(0, 0),
+            b2 = new _P(0, 0),
+            I = new _P(0, 0);
+        //ray line    
+        a1.x = pt1.x;
+        a1.y = pt1.z;
+        a2.x = pt2.x;
+        a2.y = pt2.z;
+        var min_dist = Infinity;
+        for (var i = 0; i < l; i += 2) {
+            b1.x = p[i].x;
+            b1.y = p[i].z;
+            b2.x = p[i + 1].x;
+            b2.y = p[i + 1].z;
+            var isc = this.getLineIntersection2(a1, a2, b1, b2);
+            if (isc !== -1) { //check if intersect
+                //console.warn(nrl);
+                if (isc.dist < min_dist) {
+                    I.x = isc.x;
+                    I.y = isc.y;
+                }
+                min_dist = isc.dist;
+            }
+        }
+
+        return I;
+    },
+
+    lambert93ToWGS: function(lambertCoords) {
+        var wgsLonLat = new OpenLayers.LonLat(lambertCoords.x, lambertCoords.y);
+        wgsLonLat.transform(new OpenLayers.Projection("EPSG:2154"), new OpenLayers.Projection("CRS:84"));
+        return wgsLonLat;
+    },
+
+    wgsToLambert93: function(wgsCoords) {
+        var lambertCoords = new OpenLayers.LonLat(wgsCoords.lon, wgsCoords.lat);
+        lambertCoords.transform(new OpenLayers.Projection("CRS:84"), new OpenLayers.Projection("EPSG:2154"));
+        return {
+            x: lambertCoords.lon,
+            y: lambertCoords.lat
+        };
+    },
 
 
-    };
+    // http://fr.wikipedia.org/wiki/MÃ©thode_de_Cardan  Thanks Bredif
+    cardan_cubic_roots: function(a, b, c, d) {
 
-    return Utils;
-});
+        if (a == 0) return this.quadratic_roots(b, c, d);
+        var vt = -b / (3 * a);
+        var a2 = a * a;
+        var b2 = b * b;
+        var a3 = a * a2;
+        var b3 = b * b2;
+        var p = c / a - b2 / (3 * a2);
+        var q = b3 / (a3 * 13.5) + d / a - b * c / (3 * a2);
+        if (p == 0) {
+            var x = this.cubic_root(-q) + vt;
+            return [x, x, x];
+        }
+        var p3_4_27 = p * p * p * 4 / 27;
+        var del = q * q + p3_4_27;
+
+        if (del > 0) {
+            var sqrt_del = Math.sqrt(del);
+            var u = this.cubic_root((-q + sqrt_del) / 2);
+            var v = this.cubic_root((-q - sqrt_del) / 2);
+            return [u + v + vt];
+        } else if (del == 0) {
+            var z0 = 3 * q / p;
+            var x0 = vt + z0;
+            var x12 = vt - z0 * 0.5;
+            return [x0, x12, x12];
+        } else // (del < 0)
+        {
+            var kos = Math.acos(-q / Math.sqrt(p3_4_27));
+            var r = 2 * Math.sqrt(-p / 3)
+            return [
+                r * Math.cos((kos) / 3) + vt,
+                r * Math.cos((kos + Math.PI) / 3) + vt,
+                r * Math.cos((kos + 2 * Math.PI) / 3) + vt
+            ];
+        }
+    },
+
+    quadratic_roots: function(a, b, c) {
+        var delta = b * b - 4 * a * c;
+        if (delta < 0) return [];
+        var x0 = -b / (2 * a);
+        if (delta == 0) return [x0];
+        var sqr_delta_2a = Math.sqrt(delta) / (2 * a);
+        return [x0 - sqr_delta_2a, x0 + sqr_delta_2a];
+    },
+
+    sgn: function(x) {
+        return (x > 0) - (x < 0);
+    },
+
+    cubic_root: function(x) {
+        return this.sgn(x) * Math.pow(Math.abs(x), 1 / 3);
+    },
+
+
+    // Return sun position with azimuth and altitude in rad       
+    getSunPosition: function() {
+
+        var m = Math,
+            PI = m.PI,
+            sin = m.sin,
+            cos = m.cos,
+            tan = m.tan,
+            asin = m.asin,
+            atan = m.atan2;
+
+        var rad = PI / 180,
+            dayMs = 1000 * 60 * 60 * 24,
+            J1970 = 2440588,
+            J2000 = 2451545,
+            e = rad * 23.4397; // obliquity of the Earth
+
+        function toJulian(date) {
+            return date.valueOf() / dayMs - 0.5 + J1970;
+        }
+
+        function toDays(date) {
+            return toJulian(date) - J2000;
+        }
+
+        function getRightAscension(l, b) {
+            return atan(sin(l) * cos(e) - tan(b) * sin(e), cos(l));
+        }
+
+        function getDeclination(l, b) {
+            return asin(sin(b) * cos(e) + cos(b) * sin(e) * sin(l));
+        }
+
+        function getAzimuth(H, phi, dec) {
+            return atan(sin(H), cos(H) * sin(phi) - tan(dec) * cos(phi));
+        }
+
+        function getAltitude(H, phi, dec) {
+            return asin(sin(phi) * sin(dec) + cos(phi) * cos(dec) * cos(H));
+        }
+
+        function getSiderealTime(d, lw) {
+            return rad * (280.16 + 360.9856235 * d) - lw;
+        }
+
+        function getSolarMeanAnomaly(d) {
+            return rad * (357.5291 + 0.98560028 * d);
+        }
+
+        function getEquationOfCenter(M) {
+            return rad * (1.9148 * sin(M) + 0.0200 * sin(2 * M) + 0.0003 * sin(3 * M));
+        }
+
+        function getEclipticLongitude(M, C) {
+            var P = rad * 102.9372; // perihelion of the Earth
+            return M + C + P + PI;
+        }
+
+        return function getSunPosition(date, lat, lon) {
+            var lw = rad * -lon,
+                phi = rad * lat,
+                d = toDays(date),
+                M = getSolarMeanAnomaly(d),
+                C = getEquationOfCenter(M),
+                L = getEclipticLongitude(M, C),
+                D = getDeclination(L, 0),
+                A = getRightAscension(L, 0),
+                t = getSiderealTime(d, lw),
+                H = t - A;
+
+            return {
+                altitude: getAltitude(H, phi, D),
+                azimuth: getAzimuth(H, phi, D) + PI // - PI/2 // origin: north !!! not like original Mourner code but more classical ref
+            };
+        };
+
+
+    },
+
+    // Return scene coordinate ({x,y,z}) of sun
+    getSunPositionInScene: function(date, lat, lon) {
+
+        if (lat == undefined) {
+            var currentPosWGS84 = Cartography.convertCoordVec3(Cartography.getCurrentPosition(), "EPSG:2154", "CRS:84");
+            lat = currentPosWGS84.z;
+            lon = currentPosWGS84.x;
+        }
+        var sun = Utils.getSunPosition()(date, lat, lon);
+        var length = 2000; // distance of the sun from the earth
+        var direction = {
+            x: 0,
+            y: 0
+        };
+        direction.x = Math.sin(sun.azimuth) * length;
+        direction.y = Math.cos(sun.azimuth) * length;
+        var realalti = Math.sin(sun.altitude) * length;
+
+        //console.log(direction, realalti);
+
+        return {
+            x: direction.x,
+            y: realalti,
+            z: direction.y
+        };
+    }
+
+
+
+};
+
+export default Utils;

--- a/src/Renderer/WebGLTools/GenericBufferObject.js
+++ b/src/Renderer/WebGLTools/GenericBufferObject.js
@@ -20,6 +20,6 @@ GenericBufferObject.prototype.computeVertex = function() {
 
 
 
-module.exports = {
-    GenericBufferObject: GenericBufferObject
+export {
+    GenericBufferObject
 };

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -4,514 +4,500 @@
  * Description: 3DEngine est l'interface avec le framework webGL.
  */
 
-define('Renderer/c3DEngine', [
-    'THREE',
-    'OrbitControls',
-    'GlobeControls',
-    'Renderer/Camera',
-    'Globe/Atmosphere',
-    'Renderer/DepthMaterial',
-    'Renderer/BasicMaterial'
-], function(
-    THREE,
-    OrbitControls,
-    GlobeControls,
-    Camera,
-    Atmosphere,
-    DepthMaterial,
-    BasicMaterial) {
+import THREE from 'THREE';
+import OrbitControls from 'OrbitControls';
+import GlobeControls from 'GlobeControls';
+import Camera from 'Renderer/Camera';
+import Atmosphere from 'Globe/Atmosphere';
+import DepthMaterial from 'Renderer/DepthMaterial';
+import BasicMaterial from 'Renderer/BasicMaterial';
+
+var instance3DEngine = null;
+var RENDER = {
+    FINAL: 0,
+    PICKING: 1
+};
+
+function c3DEngine() {
+    //Constructor
+
+    if (instance3DEngine !== null) {
+        throw new Error("Cannot instantiate more than one c3DEngine");
+    }
+
+    THREE.ShaderChunk["logdepthbuf_pars_vertex"];
+
+    this.debug = false;
+    //this.debug      = true;
+    this.scene = undefined;
+    this.scene3D = new THREE.Scene();
+    this.width = this.debug ? window.innerWidth * 0.5 : window.innerWidth;
+    this.height = window.innerHeight;
+
+    this.renderer = undefined;
+    this.controls = undefined;
+    this.camera = undefined;
+    this.camDebug = undefined;
+    this.size = 1.0;
+    this.dnear = 0.0;
+    this.dfar = 0.0;
+    this.stateRender = RENDER.FINAL;
+    this.positionBuffer = null;
+
+    this.initCamera();
+
+    var material = new BasicMaterial(new THREE.Color(1, 0, 0));
+    var material2 = new BasicMaterial(new THREE.Color(0, 0, 1));
+    var geometry = new THREE.CylinderGeometry(0.6, 0.01, 2, 32);
+    this.dummy = new THREE.Mesh(geometry, material);
+    this.dummy2 = new THREE.Mesh(geometry, material2);
+
+    this.dummy2.material.enableRTC(false);
+    this.dummy.material.enableRTC(false);
+
+    //        this.scene3D.add(this.dummy);
+    //        this.scene3D.add(this.dummy2);
+
+    this.pickingTexture = new THREE.WebGLRenderTarget(this.width, this.height);
+    this.pickingTexture.texture.minFilter = THREE.LinearFilter;
+    this.pickingTexture.texture.generateMipmaps = false;
+    this.pickingTexture.texture.type = THREE.FloatType;
+    this.pickingTexture.depthBuffer = true;
+
+    this.renderScene = function() {
 
-    var instance3DEngine = null;
-    var RENDER = {
-        FINAL: 0,
-        PICKING: 1
-    };
-
-    function c3DEngine() {
-        //Constructor
-
-        if (instance3DEngine !== null) {
-            throw new Error("Cannot instantiate more than one c3DEngine");
-        }
-
-        THREE.ShaderChunk["logdepthbuf_pars_vertex"];
-
-        this.debug = false;
-        //this.debug      = true;
-        this.scene = undefined;
-        this.scene3D = new THREE.Scene();
-        this.width = this.debug ? window.innerWidth * 0.5 : window.innerWidth;
-        this.height = window.innerHeight;
-
-        this.renderer = undefined;
-        this.controls = undefined;
-        this.camera = undefined;
-        this.camDebug = undefined;
-        this.size = 1.0;
-        this.dnear = 0.0;
-        this.dfar = 0.0;
-        this.stateRender = RENDER.FINAL;
-        this.positionBuffer = null;
-
-        this.initCamera();
-
-        var material = new BasicMaterial(new THREE.Color(1, 0, 0));
-        var material2 = new BasicMaterial(new THREE.Color(0, 0, 1));
-        var geometry = new THREE.CylinderGeometry(0.6, 0.01, 2, 32);
-        this.dummy = new THREE.Mesh(geometry, material);
-        this.dummy2 = new THREE.Mesh(geometry, material2);
-
-        this.dummy2.material.enableRTC(false);
-        this.dummy.material.enableRTC(false);
-
-        //        this.scene3D.add(this.dummy);
-        //        this.scene3D.add(this.dummy2);
-
-        this.pickingTexture = new THREE.WebGLRenderTarget(this.width, this.height);
-        this.pickingTexture.texture.minFilter = THREE.LinearFilter;
-        this.pickingTexture.texture.generateMipmaps = false;
-        this.pickingTexture.texture.type = THREE.FloatType;
-        this.pickingTexture.depthBuffer = true;
-
-        this.renderScene = function() {
-
-            this.renderer.clear();
-            this.renderer.setViewport(0, 0, this.width, this.height);
-            this.renderer.render(this.scene3D, this.camera.camera3D);
-
-            if (this.debug) {
-
-                this.enableRTC(false);
-                this.camera.camHelper().visible = true;
-                this.renderer.setViewport(this.width, 0, this.width, this.height);
-                this.renderer.render(this.scene3D, this.camDebug);
-                this.enableRTC(true);
-                this.camera.camHelper().visible = false;
-            }
-
-        }.bind(this);
-
-        this.update = function() {
-            this.camera.update();
-            this.updateControl();
-            this.scene.wait();
-            this.renderScene();
-
-        }.bind(this);
-
-        this.onWindowResize = function() {
-
-            this.width = this.debug ? window.innerWidth * 0.5 : window.innerWidth;
-            this.height = window.innerHeight;
-            this.camera.resize(this.width, this.height);
-
-            this.scene.updateCamera();
-
-            if (this.camDebug) {
-                this.camDebug.aspect = this.camera.ratio;
-                this.camDebug.updateProjectionMatrix();
-            }
-
-            this.renderer.setSize(window.innerWidth, window.innerHeight);
-            this.update();
-            this.renderScene();
-        }.bind(this);
-
-    };
-
-    /**
-     * Intialisation camera and debug camera
-     * @returns {undefined}
-     */
-    c3DEngine.prototype.initCamera = function() {
-        this.camera = new Camera(this.width, this.height, this.debug);
-
-        if (this.controls instanceof THREE.OrbitControls)
-            this.scene3D.add(this.camera.camera3D);
-
-        if (this.debug) {
-            this.camDebug = new THREE.PerspectiveCamera(30, this.camera.ratio);
-
-        }
-    };
-
-    /**
-     * Initialisation renderer THREE.js
-     * @returns {undefined}
-     */
-    c3DEngine.prototype.initRenderer = function() {
-        this.renderer = new THREE.WebGLRenderer({
-            antialias: true,
-            alpha: true,
-            logarithmicDepthBuffer: true
-        });
-        this.renderer.setPixelRatio(window.devicePixelRatio);
-        this.renderer.setSize(window.innerWidth, window.innerHeight);
-        this.renderer.setClearColor(0x030508);
-        this.renderer.autoClear = false;
-
-        document.body.appendChild(this.renderer.domElement);
-    };
-
-    /**
-     * 
-     * @param {type} scene
-     * @param {type} position
-     * @returns {undefined}
-     */
-    c3DEngine.prototype.init = function(scene, position) {
-
-        this.scene = scene;
-        this.size = this.scene.size().x;
-        this.camera.setPosition(position);
-
-        // if near is too small --> bug no camera helper
-        this.camera.camera3D.near = this.size * 2.333;
-        this.camera.camera3D.far = this.size * 10;
-        this.camera.camera3D.updateProjectionMatrix();
-        this.camera.camera3D.updateMatrixWorld(true);
-
-        if (this.debug) {
-
-            this.camDebug.position.x = -this.size * 6;
-            this.camDebug.lookAt(new THREE.Vector3(0, 0, 0));
-            this.camDebug.near = this.size * 0.1;
-            this.camDebug.far = this.size * 10;
-            this.camDebug.updateProjectionMatrix();
-            this.camera.createCamHelper();
-            this.scene3D.add(this.camera.camHelper());
-            var axisHelper = new THREE.AxisHelper(this.size * 1.33);
-            this.scene3D.add(axisHelper);
-        }
-
-        if (this.controls instanceof THREE.GlobeControls) {
-            var axisHelper = new THREE.AxisHelper(this.size * 1.33);
-            this.scene3D.add(axisHelper);
-        }
-
-        this.camera.camera3D.near = Math.max(15.0, 0.000002352 * this.size);
-        this.camera.camera3D.updateProjectionMatrix();
-        this.initRenderer();
-        this.initControls(this.size);
-
-        //this.controls.target        = target;        
-        window.addEventListener('resize', this.onWindowResize, false);
-        this.controls.addEventListener('change', this.update);
-
-    };
-
-    /**
-     * TODO : temporaire
-     * update control parameter in function of distance of globe
-     * @returns {undefined}
-     */
-    c3DEngine.prototype.updateControl = function() {
-        var len = this.camera.position().length();
-        var lim = this.size * 1.3;
-
-        if (len < lim) {
-            var t = Math.pow(Math.cos((lim - len) / (lim - this.size * 0.9981) * Math.PI * 0.5), 1.5);
-            if (this.controls instanceof THREE.OrbitControls) {
-                this.controls.zoomSpeed = t * 2.0;
-                this.controls.rotateSpeed = 0.8 * t;
-            }
-            var color = new THREE.Color(0x93d5f8);
-
-            this.renderer.setClearColor(color.multiplyScalar(1.0 - t));
-        } else if (len >= lim && this.controls.zoomSpeed !== 1.0) {
-            this.controls.zoomSpeed = 1.0;
-            this.controls.rotateSpeed = 1.0;
-            this.renderer.setClearColor(0x030508);
-        }
-    };
-
-    c3DEngine.prototype.enableRTC = function(enable) {
-        for (var x = 0; x < this.scene3D.children.length; x++) {
-            var node = this.scene3D.children[x];
-
-            if (node.enableRTC)
-                node.traverseVisible(enable ? this.rtcOn.bind(this) : this.rtcOff.bind(this));
-            else
-                node.visible = enable;
-
-        }
-
-    };
-
-    c3DEngine.prototype.enablePickingRender = function(enable) {
-        for (var x = 0; x < this.scene3D.children.length; x++) {
-            var node = this.scene3D.children[x];
-
-            if (node.enablePickingRender)
-                node.traverseVisible(enable ? this.pickingOn.bind(this) : this.pickingOff.bind(this));
-            else
-                node.visible = !enable;
-        }
-    };
-
-    c3DEngine.prototype.rtcOn = function(obj3D) {
-        obj3D.enableRTC(true);
-    };
-
-    c3DEngine.prototype.rtcOff = function(obj3D) {
-        obj3D.enableRTC(false);
-    };
-
-    c3DEngine.prototype.pickingOn = function(obj3D) {
-        obj3D.enablePickingRender(true);
-    };
-
-    c3DEngine.prototype.pickingOff = function(obj3D) {
-        obj3D.enablePickingRender(false);
-    };
-
-    /**
-     */
-    c3DEngine.prototype.style2Engine = function() {
-        //TODO: Implement Me 
-
-    };
-
-    /**
-     * @documentation Initialisation of controls camera
-     * @param {type} size
-     * @returns {undefined}
-     */
-
-    c3DEngine.prototype.initControls = function(size) {
-
-        //this.controls   = new THREE.OrbitControls( this.camera.camera3D,this.renderer.domElement );        
-        this.controls = new THREE.GlobeControls(this.camera.camera3D, this.renderer.domElement, this);
-
-        this.controls.target = new THREE.Vector3(0, 0, 0);
-        this.controls.damping = 0.1;
-        this.controls.noPan = false;
-        this.controls.rotateSpeed = 0.8;
-        this.controls.zoomSpeed = 1.0;
-        this.controls.minDistance = 30;
-        this.controls.maxDistance = size * 8.0;
-        this.controls.keyPanSpeed = 0.01;
-
-    };
-
-    /**
-     * TODO : to delete
-     * @param {type} mesh
-     * @param {type} texture
-     * @returns {undefined}
-     */
-    c3DEngine.prototype.setTexture = function(mesh, texture) {
-        //TODO: Implement Me         
-        mesh.material = new THREE.MeshBasicMaterial({
-            color: 0xffffff,
-            map: texture
-        });
-    };
-
-    /**
-     * add nodeMesh in scene 3D
-     * @param {type} node
-     * @returns {undefined}
-     */
-    c3DEngine.prototype.add3DScene = function(node) {
-
-        if (Array.isArray(node))
-
-            this.scene3D.add.apply(this.scene3D, node);
-
-        else
-
-            this.scene3D.add(node);
-
-    };
-
-    /**
-     */
-    c3DEngine.prototype.precision = function() {
-        //TODO: Implement Me 
-
-    };
-
-    /*
-     * return 
-     */
-    c3DEngine.prototype.getWindowSize = function() {
-
-        return new THREE.Vector2(this.width, this.height);
-    };
-
-    /**
-     * return renderer THREE.js
-     * @returns {undefined|c3DEngine_L7.THREE.WebGLRenderer}
-     */
-    c3DEngine.prototype.getRenderer = function() {
-
-        return this.renderer;
-    };
-
-    c3DEngine.prototype.setStateRender = function(stateRender) {
-        if (this.stateRender !== stateRender) {
-            this.stateRender = stateRender;
-
-            switch (this.stateRender) {
-                case RENDER.FINAL:
-                    this.enablePickingRender(false);
-                    break;
-                case RENDER.PICKING:
-                    this.enablePickingRender(true);
-                    break;
-                default:
-                    this.stateRender = RENDER.FINAL;
-                    this.enablePickingRender(false);
-            }
-        }
-    };
-
-    c3DEngine.prototype.updatePositionBuffer = function() {
-
-
-    };
-
-    c3DEngine.prototype.renderTobuffer = function(x, y, width, height, mode) {
-
-        // TODO Deallocate render texture
-        var originalState = this.stateRender;
-        this.setStateRender(mode);
         this.renderer.clear();
         this.renderer.setViewport(0, 0, this.width, this.height);
-        this.renderer.render(this.scene3D, this.camera.camera3D, this.pickingTexture);
-        this.setStateRender(originalState);
+        this.renderer.render(this.scene3D, this.camera.camera3D);
 
-        var pixelBuffer = new Float32Array(width * height * 4);
-        this.renderer.readRenderTargetPixels(this.pickingTexture, x, y, width, height, pixelBuffer);
+        if (this.debug) {
 
-        return pixelBuffer;
-    };
+            this.enableRTC(false);
+            this.camera.camHelper().visible = true;
+            this.renderer.setViewport(this.width, 0, this.width, this.height);
+            this.renderer.render(this.scene3D, this.camDebug);
+            this.enableRTC(true);
+            this.camera.camHelper().visible = false;
+        }
 
-    c3DEngine.prototype.bufferToImage = function(pixelBuffer, width, height) {
+    }.bind(this);
 
-        var canvas = document.createElement("canvas");
-        var ctx = canvas.getContext("2d");
+    this.update = function() {
+        this.camera.update();
+        this.updateControl();
+        this.scene.wait();
+        this.renderScene();
 
-        // size the canvas to your desired image
-        canvas.width = width;
-        canvas.height = height;
+    }.bind(this);
 
-        var imgData = ctx.getImageData(0, 0, width, height);
-        imgData.data.set(pixelBuffer);
+    this.onWindowResize = function() {
 
-        ctx.putImageData(imgData, 0, 0);
+        this.width = this.debug ? window.innerWidth * 0.5 : window.innerWidth;
+        this.height = window.innerHeight;
+        this.camera.resize(this.width, this.height);
 
-        // create a new img object
-        var image = new Image();
+        this.scene.updateCamera();
 
-        // set the img.src to the canvas data url
-        image.src = canvas.toDataURL();
+        if (this.camDebug) {
+            this.camDebug.aspect = this.camera.ratio;
+            this.camDebug.updateProjectionMatrix();
+        }
 
-        return image;
+        this.renderer.setSize(window.innerWidth, window.innerHeight);
+        this.update();
+        this.renderScene();
+    }.bind(this);
 
-    };
+};
 
-    c3DEngine.prototype.updatePositionBuffer = function() {
-        this.camera.camera3D.updateMatrixWorld();
-        this.dummy.visible = false;
-        this.positionBuffer = this.renderTobuffer(0, 0, this.width, this.height, RENDER.PICKING);
-        this.dummy.visible = true;
-        this.renderScene(); // TODO debug to remove white screen, but why?    
+/**
+ * Intialisation camera and debug camera
+ * @returns {undefined}
+ */
+c3DEngine.prototype.initCamera = function() {
+    this.camera = new Camera(this.width, this.height, this.debug);
 
-    };
+    if (this.controls instanceof THREE.OrbitControls)
+        this.scene3D.add(this.camera.camera3D);
 
-    c3DEngine.prototype.pickingInPositionBuffer = function(mouse, scene) {
+    if (this.debug) {
+        this.camDebug = new THREE.PerspectiveCamera(30, this.camera.ratio);
 
-        if (this.positionBuffer === null)
-            this.updatePositionBuffer();
+    }
+};
 
-        if (mouse === undefined)
-            mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2));
+/**
+ * Initialisation renderer THREE.js
+ * @returns {undefined}
+ */
+c3DEngine.prototype.initRenderer = function() {
+    this.renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+        logarithmicDepthBuffer: true
+    });
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    this.renderer.setClearColor(0x030508);
+    this.renderer.autoClear = false;
 
-        var coord = new THREE.Vector2(mouse.x, this.height - mouse.y);
+    document.body.appendChild(this.renderer.domElement);
+};
 
-        var i = (coord.y * this.width + coord.x) * 4;
+/**
+ * 
+ * @param {type} scene
+ * @param {type} position
+ * @returns {undefined}
+ */
+c3DEngine.prototype.init = function(scene, position) {
 
-        if (scene)
-            scene.selectNodeId(this.positionBuffer[i + 3]);
+    this.scene = scene;
+    this.size = this.scene.size().x;
+    this.camera.setPosition(position);
 
-        var glslPosition = new THREE.Vector3(this.positionBuffer[i + 0], this.positionBuffer[i + 1], this.positionBuffer[i + 2]);
+    // if near is too small --> bug no camera helper
+    this.camera.camera3D.near = this.size * 2.333;
+    this.camera.camera3D.far = this.size * 10;
+    this.camera.camera3D.updateProjectionMatrix();
+    this.camera.camera3D.updateMatrixWorld(true);
 
-        var worldPosition = glslPosition.applyMatrix4(this.camera.camera3D.matrixWorld);
+    if (this.debug) {
 
-        return worldPosition;
+        this.camDebug.position.x = -this.size * 6;
+        this.camDebug.lookAt(new THREE.Vector3(0, 0, 0));
+        this.camDebug.near = this.size * 0.1;
+        this.camDebug.far = this.size * 10;
+        this.camDebug.updateProjectionMatrix();
+        this.camera.createCamHelper();
+        this.scene3D.add(this.camera.camHelper());
+        var axisHelper = new THREE.AxisHelper(this.size * 1.33);
+        this.scene3D.add(axisHelper);
+    }
 
-    };
+    if (this.controls instanceof THREE.GlobeControls) {
+        var axisHelper = new THREE.AxisHelper(this.size * 1.33);
+        this.scene3D.add(axisHelper);
+    }
 
-    /**
-     * 
-     * @param {type} mouse : mouse position on screen in pixel
-     * @param {type} scene     
-     * @returns THREE.Vector3 position cartesien in world space
-     * */
-    c3DEngine.prototype.getPickingPosition = function(mouse, scene) {
-        if (mouse === undefined)
-            mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2));
+    this.camera.camera3D.near = Math.max(15.0, 0.000002352 * this.size);
+    this.camera.camera3D.updateProjectionMatrix();
+    this.initRenderer();
+    this.initControls(this.size);
 
-        this.camera.camera3D.updateMatrixWorld();
+    //this.controls.target        = target;        
+    window.addEventListener('resize', this.onWindowResize, false);
+    this.controls.addEventListener('change', this.update);
 
-        this.dummy.visible = false;
+};
 
-        var buffer = this.renderTobuffer(mouse.x, this.height - mouse.y, 1, 1, RENDER.PICKING);
-        this.dummy.visible = true;
+/**
+ * TODO : temporaire
+ * update control parameter in function of distance of globe
+ * @returns {undefined}
+ */
+c3DEngine.prototype.updateControl = function() {
+    var len = this.camera.position().length();
+    var lim = this.size * 1.3;
 
-        var glslPosition = new THREE.Vector3().fromArray(buffer);
+    if (len < lim) {
+        var t = Math.pow(Math.cos((lim - len) / (lim - this.size * 0.9981) * Math.PI * 0.5), 1.5);
+        if (this.controls instanceof THREE.OrbitControls) {
+            this.controls.zoomSpeed = t * 2.0;
+            this.controls.rotateSpeed = 0.8 * t;
+        }
+        var color = new THREE.Color(0x93d5f8);
 
-        if (scene)
-            scene.selectNodeId(buffer[3]);
+        this.renderer.setClearColor(color.multiplyScalar(1.0 - t));
+    } else if (len >= lim && this.controls.zoomSpeed !== 1.0) {
+        this.controls.zoomSpeed = 1.0;
+        this.controls.rotateSpeed = 1.0;
+        this.renderer.setClearColor(0x030508);
+    }
+};
 
-        var worldPosition = glslPosition.applyMatrix4(this.camera.camera3D.matrixWorld);
+c3DEngine.prototype.enableRTC = function(enable) {
+    for (var x = 0; x < this.scene3D.children.length; x++) {
+        var node = this.scene3D.children[x];
 
-        return worldPosition;
+        if (node.enableRTC)
+            node.traverseVisible(enable ? this.rtcOn.bind(this) : this.rtcOff.bind(this));
+        else
+            node.visible = enable;
 
-    };
+    }
 
-    c3DEngine.prototype.placeDummy = function(dummy, position) {
-        dummy.position.copy(position);
-        var size = position.clone().sub(this.camera.position()).length() / 200; // TODO distance                
-        dummy.scale.copy(new THREE.Vector3(size, size, size));
-        dummy.lookAt(new THREE.Vector3());
-        dummy.quaternion.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), -Math.PI / 2));
-        dummy.translateY(size);
-        dummy.updateMatrix();
-        dummy.updateMatrixWorld();
-    };
+};
 
-    c3DEngine.prototype.cartesianToGeo = function(position) {
-        var p = position.clone();
-        p.x = -position.x;
-        p.y = position.z;
-        p.z = position.y;
+c3DEngine.prototype.enablePickingRender = function(enable) {
+    for (var x = 0; x < this.scene3D.children.length; x++) {
+        var node = this.scene3D.children[x];
 
-        var R = p.length();
-        var a = 6378137;
-        var b = 6356752.3142451793;
-        var e = Math.sqrt((a * a - b * b) / (a * a));
-        var f = 1 - Math.sqrt(1 - e * e);
-        var rsqXY = Math.sqrt(p.x * p.x + p.y * p.y);
+        if (node.enablePickingRender)
+            node.traverseVisible(enable ? this.pickingOn.bind(this) : this.pickingOff.bind(this));
+        else
+            node.visible = !enable;
+    }
+};
 
-        var theta = Math.atan2(p.y, p.x);
-        var nu = Math.atan(p.z / rsqXY * ((1 - f) + e * e * a / R));
+c3DEngine.prototype.rtcOn = function(obj3D) {
+    obj3D.enableRTC(true);
+};
 
-        var sinu = Math.sin(nu);
-        var cosu = Math.cos(nu);
+c3DEngine.prototype.rtcOff = function(obj3D) {
+    obj3D.enableRTC(false);
+};
 
-        var phi = Math.atan((p.z * (1 - f) + e * e * a * sinu * sinu * sinu) / ((1 - f) * (rsqXY - e * e * a * cosu * cosu * cosu)));
+c3DEngine.prototype.pickingOn = function(obj3D) {
+    obj3D.enablePickingRender(true);
+};
 
-        var h = (rsqXY * Math.cos(phi)) + p.z * Math.sin(phi) - a * Math.sqrt(1 - e * e * Math.sin(phi) * Math.sin(phi));
+c3DEngine.prototype.pickingOff = function(obj3D) {
+    obj3D.enablePickingRender(false);
+};
 
-        console.log(theta / Math.PI * 180 + ' ' + phi / Math.PI * 180 + ' ' + h);
-    };
+/**
+ */
+c3DEngine.prototype.style2Engine = function() {
+    //TODO: Implement Me 
 
-    return function(scene) {
-        instance3DEngine = instance3DEngine || new c3DEngine(scene);
-        return instance3DEngine;
-    };
+};
 
-});
+/**
+ * @documentation Initialisation of controls camera
+ * @param {type} size
+ * @returns {undefined}
+ */
+
+c3DEngine.prototype.initControls = function(size) {
+
+    //this.controls   = new THREE.OrbitControls( this.camera.camera3D,this.renderer.domElement );        
+    this.controls = new THREE.GlobeControls(this.camera.camera3D, this.renderer.domElement, this);
+
+    this.controls.target = new THREE.Vector3(0, 0, 0);
+    this.controls.damping = 0.1;
+    this.controls.noPan = false;
+    this.controls.rotateSpeed = 0.8;
+    this.controls.zoomSpeed = 1.0;
+    this.controls.minDistance = 30;
+    this.controls.maxDistance = size * 8.0;
+    this.controls.keyPanSpeed = 0.01;
+
+};
+
+/**
+ * TODO : to delete
+ * @param {type} mesh
+ * @param {type} texture
+ * @returns {undefined}
+ */
+c3DEngine.prototype.setTexture = function(mesh, texture) {
+    //TODO: Implement Me         
+    mesh.material = new THREE.MeshBasicMaterial({
+        color: 0xffffff,
+        map: texture
+    });
+};
+
+/**
+ * add nodeMesh in scene 3D
+ * @param {type} node
+ * @returns {undefined}
+ */
+c3DEngine.prototype.add3DScene = function(node) {
+
+    if (Array.isArray(node))
+
+        this.scene3D.add.apply(this.scene3D, node);
+
+    else
+
+        this.scene3D.add(node);
+
+};
+
+/**
+ */
+c3DEngine.prototype.precision = function() {
+    //TODO: Implement Me 
+
+};
+
+/*
+ * return 
+ */
+c3DEngine.prototype.getWindowSize = function() {
+
+    return new THREE.Vector2(this.width, this.height);
+};
+
+/**
+ * return renderer THREE.js
+ * @returns {undefined|c3DEngine_L7.THREE.WebGLRenderer}
+ */
+c3DEngine.prototype.getRenderer = function() {
+
+    return this.renderer;
+};
+
+c3DEngine.prototype.setStateRender = function(stateRender) {
+    if (this.stateRender !== stateRender) {
+        this.stateRender = stateRender;
+
+        switch (this.stateRender) {
+            case RENDER.FINAL:
+                this.enablePickingRender(false);
+                break;
+            case RENDER.PICKING:
+                this.enablePickingRender(true);
+                break;
+            default:
+                this.stateRender = RENDER.FINAL;
+                this.enablePickingRender(false);
+        }
+    }
+};
+
+c3DEngine.prototype.updatePositionBuffer = function() {};
+
+c3DEngine.prototype.renderTobuffer = function(x, y, width, height, mode) {
+
+    // TODO Deallocate render texture
+    var originalState = this.stateRender;
+    this.setStateRender(mode);
+    this.renderer.clear();
+    this.renderer.setViewport(0, 0, this.width, this.height);
+    this.renderer.render(this.scene3D, this.camera.camera3D, this.pickingTexture);
+    this.setStateRender(originalState);
+
+    var pixelBuffer = new Float32Array(width * height * 4);
+    this.renderer.readRenderTargetPixels(this.pickingTexture, x, y, width, height, pixelBuffer);
+
+    return pixelBuffer;
+};
+
+c3DEngine.prototype.bufferToImage = function(pixelBuffer, width, height) {
+
+    var canvas = document.createElement("canvas");
+    var ctx = canvas.getContext("2d");
+
+    // size the canvas to your desired image
+    canvas.width = width;
+    canvas.height = height;
+
+    var imgData = ctx.getImageData(0, 0, width, height);
+    imgData.data.set(pixelBuffer);
+
+    ctx.putImageData(imgData, 0, 0);
+
+    // create a new img object
+    var image = new Image();
+
+    // set the img.src to the canvas data url
+    image.src = canvas.toDataURL();
+
+    return image;
+
+};
+
+c3DEngine.prototype.updatePositionBuffer = function() {
+    this.camera.camera3D.updateMatrixWorld();
+    this.dummy.visible = false;
+    this.positionBuffer = this.renderTobuffer(0, 0, this.width, this.height, RENDER.PICKING);
+    this.dummy.visible = true;
+    this.renderScene(); // TODO debug to remove white screen, but why?    
+
+};
+
+c3DEngine.prototype.pickingInPositionBuffer = function(mouse, scene) {
+
+    if (this.positionBuffer === null)
+        this.updatePositionBuffer();
+
+    if (mouse === undefined)
+        mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2));
+
+    var coord = new THREE.Vector2(mouse.x, this.height - mouse.y);
+
+    var i = (coord.y * this.width + coord.x) * 4;
+
+    if (scene)
+        scene.selectNodeId(this.positionBuffer[i + 3]);
+
+    var glslPosition = new THREE.Vector3(this.positionBuffer[i + 0], this.positionBuffer[i + 1], this.positionBuffer[i + 2]);
+
+    var worldPosition = glslPosition.applyMatrix4(this.camera.camera3D.matrixWorld);
+
+    return worldPosition;
+
+};
+
+/**
+ * 
+ * @param {type} mouse : mouse position on screen in pixel
+ * @param {type} scene     
+ * @returns THREE.Vector3 position cartesien in world space 
+ **/
+c3DEngine.prototype.getPickingPosition = function(mouse, scene) {
+    if (mouse === undefined)
+        mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2));
+
+    this.camera.camera3D.updateMatrixWorld();
+
+    this.dummy.visible = false;
+
+    var buffer = this.renderTobuffer(mouse.x, this.height - mouse.y, 1, 1, RENDER.PICKING);
+    this.dummy.visible = true;
+
+    var glslPosition = new THREE.Vector3().fromArray(buffer);
+
+    if (scene)
+        scene.selectNodeId(buffer[3]);
+
+    var worldPosition = glslPosition.applyMatrix4(this.camera.camera3D.matrixWorld);
+
+    return worldPosition;
+
+};
+
+c3DEngine.prototype.placeDummy = function(dummy, position) {
+    dummy.position.copy(position);
+    var size = position.clone().sub(this.camera.position()).length() / 200; // TODO distance                
+    dummy.scale.copy(new THREE.Vector3(size, size, size));
+    dummy.lookAt(new THREE.Vector3());
+    dummy.quaternion.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), -Math.PI / 2));
+    dummy.translateY(size);
+    dummy.updateMatrix();
+    dummy.updateMatrixWorld();
+};
+
+c3DEngine.prototype.cartesianToGeo = function(position) {
+    var p = position.clone();
+    p.x = -position.x;
+    p.y = position.z;
+    p.z = position.y;
+
+    var R = p.length();
+    var a = 6378137;
+    var b = 6356752.3142451793;
+    var e = Math.sqrt((a * a - b * b) / (a * a));
+    var f = 1 - Math.sqrt(1 - e * e);
+    var rsqXY = Math.sqrt(p.x * p.x + p.y * p.y);
+
+    var theta = Math.atan2(p.y, p.x);
+    var nu = Math.atan(p.z / rsqXY * ((1 - f) + e * e * a / R));
+
+    var sinu = Math.sin(nu);
+    var cosu = Math.cos(nu);
+
+    var phi = Math.atan((p.z * (1 - f) + e * e * a * sinu * sinu * sinu) / ((1 - f) * (rsqXY - e * e * a * cosu * cosu * cosu)));
+
+    var h = (rsqXY * Math.cos(phi)) + p.z * Math.sin(phi) - a * Math.sqrt(1 - e * e * Math.sin(phi) * Math.sin(phi));
+
+    console.log(theta / Math.PI * 180 + ' ' + phi / Math.PI * 180 + ' ' + h);
+};
+
+export default function(scene) {
+    instance3DEngine = instance3DEngine || new c3DEngine(scene);
+    return instance3DEngine;
+};

--- a/src/Scene/BoundingBox.js
+++ b/src/Scene/BoundingBox.js
@@ -14,180 +14,176 @@
  * @param {type} OBB
  * @returns {BoundingBox_L10.BoundingBox}
  */
-define('Scene/BoundingBox', [
-    'Core/defaultValue',
-    'Core/Math/MathExtented',
-    'Core/Math/Point2D',
-    'Core/Geographic/CoordCarto',
-    'THREE',
-    'OBB'
-], function(defaultValue, MathExt, Point2D, CoordCarto, THREE, OBB) {
+import defaultValue from 'Core/defaultValue';
+import MathExt from 'Core/Math/MathExtented';
+import Point2D from 'Core/Math/Point2D';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import THREE from 'THREE';
+import OBB from 'OBB';
 
-    /**
-     * 
-     * @param {type} minLongitude : longitude minimum
-     * @param {type} maxLongitude : longitude maximum
-     * @param {type} minLatitude  : latitude minimum 
-     * @param {type} maxLatitude  : latitude maximum 
-     * @param {type} parentCenter : center parent
-     * @param {type} minAltitude  : altitude minimum
-     * @param {type} maxAltitude  : altitude maximum  
-     * @returns {BoundingBox_L7.BoundingBox}
-     */
-    function BoundingBox(minLongitude, maxLongitude, minLatitude, maxLatitude, parentCenter, minAltitude, maxAltitude) {
-        //Constructor
+/**
+ * 
+ * @param {type} minLongitude : longitude minimum
+ * @param {type} maxLongitude : longitude maximum
+ * @param {type} minLatitude  : latitude minimum 
+ * @param {type} maxLatitude  : latitude maximum 
+ * @param {type} parentCenter : center parent
+ * @param {type} minAltitude  : altitude minimum
+ * @param {type} maxAltitude  : altitude maximum  
+ * @returns {BoundingBox_L7.BoundingBox}
+ */
+function BoundingBox(minLongitude, maxLongitude, minLatitude, maxLatitude, parentCenter, minAltitude, maxAltitude) {
+    //Constructor
 
-        this.minCarto = new CoordCarto(defaultValue(minLongitude, 0), defaultValue(minLatitude, -MathExt.PI_OV_TWO), defaultValue(minAltitude, -10000));
-        this.maxCarto = new CoordCarto(defaultValue(maxLongitude, MathExt.TWO_PI), defaultValue(maxLatitude, MathExt.PI_OV_TWO), defaultValue(maxAltitude, 10000));
+    this.minCarto = new CoordCarto(defaultValue(minLongitude, 0), defaultValue(minLatitude, -MathExt.PI_OV_TWO), defaultValue(minAltitude, -10000));
+    this.maxCarto = new CoordCarto(defaultValue(maxLongitude, MathExt.TWO_PI), defaultValue(maxLatitude, MathExt.PI_OV_TWO), defaultValue(maxAltitude, 10000));
 
-        this.dimension = new Point2D(Math.abs(this.maxCarto.longitude - this.minCarto.longitude), Math.abs(this.maxCarto.latitude - this.minCarto.latitude));
-        this.halfDimension = new Point2D(this.dimension.x * 0.5, this.dimension.y * 0.5);
-        this.center = new Point2D(this.minCarto.longitude + this.halfDimension.x, this.minCarto.latitude + this.halfDimension.y);
-        //this.relativeCenter = parentCenter === undefined ? this.center : new Point2D(this.center.x - parentCenter.x,this.center.y - parentCenter.y);
-        this.size = Math.sqrt(this.dimension.x * this.dimension.x + this.dimension.y * this.dimension.y);
+    this.dimension = new Point2D(Math.abs(this.maxCarto.longitude - this.minCarto.longitude), Math.abs(this.maxCarto.latitude - this.minCarto.latitude));
+    this.halfDimension = new Point2D(this.dimension.x * 0.5, this.dimension.y * 0.5);
+    this.center = new Point2D(this.minCarto.longitude + this.halfDimension.x, this.minCarto.latitude + this.halfDimension.y);
+    //this.relativeCenter = parentCenter === undefined ? this.center : new Point2D(this.center.x - parentCenter.x,this.center.y - parentCenter.y);
+    this.size = Math.sqrt(this.dimension.x * this.dimension.x + this.dimension.y * this.dimension.y);
 
+}
+
+/**
+ * @documentation: Retourne True if point is inside the bounding box
+ *
+ * @param point {[object Object]} 
+ */
+BoundingBox.prototype.isInside = function(point) {
+    //TODO: Implement Me 
+
+    return point.x <= this.maxCarto.longitude && point.x >= this.minCarto.longitude && point.y <= this.maxCarto.latitude && point.y >= this.minCarto.latitude;
+
+};
+
+BoundingBox.prototype.BBoxIsInside = function(bbox) {
+    //TODO: Implement Me 
+
+    return bbox.maxCarto.longitude <= this.maxCarto.longitude && bbox.minCarto.longitude >= this.minCarto.longitude && bbox.maxCarto.latitude <= this.maxCarto.latitude && bbox.minCarto.latitude >= this.minCarto.latitude;
+
+};
+
+BoundingBox.prototype.pitScale = function(bbox) {
+    var pitX = Math.abs(bbox.minCarto.longitude - this.minCarto.longitude) / this.dimension.x;
+    var pitY = Math.abs(bbox.maxCarto.latitude - this.maxCarto.latitude) / this.dimension.y;
+    var scale = bbox.dimension.x / this.dimension.x;
+    return new THREE.Vector3(pitX, pitY, scale);
+};
+
+/**
+ * @documentation: Set the bounding box with the center of the box and the half dimension of the box
+ * @param {type} center : center of the box
+ * @param {type} halfDimension : half dimension of box
+ * @returns {undefined}
+ */
+BoundingBox.prototype.set = function(center, halfDimension) {
+
+    this.halfDimension = halfDimension;
+    this.center = center;
+
+};
+
+/**
+ * @documentation: Set altitude of bounding box
+ * @param {type} min : minimum altitude
+ * @param {type} max : maximum altitude
+ * @returns {undefined}
+ */
+BoundingBox.prototype.setAltitude = function(min, max) {
+
+    this.minCarto.altitude = min;
+    this.maxCarto.altitude = max;
+
+};
+
+/**
+ * @documentation: Return true if this bounding box intersect with the bouding box parameter
+ * @param {type} bbox
+ * @returns {Boolean}
+ */
+BoundingBox.prototype.intersect = function(bbox) {
+    return !(this.minCarto.longitude >= bbox.maxCarto.longitude || this.maxCarto.longitude <= bbox.minCarto.longitude || this.minCarto.latitude >= bbox.maxCarto.latitude || this.maxCarto.latitude <= bbox.minCarto.latitude);
+
+};
+
+/**
+ * @documentation:Compute the bounding box of a tile oriented ellipsoidal bounded by the bounding box
+ * @param {type} ellipsoid
+ * @param {type} normal
+ * @param {type} center
+ * @returns {BoundingBox_L7.THREE.OBB}
+ */
+BoundingBox.prototype.get3DBBox = function(ellipsoid, center) {
+
+    var cardinals = [];
+
+    var normal = center.clone().normalize();
+
+    var phiStart = this.minCarto.longitude;
+    var phiLength = this.dimension.x;
+
+    var thetaStart = this.minCarto.latitude;
+    var thetaLength = this.dimension.y;
+
+    //      0---1---2
+    //      |       |
+    //      7       3
+    //      |       |
+    //      6---5---4
+
+    cardinals.push(new CoordCarto(phiStart, thetaStart, 0));
+    cardinals.push(new CoordCarto(phiStart + this.halfDimension.x, thetaStart, 0));
+    cardinals.push(new CoordCarto(phiStart + phiLength, thetaStart, 0));
+    cardinals.push(new CoordCarto(phiStart + phiLength, thetaStart + this.halfDimension.y, 0));
+    cardinals.push(new CoordCarto(phiStart + phiLength, thetaStart + thetaLength, 0));
+    cardinals.push(new CoordCarto(phiStart + this.halfDimension.x, thetaStart + thetaLength, 0));
+    cardinals.push(new CoordCarto(phiStart, thetaStart + thetaLength, 0));
+    cardinals.push(new CoordCarto(phiStart, thetaStart + this.halfDimension.y, 0));
+
+    var cardinals3D = [];
+    var cardin3DPlane = [];
+
+    var maxV = new THREE.Vector3(-1000, -1000, -1000);
+    var minV = new THREE.Vector3(1000, 1000, 1000);
+    var maxHeight = 0;
+    var planeZ = new THREE.Quaternion();
+    var qRotY = new THREE.Quaternion();
+    var vec = new THREE.Vector3();
+    var tangentPlane = new THREE.Plane(normal);
+
+    planeZ.setFromUnitVectors(normal, new THREE.Vector3(0, 1, 0));
+    qRotY.setFromAxisAngle(new THREE.Vector3(0, 1, 0), -this.center.x);
+    qRotY.multiply(planeZ);
+
+    for (var i = 0; i < cardinals.length; i++) {
+        cardinals3D.push(ellipsoid.cartographicToCartesian(cardinals[i]));
+        cardin3DPlane.push(tangentPlane.projectPoint(cardinals3D[i]));
+        vec.subVectors(cardinals3D[i], center);
+        maxHeight = Math.max(maxHeight, cardin3DPlane[i].distanceTo(vec));
+        cardin3DPlane[i].applyQuaternion(qRotY);
+        maxV.max(cardin3DPlane[i]);
+        minV.min(cardin3DPlane[i]);
     }
 
-    /**
-     * @documentation: Retourne True if point is inside the bounding box
-     *
-     * @param point {[object Object]} 
-     */
-    BoundingBox.prototype.isInside = function(point) {
-        //TODO: Implement Me 
+    maxHeight = maxHeight * 0.5;
+    var width = Math.abs(maxV.z - minV.z) * 0.5;
+    var height = Math.abs(maxV.x - minV.x) * 0.5;
+    var delta = height - Math.abs(cardin3DPlane[5].x);
+    var max = new THREE.Vector3(width, height, maxHeight);
+    var min = new THREE.Vector3(-width, -height, -maxHeight);
+    var obb = new THREE.OBB(min, max);
 
-        return point.x <= this.maxCarto.longitude && point.x >= this.minCarto.longitude && point.y <= this.maxCarto.latitude && point.y >= this.minCarto.latitude;
+    //var l  = center.length();
+    //obb.position.copy(center);                
+    obb.lookAt(normal);
+    obb.translateZ(-maxHeight);
+    obb.translateY(delta);
+    obb.update();
 
-    };
+    return obb;
 
-    BoundingBox.prototype.BBoxIsInside = function(bbox) {
-        //TODO: Implement Me 
+};
 
-        return bbox.maxCarto.longitude <= this.maxCarto.longitude && bbox.minCarto.longitude >= this.minCarto.longitude && bbox.maxCarto.latitude <= this.maxCarto.latitude && bbox.minCarto.latitude >= this.minCarto.latitude;
-
-    };
-
-    BoundingBox.prototype.pitScale = function(bbox) {
-        var pitX = Math.abs(bbox.minCarto.longitude - this.minCarto.longitude) / this.dimension.x;
-        var pitY = Math.abs(bbox.maxCarto.latitude - this.maxCarto.latitude) / this.dimension.y;
-        var scale = bbox.dimension.x / this.dimension.x;
-        return new THREE.Vector3(pitX, pitY, scale);
-    };
-
-    /**
-     * @documentation: Set the bounding box with the center of the box and the half dimension of the box
-     * @param {type} center : center of the box
-     * @param {type} halfDimension : half dimension of box
-     * @returns {undefined}
-     */
-    BoundingBox.prototype.set = function(center, halfDimension) {
-
-        this.halfDimension = halfDimension;
-        this.center = center;
-
-    };
-
-    /**
-     * @documentation: Set altitude of bounding box
-     * @param {type} min : minimum altitude
-     * @param {type} max : maximum altitude
-     * @returns {undefined}
-     */
-    BoundingBox.prototype.setAltitude = function(min, max) {
-
-        this.minCarto.altitude = min;
-        this.maxCarto.altitude = max;
-
-    };
-
-    /**
-     * @documentation: Return true if this bounding box intersect with the bouding box parameter
-     * @param {type} bbox
-     * @returns {Boolean}
-     */
-    BoundingBox.prototype.intersect = function(bbox) {
-        return !(this.minCarto.longitude >= bbox.maxCarto.longitude || this.maxCarto.longitude <= bbox.minCarto.longitude || this.minCarto.latitude >= bbox.maxCarto.latitude || this.maxCarto.latitude <= bbox.minCarto.latitude);
-
-    };
-
-    /**
-     * @documentation:Compute the bounding box of a tile oriented ellipsoidal bounded by the bounding box
-     * @param {type} ellipsoid
-     * @param {type} normal
-     * @param {type} center
-     * @returns {BoundingBox_L7.THREE.OBB}
-     */
-    BoundingBox.prototype.get3DBBox = function(ellipsoid, center) {
-
-        var cardinals = [];
-
-        var normal = center.clone().normalize();
-
-        var phiStart = this.minCarto.longitude;
-        var phiLength = this.dimension.x;
-
-        var thetaStart = this.minCarto.latitude;
-        var thetaLength = this.dimension.y;
-
-        //      0---1---2
-        //      |       |
-        //      7       3
-        //      |       |
-        //      6---5---4
-
-        cardinals.push(new CoordCarto(phiStart, thetaStart, 0));
-        cardinals.push(new CoordCarto(phiStart + this.halfDimension.x, thetaStart, 0));
-        cardinals.push(new CoordCarto(phiStart + phiLength, thetaStart, 0));
-        cardinals.push(new CoordCarto(phiStart + phiLength, thetaStart + this.halfDimension.y, 0));
-        cardinals.push(new CoordCarto(phiStart + phiLength, thetaStart + thetaLength, 0));
-        cardinals.push(new CoordCarto(phiStart + this.halfDimension.x, thetaStart + thetaLength, 0));
-        cardinals.push(new CoordCarto(phiStart, thetaStart + thetaLength, 0));
-        cardinals.push(new CoordCarto(phiStart, thetaStart + this.halfDimension.y, 0));
-
-        var cardinals3D = [];
-        var cardin3DPlane = [];
-
-        var maxV = new THREE.Vector3(-1000, -1000, -1000);
-        var minV = new THREE.Vector3(1000, 1000, 1000);
-        var maxHeight = 0;
-        var planeZ = new THREE.Quaternion();
-        var qRotY = new THREE.Quaternion();
-        var vec = new THREE.Vector3();
-        var tangentPlane = new THREE.Plane(normal);
-
-        planeZ.setFromUnitVectors(normal, new THREE.Vector3(0, 1, 0));
-        qRotY.setFromAxisAngle(new THREE.Vector3(0, 1, 0), -this.center.x);
-        qRotY.multiply(planeZ);
-
-        for (var i = 0; i < cardinals.length; i++) {
-            cardinals3D.push(ellipsoid.cartographicToCartesian(cardinals[i]));
-            cardin3DPlane.push(tangentPlane.projectPoint(cardinals3D[i]));
-            vec.subVectors(cardinals3D[i], center);
-            maxHeight = Math.max(maxHeight, cardin3DPlane[i].distanceTo(vec));
-            cardin3DPlane[i].applyQuaternion(qRotY);
-            maxV.max(cardin3DPlane[i]);
-            minV.min(cardin3DPlane[i]);
-        }
-
-        maxHeight = maxHeight * 0.5;
-        var width = Math.abs(maxV.z - minV.z) * 0.5;
-        var height = Math.abs(maxV.x - minV.x) * 0.5;
-        var delta = height - Math.abs(cardin3DPlane[5].x);
-        var max = new THREE.Vector3(width, height, maxHeight);
-        var min = new THREE.Vector3(-width, -height, -maxHeight);
-        var obb = new THREE.OBB(min, max);
-
-        //var l  = center.length();
-        //obb.position.copy(center);                
-        obb.lookAt(normal);
-        obb.translateZ(-maxHeight);
-        obb.translateY(delta);
-        obb.update();
-
-        return obb;
-
-    };
-
-    return BoundingBox;
-
-});
+export default BoundingBox;

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -4,204 +4,206 @@
  * Description: BrowseTree parcourt un arbre de Node. Lors du parcours un ou plusieur NodeProcess peut etre appliqué sur certains Node.
  */
 
-define('Scene/BrowseTree', ['THREE', 'Globe/EllipsoidTileMesh', 'Scene/NodeProcess', 'OBBHelper'], function(THREE, EllipsoidTileMesh) {
+import THREE from 'THREE';
+import EllipsoidTileMesh from 'Globe/EllipsoidTileMesh';
+import 'Scene/NodeProcess';
+import 'OBBHelper';
 
-    function BrowseTree(scene) {
-        //Constructor
+function BrowseTree(scene) {
+    //Constructor
 
-        this.oneNode = 0;
-        this.scene = scene;
-        this.nodeProcess = undefined;
-        this.tree = undefined;
-        this.date = new Date();
-        this.fogDistance = 1000000000.0;
-        this.mfogDistance = 1000000000.0;
-        this.visibleNodes = 0;
-        this.selectNodeId = -1;
-        this.selectNode = null;
-        this.cachedRTC = null;
+    this.oneNode = 0;
+    this.scene = scene;
+    this.nodeProcess = undefined;
+    this.tree = undefined;
+    this.date = new Date();
+    this.fogDistance = 1000000000.0;
+    this.mfogDistance = 1000000000.0;
+    this.visibleNodes = 0;
+    this.selectNodeId = -1;
+    this.selectNode = null;
+    this.cachedRTC = null;
+
+}
+
+
+BrowseTree.prototype.addNodeProcess = function(nodeProcess) {
+    this.nodeProcess = nodeProcess;
+};
+
+BrowseTree.prototype.NodeProcess = function() {
+    return this.nodeProcess;
+};
+
+/**
+ * @documentation: Process to apply to each node
+ * @param {type} node   : node current to apply process
+ * @param {type} camera : current camera needed to process
+ * @param {type} optional  : optional process
+ * @returns {Boolean}
+ */
+BrowseTree.prototype.processNode = function(node, camera, optional) {
+    if (node instanceof EllipsoidTileMesh) {
+
+        node.setVisibility(false);
+        node.setSelected(false);
+
+        if (node.loaded && this.nodeProcess.frustumCullingOBB(node, camera)) {
+            if (this.nodeProcess.horizonCulling(node, camera)) {
+
+                if (node.parent.material !== undefined && node.parent.material.visible === true)
+
+                    return node.setVisibility(false);
+
+                var sse = this.nodeProcess.SSE(node, camera);
+
+                if (optional && (sse || node.level < 2) && node.material.visible === true && node.wait === false)
+
+                    this.tree.subdivide(node);
+
+                else if (!sse && node.level >= 2 && node.material.visible === false && node.wait === false) {
+
+                    node.setMaterialVisibility(true);
+                    this.uniformsProcess(node, camera);
+                    node.setChildrenVisibility(false);
+
+                    return false;
+                }
+            }
+        }
+
+        if (node.visible && node.material.visible)
+            this.uniformsProcess(node, camera);
+
+        return node.visible;
+    }
+
+    return true;
+};
+
+
+BrowseTree.prototype.uniformsProcess = function(node, camera) {
+    node.setMatrixRTC(this.getRTCMatrix(node.absoluteCenter, camera));
+    if (node.id === this.selectNodeId) {
+        node.setSelected(node.visible && node.material.visible);
+        if (this.selectNode !== node) {
+            this.selectNode = node;
+            console.log(node);
+        }
+    }
+
+    node.setFog(this.fogDistance);
+};
+
+BrowseTree.prototype.getRTCMatrix = function(center, camera, node) {
+    // TODO gerer orientation et echelle de l'objet        
+    //        var position    = new THREE.Vector3().subVectors(camera.camera3D.position,center);
+    //        var quaternion  = new THREE.Quaternion().copy(camera.camera3D.quaternion);       
+    //        var matrix      = new THREE.Matrix4().compose(position,quaternion,new THREE.Vector3(1,1,1));
+    //        var matrixInv   = new THREE.Matrix4().getInverse(matrix);  
+    //        var centerEye   = new THREE.Vector4().applyMatrix4(matrixInv) ;                        
+    //        var mvc         = matrixInv.setPosition(centerEye);      
+    //        return            new THREE.Matrix4().multiplyMatrices(camera.camera3D.projectionMatrix,mvc);
+
+    var position = new THREE.Vector3().subVectors(camera.camera3D.position, center);
+    var quaternion = new THREE.Quaternion().copy(camera.camera3D.quaternion);
+
+
+    var matrix = new THREE.Matrix4().compose(position, quaternion, new THREE.Vector3(1, 1, 1));
+    var matrixInv = new THREE.Matrix4().getInverse(matrix);
+
+    if (node) {
+        var model = node.matrixWorld.clone().setPosition(new THREE.Vector3());
+        matrixInv.multiply(model);
 
     }
 
+    var centerEye = new THREE.Vector4().applyMatrix4(matrixInv);
+    var mvc = matrixInv.setPosition(centerEye);
+    return new THREE.Matrix4().multiplyMatrices(camera.camera3D.projectionMatrix, mvc);
 
-    BrowseTree.prototype.addNodeProcess = function(nodeProcess) {
-        this.nodeProcess = nodeProcess;
-    };
+};
 
-    BrowseTree.prototype.NodeProcess = function() {
-        return this.nodeProcess;
-    };
+/**
+ * @documentation: Initiate traverse tree 
+ * @param {type} tree       : tree 
+ * @param {type} camera     : current camera
+ * @param {type} optional   : optional process
+ * @returns {undefined}
+ */
+BrowseTree.prototype.browse = function(tree, camera, optional) {
 
-    /**
-     * @documentation: Process to apply to each node
-     * @param {type} node   : node current to apply process
-     * @param {type} camera : current camera needed to process
-     * @param {type} optional  : optional process
-     * @returns {Boolean}
-     */
-    BrowseTree.prototype.processNode = function(node, camera, optional) {
-        if (node instanceof EllipsoidTileMesh) {
+    this.tree = tree;
+    camera.camera3D.updateMatrix();
+    camera.camera3D.updateMatrixWorld(true);
+    camera.camera3D.matrixWorldInverse.getInverse(camera.camera3D.matrixWorld);
 
-            node.setVisibility(false);
-            node.setSelected(false);
+    var distance = camera.camera3D.position.length();
 
-            if (node.loaded && this.nodeProcess.frustumCullingOBB(node, camera)) {
-                if (this.nodeProcess.horizonCulling(node, camera)) {
+    this.fogDistance = this.mfogDistance * Math.pow((distance - 6300000) / 25000000, 1.6);
 
-                    if (node.parent.material !== undefined && node.parent.material.visible === true)
+    this.nodeProcess.preHorizonCulling(camera);
 
-                        return node.setVisibility(false);
+    for (var i = 0; i < tree.children.length; i++)
+        this._browse(tree.children[i], camera, optional);
+};
 
-                    var sse = this.nodeProcess.SSE(node, camera);
+/**
+ * @documentation: Recursive traverse tree
+ * @param {type} node       : current node     
+ * @param {type} camera     : current camera
+ * @param {type} optional   : optional process
+ * @returns {undefined}
+ */
+BrowseTree.prototype._browse = function(node, camera, optional) {
 
-                    if (optional && (sse || node.level < 2) && node.material.visible === true && node.wait === false)
+    //this.bBoxHelper(node);
+    if (this.processNode(node, camera, optional))
+        for (var i = 0; i < node.children.length; i++)
+            this._browse(node.children[i], camera, optional);
+    else
+        this._clean(node, node.level + 2, camera);
 
-                        this.tree.subdivide(node);
+};
 
-                    else if (!sse && node.level >= 2 && node.material.visible === false && node.wait === false) {
-
-                        node.setMaterialVisibility(true);
-                        this.uniformsProcess(node, camera);
-                        node.setChildrenVisibility(false);
-
-                        return false;
-                    }
-                }
-            }
-
-            if (node.visible && node.material.visible)
-                this.uniformsProcess(node, camera);
-
-            return node.visible;
-        }
-
+BrowseTree.prototype._clean = function(node, level, camera) {
+    if (node.children.length === 0)
         return true;
-    };
+
+    var childrenCleaned = 0;
+    for (var i = 0; i < node.children.length; i++) {
+        var child = node.children[i];
+        // TODO node.wait === true ---> delete child and switch to node.wait = false
+        if (this._clean(child, level, camera) && ((child.level >= level && child.children.length === 0 && !this.nodeProcess.SSE(child, camera) && !node.wait) || node.level === 2))
+            childrenCleaned++;
+    }
+
+    if (childrenCleaned === node.children.length) {
+        node.disposeChildren();
+        return true;
+    } else
+        return false;
+
+};
 
 
-    BrowseTree.prototype.uniformsProcess = function(node, camera) {
-        node.setMatrixRTC(this.getRTCMatrix(node.absoluteCenter, camera));
-        if (node.id === this.selectNodeId) {
-            node.setSelected(node.visible && node.material.visible);
-            if (this.selectNode !== node) {
-                this.selectNode = node;
-                console.log(node);
-            }
-        }
+BrowseTree.prototype.updateLayer = function(layer) {
 
-        node.setFog(this.fogDistance);
-    };
+    var root = layer.children[0];
+    for (var c = 0; c < root.children.length; c++) {
+        var node = root.children[c];
 
-    BrowseTree.prototype.getRTCMatrix = function(center, camera, node) {
-        // TODO gerer orientation et echelle de l'objet        
-        //        var position    = new THREE.Vector3().subVectors(camera.camera3D.position,center);
-        //        var quaternion  = new THREE.Quaternion().copy(camera.camera3D.quaternion);       
-        //        var matrix      = new THREE.Matrix4().compose(position,quaternion,new THREE.Vector3(1,1,1));
-        //        var matrixInv   = new THREE.Matrix4().getInverse(matrix);  
-        //        var centerEye   = new THREE.Vector4().applyMatrix4(matrixInv) ;                        
-        //        var mvc         = matrixInv.setPosition(centerEye);      
-        //        return            new THREE.Matrix4().multiplyMatrices(camera.camera3D.projectionMatrix,mvc);
+        this.rtc = this.getRTCMatrix(node.position, this.scene.currentCamera(), node);
 
-        var position = new THREE.Vector3().subVectors(camera.camera3D.position, center);
-        var quaternion = new THREE.Quaternion().copy(camera.camera3D.quaternion);
+        var cRTC = function(obj) {
+            if (obj.material && obj.material.setMatrixRTC)
+                obj.material.setMatrixRTC(this.rtc);
 
+        }.bind(this);
 
-        var matrix = new THREE.Matrix4().compose(position, quaternion, new THREE.Vector3(1, 1, 1));
-        var matrixInv = new THREE.Matrix4().getInverse(matrix);
+        node.traverse(cRTC);
 
-        if (node) {
-            var model = node.matrixWorld.clone().setPosition(new THREE.Vector3());
-            matrixInv.multiply(model);
+    }
+};
 
-        }
-
-        var centerEye = new THREE.Vector4().applyMatrix4(matrixInv);
-        var mvc = matrixInv.setPosition(centerEye);
-        return new THREE.Matrix4().multiplyMatrices(camera.camera3D.projectionMatrix, mvc);
-
-    };
-
-    /**
-     * @documentation: Initiate traverse tree 
-     * @param {type} tree       : tree 
-     * @param {type} camera     : current camera
-     * @param {type} optional   : optional process
-     * @returns {undefined}
-     */
-    BrowseTree.prototype.browse = function(tree, camera, optional) {
-
-        this.tree = tree;
-        camera.camera3D.updateMatrix();
-        camera.camera3D.updateMatrixWorld(true);
-        camera.camera3D.matrixWorldInverse.getInverse(camera.camera3D.matrixWorld);
-
-        var distance = camera.camera3D.position.length();
-
-        this.fogDistance = this.mfogDistance * Math.pow((distance - 6300000) / 25000000, 1.6);
-
-        this.nodeProcess.preHorizonCulling(camera);
-
-        for (var i = 0; i < tree.children.length; i++)
-            this._browse(tree.children[i], camera, optional);
-    };
-
-    /**
-     * @documentation: Recursive traverse tree
-     * @param {type} node       : current node     
-     * @param {type} camera     : current camera
-     * @param {type} optional   : optional process
-     * @returns {undefined}
-     */
-    BrowseTree.prototype._browse = function(node, camera, optional) {
-
-        //this.bBoxHelper(node);
-        if (this.processNode(node, camera, optional))
-            for (var i = 0; i < node.children.length; i++)
-                this._browse(node.children[i], camera, optional);
-        else
-            this._clean(node, node.level + 2, camera);
-
-    };
-
-    BrowseTree.prototype._clean = function(node, level, camera) {
-        if (node.children.length === 0)
-            return true;
-
-        var childrenCleaned = 0;
-        for (var i = 0; i < node.children.length; i++) {
-            var child = node.children[i];
-            // TODO node.wait === true ---> delete child and switch to node.wait = false
-            if (this._clean(child, level, camera) && ((child.level >= level && child.children.length === 0 && !this.nodeProcess.SSE(child, camera) && !node.wait) || node.level === 2))
-                childrenCleaned++;
-        }
-
-        if (childrenCleaned === node.children.length) {
-            node.disposeChildren();
-            return true;
-        } else
-            return false;
-
-    };
-
-
-    BrowseTree.prototype.updateLayer = function(layer) {
-
-        var root = layer.children[0];
-        for (var c = 0; c < root.children.length; c++) {
-            var node = root.children[c];
-
-            this.rtc = this.getRTCMatrix(node.position, this.scene.currentCamera(), node);
-
-            var cRTC = function(obj) {
-                if (obj.material && obj.material.setMatrixRTC)
-                    obj.material.setMatrixRTC(this.rtc);
-
-            }.bind(this);
-
-            node.traverse(cRTC);
-
-        }
-    };
-
-    return BrowseTree;
-});
+export default BrowseTree;

--- a/src/Scene/Description.js
+++ b/src/Scene/Description.js
@@ -13,6 +13,6 @@ function Description() {
 
 
 
-module.exports = {
-    Description: Description
+export {
+    Description
 };

--- a/src/Scene/DescriptionManager.js
+++ b/src/Scene/DescriptionManager.js
@@ -20,6 +20,6 @@ DescriptionManager.prototype.descriptionToContent = function() {
 
 
 
-module.exports = {
-    DescriptionManager: DescriptionManager
+export {
+    DescriptionManager
 };

--- a/src/Scene/Layer.js
+++ b/src/Scene/Layer.js
@@ -13,48 +13,44 @@
  * @param {type} NodeMesh
  * @returns {Layer_L15.Layer}
  */
-define('Scene/Layer', [
-    'THREE',
-    'Scene/Node',
-    'Core/Commander/InterfaceCommander',
-    'Core/Geographic/Projection',
-    'Renderer/NodeMesh'
-], function(THREE, Node, InterfaceCommander, Projection, NodeMesh) {
+import THREE from 'THREE';
+import Node from 'Scene/Node';
+import InterfaceCommander from 'Core/Commander/InterfaceCommander';
+import Projection from 'Core/Geographic/Projection';
+import NodeMesh from 'Renderer/NodeMesh';
 
-    function Layer(type, param) {
-        //Constructor
+function Layer(type, param) {
+    //Constructor
 
-        Node.call(this);
-        // Requeter
-        this.interCommand = type !== undefined ? new InterfaceCommander(type, param) : undefined;
-        this.descriManager = null;
-        this.projection = new Projection();
+    Node.call(this);
+    // Requeter
+    this.interCommand = type !== undefined ? new InterfaceCommander(type, param) : undefined;
+    this.descriManager = null;
+    this.projection = new Projection();
 
+}
+
+Layer.prototype = Object.create(Node.prototype);
+
+Layer.prototype.constructor = Layer;
+
+// Should be plural as it return an array of meshes
+Layer.prototype.getMesh = function() {
+    var meshs = [];
+
+    for (var i = 0; i < this.children.length; i++) {
+        var node = this.children[i];
+
+
+        if (node instanceof NodeMesh || node instanceof THREE.Mesh)
+            meshs.push(node);
+        else if (node instanceof Layer) {
+            meshs = meshs.concat(node.getMesh());
+        }
     }
 
-    Layer.prototype = Object.create(Node.prototype);
+    return meshs;
 
-    Layer.prototype.constructor = Layer;
+};
 
-    // Should be plural as it return an array of meshes
-    Layer.prototype.getMesh = function() {
-        var meshs = [];
-
-        for (var i = 0; i < this.children.length; i++) {
-            var node = this.children[i];
-
-
-            if (node instanceof NodeMesh || node instanceof THREE.Mesh)
-                meshs.push(node);
-            else if (node instanceof Layer) {
-                meshs = meshs.concat(node.getMesh());
-            }
-        }
-
-        return meshs;
-
-    };
-
-    return Layer;
-
-});
+export default Layer;

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -5,149 +5,144 @@
  * Cette class permet de construire une structure de Node avec les membres parent et enfants.
  */
 
-define('Scene/Node', [], function() {
+function Node() {
+    //Constructor
+
+    this.parent = null;
+    this.children = [];
+    this.bbox = null;
+    this.url = null;
+    this.content = null;
+    this.link = null;
+    this.description = null;
+    this.id = null;
+    this.saveState = null;
+    this.level = 0;
+    this.screenSpaceError = 0.0;
+    this.loaded = false;
+    this.wait = false;
+
+}
 
 
-    function Node() {
-        //Constructor
+/**
+ * @documentation: Retourne le nombre d'enfants du Node
+ *
+ * @return  {int} 
+ */
+Node.prototype.childrenCount = function() {
 
-        this.parent = null;
-        this.children = [];
-        this.bbox = null;
-        this.url = null;
-        this.content = null;
-        this.link = null;
-        this.description = null;
-        this.id = null;
-        this.saveState = null;
-        this.level = 0;
-        this.screenSpaceError = 0.0;
-        this.loaded = false;
-        this.wait = false;
+    return this.children.length;
 
+};
+
+Node.prototype.noChild = function() {
+
+    return this.children.length === 0;
+
+};
+
+Node.prototype.childrenLoaded = function() {
+
+    for (var i = 0, max = this.children.length; i < max; i++) {
+        if (this.children[i].loaded === false)
+            return false;
     }
 
-
-    /**
-     * @documentation: Retourne le nombre d'enfants du Node
-     *
-     * @return  {int} 
-     */
-    Node.prototype.childrenCount = function() {
-
-        return this.children.length;
-
-    };
-
-    Node.prototype.noChild = function() {
-
-        return this.children.length === 0;
-
-    };
-
-    Node.prototype.childrenLoaded = function() {
-
-        for (var i = 0, max = this.children.length; i < max; i++) {
-            if (this.children[i].loaded === false)
-                return false;
-        }
-
-        return true;
-    };
+    return true;
+};
 
 
 
-    /**
-     * @documentation: Rafraichi le Node si le contenu ou  le style a été modifié.
-     *
-     */
-    Node.prototype.update = function() {
-        //TODO: Implement Me 
+/**
+ * @documentation: Rafraichi le Node si le contenu ou  le style a été modifié.
+ *
+ */
+Node.prototype.update = function() {
+    //TODO: Implement Me 
 
-    };
+};
 
-    /**
-     * 
-     * @param {type} level
-     * @returns {undefined}
-     */
-    Node.prototype.getParentLevel = function(level) {
-        return (this.parent.level === level) ? this.parent : this.parent.getParentLevel(level);
-    };
+/**
+ * 
+ * @param {type} level
+ * @returns {undefined}
+ */
+Node.prototype.getParentLevel = function(level) {
+    return (this.parent.level === level) ? this.parent : this.parent.getParentLevel(level);
+};
 
-    /**
-     * @documentation: Méthode qui créer un memento de l'état de Node avant modification.
-     *
-     * @return  {[object Object]} 
-     */
-    Node.prototype.hydrate = function() {
-        //TODO: Implement Me 
+/**
+ * @documentation: Méthode qui créer un memento de l'état de Node avant modification.
+ *
+ * @return  {[object Object]} 
+ */
+Node.prototype.hydrate = function() {
+    //TODO: Implement Me 
 
-    };
-
-
-    /**
-     * @documentation: Cette méthode modifie l'état du node en fonction d'un memento.
-     *
-     * @param mem {[object Object]} 
-     */
-    Node.prototype.dehydrate = function(mem) {
-        //TODO: Implement Me 
-
-    };
-
-    /**
-     * @documentation: Ajoute un enfant au Node.
-     *
-     * @param child {[object Object]} 
-     */
-    Node.prototype.add = function(child) {
-        //TODO: Implement Me 
-        this.children.push(child);
-    };
-
-    /**
-     * @documentation: Retire un enfant au node.
-     *
-     * @param child {[object Object]} 
-     */
-    Node.prototype.remove = function(child) {
-        //TODO: Implement Me 
-
-    };
+};
 
 
-    /**
-     * @documentation: Cette Méthode permet étendre un objet enfant des fonctions prototypes de Node.
-     *
-     * @param childClass {Object} 
-     */
+/**
+ * @documentation: Cette méthode modifie l'état du node en fonction d'un memento.
+ *
+ * @param mem {[object Object]} 
+ */
+Node.prototype.dehydrate = function(mem) {
+    //TODO: Implement Me 
 
-    Node.extend = function(childClass) {
+};
 
-        function propName(prop, value) {
-            for (var i in prop) {
-                if (prop[i] === value) {
-                    return i;
-                }
+/**
+ * @documentation: Ajoute un enfant au Node.
+ *
+ * @param child {[object Object]} 
+ */
+Node.prototype.add = function(child) {
+    //TODO: Implement Me 
+    this.children.push(child);
+};
+
+/**
+ * @documentation: Retire un enfant au node.
+ *
+ * @param child {[object Object]} 
+ */
+Node.prototype.remove = function(child) {
+    //TODO: Implement Me 
+
+};
+
+
+/**
+ * @documentation: Cette Méthode permet étendre un objet enfant des fonctions prototypes de Node.
+ *
+ * @param childClass {Object} 
+ */
+
+Node.extend = function(childClass) {
+
+    function propName(prop, value) {
+        for (var i in prop) {
+            if (prop[i] === value) {
+                return i;
             }
-            return false;
         }
+        return false;
+    }
 
-        for (var p in Node.prototype) {
-            var protoName = propName(Node.prototype, Node.prototype[p]);
+    for (var p in Node.prototype) {
+        var protoName = propName(Node.prototype, Node.prototype[p]);
 
 
-            if (protoName !== "add" && protoName !== "remove") {
-                childClass.prototype[protoName] = Node.prototype[p];
-            }
-        };
-
+        if (protoName !== "add" && protoName !== "remove") {
+            childClass.prototype[protoName] = Node.prototype[p];
+        }
     };
 
+};
 
-    return Node;
 
-});
+export default Node;
 
 //module.exports = {Node:Node};

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -4,194 +4,196 @@
  * Description: NodeProcess effectue une opération sur un Node.
  */
 
-define('Scene/NodeProcess', ['Scene/BoundingBox', 'Renderer/Camera', 'Core/Math/MathExtented', 'THREE', 'Core/defaultValue'], function(BoundingBox, Camera, MathExt, THREE, defaultValue) {
+import BoundingBox from 'Scene/BoundingBox';
+import Camera from 'Renderer/Camera';
+import MathExt from 'Core/Math/MathExtented';
+import THREE from 'THREE';
+import defaultValue from 'Core/defaultValue';
 
 
-    function NodeProcess(camera3D, size, bbox) {
-        //Constructor
-        this.camera = new Camera();
-        this.camera.camera3D = camera3D.clone();
+function NodeProcess(camera3D, size, bbox) {
+    //Constructor
+    this.camera = new Camera();
+    this.camera.camera3D = camera3D.clone();
 
-        this.bbox = defaultValue(bbox, new BoundingBox(MathExt.PI_OV_TWO + MathExt.PI_OV_FOUR, MathExt.PI + MathExt.PI_OV_FOUR, 0, MathExt.PI_OV_TWO));
+    this.bbox = defaultValue(bbox, new BoundingBox(MathExt.PI_OV_TWO + MathExt.PI_OV_FOUR, MathExt.PI + MathExt.PI_OV_FOUR, 0, MathExt.PI_OV_TWO));
 
-        this.vhMagnitudeSquared = 1.0;
+    this.vhMagnitudeSquared = 1.0;
 
-        this.r = defaultValue(size, new THREE.Vector3());
-        this.cV = new THREE.Vector3();
+    this.r = defaultValue(size, new THREE.Vector3());
+    this.cV = new THREE.Vector3();
 
+}
+
+/**
+ * @documentation: Apply backface culling on node, change visibility; return true if the node is visible
+ * @param {type} node   : node to cull
+ * @param {type} camera : camera for the culling
+ * @returns {Boolean}
+ */
+NodeProcess.prototype.backFaceCulling = function(node, camera) {
+    var normal = camera.direction;
+    for (var n = 0; n < node.normals().length; n++) {
+
+        var dot = normal.dot(node.normals()[n]);
+        if (dot > 0) {
+            node.visible = true;
+            return true;
+        }
+    };
+
+    //??node.visible = true;
+
+    return node.visible;
+
+};
+
+NodeProcess.prototype.updateCamera = function(camera) {
+    this.camera = new Camera(camera.width, camera.height);
+    this.camera.camera3D = camera.camera3D.clone();
+};
+
+/**
+ * @documentation: Cull node with frustrum
+ * @param {type} node   : node to cull
+ * @param {type} camera : camera for culling
+ * @returns {unresolved}
+ */
+NodeProcess.prototype.frustumCulling = function(node, camera) {
+    var frustum = camera.frustum;
+
+    return frustum.intersectsObject(node);
+};
+
+/**
+ * @documentation: Compute screen space error of node in function of camera
+ * @param {type} node
+ * @param {type} camera
+ * @returns {Boolean}
+ */
+NodeProcess.prototype.SSE = function(node, camera) {
+    return camera.SSE(node) > 6.0;
+};
+
+/**
+ * @documentation: Cull node with frustrum and oriented bounding box of node
+ * @param {type} node
+ * @param {type} camera
+ * @returns {NodeProcess_L7.NodeProcess.prototype.frustumCullingOBB.node@pro;camera@call;getFrustum@call;intersectsBox}
+ */
+NodeProcess.prototype.frustumCullingOBB = function(node, camera) {
+
+    var obb = node.OBB();
+
+    var l = node.absoluteCenter.length();
+
+    obb.translateZ(l);
+    obb.update();
+
+    var quadInv = obb.quadInverse().clone();
+
+    // position in local space
+    this.camera.setPosition(obb.worldToLocal(camera.position().clone()));
+    // rotation in local space
+    this.camera.setRotation(quadInv.multiply(camera.camera3D.quaternion));
+
+    obb.translateZ(-l);
+
+    obb.update();
+
+    return node.setVisibility(this.camera.getFrustum().intersectsBox(obb.box3D));
+
+};
+
+/**
+ * @documentation: Cull node with frustrum and the bounding box of node
+ * @param {type} node
+ * @param {type} camera
+ * @returns {unresolved}
+ */
+NodeProcess.prototype.frustumBB = function(node, camera) {
+
+    return node.setVisibility(node.bbox.intersect(this.bbox));
+
+};
+
+/**
+ * @documentation:pre calcul for horizon culling
+ * @param {type} camera
+ * @returns {undefined}
+ */
+NodeProcess.prototype.preHorizonCulling = function(camera) {
+
+    this.cV = MathExt.divideVectors(camera.position(), this.r);
+
+    this.vhMagnitudeSquared = MathExt.lenghtSquared(this.cV) - 1.0;
+
+};
+
+/**
+ * @documentation: return true if point is occuled by horizon 
+ * @param {type} point
+ * @returns {Boolean}
+ */
+NodeProcess.prototype.pointHorizonCulling = function(point) {
+
+    var t = MathExt.divideVectors(point, this.r);
+
+    // Vector VT
+    var vT = new THREE.Vector3();
+    vT.subVectors(t, this.cV);
+
+    var vtMagnitudeSquared = MathExt.lenghtSquared(vT);
+
+    var dot = -vT.dot(this.cV);
+
+    var isOccluded = dot > this.vhMagnitudeSquared &&
+        dot * dot / vtMagnitudeSquared > this.vhMagnitudeSquared;
+
+    return isOccluded;
+};
+
+/**
+ * @documentation: cull node with horizon 
+ * @param {type} node
+ * @returns {Boolean}
+ */
+NodeProcess.prototype.horizonCulling = function(node) {
+
+    // horizonCulling Oriented bounding box
+    var points = node.OBB().pointsWorld;
+    var center = node.absoluteCenter;
+    var isVisible = false;
+    for (var i = 0, max = points.length; i < max; i++) {
+        var point = points[i].add(center);
+
+        if (!this.pointHorizonCulling(point)) {
+            isVisible = true;
+            break;
+        }
     }
 
-    /**
-     * @documentation: Apply backface culling on node, change visibility; return true if the node is visible
-     * @param {type} node   : node to cull
-     * @param {type} camera : camera for the culling
-     * @returns {Boolean}
+    /*
+     var points    = node.geometry.tops;      
+     var isVisible = false;
+     for (var i = 0, max = points.length; i < max; i++) 
+     {                    
+           if(!this.pointHorizonCulling(points[i]))
+           {
+               isVisible = true;
+               break;
+           }
+     }
      */
-    NodeProcess.prototype.backFaceCulling = function(node, camera) {
-        var normal = camera.direction;
-        for (var n = 0; n < node.normals().length; n++) {
 
-            var dot = normal.dot(node.normals()[n]);
-            if (dot > 0) {
-                node.visible = true;
-                return true;
-            }
-        };
+    return node.setVisibility(isVisible);
+    //      if(isVisible === false)
+    //          node.tMat.setDebug(1);
+    //      else
+    //          node.tMat.setDebug(0);
+    //   
 
-        //??node.visible = true;
-
-        return node.visible;
-
-    };
-
-    NodeProcess.prototype.updateCamera = function(camera) {
-        this.camera = new Camera(camera.width, camera.height);
-        this.camera.camera3D = camera.camera3D.clone();
-    };
-
-    /**
-     * @documentation: Cull node with frustrum
-     * @param {type} node   : node to cull
-     * @param {type} camera : camera for culling
-     * @returns {unresolved}
-     */
-    NodeProcess.prototype.frustumCulling = function(node, camera) {
-        var frustum = camera.frustum;
-
-        return frustum.intersectsObject(node);
-    };
-
-    /**
-     * @documentation: Compute screen space error of node in function of camera
-     * @param {type} node
-     * @param {type} camera
-     * @returns {Boolean}
-     */
-    NodeProcess.prototype.SSE = function(node, camera) {
-        return camera.SSE(node) > 6.0;
-    };
-
-    /**
-     * @documentation: Cull node with frustrum and oriented bounding box of node
-     * @param {type} node
-     * @param {type} camera
-     * @returns {NodeProcess_L7.NodeProcess.prototype.frustumCullingOBB.node@pro;camera@call;getFrustum@call;intersectsBox}
-     */
-    NodeProcess.prototype.frustumCullingOBB = function(node, camera) {
-
-        var obb = node.OBB();
-
-        var l = node.absoluteCenter.length();
-
-        obb.translateZ(l);
-        obb.update();
-
-        var quadInv = obb.quadInverse().clone();
-
-        // position in local space
-        this.camera.setPosition(obb.worldToLocal(camera.position().clone()));
-        // rotation in local space
-        this.camera.setRotation(quadInv.multiply(camera.camera3D.quaternion));
-
-        obb.translateZ(-l);
-
-        obb.update();
-
-        return node.setVisibility(this.camera.getFrustum().intersectsBox(obb.box3D));
-
-    };
-
-    /**
-     * @documentation: Cull node with frustrum and the bounding box of node
-     * @param {type} node
-     * @param {type} camera
-     * @returns {unresolved}
-     */
-    NodeProcess.prototype.frustumBB = function(node, camera) {
-
-        return node.setVisibility(node.bbox.intersect(this.bbox));
-
-    };
-
-    /**
-     * @documentation:pre calcul for horizon culling
-     * @param {type} camera
-     * @returns {undefined}
-     */
-    NodeProcess.prototype.preHorizonCulling = function(camera) {
-
-        this.cV = MathExt.divideVectors(camera.position(), this.r);
-
-        this.vhMagnitudeSquared = MathExt.lenghtSquared(this.cV) - 1.0;
-
-    };
-
-    /**
-     * @documentation: return true if point is occuled by horizon 
-     * @param {type} point
-     * @returns {Boolean}
-     */
-    NodeProcess.prototype.pointHorizonCulling = function(point) {
-
-        var t = MathExt.divideVectors(point, this.r);
-
-        // Vector VT
-        var vT = new THREE.Vector3();
-        vT.subVectors(t, this.cV);
-
-        var vtMagnitudeSquared = MathExt.lenghtSquared(vT);
-
-        var dot = -vT.dot(this.cV);
-
-        var isOccluded = dot > this.vhMagnitudeSquared &&
-            dot * dot / vtMagnitudeSquared > this.vhMagnitudeSquared;
-
-        return isOccluded;
-    };
-
-    /**
-     * @documentation: cull node with horizon 
-     * @param {type} node
-     * @returns {Boolean}
-     */
-    NodeProcess.prototype.horizonCulling = function(node) {
-
-        // horizonCulling Oriented bounding box
-        var points = node.OBB().pointsWorld;
-        var center = node.absoluteCenter;
-        var isVisible = false;
-        for (var i = 0, max = points.length; i < max; i++) {
-            var point = points[i].add(center);
-
-            if (!this.pointHorizonCulling(point)) {
-                isVisible = true;
-                break;
-            }
-        }
-
-        /*
-         var points    = node.geometry.tops;      
-         var isVisible = false;
-         for (var i = 0, max = points.length; i < max; i++) 
-         {                    
-               if(!this.pointHorizonCulling(points[i]))
-               {
-                   isVisible = true;
-                   break;
-               }
-         }
-         */
-
-        return node.setVisibility(isVisible);
-        //      if(isVisible === false)
-        //          node.tMat.setDebug(1);
-        //      else
-        //          node.tMat.setDebug(0);
-        //   
-
-    };
+};
 
 
-    return NodeProcess;
-
-});
+export default NodeProcess;

--- a/src/Scene/NodeProvider.js
+++ b/src/Scene/NodeProvider.js
@@ -4,7 +4,7 @@
  * Description: Factory/Provider de Nodes
  */
 
-var Provider = require('Provider');
+import Provider from 'Provider';
 
 function NodeProvider() {
     //Constructor
@@ -24,6 +24,6 @@ NodeProvider.prototype.createObject = function(type) {
 
 
 
-module.exports = {
-    NodeProvider: NodeProvider
+export {
+    NodeProvider
 };

--- a/src/Scene/Octree.js
+++ b/src/Scene/Octree.js
@@ -4,7 +4,7 @@
  * Description: Structure de données spatiales possedant jusqu'à 8 Nodes 
  */
 
-var SpatialHash = require('SpatialHash');
+import SpatialHash from 'SpatialHash';
 
 function Octree() {
     //Constructor
@@ -15,6 +15,6 @@ function Octree() {
 Octree.prototype = new SpatialHash();
 
 
-module.exports = {
-    Octree: Octree
+export {
+    Octree
 };

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -10,127 +10,123 @@
  * @param {type} Quad
  * @returns {Quadtree_L13.Quadtree}
  */
-define('Scene/Quadtree', [
-    'Scene/Layer',
-    'Core/Geographic/Quad'
-], function(Layer, Quad) {
+import Layer from 'Scene/Layer';
+import Quad from 'Core/Geographic/Quad';
 
 
-    function Quadtree(type, schemeTile, size, link) {
-        Layer.call(this, type, size);
+function Quadtree(type, schemeTile, size, link) {
+    Layer.call(this, type, size);
 
 
-        this.link = link;
-        this.schemeTile = schemeTile;
-        this.tileType = type;
+    this.link = link;
+    this.schemeTile = schemeTile;
+    this.tileType = type;
 
-        for (var i = 0; i < this.schemeTile.rootCount(); i++) {
-            this.createTile(this.schemeTile.getRoot(i), this);
-        }
-
-        this.interCommand.managerCommands.runAllCommands().then(function() {
-
-            for (var i = 0; i < this.schemeTile.rootCount(); i++) {
-                this.subdivide(this.children[i]);
-
-                this.interCommand.managerCommands.runAllCommands().then(function() {
-                    this.subdivideChildren(this.children[i]);
-
-                }.bind(this));
-            }
-
-        }.bind(this));
-
+    for (var i = 0; i < this.schemeTile.rootCount(); i++) {
+        this.createTile(this.schemeTile.getRoot(i), this);
     }
 
-    Quadtree.prototype = Object.create(Layer.prototype);
+    this.interCommand.managerCommands.runAllCommands().then(function() {
 
-    Quadtree.prototype.constructor = Quadtree;
+        for (var i = 0; i < this.schemeTile.rootCount(); i++) {
+            this.subdivide(this.children[i]);
 
-    Quadtree.prototype.northWest = function(node) {
-        return node.children[0];
-    };
+            this.interCommand.managerCommands.runAllCommands().then(function() {
+                this.subdivideChildren(this.children[i]);
 
-    Quadtree.prototype.northEast = function(node) {
-        return node.children[1];
-    };
-
-    Quadtree.prototype.southWest = function(node) {
-        return node.children[2];
-    };
-
-    Quadtree.prototype.southEast = function(node) {
-        return node.children[3];
-    };
-
-    Quadtree.prototype.createTile = function(bbox, parent) {
-
-        this.interCommand.getTile(bbox, parent);
-
-    };
-
-    /**
-     * @documentation: subdivise node if necessary
-     * @param {type} node
-     * @returns {Array} four bounding box
-     */
-    Quadtree.prototype.subdivide = function(node) {
-
-        if (!this.update(node))
-            return;
-
-        node.wait = true;
-        var quad = new Quad(node.bbox);
-        this.createTile(quad.northWest, node);
-        this.createTile(quad.northEast, node);
-        this.createTile(quad.southWest, node);
-        this.createTile(quad.southEast, node);
-
-    };
-
-    /**
-     * @documentation: update node 
-     * @param {type} node
-     * @returns {Boolean}
-     */
-    Quadtree.prototype.update = function(node) {
-
-        //TODO debug freeze 
-        //        if(node.level > 17  || (node.wait === true && node.childrenCount() === 4))
-        if (node.level > 17 || node.wait === true)
-            return false;
-
-        if (node.childrenCount() > 0 && node.wait === false) {
-            //node.setChildrenVisibility(true);    // Useless
-            node.setMaterialVisibility(!(node.childrenCount() === 4 && node.childrenLoaded()));
-
-            /*
-            if(node.material.nbTextures === node.material.Textures_01.length){
-                node.setChildrenVisibility(true);
-            }
-            */
-
-
-            return false;
+            }.bind(this));
         }
 
-        return true;
-    };
+    }.bind(this));
 
-    /**
-     * @documentation: subdivide children
-     * @param {type} node : node to subdivide
-     * @returns {undefined}
-     */
-    Quadtree.prototype.subdivideChildren = function(node) {
-        if (node.level === 3)
-            return;
-        for (var i = 0; i < node.children.length; i++) {
-            this.subdivide(node.children[i]);
-            //this.subdivideChildren(node.children[i]);
+}
+
+Quadtree.prototype = Object.create(Layer.prototype);
+
+Quadtree.prototype.constructor = Quadtree;
+
+Quadtree.prototype.northWest = function(node) {
+    return node.children[0];
+};
+
+Quadtree.prototype.northEast = function(node) {
+    return node.children[1];
+};
+
+Quadtree.prototype.southWest = function(node) {
+    return node.children[2];
+};
+
+Quadtree.prototype.southEast = function(node) {
+    return node.children[3];
+};
+
+Quadtree.prototype.createTile = function(bbox, parent) {
+
+    this.interCommand.getTile(bbox, parent);
+
+};
+
+/**
+ * @documentation: subdivise node if necessary
+ * @param {type} node
+ * @returns {Array} four bounding box
+ */
+Quadtree.prototype.subdivide = function(node) {
+
+    if (!this.update(node))
+        return;
+
+    node.wait = true;
+    var quad = new Quad(node.bbox);
+    this.createTile(quad.northWest, node);
+    this.createTile(quad.northEast, node);
+    this.createTile(quad.southWest, node);
+    this.createTile(quad.southEast, node);
+
+};
+
+/**
+ * @documentation: update node 
+ * @param {type} node
+ * @returns {Boolean}
+ */
+Quadtree.prototype.update = function(node) {
+
+    //TODO debug freeze 
+    //        if(node.level > 17  || (node.wait === true && node.childrenCount() === 4))
+    if (node.level > 17 || node.wait === true)
+        return false;
+
+    if (node.childrenCount() > 0 && node.wait === false) {
+        //node.setChildrenVisibility(true);    // Useless
+        node.setMaterialVisibility(!(node.childrenCount() === 4 && node.childrenLoaded()));
+
+        /*
+        if(node.material.nbTextures === node.material.Textures_01.length){
+            node.setChildrenVisibility(true);
         }
-    };
+        */
 
-    return Quadtree;
 
-});
+        return false;
+    }
+
+    return true;
+};
+
+/**
+ * @documentation: subdivide children
+ * @param {type} node : node to subdivide
+ * @returns {undefined}
+ */
+Quadtree.prototype.subdivideChildren = function(node) {
+    if (node.level === 3)
+        return;
+    for (var i = 0; i < node.children.length; i++) {
+        this.subdivide(node.children[i]);
+        //this.subdivideChildren(node.children[i]);
+    }
+};
+
+export default Quadtree;

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -12,214 +12,210 @@
  * @param {type} BrowseTree
  * @returns {Function}
  */
-define('Scene/Scene', [
-    'Renderer/c3DEngine',
-    'Globe/Globe',
-    'Core/Commander/ManagerCommands',
-    'Scene/BrowseTree',
-    'Scene/NodeProcess',
-    'Scene/Quadtree',
-    'Scene/Layer',
-    'Core/Geographic/CoordCarto',
-    'Core/System/Capabilities'
-], function(c3DEngine, Globe, ManagerCommands, BrowseTree, NodeProcess, Quadtree, Layer, CoordCarto, Capabilities) {
+import c3DEngine from 'Renderer/c3DEngine';
+import Globe from 'Globe/Globe';
+import ManagerCommands from 'Core/Commander/ManagerCommands';
+import BrowseTree from 'Scene/BrowseTree';
+import NodeProcess from 'Scene/NodeProcess';
+import Quadtree from 'Scene/Quadtree';
+import Layer from 'Scene/Layer';
+import CoordCarto from 'Core/Geographic/CoordCarto';
+import Capabilities from 'Core/System/Capabilities';
 
-    var instanceScene = null;
+var instanceScene = null;
 
-    function Scene() {
-        //Constructor        
-        if (instanceScene !== null) {
-            throw new Error("Cannot instantiate more than one Scene");
-        }
-        this.layers = [];
-        this.cameras = null;
-        this.selectNodes = null;
-        this.managerCommand = ManagerCommands();
-        this.gfxEngine = c3DEngine();
-        this.browserScene = new BrowseTree(this);
-        this.cap = new Capabilities();
+function Scene() {
+    //Constructor        
+    if (instanceScene !== null) {
+        throw new Error("Cannot instantiate more than one Scene");
+    }
+    this.layers = [];
+    this.cameras = null;
+    this.selectNodes = null;
+    this.managerCommand = ManagerCommands();
+    this.gfxEngine = c3DEngine();
+    this.browserScene = new BrowseTree(this);
+    this.cap = new Capabilities();
+}
+
+Scene.prototype.constructor = Scene;
+/**
+ */
+Scene.prototype.updateCommand = function() {
+    //TODO: Implement Me 
+
+};
+
+Scene.prototype.updateCommand = function() {
+    //TODO: Implement Me 
+};
+
+/**
+ * @documentation: return current camera 
+ * @returns {Scene_L7.Scene.gfxEngine.camera}
+ */
+Scene.prototype.currentCamera = function() {
+    return this.gfxEngine.camera;
+};
+
+Scene.prototype.updateCamera = function() {
+    this.browserScene.NodeProcess().updateCamera(this.gfxEngine.camera);
+};
+
+/**
+ * @documentation: initialisation scene 
+ * @returns {undefined}
+ */
+Scene.prototype.init = function(pos) {
+    this.managerCommand.init(this);
+    var globe = new Globe();
+    this.add(globe);
+    console.log('eee');
+
+
+    //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(2.33,48.87,25000000));        
+    //
+    var position = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(pos.lat, pos.lon, pos.alt));
+
+    //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(2.33,,25000000));
+    //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(48.7,2.33,25000000));        
+
+    //var target      = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(2.33,48.87,0));
+    //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(0,48.87,25000000));
+
+    this.gfxEngine.init(this, position);
+    this.browserScene.addNodeProcess(new NodeProcess(this.currentCamera().camera3D, globe.size));
+    this.gfxEngine.update();
+
+};
+
+Scene.prototype.size = function() {
+    return this.layers[0].size;
+};
+
+/**
+ */
+Scene.prototype.updateCamera = function() {
+    //TODO: Implement Me 
+
+};
+
+/**
+ * 
+ * @param {type} run
+ * @returns {undefined}
+ */
+Scene.prototype.sceneProcess = function(run) {
+
+    //console.log(this.managerCommand.queueAsync.length);
+
+    if (this.layers[0] !== undefined && this.currentCamera() !== undefined) {
+
+        this.browserScene.browse(this.layers[0].terrain, this.currentCamera(), true);
+
+        this.managerCommand.runAllCommands();
+
+        //this.renderScene3D();  
+        this.updateScene3D();
+
     }
 
-    Scene.prototype.constructor = Scene;
-    /**
-     */
-    Scene.prototype.updateCommand = function() {
-        //TODO: Implement Me 
+};
 
-    };
+Scene.prototype.realtimeSceneProcess = function() {
 
-    Scene.prototype.updateCommand = function() {
-        //TODO: Implement Me 
-    };
+    if (this.currentCamera !== undefined)
+        for (var l = 0; l < this.layers.length; l++) {
+            var layer = this.layers[l];
 
-    /**
-     * @documentation: return current camera 
-     * @returns {Scene_L7.Scene.gfxEngine.camera}
-     */
-    Scene.prototype.currentCamera = function() {
-        return this.gfxEngine.camera;
-    };
+            for (var sl = 0; sl < layer.children.length; sl++) {
+                var sLayer = layer.children[sl];
 
-    Scene.prototype.updateCamera = function() {
-        this.browserScene.NodeProcess().updateCamera(this.gfxEngine.camera);
-    };
+                if (sLayer instanceof Quadtree)
+                    this.browserScene.browse(sLayer, this.currentCamera(), false);
+                else if (sLayer instanceof Layer)
+                    this.browserScene.updateLayer(sLayer);
 
-    /**
-     * @documentation: initialisation scene 
-     * @returns {undefined}
-     */
-    Scene.prototype.init = function(pos) {
-        this.managerCommand.init(this);
-        var globe = new Globe();
-        this.add(globe);
-        console.log('eee');
-
-
-        //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(2.33,48.87,25000000));        
-        //
-        var position = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(pos.lat, pos.lon, pos.alt));
-
-        //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(2.33,,25000000));
-        //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(48.7,2.33,25000000));        
-
-        //var target      = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(2.33,48.87,0));
-        //var position    = globe.ellipsoid().cartographicToCartesian(new CoordCarto().setFromDegreeGeo(0,48.87,25000000));
-
-        this.gfxEngine.init(this, position);
-        this.browserScene.addNodeProcess(new NodeProcess(this.currentCamera().camera3D, globe.size));
-        this.gfxEngine.update();
-
-    };
-
-    Scene.prototype.size = function() {
-        return this.layers[0].size;
-    };
-
-    /**
-     */
-    Scene.prototype.updateCamera = function() {
-        //TODO: Implement Me 
-
-    };
-
-    /**
-     * 
-     * @param {type} run
-     * @returns {undefined}
-     */
-    Scene.prototype.sceneProcess = function(run) {
-
-        //console.log(this.managerCommand.queueAsync.length);
-
-        if (this.layers[0] !== undefined && this.currentCamera() !== undefined) {
-
-            this.browserScene.browse(this.layers[0].terrain, this.currentCamera(), true);
-
-            this.managerCommand.runAllCommands();
-
-            //this.renderScene3D();             
-            this.updateScene3D();
-
-        }
-
-    };
-
-    Scene.prototype.realtimeSceneProcess = function() {
-
-        if (this.currentCamera !== undefined)
-            for (var l = 0; l < this.layers.length; l++) {
-                var layer = this.layers[l];
-
-                for (var sl = 0; sl < layer.children.length; sl++) {
-                    var sLayer = layer.children[sl];
-
-                    if (sLayer instanceof Quadtree)
-                        this.browserScene.browse(sLayer, this.currentCamera(), false);
-                    else if (sLayer instanceof Layer)
-                        this.browserScene.updateLayer(sLayer);
-
-                }
             }
-    };
-
-    /**
-     * 
-     * @returns {undefined}
-     */
-    Scene.prototype.updateScene3D = function() {
-
-        this.gfxEngine.update();
-    };
-
-    Scene.prototype.wait = function() {
-
-        var waitTime = 20;
-
-        this.realtimeSceneProcess();
-
-        if (this.timer === null) {
-            this.timer = window.setTimeout(this.sceneProcess.bind(this), waitTime);
-        } else {
-            window.clearInterval(this.timer);
-            this.timer = window.setTimeout(this.sceneProcess.bind(this), waitTime);
         }
+};
 
-    };
+/**
+ * 
+ * @returns {undefined}
+ */
+Scene.prototype.updateScene3D = function() {
 
-    /**
-     */
-    Scene.prototype.renderScene3D = function() {
+    this.gfxEngine.update();
+};
 
-        this.gfxEngine.renderScene();
+Scene.prototype.wait = function() {
 
-    };
+    var waitTime = 20;
 
-    Scene.prototype.scene3D = function() {
+    this.realtimeSceneProcess();
 
-        return this.gfxEngine.scene3D;
-    };
+    if (this.timer === null) {
+        this.timer = window.setTimeout(this.sceneProcess.bind(this), waitTime);
+    } else {
+        window.clearInterval(this.timer);
+        this.timer = window.setTimeout(this.sceneProcess.bind(this), waitTime);
+    }
 
-    /**
-     * @documentation: Ajoute des Layers dans la scène.
-     *
-     * @param node {[object Object]} 
-     */
-    Scene.prototype.add = function(node) {
-        //TODO: Implement Me 
+};
 
-        this.layers.push(node);
+/**
+ */
+Scene.prototype.renderScene3D = function() {
 
-        this.gfxEngine.add3DScene(node.getMesh());
-    };
+    this.gfxEngine.renderScene();
 
-    /**
-     * @documentation: Retire des layers de la scène
-     *
-     * @param layer {[object Object]} 
-     */
-    Scene.prototype.remove = function(layer) {
-        //TODO: Implement Me 
+};
 
-    };
+Scene.prototype.scene3D = function() {
+
+    return this.gfxEngine.scene3D;
+};
+
+/**
+ * @documentation: Ajoute des Layers dans la scène.
+ *
+ * @param node {[object Object]} 
+ */
+Scene.prototype.add = function(node) {
+    //TODO: Implement Me 
+
+    this.layers.push(node);
+
+    this.gfxEngine.add3DScene(node.getMesh());
+};
+
+/**
+ * @documentation: Retire des layers de la scène
+ *
+ * @param layer {[object Object]} 
+ */
+Scene.prototype.remove = function(layer) {
+    //TODO: Implement Me 
+
+};
 
 
-    /**
-     * @param layers {[object Object]} 
-     */
-    Scene.prototype.select = function(layers) {
-        //TODO: Implement Me 
+/**
+ * @param layers {[object Object]} 
+ */
+Scene.prototype.select = function(layers) {
+    //TODO: Implement Me 
 
-    };
+};
 
-    Scene.prototype.selectNodeId = function(id) {
+Scene.prototype.selectNodeId = function(id) {
 
-        this.browserScene.selectNodeId = id;
+    this.browserScene.selectNodeId = id;
 
-    };
+};
 
-    return function() {
-        instanceScene = instanceScene || new Scene();
-        return instanceScene;
-    };
-
-});
+export default function() {
+    instanceScene = instanceScene || new Scene();
+    return instanceScene;
+};

--- a/src/Scene/SchemeTile.js
+++ b/src/Scene/SchemeTile.js
@@ -5,38 +5,36 @@
  */
 
 
-define('Scene/SchemeTile', ['Scene/BoundingBox'], function(BoundingBox) {
+import BoundingBox from 'Scene/BoundingBox';
 
-    function SchemeTile() {
-        //Constructor
+function SchemeTile() {
+    //Constructor
 
-        this.maximumChildren = 4;
-        this.schemeBB = [];
+    this.maximumChildren = 4;
+    this.schemeBB = [];
 
-    }
-    /**
-     * 
-     * @param {type} minLo
-     * @param {type} maxLo
-     * @param {type} minLa
-     * @param {type} maxLa
-     * @returns {SchemeTile_L8.SchemeTile.prototype@pro;schemeBB@call;push}
-     */
+}
+/**
+ * 
+ * @param {type} minLo
+ * @param {type} maxLo
+ * @param {type} minLa
+ * @param {type} maxLa
+ * @returns {SchemeTile_L8.SchemeTile.prototype@pro;schemeBB@call;push}
+ */
 
-    SchemeTile.prototype.add = function(minLo, maxLo, minLa, maxLa) {
-        return this.schemeBB.push(new BoundingBox(minLo, maxLo, minLa, maxLa));
-    };
-
-
-    SchemeTile.prototype.rootCount = function() {
-        return this.schemeBB.length;
-    };
-
-    SchemeTile.prototype.getRoot = function(id) {
-        return this.schemeBB[id];
-    };
+SchemeTile.prototype.add = function(minLo, maxLo, minLa, maxLa) {
+    return this.schemeBB.push(new BoundingBox(minLo, maxLo, minLa, maxLa));
+};
 
 
-    return SchemeTile;
+SchemeTile.prototype.rootCount = function() {
+    return this.schemeBB.length;
+};
 
-});
+SchemeTile.prototype.getRoot = function(id) {
+    return this.schemeBB[id];
+};
+
+
+export default SchemeTile;

--- a/src/Scene/Semantics.js
+++ b/src/Scene/Semantics.js
@@ -4,7 +4,7 @@
  * Description: Description sémantique du Node
  */
 
-var Description = require('Description');
+import Description from 'Description';
 
 function Semantics() {
     //Constructor
@@ -15,6 +15,6 @@ function Semantics() {
 Semantics.prototype = new Description();
 
 
-module.exports = {
-    Semantics: Semantics
+export {
+    Semantics
 };

--- a/src/Scene/SpatialHash.js
+++ b/src/Scene/SpatialHash.js
@@ -39,6 +39,6 @@ SpatialHash.prototype.buildRoot = function() {
 
 
 
-module.exports = {
-    SpatialHash: SpatialHash
+export {
+    SpatialHash
 };

--- a/src/Scene/Style.js
+++ b/src/Scene/Style.js
@@ -4,7 +4,7 @@
  * Description: Description du style du Node. Le style et contenue sont les deux éléments permettant de convertir le Node pour le moteur graphique.
  */
 
-var Description = require('Description');
+import Description from 'Description';
 
 function Style() {
     //Constructor
@@ -17,6 +17,6 @@ function Style() {
 Style.prototype = new Description();
 
 
-module.exports = {
-    Style: Style
+export {
+    Style
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,14 @@ module.exports = {
   module: {
     loaders: [
       {
+        test: /\.js$/,
+        include: [
+          path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'test')
+        ],
+        loader: 'babel'
+      },
+      {
         test: /\.glsl$/,
         include: [
           path.resolve(__dirname, 'src'),


### PR DESCRIPTION
This is an (almost) automated conversion:
- first "unname" the AMD modules,
  
  ```
  sed -i "s|define.'[^']*',|define(|g" $(git grep --name-only  -e "define[(]'[^']*',")
  ```
- then convert them to ES6 modules through amdtoes6 (use `npm install amd-to-es6` to install the tool).
  
  ```
  amdtoes6 -d src/ -o src/ -b
  ```
- finally, convert CommonJS modules to ES6 modules through esnext (use `npm install esnext` to install the tool).
  
  ```
  find src/ -type f -name "*.js" \
      -not -name "*.min.js" -not -name "optimer_regular.js" \
      -exec esnext -I -w modules.commonjs {} \;
  ```
