### PR TITLE
Quadtree

### DIFF
--- a/src/Renderer/NodeMesh.js
+++ b/src/Renderer/NodeMesh.js
@@ -43,8 +43,6 @@ define('Renderer/NodeMesh', ['Scene/Node', 'THREE'], function(Node, THREE) {
 
         if (this.content !== null)
             this.content.visible = show;
-
-        return show;
     };
 
     NodeMesh.prototype.setDisplayed = function(show) {
@@ -58,7 +56,7 @@ define('Renderer/NodeMesh', ['Scene/Node', 'THREE'], function(Node, THREE) {
 
     NodeMesh.prototype.isDisplayed = function() {
         return this.material.visible;
-    }
+    };
 
     Node.extend(NodeMesh);
 

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -31,6 +31,14 @@ define('Scene/Node', [], function() {
     }
 
 
+    Node.prototype.setVisibility = function(show) {
+        this.visible = show;
+    };
+
+    Node.prototype.setDisplayed = function(show) {
+        // The default node has nothing to display
+    };
+
     /**
      * @documentation: Retourne le nombre d'enfants du Node
      *
@@ -152,7 +160,7 @@ define('Scene/Node', [], function() {
             var protoName = propName(Node.prototype, Node.prototype[p]);
 
 
-            if (protoName !== "add" && protoName !== "remove") {
+            if (protoName !== "add" && protoName !== "remove" & protoName !== "setVisibility" && protoName !== "setDisplayed") {
                 childClass.prototype[protoName] = Node.prototype[p];
             }
         }

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -27,7 +27,7 @@ define('Scene/Quadtree', [
         this.maxLevel = 17;
         var rootNode = new NodeMesh();
 
-        rootNode.frustumCulled = false
+        rootNode.frustumCulled = false;
         rootNode.material.visible = false;
 
         rootNode.link = this.link;
@@ -69,67 +69,18 @@ define('Scene/Quadtree', [
     };
 
     /**
-     * @documentation: subdivise node if necessary
+     * @documentation: returns bounding boxes of a node's quadtree subdivision
      * @param {type} node
-     * @returns {Array} four bounding box
+     * @returns {Array} an array of four bounding boxex
      */
-    Quadtree.prototype.up = function(node) {
-        if (node.pendingSubdivision) {
-            return;
-        }
-        if (!this.update(node)) {
-            return;
+    Quadtree.prototype.subdivide = function (node) {
+        if(node.pendingSubdivision || node.level > this.maxLevel){
+            return [];
         }
 
-        node.pendingSubdivision = true;
         var quad = new Quad(node.bbox);
-        this.requestNewTile(quad.northWest, node);
-        this.requestNewTile(quad.northEast, node);
-        this.requestNewTile(quad.southWest, node);
-        this.requestNewTile(quad.southEast, node);
 
-        node.setDisplayed(true);
-    };
-
-    Quadtree.prototype.down = function(node)
-    {
-        for (var i = 0; i < this.children.length; i++) {
-            var child = this.children[i];
-            if (child instanceof NodeMesh) {
-                child.setDisplayed(false);
-            } else {
-                child.visible = false;
-            }
-        }
-
-        node.setDisplayed(true);
-    }
-
-    Quadtree.prototype.upSubLayer = function(node) {
-
-        var id = node.getDownScaledLayer();
-
-        if(id !== undefined) {
-            var params = { layer : this.children[id+1], subLayer : id};
-            this.interCommand.request(params, node);
-        }
-
-    };
-
-    /**
-     * @documentation: update node
-     * @param {type} node
-     * @returns {Boolean}
-     */
-    Quadtree.prototype.update = function(node) {
-
-        if (node.level > this.maxLevel)
-            return false;
-        else if (node.childrenCount() > 0 ) {
-            return false;
-        }
-
-        return true;
+        return [quad.northWest, quad.northEast, quad.southWest, quad.southEast];
     };
 
     return Quadtree;


### PR DESCRIPTION
This PR aims at clarifying the role of Quadtree. Quadtree no longer has up, down and upSublayer functions. The divide function has been added, which returns an array of bounding boxes.

Visibility and tile creation operations are moved to Nodeprocess, allowing most visibility changes to happen in the same class.
