### PR TITLE
Test on Windows through AppVeyor, and use NPM prepublishOnly rather than prepublish

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+# See https://www.appveyor.com/docs/lang/nodejs-iojs
+install:
+  - ps: Install-Product node stable
+  - node --version
+  - npm --version
+  - npm ci
+
+test_script:
+  - npm test
+
+build: off

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "webpack -p",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
-    "prepublish": "npm run build && npm run transpile"
+    "prepublishOnly": "npm run build && npm run transpile"
   },
   "files": [
     "*.md",


### PR DESCRIPTION
Actually, I'm not really sure about this, because AppVeyor has a really strange concept of "account" vs "user".
The checks currently are at https://ci.appveyor.com/project/tbroyer/itowns2/build/1.0.1 (notice that it's linked to my account, not to some sort of organization). I can rename my "account" to "iTowns", and according to their documentations I (the "user")could be a "member" of another, personal, "account"; but I'm really not sure they'd let me **create** that other account.

So, well, this PR adds AppVeyor configuration, and that's what's important.  
But ultimately maybe someone who only intends to use AppVeyor for iTowns should sign-up there, rename his account to `iTowns` and create the job.  
In the mean time, I'm OK with having itowns2 under my personal AppVeyor account (as I intend to eventually use AppVeyor for other projects, I'm not going to rename my account), so if everyone's OK with seeing my name in the AppVeyor URLs, then that's OK.
