### PR TITLE
Tile creation and update

### DIFF
--- a/src/Core/Commander/Command.js
+++ b/src/Core/Commander/Command.js
@@ -16,7 +16,7 @@ define('Core/Commander/Command', [], function() {
         this.inParallel = null;
         this.inBuffers = null;
         this.outBuffers = null;
-        this.paramsFunction = {};
+        this.parameters = {};
         this.processFunction = null;
         this.async = null;
         this.force = null;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -34,8 +34,9 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
 
     InterfaceCommander.prototype.request = function(parameters, requester, layer) {
 
+        requester.pending = true;
         var command = new Command();
-        command.type = this.type;
+        //command.type = this.type;
         command.requester = requester;
         command.paramsFunction = parameters;
         command.layer = layer;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -26,7 +26,7 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
 
     InterfaceCommander.prototype.request = function(type, requester, layer, parameters) {
 
-        if(type === undefined || type === "none") return;
+        if(type === undefined || type === "none" || type === "ready") return;
 
         requester.pending = true;
         var command = new Command();

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -38,7 +38,6 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
             if(parameters.callback) {
                 parameters.callback();
             }
-            console.log(type);
             requester.pending = false;
         };
 

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -40,7 +40,7 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
         var command = new Command();
         command.type = type;
         command.requester = requester;
-        command.paramsFunction = parameters;
+        command.parameters = parameters;
         command.layer = layer;
 
         //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -11,6 +11,7 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
 
         this.managerCommands = ManagerCommands();
         this.type = type;
+        this.pendingRequests = {};
 
     }
 
@@ -26,20 +27,26 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
 
     InterfaceCommander.prototype.request = function(type, requester, layer, parameters) {
 
-        if(requester.pending || type === undefined || type === "ready") return;
+        if(type === undefined) return;
 
-        requester.pending = true;
+        var key = requester.id + "." + type;
+        if(this.pendingRequests[key] !== undefined) return;
+
         var command = new Command();
         command.type = type;
         command.requester = requester;
         command.parameters = parameters;
         command.layer = layer;
+
+        var that = this;
         command.callback = function() {
             if(parameters.callback) {
                 parameters.callback();
             }
-            requester.pending = false;
+            that.pendingRequests[key] = undefined;
         };
+
+        this.pendingRequests[key] = command;
 
         //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;
 

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -32,13 +32,13 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
         this._builderCommand();
     };
 
-    InterfaceCommander.prototype.request = function(parameters, requester, layer) {
+    InterfaceCommander.prototype.request = function(type, requester, layer, parameters) {
 
-        if(parameters.type === undefined || parameters.type === "none") return;
+        if(type === undefined || type === "none") return;
 
         requester.pending = true;
         var command = new Command();
-        command.type = parameters.type;
+        command.type = type;
         command.requester = requester;
         command.paramsFunction = parameters;
         command.layer = layer;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -34,9 +34,11 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
 
     InterfaceCommander.prototype.request = function(parameters, requester, layer) {
 
+        if(parameters.type === undefined || parameters.type === "none") return;
+
         requester.pending = true;
         var command = new Command();
-        //command.type = this.type;
+        command.type = parameters.type;
         command.requester = requester;
         command.paramsFunction = parameters;
         command.layer = layer;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -26,7 +26,7 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
 
     InterfaceCommander.prototype.request = function(type, requester, layer, parameters) {
 
-        if(type === undefined || type === "none" || type === "ready") return;
+        if(requester.pending || type === undefined || type === "ready") return;
 
         requester.pending = true;
         var command = new Command();
@@ -34,6 +34,13 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
         command.requester = requester;
         command.parameters = parameters;
         command.layer = layer;
+        command.callback = function() {
+            if(parameters.callback) {
+                parameters.callback();
+            }
+            console.log(type);
+            requester.pending = false;
+        };
 
         //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;
 

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -65,7 +65,6 @@ define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', [
         var providerWMTS = manager.getProvider(map.tiles).providerWMTS;
 
         providerWMTS.addLayer(layer);
-        manager.addLayer(map.colorTerrain,providerWMTS);
         map.colorTerrain.services.push(layer.id);
 
     };
@@ -77,7 +76,6 @@ define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', [
         var providerWMTS = manager.getProvider(map.tiles).providerWMTS;
 
         providerWMTS.addLayer(layer);
-        manager.addLayer(map.elevationTerrain,providerWMTS);
         map.elevationTerrain.services.push(layer.id);
 
     };

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -131,6 +131,7 @@ define('Core/Commander/ManagerCommands', [
                 if(!node || node.disposed) {
                     return;
                 } else if(node.parent.visible === false) {
+                    node.parent.disposeChildren();
                     com.callback();
                     return;
                 } else {

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -122,22 +122,17 @@ define('Core/Commander/ManagerCommands', [
         ManagerCommands.prototype.deQueue = function() {
 
             while (this.queueAsync.length > 0) {
-                var com = this.queueAsync.peek();
-                var parent = com.requester;
+                var com = this.queueAsync.dequeue();
+                var node = com.requester;
 
-                /*if (parent.visible === false && parent.level >= 2) {
-
-                    while (parent.children.length > 0) {
-                        var child = parent.children[0];
-                        child.dispose();
-                        parent.remove(child);
-                    }
-                    parent.wait = false;
-                    parent.false = false;
-                    this.queueAsync.dequeue();
-                } else*/
-                    return this.queueAsync.dequeue();
-
+                if(!node || node.disposed) {
+                    return;
+                } else if(node.parent.visible === false) {
+                    node.pending = false;
+                    return;
+                } else {
+                    return com;
+                }
             }
 
             return undefined;

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -131,7 +131,7 @@ define('Core/Commander/ManagerCommands', [
                 if(!node || node.disposed) {
                     return;
                 } else if(node.parent.visible === false) {
-                    node.pending = false;
+                    com.callback();
                     return;
                 } else {
                     return com;

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -125,7 +125,7 @@ define('Core/Commander/ManagerCommands', [
                 var com = this.queueAsync.peek();
                 var parent = com.requester;
 
-                if (parent.visible === false && parent.level >= 2) {
+                /*if (parent.visible === false && parent.level >= 2) {
 
                     while (parent.children.length > 0) {
                         var child = parent.children[0];
@@ -135,7 +135,7 @@ define('Core/Commander/ManagerCommands', [
                     parent.wait = false;
                     parent.false = false;
                     this.queueAsync.dequeue();
-                } else
+                } else*/
                     return this.queueAsync.dequeue();
 
             }

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -110,8 +110,11 @@ define('Core/Commander/ManagerCommands', [
 
             while (this.queueAsync.length > 0 && arrayTasks.length < nT) {
                 var command = this.deQueue();
-                if(command)
-                    arrayTasks.push(this.providerMap[command.layer.id].executeCommand(command));
+                if(command) {
+                    var task = this.providerMap[command.layer.id].executeCommand(command);
+                    task = task.then(command.callback());
+                    arrayTasks.push(task);
+                }
             }
 
             return arrayTasks;

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -112,7 +112,7 @@ define('Core/Commander/ManagerCommands', [
                 var command = this.deQueue();
                 if(command) {
                     var task = this.providerMap[command.layer.id].executeCommand(command);
-                    task = task.then(command.callback());
+                    task = task.then(command.callback);
                     arrayTasks.push(task);
                 }
             }

--- a/src/Core/Commander/Providers/IoDriver_Image.js
+++ b/src/Core/Commander/Providers/IoDriver_Image.js
@@ -25,6 +25,7 @@ define('Core/Commander/Providers/IoDriver_Image', ['Core/Commander/Providers/IoD
         {
 
             var image = new Image();
+            resolve.image = image; // avoid image deletion by garbage collector
 
             image.addEventListener('load', function(/*event*/) {
 

--- a/src/Core/Commander/Providers/IoDriver_XBIL.js
+++ b/src/Core/Commander/Providers/IoDriver_XBIL.js
@@ -91,6 +91,7 @@ define('Core/Commander/Providers/IoDriver_XBIL', ['Core/Commander/Providers/IoDr
         //return new Promise(function(resolve/*, reject*/)
         {
             var xhr = new XMLHttpRequest();
+            resolve.xhr = xhr; // avoid deletion by garbage collector
 
 
             //The responseType property cannot be set when the XMLHttpRequest is not async, that is, synchronous.

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -60,13 +60,6 @@ define('Core/Commander/Providers/TileProvider', [
             this.tree = null;
             this.nNode = 0;
 
-            this.testWMS = new WMS_Provider({
-                url: "http://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv",
-                layer: "GEBCO_LATEST",
-                srs: "EPSG:4326",
-                format: "image/jpeg"
-            });
-
         }
 
         TileProvider.prototype.constructor = TileProvider;
@@ -148,13 +141,11 @@ define('Core/Commander/Providers/TileProvider', [
                 tile.updateMatrix();
                 tile.updateMatrixWorld();
 
-                //if(tileCoord.zoom > 3 )
-                    //tileCoord =  undefined;
-
                 tile.texturesNeeded =+ 1;
+
                 return when();
             } else if(command.type === "elevation") {
-                // TODO: remvoe hard-written values
+                // TODO: remove hard-written values
                 var elevationlayerId = tile.tileCoord.zoom > 11 ? 'IGN_MNT_HIGHRES' : 'IGN_MNT';
                 return this.providerElevationTexture.getElevationTexture(tile.tileCoord, elevationlayerId).then(function(terrain) {
                     if(this.disposed) return;
@@ -162,25 +153,11 @@ define('Core/Commander/Providers/TileProvider', [
                 }.bind(tile));
 
             } else if(command.type === "imagery") {
-                var box = {minCarto: {}, maxCarto: {}};
-                box.minCarto.longitude = tile.bbox.minCarto.longitude * 180 / 3.14;
-                box.minCarto.latitude = tile.bbox.minCarto.latitude * 180 / 3.14;
-                box.maxCarto.longitude = tile.bbox.maxCarto.longitude * 180 / 3.14;
-                box.maxCarto.latitude = tile.bbox.maxCarto.latitude * 180 / 3.14;
-                box.minCarto.longitude -= 180;
-                box.maxCarto.longitude -= 180;
-                return this.testWMS.getTexture(box).then(function(colorTexture) {
+                return this.providerWMTS.getColorTextures(tile,"IGNPO").then(function(result)
+                {
                     if(this.disposed) return;
-                    colorTexture.level = this.level;
-                    var pack = {};
-                    pack.texture = colorTexture;
-                    pack.pitch = {x: 0, y: 0, z: 1};
-                    this.setTexturesLayer([pack], 1);
+                    this.setTexturesLayer(result,1);
                 }.bind(tile));
-                /*var colorlayerId = command.paramsFunction.layer.colorLayerId;//'IGNPO';
-                this.providerColorTexture.getColorTexture(tile.tileCoord,{x:0.0,y:0.0,z:1.0},colorlayerId).then(function(colorTextures) {
-                    this.setTexturesLayer([colorTextures],1);
-                }.bind(tile));*/
             }
         };
 

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -152,10 +152,11 @@ define('Core/Commander/Providers/TileProvider', [
                     //tileCoord =  undefined;
 
                 tile.texturesNeeded =+ 1;
+                return when();
             } else if(command.type === "elevation") {
                 // TODO: remvoe hard-written values
                 var elevationlayerId = tile.tileCoord.zoom > 11 ? 'IGN_MNT_HIGHRES' : 'IGN_MNT';
-                this.providerElevationTexture.getElevationTexture(tile.tileCoord, elevationlayerId).then(function(terrain) {
+                return this.providerElevationTexture.getElevationTexture(tile.tileCoord, elevationlayerId).then(function(terrain) {
                     if(this.disposed) return;
                     this.setTextureElevation(terrain);
                 }.bind(tile));
@@ -168,7 +169,7 @@ define('Core/Commander/Providers/TileProvider', [
                 box.maxCarto.latitude = tile.bbox.maxCarto.latitude * 180 / 3.14;
                 box.minCarto.longitude -= 180;
                 box.maxCarto.longitude -= 180;
-                this.testWMS.getTexture(box).then(function(colorTexture) {
+                return this.testWMS.getTexture(box).then(function(colorTexture) {
                     if(this.disposed) return;
                     colorTexture.level = this.level;
                     var pack = {};

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -105,18 +105,22 @@ define('Core/Commander/Providers/TileProvider', [
 
         TileProvider.prototype.executeCommand = function(command) {
 
-            var bbox = command.paramsFunction.bbox;
+            var tile = command.requester;//new command.type(params,this.builder);
+            var bbox = tile.bbox;
 
             // TODO not generic
             var tileCoord = this.projection.WGS84toWMTS(bbox);
-            var parent = command.requester;
+            var parent = tile.parent;
+            //var parent = command.requester;
 
             // build tile
             var geometry = undefined; //getGeometry(bbox,tileCoord);
 
-            var params = {bbox:bbox,zoom:tileCoord.zoom,segment:16,center:null,projected:null}
+            var params = {bbox:bbox,zoom:tileCoord.zoom,segment:16,center:null,projected:null};
 
-            var tile = new command.type(params,this.builder);
+
+            tile.setGeometry(new TileGeometry(params, this.builder), params.center);   //TODO: use cache?
+            // set material too ?
 
             tile.tileCoord = tileCoord;
             tile.material.setUuid(this.nNode++);
@@ -132,12 +136,13 @@ define('Core/Commander/Providers/TileProvider', [
             tile.position.copy(params.center);
             tile.setVisibility(false);
 
-            parent.add(tile);
+            //parent.add(tile);
             tile.updateMatrix();
             tile.updateMatrixWorld();
 
-            var elevationlayerId = command.paramsFunction.elevationLayerId[tileCoord.zoom > 11 ? 1 : 0];
-            var colorlayerId = command.paramsFunction.colorLayerId;
+            // TODO: TEMP
+            var elevationlayerId = tileCoord.zoom > 11 ? 'IGN_MNT_HIGHRES' : 'IGN_MNT';
+            var colorlayerId = 'IGNPO';
 
             if(tileCoord.zoom > 3 )
                 tileCoord =  undefined;

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -143,6 +143,10 @@ define('Core/Commander/Providers/TileProvider', [
 
                 tile.texturesNeeded =+ 1;
 
+                if(tile.level !== 0) {
+                    tile.setTexturesFromParent();
+                }
+
                 return when();
             } else if(command.type === "elevation") {
                 // TODO: remove hard-written values

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -158,6 +158,7 @@ define('Core/Commander/Providers/TileProvider', [
                 // TODO: remvoe hard-written values
                 var elevationlayerId = tile.tileCoord.zoom > 11 ? 'IGN_MNT_HIGHRES' : 'IGN_MNT';
                 this.providerElevationTexture.getElevationTexture(tile.tileCoord, elevationlayerId).then(function(terrain) {
+                    if(this.disposed) return;
                     this.setTextureElevation(terrain);
                 }.bind(tile));
 
@@ -170,6 +171,7 @@ define('Core/Commander/Providers/TileProvider', [
                 box.minCarto.longitude -= 180;
                 box.maxCarto.longitude -= 180;
                 this.testWMS.getTexture(box).then(function(colorTexture) {
+                    if(this.disposed) return;
                     colorTexture.level = this.level;
                     var pack = {};
                     pack.texture = colorTexture;
@@ -182,6 +184,10 @@ define('Core/Commander/Providers/TileProvider', [
                 }.bind(tile));*/
             }
         };
+
+        /*var test = function (tile, f, callback) {
+
+        };*/
 
         return TileProvider;
 

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -42,6 +42,7 @@ define('Core/Commander/Providers/WMS_Provider', [
 
             this.baseUrl = options.url || "";
             this.layer = options.layer || "";
+            this.style = options.style || "";
             this.format = defaultValue(options.format, "image/jpeg");
             this.srs = options.srs || "";
             this.width = defaultValue(options.width, 256);
@@ -63,7 +64,8 @@ define('Core/Commander/Providers/WMS_Provider', [
                 "&SERVICE=WMS&VERSION=1.1.1" + "&REQUEST=GetMap&BBOX=" +
                 bbox.minCarto.longitude + "," + bbox.minCarto.latitude + "," +
                 bbox.maxCarto.longitude + "," + bbox.maxCarto.latitude +
-                "&WIDTH=" + this.width + "&HEIGHT=" + this.height + "&SRS=" + this.srs;
+                "&WIDTH=" + this.width + "&HEIGHT=" + this.height + "&SRS=" + this.srs +
+                "&STYLES=";
             return url;
         };
 
@@ -121,6 +123,8 @@ define('Core/Commander/Providers/WMS_Provider', [
                 result.texture.magFilter = THREE.LinearFilter;
                 result.texture.minFilter = THREE.LinearFilter;
                 result.texture.anisotropy = 16;
+                result.texture.needsUpdate = true;
+                result.texture.url = url;
 
                 this.cache.addRessource(url, result.texture);
                 return result.texture;

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -326,6 +326,9 @@ define('Core/Commander/Providers/WMTS_Provider', [
                 else
                     tile.material.nbTextures -= colorTexturesNeeded;
 
+                // TODO: temporarily disabled texture upscaling
+                lookAtAncestor = false;
+
                 for (var row = box[0].row; row < box[1].row + 1; row++) {
 
                    var cooWMTS = new CoordWMTS(box[0].zoom, row, col);

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -251,7 +251,10 @@ define('Core/Commander/Providers/WMTS_Provider', [
                     result.texture.minFilter = THREE.LinearFilter;
                     result.texture.anisotropy = 16;
                     result.texture.url = url;
-                    result.texture['level'] = coWMTS.zoom;
+                    result.texture.level = coWMTS.zoom;
+                    var box = this.projection.WMTStoWGS84(coWMTS);
+                    result.texture.coord = coWMTS;
+                    result.texture.box = new THREE.Box2(new THREE.Vector2(box[0], box[2]), new THREE.Vector2(box[1], box[3]));
 
                     this.cache.addRessource(url, result.texture);
                 }

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -324,13 +324,6 @@ define('Core/Commander/Providers/WMTS_Provider', [
 
                 var colorTexturesNeeded = box[1].row + 1 - box[0].row;
 
-                if(lookAtAncestor)
-                    tile.texturesNeeded += colorTexturesNeeded;
-                else
-                    tile.material.nbTextures -= colorTexturesNeeded;
-
-                // TODO: temporarily disabled texture upscaling
-                lookAtAncestor = false;
 
                 for (var row = box[0].row; row < box[1].row + 1; row++) {
 

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -209,7 +209,9 @@ define('Core/Commander/Providers/WMTS_Provider', [
 
                 if(parent.downScaledLayer(0))
                 {
-                    var layerId = command.paramsFunction.elevationLayerId[parent.tileCoord.zoom > 11 ? 1 : 0];
+                    //var layerId = command.paramsFunction.elevationLayerId[parent.tileCoord.zoom > 11 ? 1 : 0];
+                    // TODO: TEMP
+                    var layerId = parent.tileCoord.zoom > 11 ? 'IGN_MNT_HIGHRES' : 'IGN_MNT';
 
                     return this.getElevationTexture(parent.tileCoord,layerId).then(function(terrain)
                     {

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -110,6 +110,22 @@ define('Core/Geographic/Projection', ['Core/Geographic/CoordWMTS', 'Core/Math/Ma
         return new CoordWMTS(zoom, row, col);
     };
 
+    // TODO : only works for one WMTS tile scheme
+    Projection.prototype.WMTStoWGS84 = function(coord) {
+
+        var x1, x2, y1, y2;
+
+        var p = MathExt.PI / Math.pow(2, coord.zoom);
+        x1 = p * coord.col;
+        x2 = x1 + p;
+        y1 = p * coord.row - MathExt.PI_OV_TWO;
+        y2 = y1 + p;
+        y1 = - y1;
+        y2 = - y2;
+
+        return [x1, x2, y2, y1];
+    };
+
     Projection.prototype.UnitaryToLongitudeWGS84 = function(u,projection,bbox)
     {
         projection.longitude = bbox.minCarto.longitude + u * bbox.dimension.x;

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -146,7 +146,6 @@ define('Globe/TileMesh', [
 
     TileMesh.prototype.setGeometry = function(geometry) {
         this.hasGeometry = true;
-        this.cullable = true;
 
 
         this.geometry = geometry;

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -160,7 +160,7 @@ define('Globe/TileMesh', [
         this.pending = false;
         this.updateGeometry = false;
         this.cullable = true;
-        this.loadingCheck();
+
 
         this.geometry = geometry;
 
@@ -207,7 +207,7 @@ define('Globe/TileMesh', [
     TileMesh.prototype.setTextureElevation = function(elevation) {
         this.pending = false;
         this.updateElevation = false;
-        this.loadingCheck();
+
         var texture;
         var pitScale;
         var ancestor;
@@ -252,11 +252,9 @@ define('Globe/TileMesh', [
         }
 
         this.material.setTexture(texture,l_ELEVATION, 0, pitScale);
-
-        this.loadingCheck();
     };
 
-    TileMesh.prototype.update = function () {
+    TileMesh.prototype.getStatus = function () {
         if(this.pending) {
             return "none";
         }
@@ -269,7 +267,7 @@ define('Globe/TileMesh', [
             // TODO: use parent data while waiting?
             return "imagery";
         }
-        return "none";
+        return "ready";
     };
 
     TileMesh.prototype.setBBoxZ = function(min, max) {
@@ -298,19 +296,16 @@ define('Globe/TileMesh', [
     TileMesh.prototype.setTexturesLayer = function(textures,idLayer){
         this.pending = false;
         this.updateImagery = false;
-        this.loadingCheck();
+
 
         if(!textures || this.material === null)
         {
-            this.loadingCheck();
             return;
         }
 
         this.material.setTexturesLayer(textures, idLayer);
 
         this.currentLevelLayers[l_COLOR] = textures[0].texture.level;
-
-        this.loadingCheck();
     };
 
     TileMesh.prototype.downScaledLayer = function(id)
@@ -369,14 +364,14 @@ define('Globe/TileMesh', [
         return this.texturesNeeded === this.material.nbLoadedTextures();
     };
 
-    TileMesh.prototype.loadingCheck = function() {
+    //TileMesh.prototype.loadingCheck = function() {
 
-        this.loaded = !this.updateImagery && !this.updateElevation && !this.updateGeometry;
+        //this.loaded = !this.updateImagery && !this.updateElevation && !this.updateGeometry;
         /*if (this.allTexturesAreLoaded())
         {
             //this.loaded = true;
         }*/
-    };
+    //};
 
     return TileMesh;
 

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -241,17 +241,26 @@ define('Globe/TileMesh', [
         this.material.setTexture(texture,l_ELEVATION, 0, pitScale);
     };
 
-    TileMesh.prototype.getStatus = function () {
-        if(this.updateGeometry) {
-            return "geometry";
-        } else if(this.updateElevation) {
-            // TODO: use parent data while waiting?
-            return "elevation";
-        } else if(this.updateImagery) {
-            // TODO: use parent data while waiting?
-            return "imagery";
+    TileMesh.prototype.getStatus = function() {
+        var status = [];
+        if(this.updateGeometry) {   // Need geometry before elevation or imagery
+            status.push("geometry");
+        } else {
+            if(this.updateElevation) {
+                // TODO: use parent data while waiting?
+                status.push("elevation");
+            }
+            if(this.updateImagery) {
+                // TODO: use parent data while waiting?
+                status.push("imagery");
+            }
         }
-        return "ready";
+        return status;
+    };
+
+    TileMesh.prototype.ready = function() {
+        // TODO: a tile can be ready even if a texture needs updating (e.g. when a texture has already been loaded but is outdated)
+        return !this.updateGeometry && !this.updateElevation && !this.updateImagery;
     };
 
     TileMesh.prototype.setBBoxZ = function(min, max) {

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -375,7 +375,6 @@ define('Globe/TileMesh', [
         /*if (this.allTexturesAreLoaded())
         {
             //this.loaded = true;
-            //this.parent.childrenLoaded();
         }*/
     };
 

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -146,7 +146,6 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.setGeometry = function(geometry) {
-        this.pending = false;
         this.updateGeometry = false;
         this.cullable = true;
 
@@ -194,7 +193,6 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.setTextureElevation = function(elevation) {
-        this.pending = false;
         this.updateElevation = false;
 
         var texture;
@@ -244,9 +242,6 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.getStatus = function () {
-        if(this.pending) {
-            return "none";
-        }
         if(this.updateGeometry) {
             return "geometry";
         } else if(this.updateElevation) {
@@ -283,7 +278,6 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.setTexturesLayer = function(textures,idLayer){
-        this.pending = false;
         this.updateImagery = false;
 
 

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -57,6 +57,9 @@ define('Globe/TileMesh', [
         this.material = new LayeredMaterial();
         this.frustumCulled = false;
         this.levelElevation = this.level;
+        this.updateElevation = true;
+        this.updateImagery = true;
+        this.updateGeometry = true;
 
         // TODO not generic
         for (var i = 0; i < groupelevation.length; i++) {
@@ -154,6 +157,9 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.setGeometry = function(geometry, center) {   // TODO: try to remove center
+        this.pending = false;
+        this.updateGeometry = false;
+
         this.geometry = geometry;
 
         this.normal = center.clone().normalize();
@@ -197,7 +203,9 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.setTextureElevation = function(elevation) {
-        var texture = undefined;
+        this.pending = false;
+        this.updateElevation = false;
+        var texture;
         var pitScale;
         var ancestor;
         var image;
@@ -245,6 +253,23 @@ define('Globe/TileMesh', [
         this.loadingCheck();
     };
 
+    TileMesh.prototype.update = function () {
+        if(this.pending) {
+            return "none";
+        }
+        if(this.updateGeometry) {
+            return "geometry";
+        } else if(this.updateElevation) {
+            // TODO: use parent data while waiting?
+            return "elevation";
+        } else if(this.updateImagery) {
+            // TODO: use parent data while waiting?
+            return "imagery";
+        }
+
+        return "none";
+    };
+
     TileMesh.prototype.setBBoxZ = function(min, max) {
 
         if(Math.floor(min) !== Math.floor(this.bbox.minCarto.altitude) || Math.floor(max) !== Math.floor(this.bbox.maxCarto.altitude) )
@@ -269,6 +294,8 @@ define('Globe/TileMesh', [
     };
 
     TileMesh.prototype.setTexturesLayer = function(textures,idLayer){
+        this.pending = false;
+        this.updateImagery = false;
 
         if(!textures || this.material === null)
         {

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -32,25 +32,26 @@ define('Globe/TileMesh', [
     var l_ELEVATION = 0;
     var l_COLOR = 1;
 
-    function TileMesh(params, builder, geometryCache) {
+    function TileMesh(params/*, builder, geometryCache*/) {
         //Constructor
         NodeMesh.call(this);
 
         this.matrixAutoUpdate = false;
         this.rotationAutoUpdate = false;
 
-        this.level = params.zoom;
+        //this.level = params.zoom;
+        this.level = params.level;  // TODO: maybe build full MTS coord?
         this.bbox = defaultValue(params.bbox, new BoundingBox());
 
-        this.geometry = defaultValue(geometryCache, new TileGeometry(params, builder));
-        this.normal = params.center.clone().normalize();
+        //this.geometry = defaultValue(geometryCache, new TileGeometry(params, builder));
+        //this.normal = params.center.clone().normalize();
 
-        this.distance = params.center.length();
+        //this.distance = params.center.length();
 
         // TODO Why move sphere center
-        this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, params.center);
+        //this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, params.center);
 
-        this.oSphere = new THREE.Sphere(this.centerSphere.clone(),this.geometry.boundingSphere.radius);
+        //this.oSphere = new THREE.Sphere(this.centerSphere.clone(),this.geometry.boundingSphere.radius);
 
         this.texturesNeeded = 0;
         this.material = new LayeredMaterial();
@@ -150,6 +151,18 @@ define('Globe/TileMesh', [
 
     TileMesh.prototype.setSelected = function(select) {
         this.material.setSelected(select);
+    };
+
+    TileMesh.prototype.setGeometry = function(geometry, center) {   // TODO: try to remove center
+        this.geometry = geometry;
+
+        this.normal = center.clone().normalize();
+
+        this.distance = center.length();
+        // TODO Why move sphere center
+        this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, center);
+
+        this.oSphere = new THREE.Sphere(this.centerSphere.clone(),this.geometry.boundingSphere.radius);
     };
 
     TileMesh.prototype.parseBufferElevation = function(image,minMax,pitScale) {

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -159,6 +159,8 @@ define('Globe/TileMesh', [
     TileMesh.prototype.setGeometry = function(geometry, center) {   // TODO: try to remove center
         this.pending = false;
         this.updateGeometry = false;
+        this.cullable = true;
+        this.loadingCheck();
 
         this.geometry = geometry;
 
@@ -205,6 +207,7 @@ define('Globe/TileMesh', [
     TileMesh.prototype.setTextureElevation = function(elevation) {
         this.pending = false;
         this.updateElevation = false;
+        this.loadingCheck();
         var texture;
         var pitScale;
         var ancestor;
@@ -266,7 +269,6 @@ define('Globe/TileMesh', [
             // TODO: use parent data while waiting?
             return "imagery";
         }
-
         return "none";
     };
 
@@ -296,6 +298,7 @@ define('Globe/TileMesh', [
     TileMesh.prototype.setTexturesLayer = function(textures,idLayer){
         this.pending = false;
         this.updateImagery = false;
+        this.loadingCheck();
 
         if(!textures || this.material === null)
         {
@@ -368,11 +371,12 @@ define('Globe/TileMesh', [
 
     TileMesh.prototype.loadingCheck = function() {
 
-        if (this.allTexturesAreLoaded())
+        this.loaded = !this.updateImagery && !this.updateElevation && !this.updateGeometry;
+        /*if (this.allTexturesAreLoaded())
         {
-            this.loaded = true;
-            this.parent.childrenLoaded();
-        }
+            //this.loaded = true;
+            //this.parent.childrenLoaded();
+        }*/
     };
 
     return TileMesh;

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -113,6 +113,7 @@ define('Globe/TileMesh', [
         this.geometry.dispose();
         this.geometry = null;
         this.material = null;
+        this.disposed = true;
     };
 
     /**
@@ -125,7 +126,6 @@ define('Globe/TileMesh', [
             this.remove(child);
             child.dispose();
         }
-        this.material.visible = true;
     };
 
     TileMesh.prototype.useParent = function() {

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -37,7 +37,14 @@ define('Renderer/LayeredMaterial', ['THREE',
         for (var l = 0; l < nbLayer; l++) {
 
             this.Textures[l] = [emptyTexture];
-            this.pitScale[l] = [new THREE.Vector3(0.0, 0.0, 0.0)];
+            this.pitScale[l] = [new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0),
+                new THREE.Vector3(0.0, 0.0, 0.0)];
             this.nbTextures[l] = 0;
         }
 
@@ -111,7 +118,7 @@ define('Renderer/LayeredMaterial', ['THREE',
     LayeredMaterial.prototype.setTexture = function(texture, layer, slot, pitScale) {
 
 
-        if(this.Textures[layer][slot] === undefined || this.Textures[layer][slot].image === undefined)
+        //if(this.Textures[layer][slot] === undefined || this.Textures[layer][slot].image === undefined)
             this.nbTextures[layer] += 1 ;
 
         this.Textures[layer][slot] = texture ? texture : emptyTexture; // BEWARE: array [] -> size: 0; array [10]="wao" -> size: 11

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -68,7 +68,7 @@ define('Renderer/LayeredMaterial', ['THREE',
         this.uniforms.lightingOn = {
              type: "i",
              value: gfxEngine().lightingOn
-        },
+        };
         this.uniforms.lightPosition = {
             type: "v3",
             value: new THREE.Vector3(-0.5, 0.0, 1.0)

--- a/src/Renderer/NodeMesh.js
+++ b/src/Renderer/NodeMesh.js
@@ -16,7 +16,6 @@ define('Renderer/NodeMesh', ['Scene/Node', 'THREE'], function(Node, THREE) {
         THREE.Mesh.call(this);
 
         this.sse = 0.0;
-        this.wait = false;
         this.helper = undefined;
 
     };

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -70,15 +70,12 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         if(node.parent.material.visible)
             return false;
 
-        if(process.process(node, camera, params)) {
+        process.process(node, camera, params);
+        if(node.visible) {
             this.uniformsProcess(node, camera);
         }
-        /*if(!process.isCulled(node, camera)) {
-            node.setVisibility(true);
-            process.SSE(node, camera,params);
-            this.uniformsProcess(node, camera);
-        }*/
-        return !node.material.visible /*&& !node.wait*/;
+
+        return process.traverseChildren(node);
 
     };
 
@@ -165,7 +162,7 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         for (var i = 0; i < node.children.length; i++) {
             var child = node.children[i];
             // TODO node.wait === true ---> delete child and switch to node.wait = false
-            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && !process.checkSSE(child, camera) && !node.wait) || node.level === 2))
+            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && !process.checkSSE(child, camera) /*&& !node.wait*/) || node.level === 2))
                 childrenCleaned++;
         }
 

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -70,13 +70,15 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         if(node.parent.material.visible)
             return false;
 
-        if(!process.isCulled(node, camera)) {
+        if(process.process(node, camera, params)) {
+            this.uniformsProcess(node, camera);
+        }
+        /*if(!process.isCulled(node, camera)) {
             node.setVisibility(true);
             process.SSE(node, camera,params);
             this.uniformsProcess(node, camera);
-        }
-
-        return !node.material.visible && !node.wait;
+        }*/
+        return !node.material.visible /*&& !node.wait*/;
 
     };
 
@@ -150,8 +152,8 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         if (this.processQuadtreeNode(node, camera, process, {withUp : optional, tree : this.tree}))
             for (var i = 0; i < node.children.length; i++)
                 this._browse(node.children[i], camera, process, optional,clean);
-        else if(clean)
-            this._clean(node, node.level + 2, process, camera);
+        /*else if(clean)
+            this._clean(node, node.level + 2, process, camera);*/
 
     };
 

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -162,7 +162,7 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         for (var i = 0; i < node.children.length; i++) {
             var child = node.children[i];
             // TODO node.wait === true ---> delete child and switch to node.wait = false
-            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && (!child.cullable || !process.checkSSE(child, camera)) /*&& !node.wait*/) || node.level === 2))
+            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && child.cullable && !process.checkSSE(child, camera) /*&& !node.wait*/) /*|| node.level === 2*/))
                 childrenCleaned++;
         }
 

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -149,8 +149,8 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         if (this.processQuadtreeNode(node, camera, process, {withUp : optional, tree : this.tree}))
             for (var i = 0; i < node.children.length; i++)
                 this._browse(node.children[i], camera, process, optional,clean);
-        /*else if(clean)
-            this._clean(node, node.level + 2, process, camera);*/
+        else if(clean)
+            this._clean(node, node.level + 2, process, camera);
 
     };
 
@@ -162,7 +162,7 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         for (var i = 0; i < node.children.length; i++) {
             var child = node.children[i];
             // TODO node.wait === true ---> delete child and switch to node.wait = false
-            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && !process.checkSSE(child, camera) /*&& !node.wait*/) || node.level === 2))
+            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && (!child.cullable || !process.checkSSE(child, camera)) /*&& !node.wait*/) || node.level === 2))
                 childrenCleaned++;
         }
 

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -162,7 +162,7 @@ define('Scene/BrowseTree', ['Globe/TileMesh', 'THREE'], function( TileMesh, THRE
         for (var i = 0; i < node.children.length; i++) {
             var child = node.children[i];
             // TODO node.wait === true ---> delete child and switch to node.wait = false
-            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && child.cullable && !process.checkSSE(child, camera) /*&& !node.wait*/) /*|| node.level === 2*/))
+            if (this._clean(child, level, process, camera) && ((child.level >= level && child.children.length === 0 && !process.checkSSE(child, camera) /*&& !node.wait*/) /*|| node.level === 2*/))
                 childrenCleaned++;
         }
 

--- a/src/Scene/Layer.js
+++ b/src/Scene/Layer.js
@@ -26,7 +26,7 @@ define('Scene/Layer', [
 
         Node.call(this);
         // Requeter
-        this.interCommand = type !== undefined ? new InterfaceCommander(type, param) : undefined;
+        //this.interCommand = type !== undefined ? new InterfaceCommander(type, param) : undefined;
         this.descriManager = null;
         this.projection = new Projection();
         this.layerId = Layer.count++;

--- a/src/Scene/Layer.js
+++ b/src/Scene/Layer.js
@@ -16,17 +16,15 @@
 define('Scene/Layer', [
     'THREE',
     'Scene/Node',
-    'Core/Commander/InterfaceCommander',
     'Core/Geographic/Projection',
     'Renderer/NodeMesh'
-], function(THREE, Node, InterfaceCommander, Projection, NodeMesh) {
+], function(THREE, Node, Projection, NodeMesh) {
 
     function Layer(type, param) {
         //Constructor
 
         Node.call(this);
         // Requeter
-        //this.interCommand = type !== undefined ? new InterfaceCommander(type, param) : undefined;
         this.descriManager = null;
         this.projection = new Projection();
         this.id = Layer.count++;

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -22,10 +22,8 @@ define('Scene/Node', [], function() {
         this.saveState = null;
         this.level = 0;
         this.screenSpaceError = 0.0;
-        this.loaded = false;
         this.visible = true;
         this.layer = null;
-        this.divided = false;
         this.pending = false;
         this.cullable = false;
 

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -23,7 +23,6 @@ define('Scene/Node', [], function() {
         this.level = 0;
         this.screenSpaceError = 0.0;
         this.loaded = false;
-        this.wait = false;
         this.visible = true;
         this.layer = null;
         this.divided = false;
@@ -49,20 +48,6 @@ define('Scene/Node', [], function() {
 
         return this.children.length === 0;
 
-    };
-
-    Node.prototype.childrenLoaded = function() {
-
-        if(!this.wait && this.childrenCount() > 0)
-            return true;
-
-        for (var i = 0, max = this.children.length; i < max; i++) {
-            if (this.children[i].loaded === false)
-                return false;
-        }
-
-        this.wait = false;
-        return true;
     };
 
     /**

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -26,6 +26,8 @@ define('Scene/Node', [], function() {
         this.wait = false;
         this.visible = true;
         this.layer = null;
+        this.divided = false;
+        this.pending = false;
 
 
     }

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -28,6 +28,7 @@ define('Scene/Node', [], function() {
         this.layer = null;
         this.divided = false;
         this.pending = false;
+        this.cullable = false;
 
 
     }

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -24,7 +24,6 @@ define('Scene/Node', [], function() {
         this.screenSpaceError = 0.0;
         this.visible = true;
         this.layer = null;
-        this.pending = false;
         this.cullable = false;
         this.disposed = false;
 

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -24,7 +24,6 @@ define('Scene/Node', [], function() {
         this.screenSpaceError = 0.0;
         this.visible = true;
         this.layer = null;
-        this.cullable = false;
         this.disposed = false;
 
 

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -26,6 +26,7 @@ define('Scene/Node', [], function() {
         this.layer = null;
         this.pending = false;
         this.cullable = false;
+        this.disposed = false;
 
 
     }
@@ -103,7 +104,7 @@ define('Scene/Node', [], function() {
         this.children.push(child);
         child.parent = this;
 
-        child.layer = this;
+        child.layer = this; // TODO: uh, this doesn't seem right
     };
 
     /**
@@ -111,9 +112,11 @@ define('Scene/Node', [], function() {
      *
      * @param child {[object Object]}
      */
-    Node.prototype.remove = function(/*child*/) {
-        //TODO: Implement Me
-
+    Node.prototype.remove = function(child) {
+        var index = this.children.indexOf(child);
+        if(index !== -1) {
+            this.children.splice(index, 1);
+        }
     };
 
 

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -121,7 +121,7 @@ define('Scene/NodeProcess', ['Scene/BoundingBox', 'Renderer/Camera', 'Core/Math/
         var updateType;
         if(node.level === 0) { // first nodes
             updateType = node.update();
-            interCommand.request({type: updateType}, node, params.tree); // TODO: change parameters
+            interCommand.request(updateType, node, params.tree, {});
 
             node.setVisibility(node.loaded);
             node.setMaterialVisibility(node.loaded);
@@ -140,7 +140,7 @@ define('Scene/NodeProcess', ['Scene/BoundingBox', 'Renderer/Camera', 'Core/Math/
                 var child = node.children[i];
                 updateType = child.update();
 
-                interCommand.request({type: updateType}, child, params.tree); // TODO: change parameters
+                interCommand.request(updateType, child, params.tree, {});
                 child.setVisibility(false);
                 child.setMaterialVisibility(false);
 

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -118,11 +118,10 @@ define('Scene/NodeProcess', ['Scene/BoundingBox', 'Renderer/Camera', 'Core/Math/
     NodeProcess.prototype.process = function(node, camera, params) {
         // When entering this function, the node is ALWAYS visible
         var interCommand = new InterfaceCommander();    // TODO: InterfaceCommander static class?
+        var updateType;
         if(node.level === 0) { // first nodes
-            if(!node.pending) {
-                interCommand.request({/*params*/}, node, params.tree); // TODO: change parameters
-                return false;
-            }
+            updateType = node.update();
+            interCommand.request({type: updateType}, node, params.tree); // TODO: change parameters
 
             node.setVisibility(node.loaded);
             node.setMaterialVisibility(node.loaded);
@@ -138,17 +137,17 @@ define('Scene/NodeProcess', ['Scene/BoundingBox', 'Renderer/Camera', 'Core/Math/
             var childrenReady = 0;
             for(var i = 0; i < node.children.length; i++) { // Display node if one or several children are not visible
                 var child = node.children[i];
-                if(!child.pending) {
-                    interCommand.request({/*params*/}, child, params.tree); // TODO: change parameters
-                } else {
-                    if(child.loaded && !this.isCulled(child,camera)) {  // If child is in camera vision, it must be loaded and have correct SSE to be displayed
-                        childrenVisible++;
-                        if(child.loaded && this.checkSSE(child, camera)) {
-                            childrenReady++;
-                        } else {
-                            child.setVisibility(false);
-                            child.setMaterialVisibility(false);
-                        }
+                updateType = child.update();
+
+                interCommand.request({type: updateType}, child, params.tree); // TODO: change parameters
+
+                if(child.loaded && !this.isCulled(child,camera)) {  // If child is in camera vision, it must be loaded and have correct SSE to be displayed
+                    childrenVisible++;
+                    if(child.loaded && this.checkSSE(child, camera)) {
+                        childrenReady++;
+                    } else {
+                        child.setVisibility(false);
+                        child.setMaterialVisibility(false);
                     }
                 }
             }

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -34,13 +34,15 @@ define('Scene/Quadtree', [
 
         rootNode.enablePickingRender = function() { return true;};
         this.add(rootNode);
+        rootNode.level = -1;    // TODO: change
 
         // TEMP
         this.colorLayerId = 'IGNPO';
         this.elevationLayerId = ['IGN_MNT','IGN_MNT_HIGHRES'];
 
         for (var i = 0; i < this.schemeTile.rootCount(); i++) {
-            this.requestNewTile(this.schemeTile.getRoot(i), rootNode);
+            //this.requestNewTile(this.schemeTile.getRoot(i), rootNode);
+            this.createTile(this.schemeTile.getRoot(i), rootNode);
         }
     }
 
@@ -64,6 +66,15 @@ define('Scene/Quadtree', [
         return node.children[3];
     };
 
+    Quadtree.prototype.createTile = function(bbox, parent) {
+
+        var params = {bbox: bbox, level: parent.level + 1, colorLayerId : this.colorLayerId, elevationLayerId : this.elevationLayerId };
+
+        var tile = new this.tileType(params);
+        parent.add(tile);
+
+    };
+/*
     Quadtree.prototype.requestNewTile = function(bbox, parent) {
 
         var params = {bbox: bbox, colorLayerId : this.colorLayerId, elevationLayerId : this.elevationLayerId };
@@ -71,7 +82,7 @@ define('Scene/Quadtree', [
         this.interCommand.request(params, parent, this);
 
     };
-
+*/
     /**
      * @documentation: subdivise node if necessary
      * @param {type} node
@@ -83,11 +94,12 @@ define('Scene/Quadtree', [
             return;
 
         node.wait = true;
+        node.divided = true;
         var quad = new Quad(node.bbox);
-        this.requestNewTile(quad.northWest, node);
-        this.requestNewTile(quad.northEast, node);
-        this.requestNewTile(quad.southWest, node);
-        this.requestNewTile(quad.southEast, node);
+        this.createTile(quad.northWest, node);
+        this.createTile(quad.northEast, node);
+        this.createTile(quad.southWest, node);
+        this.createTile(quad.southEast, node);
 
     };
 
@@ -95,7 +107,7 @@ define('Scene/Quadtree', [
     {
         node.setMaterialVisibility(true);
         node.setChildrenVisibility(false);
-    }
+    };
 
     Quadtree.prototype.upSubLayer = function(node) {
 
@@ -104,7 +116,7 @@ define('Scene/Quadtree', [
         if(id !== undefined)
         {
             var params = {subLayer : id,colorLayerId : this.colorLayerId,elevationLayerId : this.elevationLayerId};
-            this.interCommand.request(params, node, this.children[id+1]);
+            //this.interCommand.request(params, node, this.children[id+1]); TODO
         }
 
     };

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -72,11 +72,9 @@ define('Scene/Quadtree', [
     /**
      * @documentation: subdivide node if necessary
      * @param {type} node
-     * @returns {Array} four bounding box
      */
     Quadtree.prototype.subdivide = function(node) {
 
-        node.divided = true;
         if(node.level >= this.maxLevel) return;
 
         var quad = new Quad(node.bbox);

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -90,10 +90,10 @@ define('Scene/Quadtree', [
      */
     Quadtree.prototype.up = function(node) {
 
-        if (!this.update(node))
-            return;
+        /*if (!this.update(node))
+            return;*/
 
-        node.wait = true;
+        //node.wait = true;
         node.divided = true;
         var quad = new Quad(node.bbox);
         this.createTile(quad.northWest, node);
@@ -132,7 +132,7 @@ define('Scene/Quadtree', [
             return false;
         else if (node.childrenCount() > 0 ) {
 
-            node.setMaterialVisibility(false);
+            //node.setMaterialVisibility(false);
 
             return false;
         }

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -34,6 +34,7 @@ define('Scene/Quadtree', [
         rootNode.enablePickingRender = function() { return true;};
         this.add(rootNode);
         rootNode.level = -1;    // TODO: change?
+        rootNode.parent = null;    // TODO temp
 
         for (var i = 0; i < this.schemeTile.rootCount(); i++) {
             this.createTile(this.schemeTile.getRoot(i), rootNode);

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -34,14 +34,13 @@ define('Scene/Quadtree', [
 
         rootNode.enablePickingRender = function() { return true;};
         this.add(rootNode);
-        rootNode.level = -1;    // TODO: change
+        rootNode.level = -1;    // TODO: change?
 
         // TEMP
         this.colorLayerId = 'IGNPO';
         this.elevationLayerId = ['IGN_MNT','IGN_MNT_HIGHRES'];
 
         for (var i = 0; i < this.schemeTile.rootCount(); i++) {
-            //this.requestNewTile(this.schemeTile.getRoot(i), rootNode);
             this.createTile(this.schemeTile.getRoot(i), rootNode);
         }
     }
@@ -74,70 +73,23 @@ define('Scene/Quadtree', [
         parent.add(tile);
 
     };
-/*
-    Quadtree.prototype.requestNewTile = function(bbox, parent) {
 
-        var params = {bbox: bbox, colorLayerId : this.colorLayerId, elevationLayerId : this.elevationLayerId };
-
-        this.interCommand.request(params, parent, this);
-
-    };
-*/
     /**
-     * @documentation: subdivise node if necessary
+     * @documentation: subdivide node if necessary
      * @param {type} node
      * @returns {Array} four bounding box
      */
-    Quadtree.prototype.up = function(node) {
+    Quadtree.prototype.subdivide = function(node) {
 
-        /*if (!this.update(node))
-            return;*/
-
-        //node.wait = true;
         node.divided = true;
+        if(node.level >= this.maxLevel) return;
+
         var quad = new Quad(node.bbox);
         this.createTile(quad.northWest, node);
         this.createTile(quad.northEast, node);
         this.createTile(quad.southWest, node);
         this.createTile(quad.southEast, node);
 
-    };
-
-    Quadtree.prototype.down = function(node)
-    {
-        node.setMaterialVisibility(true);
-        node.setChildrenVisibility(false);
-    };
-
-    Quadtree.prototype.upSubLayer = function(node) {
-
-        var id = node.getDownScaledLayer();
-
-        if(id !== undefined)
-        {
-            var params = {subLayer : id,colorLayerId : this.colorLayerId,elevationLayerId : this.elevationLayerId};
-            //this.interCommand.request(params, node, this.children[id+1]); TODO
-        }
-
-    };
-
-    /**
-     * @documentation: update node
-     * @param {type} node
-     * @returns {Boolean}
-     */
-    Quadtree.prototype.update = function(node) {
-
-        if (node.level > this.maxLevel)
-            return false;
-        else if (node.childrenCount() > 0 ) {
-
-            //node.setMaterialVisibility(false);
-
-            return false;
-        }
-
-        return true;
     };
 
     return Quadtree;


### PR DESCRIPTION
Not ready for pull yet. Pull request for visibility, since quite a lot of things are changing.
Solve (at least partially) issues #70, #54 and #57

Content:
- Tile instantiation pushed from command to quadtree. The tile are created empty, save from the metadata (tile coordinates, bounding box, ...)
- Commands feed data to a tile. It is recommended that a command's requester is the tile that needs the data
- New update mechanism (see below)

How to handle tile loading:
- A layer only has one provider. If you need multiple provider for a tile, build a composite provider such as TileProvider.
- Tiles have an getStatus() function which returns the type of data it currently needs in the form of an array of string. ~~"none" or _undefined_ indicate that no data is needed, "ready" indicates the tile is ready to be rendered.~~ **Any string will result in the creation of a new command, an array of string will result in the creation of multiple commands. getStatus() should return only the types of the data that it can currently load (e.g. don't return "elevation" if you don't have the underlying geometry)**
- The provider linked to the layer must have an executeCommand(command) function. The _command_ object has four attributes: type (the type of data needed), requester (the tile that needs data), layer (the layer of the tile) and parameters (any other parameters you may need)
- To each layer is bound a NodeProcess. NodeProcess decides whether a node should be displayed, refined, etc. NodeProcess.js may need tweaking if you want to reuse it for your own data structure. It should work for any hierarchical structure on a globe, with a refinement strategy which replaces parent tile with children tiles (i.e. no additive refinement).

Important tile attributes:
- cullable: must be set to true as soon as the tile can be tested for culling. Often, this will mean the bounding box is ready
- ~~pending: automatically set to true when a command is created. Must be set to false when the expected data is added to the tile~~ **Handled by the interface commander**
- visible: the tile is visible but not necessarily rendered
- material.visible: the tile is rendered
- disposed: set to true when tile is being deleted
- ~~divided: the tile has been divided (refined). Set to true by the Quadtree class~~
- ~~loaded: tile is ready to be displayed~~

Example: see TileProvider.js, TileMesh.js and NodeProcess.js

TODO list:
- [x] Minor changes to BrowseTree/NodeProcess
- [x] Restore command cancellation
- [x] Clean up (remove dead and commented code)
- [x] Merge with current master
- [x] Reuse WMTS for imagery
- [x] ~~Call browse() when a tile has been updated (loading is stuck until the camera moves otherwise)~~ **Fixed, I wasn't using the providers correctly (not returning promises)**
- [x] Clean globe API to reflect these changes

Why these changes?
- The goal is to better define the place where the node's states are changed. Visibility states (visible and material.visible) are changed only in NodeProcess, loading states (loaded, cullable) are changed in the tile class. ~~Only pending is a bit out of place (in interfaceCommander and tile classes, maybe this could be solved by using a callback after each command is executed)~~ **Fixed using callbacks**. This kind of separation helps when trying to understand what is going wrong and where when debugging
- Creating tiles early offers more control on the loading of data and cancelling of commands
- Moves some dependencies that seemed out of place in other classes
- The getStatus function is more flexible (easy way to define the order in which the data must be loaded or to ask for data to be reloaded/changed...)

~~Edit: If you want to test the branch, you will see that there are still problems with the texturing of the globe. There are weird things happening with the UVs of the texture that I didn't quite investigate yet. I temporarily fixed it by modifying the shader (which I didn't commit). I attached the diff if you want to try the branch: [shader.txt](https://github.com/iTowns/itowns2/files/215390/shader.txt)~~
