### PR TITLE
Add earlyDropFunction attribute to Commands

### DIFF
--- a/src/Core/Commander/Command.js
+++ b/src/Core/Commander/Command.js
@@ -18,14 +18,13 @@ define('Core/Commander/Command', [], function() {
         this.outBuffers = null;
         this.paramsFunction = {};
         this.processFunction = null;
+        this.earlyDropFunction = null;
         this.async = null;
-        this.force = null;
         this.type = null;
         this.addInHistory = null;
         this.source = null;
         this.requester = null;
         this.provider = null;
-
     }
 
     Command.prototype.constructor = Command;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -24,13 +24,14 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
         this._builderCommand();
     };
 
-    InterfaceCommander.prototype.request = function(parameters, requester) {
+    InterfaceCommander.prototype.request = function(parameters, requester, earlyDropFunction) {
 
         var command = new Command();
         command.type = this.type;
         command.requester = requester;
         command.paramsFunction = parameters;
         command.layer = parameters.layer;
+        command.earlyDropFunction = earlyDropFunction;
 
         command.promise = new when.promise(function(resolve, reject) {
             command.resolve = resolve;

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -156,20 +156,19 @@ define('Core/Commander/ManagerCommands', [
         ManagerCommands.prototype.deQueue = function() {
 
             while (this.queueAsync.length > 0) {
-                var com = this.queueAsync.peek();
-                var parent = com.requester;
-
-                if (parent.visible === false && parent.level >= 2) {
-
-                    while (parent.children.length > 0) {
-                        var child = parent.children[0];
+                var cmd = this.queueAsync.peek();
+                var requester = cmd.requester;
+                if (cmd.earlyDropFunction && cmd.earlyDropFunction(cmd)) {
+                    while (requester.children.length > 0) {
+                        var child = requester.children[0];
                         child.dispose();
-                        parent.remove(child);
+                        requester.remove(child);
                     }
-                    parent.pendingSubdivision = false;
+                    requester.pendingSubdivision = false;
                     this.queueAsync.dequeue();
-                } else
+                } else {
                     return this.queueAsync.dequeue();
+                }
 
             }
 

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -96,6 +96,12 @@ define('Scene/NodeProcess',
         }
     };
 
+
+    function commandCancellationFn(cmd) {
+        // allow cancellation of the command if the node isn't visible anymore
+        return cmd.requester.visible === false && 2 <= cmd.requester.level;
+    }
+
     NodeProcess.prototype.refineNodeLayers = function (node, camera, params) {
         // find downscaled layer
         var id = node.getDownScaledLayer();
@@ -103,7 +109,7 @@ define('Scene/NodeProcess',
         if(id !== undefined) {
             // update downscaled layer to appropriate scale
             var args = {layer : params.tree.children[id+1], subLayer : id};
-            params.tree.interCommand.request(args, node).then(function(result) {
+            params.tree.interCommand.request(args, node, commandCancellationFn).then(function(result) {
                 if (!result) {
                     return;
                 }


### PR DESCRIPTION
Allow the user to specify a function to decide if a Command
must be cancelled.

Note that children creation commands are tagged as non-cancellable.
That's because children creation only happens when a node has no children.

If 1 of the child creation request is cancelled the node
will be in an invalid state: 3 children and no way to create
the last one.

Fix #82 'Tiles are not displayed'

@gchoqueux r?
