### PR TITLE
Replace size by ellipsoid in most constructors.

### DIFF
--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -14,6 +14,7 @@ define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', [
        'Core/Commander/Providers/WMTS_Provider',
        'Core/Commander/Providers/TileProvider',
        'Core/Geographic/CoordCarto',
+       'Core/Math/Ellipsoid',
        'Core/Geographic/Projection'], function(
            EventsManager,
            Scene,
@@ -23,6 +24,7 @@ define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', [
            WMTS_Provider,
            TileProvider,
            CoordCarto,
+           Ellipsoid,
            Projection) {
 
     var loaded = false;
@@ -230,9 +232,11 @@ define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', [
         //gLDebug = true; // true to support GLInspector addon
         //debugMode = true;
 
-        this.scene = Scene(coordCarto,viewerDiv,debugMode,gLDebug);
+        var ellipsoid = new Ellipsoid({x:6378137,y: 6356752.3142451793,z:6378137});
 
-        var map = new Globe(this.scene.size,gLDebug);
+        this.scene = Scene(coordCarto, ellipsoid, viewerDiv, debugMode, gLDebug);
+
+        var map = new Globe(ellipsoid, gLDebug);
 
         this.scene.add(map);
 
@@ -241,7 +245,7 @@ define('Core/Commander/Interfaces/ApiInterface/ApiGlobe', [
         var wmtsProvider = new WMTS_Provider({support : map.gLDebug});
         this.scene.managerCommand.addProtocolProvider('wmts', wmtsProvider);
         this.scene.managerCommand.addProtocolProvider('wmtsc', wmtsProvider);
-        this.scene.managerCommand.addProtocolProvider('tile', new TileProvider(map.size));
+        this.scene.managerCommand.addProtocolProvider('tile', new TileProvider(ellipsoid));
 
         var wgs84TileLayer = {
             protocol: 'tile',

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -21,7 +21,6 @@ define('Core/Commander/Providers/TileProvider', [
         'Core/Geographic/Projection',
         'Globe/TileGeometry',
         'Core/Geographic/CoordWMTS',
-        'Core/Math/Ellipsoid',
         'Globe/BuilderEllipsoidTile',
         'Core/defaultValue',
         'Scene/BoundingBox'
@@ -32,18 +31,17 @@ define('Core/Commander/Providers/TileProvider', [
         Projection,
         TileGeometry,
         CoordWMTS,
-        Ellipsoid,
         BuilderEllipsoidTile,
         defaultValue,
         BoundingBox
     ) {
 
-        function TileProvider(size) {
+        function TileProvider(ellipsoid) {
             //Constructor
             Provider.call(this, null);
 
             this.projection = new Projection();
-            this.ellipsoid = new Ellipsoid(size);
+            this.ellipsoid = ellipsoid;
             this.builder = new BuilderEllipsoidTile(this.ellipsoid,this.projection);
 
             this.cacheGeometry = [];

--- a/src/Globe/Atmosphere.js
+++ b/src/Globe/Atmosphere.js
@@ -19,9 +19,11 @@ define('Globe/Atmosphere', [
   ],
   function(NodeMesh, THREE, defaultValue,Sky , skyFS, skyVS, groundFS, groundVS, GlowFS, GlowVS) {
 
-    function Atmosphere(size) {
+    function Atmosphere(ellipsoid) {
 
         NodeMesh.call(this);
+
+        var size = ellipsoid.size;
 
         this.realistic = false;
         this.sphereSun = null;

--- a/src/Globe/Globe.js
+++ b/src/Globe/Globe.js
@@ -10,7 +10,6 @@ define('Globe/Globe', [
     'Scene/Quadtree',
     'Scene/SchemeTile',
     'Core/Math/MathExtented',
-    'Core/Math/Ellipsoid',
     'Globe/TileMesh',
     'Globe/Atmosphere',
     'Globe/Clouds',
@@ -20,10 +19,10 @@ define('Globe/Globe', [
     'Scene/LayersConfiguration',
     'THREE'
 ], function(defaultValue, Layer, Quadtree, SchemeTile, MathExt,
-    Ellipsoid, TileMesh, Atmosphere, Clouds, Capabilities,
+    TileMesh, Atmosphere, Clouds, Capabilities,
     CoordCarto, BasicMaterial, LayersConfiguration, THREE) {
 
-    function Globe(size,gLDebug) {
+    function Globe(ellipsoid, gLDebug) {
         //Constructor
 
         Layer.call(this);
@@ -31,8 +30,7 @@ define('Globe/Globe', [
         var caps = new Capabilities();
         this.NOIE = !caps.isInternetExplorer();
         this.gLDebug = gLDebug;
-        this.size = size;
-        this.ellipsoid = new Ellipsoid(this.size);
+        this.ellipsoid = ellipsoid;
 
         this.batiments = new Layer();
         this.layerWGS84Zup = new Layer();
@@ -44,10 +42,10 @@ define('Globe/Globe', [
 
         kml.visible = false;
 
-        this.tiles = new Quadtree(TileMesh, this.SchemeTileWMTS(2), this.size, kml);
+        this.tiles = new Quadtree(TileMesh, this.SchemeTileWMTS(2), kml);
         this.layersConfiguration = new LayersConfiguration();
 
-        this.atmosphere = this.NOIE ? new Atmosphere(this.size) : undefined;
+        this.atmosphere = this.NOIE ? new Atmosphere(this.ellipsoid) : undefined;
         this.clouds = new Clouds();
 
         var material = new BasicMaterial(new THREE.Color(1, 0, 0));

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -198,7 +198,7 @@ define('Renderer/c3DEngine', [
         }.bind(this);
 
         this.scene = scene;
-        this.size = this.scene.size.x;
+        this.size = this.scene.size().x;
 
         //
         // init camera

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -15,7 +15,7 @@ define('Scene/NodeProcess',
 ], function(BoundingBox, Camera, MathExt, InterfaceCommander, THREE, defaultValue, Projection) {
 
 
-    function NodeProcess(camera, size, bbox) {
+    function NodeProcess(camera, ellipsoid, bbox) {
         //Constructor
         this.camera = new Camera();
         this.camera.camera3D = camera.camera3D.clone();
@@ -24,7 +24,7 @@ define('Scene/NodeProcess',
 
         this.vhMagnitudeSquared = 1.0;
 
-        this.r = defaultValue(size, new THREE.Vector3());
+        this.r = defaultValue(ellipsoid.size, new THREE.Vector3());
         this.cV = new THREE.Vector3();
         this.projection = new Projection();
     }

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -41,7 +41,7 @@ define('Scene/Quadtree', [
         }
     }
 
-    function Quadtree(type, schemeTile, size, link) {
+    function Quadtree(type, schemeTile, link) {
         Layer.call(this);
 
         this.interCommand = new InterfaceCommander(type, commandQueuePriorityFunction);

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -18,7 +18,6 @@ define('Scene/Scene', [
     'Core/Commander/ManagerCommands',
     'Core/Commander/Providers/TileProvider',
     'Core/Commander/Providers/PanoramicProvider',
-    'Core/Math/Ellipsoid',
     'Renderer/PanoramicMesh',
     'Scene/BrowseTree',
     'Scene/NodeProcess',
@@ -36,7 +35,6 @@ define('Scene/Scene', [
         ManagerCommands,
         TileProvider,
         PanoramicProvider,
-        Ellipsoid,
         PanoramicMesh,
         BrowseTree,
         NodeProcess,
@@ -54,16 +52,15 @@ define('Scene/Scene', [
     var SUBDIVISE = 1;
     var CLEAN = 2;
 
-    function Scene(coordCarto,viewerDiv, debugMode,gLDebug) {
+    function Scene(coordCarto, ellipsoid, viewerDiv, debugMode ,gLDebug) {
 
         if (instanceScene !== null) {
             throw new Error("Cannot instantiate more than one Scene");
         }
 
-        // /!\ Doesn't work
-        this.size = {x:6378137,y: 6356752.3142451793,z:6378137};
+        this.ellipsoid = ellipsoid;
 
-        var positionCamera = new Ellipsoid(this.size).cartographicToCartesian(new CoordCarto().setFromDegreeGeo(coordCarto.longitude, coordCarto.latitude, coordCarto.altitude));
+        var positionCamera = this.ellipsoid.cartographicToCartesian(new CoordCarto().setFromDegreeGeo(coordCarto.longitude, coordCarto.latitude, coordCarto.altitude));
 
         this.layers = [];
         this.map = null;
@@ -110,7 +107,7 @@ define('Scene/Scene', [
     };
 
     Scene.prototype.getEllipsoid = function(){
-        return this.layers[0].node.ellipsoid;
+        return this.ellipsoid;
     }
 
     Scene.prototype.updateCamera = function() {
@@ -123,7 +120,7 @@ define('Scene/Scene', [
 //    };
 
     Scene.prototype.size = function() {
-        return this.size;
+        return this.ellipsoid.size;
     };
 
     /**
@@ -214,7 +211,7 @@ define('Scene/Scene', [
         if(node instanceof Globe)
         {
             this.map = node;
-            nodeProcess = nodeProcess || new NodeProcess(this.currentCamera(), node.size);
+            nodeProcess = nodeProcess || new NodeProcess(this.currentCamera(), node.ellipsoid);
             //this.quadTreeRequest(node.tiles, nodeProcess);
 
         }


### PR DESCRIPTION
Size is too generic of a term and handing an ellipsoid to a class has far more sense than handing a 3-dimensional vector.

This work will also help the future implementation of the planar mode.
