### PR TITLE
Prevent creation of the same command multiple times

### DIFF
--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -24,6 +24,7 @@ define('Scene/Node', [], function() {
         this.screenSpaceError = 0.0;
         this.loaded = false;
         this.pendingSubdivision = false;
+        this.pendingLayers = {};
         this.visible = true;
         this.layer = null;
 

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -107,17 +107,24 @@ define('Scene/NodeProcess',
         if(id !== undefined) {
             // update downscaled layer to appropriate scale
             var args = {layer : params.tree.children[id+1], subLayer : id};
-            params.tree.interCommand.request(args, node, refinementCommandCancellationFn).then(function(result) {
-                if (!result) {
-                    return;
-                }
 
-                if (id === 0) {
-                    node.setTextureElevation(result);
-                } else if (id === 1) {
-                    node.setTexturesLayer(result, id);
-                }
-            });
+            // prevent multiple command creation
+            if(node.pendingLayers[id] === undefined) {
+                node.pendingLayers[id] = true;
+
+                params.tree.interCommand.request(args, node, refinementCommandCancellationFn).then(function(result) {
+                    node.pendingLayers[id] = undefined;
+                    if (!result) {
+                        return;
+                    }
+
+                    if (id === 0) {
+                        node.setTextureElevation(result);
+                    } else if (id === 1) {
+                        node.setTexturesLayer(result, id);
+                    }
+                });
+            }
         }
     };
 


### PR DESCRIPTION
Refinement commands were created even when there was already a command under way.
A pending attribute has been added to the node to prevent this from happening.
