### PR TITLE
Command: mark tile creation commands as non-cancellable

### DIFF
--- a/src/Core/Commander/Command.js
+++ b/src/Core/Commander/Command.js
@@ -18,14 +18,13 @@ define('Core/Commander/Command', [], function() {
         this.outBuffers = null;
         this.paramsFunction = {};
         this.processFunction = null;
+        this.cancellable = false;
         this.async = null;
-        this.force = null;
         this.type = null;
         this.addInHistory = null;
         this.source = null;
         this.requester = null;
         this.provider = null;
-
     }
 
     Command.prototype.constructor = Command;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -24,13 +24,14 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
         this._builderCommand();
     };
 
-    InterfaceCommander.prototype.request = function(parameters, requester) {
+    InterfaceCommander.prototype.request = function(parameters, requester, cancellable) {
 
         var command = new Command();
         command.type = this.type;
         command.requester = requester;
         command.paramsFunction = parameters;
         command.layer = parameters.layer;
+        command.cancellable = cancellable;
 
         //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;
 

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -122,20 +122,21 @@ define('Core/Commander/ManagerCommands', [
         ManagerCommands.prototype.deQueue = function() {
 
             while (this.queueAsync.length > 0) {
-                var com = this.queueAsync.peek();
-                var parent = com.requester;
-
-                if (parent.visible === false && parent.level >= 2) {
-
-                    while (parent.children.length > 0) {
-                        var child = parent.children[0];
+                var cmd = this.queueAsync.peek();
+                var requester = cmd.requester;
+                if (requester.visible === false &&
+                    !cmd.cancellable &&
+                    requester.level >= 2) {
+                    while (requester.children.length > 0) {
+                        var child = requester.children[0];
                         child.dispose();
-                        parent.remove(child);
+                        requester.remove(child);
                     }
-                    parent.pendingSubdivision = false;
+
                     this.queueAsync.dequeue();
-                } else
+                } else {
                     return this.queueAsync.dequeue();
+                }
 
             }
 

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -64,7 +64,7 @@ define('Scene/Quadtree', [
 
         var params = {layer : this,bbox: bbox };
 
-        this.interCommand.request(params, parent);
+        this.interCommand.request(params, parent, false);
 
     };
 
@@ -111,7 +111,7 @@ define('Scene/Quadtree', [
 
         if(id !== undefined) {
             var params = { layer : this.children[id+1], subLayer : id};
-            this.interCommand.request(params, node);
+            this.interCommand.request(params, node, true);
         }
 
     };


### PR DESCRIPTION
Children creation only happens when a node has no children.

If 1 of the child creation request is cancelled the node
will be in an invalid state: 3 children and no way to create
the last one.

Fix #82 'Tiles are not displayed'

@gchoqueux can you review this changeset please ?
