### PR TITLE
Rework layer params

### DIFF
--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -202,8 +202,7 @@ define('Core/Commander/Providers/WMTS_Provider', [
          */
         WMTS_Provider.prototype.getElevationTexture = function(tile,services) {
 
-
-            tile.texturesNeeded =+ 1;
+            tile.texturesNeeded += 1;
 
             var layerId = services[0];
             var layer = this.layersWMTS[layerId];

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -370,7 +370,7 @@ define('Core/Commander/Providers/WMTS_Provider', [
             return tile.level >= layer.zoom.min && tile.level <= layer.zoom.max;
         }
 
-        WMTS_Provider.prototype.getColorTextures = function(tile,layerWMTSId,params) {
+        WMTS_Provider.prototype.getColorTextures = function(tile,layerWMTSId) {
 
             var promises = [];
             var paramMaterial = [];
@@ -384,12 +384,8 @@ define('Core/Commander/Providers/WMTS_Provider', [
 
                 var layer = this.layersWMTS[layerWMTSId[i]];
 
-                if (this.tileInsideLimit(tile,layer))
-                {
+                if (this.tileInsideLimit(tile,layer)) {
                     var bcoord = tile.WMTSs[layer.tileMatrixSet];
-
-                    if(lookAtAncestor)
-                        paramMaterial.push({tileMT:layer.tileMatrixSet,pit:promises.length,visible:params[i].visible,opacity:params[i].opacity,fx:layer.fx,idLayer:layerWMTSId[i]});
 
                     // WARNING the direction textures is important
                     for (var row = bcoord[1].row; row >=  bcoord[0].row; row--) {
@@ -397,17 +393,14 @@ define('Core/Commander/Providers/WMTS_Provider', [
                        var cooWMTS = new CoordWMTS(bcoord[0].zoom, row, bcoord[0].col);
                        var pitch = new THREE.Vector3(0.0,0.0,1.0);
 
-                       if(lookAtAncestor)
+                       if(lookAtAncestor) {
                             cooWMTS = this.projection.WMTS_WGS84Parent(cooWMTS,this.getZoomAncestor(tile,layer),pitch);
+                       }
 
                        promises.push(this.getColorTexture(cooWMTS,pitch,layerWMTSId[i]));
-
                     }
                 }
             }
-
-            if (lookAtAncestor)
-                tile.setParamsColor(promises.length,paramMaterial);
 
             if (promises.length)
                 return when.all(promises);

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -109,13 +109,10 @@ define('Globe/TileMesh', [
         this.material = null;
     };
 
-    TileMesh.prototype.setParamsColor = function(nbTexturesColor,paramsTextureColor) {
-
-        this.texturesNeeded += nbTexturesColor;
+    TileMesh.prototype.setColorLayerParameters = function(paramsTextureColor) {
         this.material.setParam(paramsTextureColor);
 
-        for (var l = 0; l < paramsTextureColor.length; l++)
-        {
+        for (var l = 0; l < paramsTextureColor.length; l++) {
             this.layersColor.push(paramsTextureColor[l].idLayer);
         }
     };


### PR DESCRIPTION
1st commit fixes a typo (except if it's not a typo, in case it needs a comment)

2nd commit commit message :

```
 Rework color layers parameters handling

 Parameters are only initialized once: when the tile has not texture.
 So let's init these param in the TileProvider, rather than hiding it
 in the first getColorTextures call.

 TileMesh.setParamsColor method has been renamed setColorLayerParameters.
```
