### PR TITLE
Use Promise for Commands

### DIFF
--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -4,7 +4,7 @@
  * Description: Cette Classe construit une commande. Cette Command ensuite pousser dans une file d'attente.
  */
 
-define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', 'Core/Commander/Command'], function(ManagerCommands, Command) {
+define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', 'Core/Commander/Command', 'when'], function(ManagerCommands, Command, when) {
 
     function InterfaceCommander(type) {
         //Constructor
@@ -32,11 +32,18 @@ define('Core/Commander/InterfaceCommander', ['Core/Commander/ManagerCommands', '
         command.paramsFunction = parameters;
         command.layer = parameters.layer;
 
+        command.promise = new when.promise(function(resolve, reject) {
+            command.resolve = resolve;
+            command.reject = reject;
+        });
+
         //command.priority = parent.sse === undefined ? 1 : Math.floor(parent.visible ? parent.sse * 10000 : 1.0) *  (parent.visible ? Math.abs(19 - parent.level) : Math.abs(parent.level) ) *10000;
 
         command.priority = requester.sse ? Math.floor(requester.isVisible() && requester.isDisplayed() ? requester.sse * requester.sse * 100000 : 1.0) : 1.0;
 
         this.managerCommands.addCommand(command);
+
+        return command.promise;
     };
 
 

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -172,7 +172,9 @@ define('Core/Commander/Providers/TileProvider', [
 
                 ];
 
-            return when.all(requests);
+            return when.all(requests).then(function() {
+                return command.resolve(tile);
+            });
         };
 
         return TileProvider;

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -319,8 +319,8 @@ define('Core/Commander/Providers/WMTS_Provider', [
             {
                 return this.getColorTextures(tile,command.paramsFunction.layer.services).then(function(result)
                 {
-                    this.setTexturesLayer(result,destination);
-                }.bind(tile));
+                    return command.resolve(result);
+                });
             }
             else if (destination === 0)
             {
@@ -334,17 +334,17 @@ define('Core/Commander/Providers/WMTS_Provider', [
                     {
                         this.setTextureElevation(terrain);
 
-                    }.bind(parent)).then(function()
-                    {
+                    }.bind(parent)).then(function() {
                         if(this.downScaledLayer(0))
-
-                            this.setTextureElevation(-2);
+                            return command.resolve(-2);
+                        else
+                            return command.resolve(undefined);
 
                     }.bind(tile));
                 }
                 else
                 {
-                    tile.setTextureElevation(-2);
+                    return command.resolve(-2);
                 }
             }
         };

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -111,7 +111,17 @@ define('Scene/Quadtree', [
 
         if(id !== undefined) {
             var params = { layer : this.children[id+1], subLayer : id};
-            this.interCommand.request(params, node);
+            this.interCommand.request(params, node).then(function(result) {
+                if (!result) {
+                    return;
+                }
+
+                if (id === 0) {
+                    node.setTextureElevation(result);
+                } else if (id === 1) {
+                    node.setTexturesLayer(result, id);
+                }
+            });
         }
 
     };


### PR DESCRIPTION
Commands are async, so Promise are a good fit for this usage.

It will ease the transition to remove logic code from Providers.
Simplified example:

``` js
    // calling site
    interCommand.request(args, node);

    // provider
    Provider.prototype.executeCommand = function(command){
        return this.getColorTextures(tile, services).then(function(result)
        {
            this.setTexturesLayer(result, destination);
        }.bind(tile));
```

Would become:

``` js
    // calling site
    interCommand.request(args, node).then(function(textures) {
          node.setTexturesLayer(result,destination);
    });

    // provider
    Provider.prototype.executeCommand = function(command){
        return this.getColorTextures(tile, services).then(function(result)
        {
            command.resolve(result);
        };
```
