### PR TITLE
Error handling

### DIFF
--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -380,7 +380,7 @@ ApiGlobe.prototype.createSceneGlobe = function createSceneGlobe(coordCarto, view
 };
 
 ApiGlobe.prototype.update = function update() {
-    this.scene.notifyChange();
+    this.scene.notifyChange(0, true);
 };
 
 ApiGlobe.prototype.showClouds = function showClouds(value, satelliteAnimation) {

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -43,6 +43,7 @@ function _instanciateQueue() {
             return p.then((result) => {
                 this.counters.executing--;
                 cmd.resolve(result);
+                // only count successul commands
                 this.counters.executed++;
             }, (err) => {
                 this.counters.executing--;
@@ -88,7 +89,7 @@ ManagerCommands.prototype.runCommand = function runCommand(command, queue, execu
         // We allow the scene to delay the update/repaint up to 100ms
         // to reduce CPU load (no need to perform an update on completion if we
         // know there's another one ending soon)
-        this.scene.notifyChange(100);
+        this.scene.notifyChange(100, true);
 
         // try to execute next command
         if (queue.counters.executing < this.maxCommandsPerHost) {

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -173,6 +173,17 @@ ManagerCommands.prototype.getProviders = function getProviders() {
 };
 
 /**
+ * Custom error thrown when cancelling commands. Allows the caller to act differently if needed.
+ */
+function CancelledCommandException(command) {
+    this.command = command;
+}
+
+CancelledCommandException.prototype.toString = function toString() {
+    return `Cancelled command ${this.command.requester.id}/${this.command.layer.id}`;
+};
+
+/**
  */
 ManagerCommands.prototype.deQueue = function deQueue(queue) {
     var st = queue.storage;
@@ -181,7 +192,7 @@ ManagerCommands.prototype.deQueue = function deQueue(queue) {
 
         if (cmd.earlyDropFunction && cmd.earlyDropFunction(cmd)) {
             queue.counters.cancelled++;
-            cmd.reject(new Error(`command canceled ${cmd.requester.id}/${cmd.layer.id}`));
+            cmd.reject(new CancelledCommandException(cmd));
         } else {
             return cmd;
         }
@@ -196,6 +207,7 @@ ManagerCommands.prototype.wait = function wait() {
     this.eventsManager.wait();
 };
 
+export { CancelledCommandException };
 
 export default function (scene) {
     instanceCommandManager = instanceCommandManager || new ManagerCommands(scene);

--- a/src/Core/Commander/Providers/IoDriver_XBIL.js
+++ b/src/Core/Commander/Providers/IoDriver_XBIL.js
@@ -9,10 +9,9 @@ import IoDriver from 'Core/Commander/Providers/IoDriver';
 
 var portableXBIL = function portableXBIL(buffer) {
     this.floatArray = new Float32Array(buffer);
-    this.max = -1000000;
-    this.min = 1000000;
-    this.texture = -1;
-    this.level = -1;
+    this.max = undefined;
+    this.min = undefined;
+    this.texture = null;
 };
 
 
@@ -61,10 +60,6 @@ IoDriver_XBIL.prototype.parseXBil = function parseXBil(buffer, url) {
     var result = new portableXBIL(buffer);
 
     var elevation = this.computeMinMaxElevation(result.floatArray);
-
-    if (elevation.min === undefined || elevation.max === undefined) {
-        throw new Error('Error processing XBIL');
-    }
 
     result.min = elevation.min;
     result.max = elevation.max;

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -101,7 +101,7 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
     tile.updateMatrix();
     tile.updateMatrixWorld();
 
-    return command.resolve(tile);
+    return Promise.resolve(tile);
 };
 
 export default TileProvider;

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -126,14 +126,13 @@ WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, bbo
     var textureCache = this.cache.getRessource(url);
 
     if (textureCache !== undefined) {
-        return Promise.resolve(textureCache ? {
+        return Promise.resolve({
             pitch,
             texture: textureCache.texture,
             min: textureCache.min,
             max: textureCache.max,
-        } : null);
+        });
     }
-
 
     // bug #74
     // var limits = layer.tileMatrixSetLimits[coWMTS.zoom];
@@ -143,25 +142,18 @@ WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, bbo
     //     return Promise.resolve(texture);
     // }
     // -> bug #74
-
     return this._IoDriver.read(url).then((result) => {
-        if (result !== undefined) {
-            result.texture = this.getTextureFloat(result.floatArray);
-            result.texture.generateMipmaps = false;
-            result.texture.magFilter = THREE.LinearFilter;
-            result.texture.minFilter = THREE.LinearFilter;
-            result.pitch = pitch;
+        result.texture = this.getTextureFloat(result.floatArray);
+        result.texture.generateMipmaps = false;
+        result.texture.magFilter = THREE.LinearFilter;
+        result.texture.minFilter = THREE.LinearFilter;
+        result.pitch = pitch;
 
-            // In RGBA elevation texture LinearFilter give some errors with nodata value.
-            // need to rewrite sample function in shader
-            this.cache.addRessource(url, result);
+        // In RGBA elevation texture LinearFilter give some errors with nodata value.
+        // need to rewrite sample function in shader
+        this.cache.addRessource(url, result);
 
-            return result;
-        } else {
-            var texture = null;
-            this.cache.addRessource(url, texture);
-            return texture;
-        }
+        return result;
     });
 };
 

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -188,7 +188,7 @@ WMS_Provider.prototype.executeCommand = function executeCommand(command) {
             tile.bbox;
 
 
-        return func(tile, layer, bbox, pitch).then(result => command.resolve(result));
+        return func(tile, layer, bbox, pitch);
     } else {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.format}`));
     }

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -159,15 +159,6 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, pa
         result.texture.generateMipmaps = false;
         result.texture.magFilter = THREE.LinearFilter;
         result.texture.minFilter = THREE.LinearFilter;
-
-        // To compare with level tile
-        result.texture.url = result.url;
-
-        // In RGBA elevation texture LinearFilter give some errors with nodata value.
-        // need to rewrite sample function in shader
-        // result.texture.magFilter = THREE.NearestFilter;
-        // result.texture.minFilter = THREE.NearestFilter;
-
         this.cache.addRessource(url, { texture: result.texture, floatArray: result.floatArray });
 
         return result;

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -226,7 +226,7 @@ WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
 
     var func = supportedFormats[layer.options.mimetype];
     if (func) {
-        return func(tile, layer, command.paramsFunction).then(result => command.resolve(result));
+        return func(tile, layer, command.paramsFunction);
     } else {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.options.mimetype}`));
     }

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -13,6 +13,8 @@ import Fetcher from 'Core/Commander/Providers/Fetcher';
 import * as THREE from 'three';
 import CacheRessource from 'Core/Commander/Providers/CacheRessource';
 
+const SIZE_TEXTURE_TILE = 256;
+
 function WMTS_Provider(options) {
     // Constructor
 
@@ -32,7 +34,7 @@ function WMTS_Provider(options) {
             // var bufferUint = new Uint8Array(buffer.buffer);
             // var texture = new THREE.DataTexture(bufferUint, 256, 256);
 
-            var texture = new THREE.DataTexture(buffer, 256, 256, THREE.AlphaFormat, THREE.FloatType);
+            var texture = new THREE.DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, THREE.AlphaFormat, THREE.FloatType);
 
             texture.needsUpdate = true;
             return texture;
@@ -128,20 +130,17 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, pa
     var textureCache = this.cache.getRessource(url);
 
     if (textureCache !== undefined) {
-        if (textureCache) {
-            const minmax = this._IoDriver.computeMinMaxElevation(
-                textureCache.floatArray,
-                256, 256,
-                pitch);
-            return Promise.resolve(
-                {
-                    pitch,
-                    texture: textureCache.texture,
-                    min: minmax.min,
-                    max: minmax.max,
-                });
-        }
-        return Promise.resolve(null);
+        const minmax = this._IoDriver.computeMinMaxElevation(
+            textureCache.floatArray,
+            SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+            pitch);
+        return Promise.resolve(
+            {
+                pitch,
+                texture: textureCache.texture,
+                min: minmax.min,
+                max: minmax.max,
+            });
     }
 
 
@@ -172,10 +171,6 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, pa
         this.cache.addRessource(url, { texture: result.texture, floatArray: result.floatArray });
 
         return result;
-    }).catch(() => {
-        var texture = null;
-        this.cache.addRessource(url, texture);
-        return texture;
     });
 };
 

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -182,16 +182,10 @@ TileMesh.prototype.setTextureElevation = function setTextureElevation(elevation)
         return;
     }
 
-    let texture;
-    let offsetScale;
+    const offsetScale = elevation.pitch || new THREE.Vector3(0, 0, 1);
+    this.setBBoxZ(elevation.min, elevation.max);
 
-    if (elevation) {
-        texture = elevation.texture;
-        offsetScale = elevation.pitch || new THREE.Vector3(0, 0, 1);
-        this.setBBoxZ(elevation.min, elevation.max);
-    }
-
-    this.materials[RendererConstant.FINAL].setTexture(texture, l_ELEVATION, 0, offsetScale);
+    this.materials[RendererConstant.FINAL].setTexture(elevation.texture, l_ELEVATION, 0, offsetScale);
     this.materials[RendererConstant.DEPTH].uniforms.texturesCount.value = this.materials[RendererConstant.FINAL].loadedTexturesCount[0];
     this.materials[RendererConstant.ID].uniforms.texturesCount.value = this.materials[RendererConstant.FINAL].loadedTexturesCount[0];
 

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -84,7 +84,7 @@ function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
     this.update = function update() {
         this.camera.update();
         this.updateControl();
-        this.scene.notifyChange();
+        this.scene.notifyChange(0, true);
     }.bind(this);
 
     this.onWindowResize = function onWindowResize() {

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -114,10 +114,13 @@ BrowseTree.prototype._browseNonDisplayableNode = function _browseNonDisplayableN
     node.sse = camera.computeNodeSSE(node);
     node.setDisplayed(false);
 
-    var sse = process.checkNodeSSE(node);
-
-    if (!sse && !node.loaded) {
+    const sse = process.checkNodeSSE(node);
+    if (!node.loaded) {
         // Make sure this node is not stuck in a !loaded state
+        // TODO: we could be smarter and do this only for visible tiles for instance
+        // but we need to be careful due to the number of possible states for a tile (pendingSubdivision,
+        // loaded, disposed etc). Also: once this is fixed we should be able to simplify the commandC
+        // cancellation function to something like: `return !node.isVisible()`
         process.refineNodeLayers(node, camera, params);
     }
 

--- a/src/Scene/LayerUpdateState.js
+++ b/src/Scene/LayerUpdateState.js
@@ -1,0 +1,60 @@
+const UPDATE_STATE = {
+    IDLE: 0,
+    PENDING: 1,
+    ERROR: 2,
+};
+const PAUSE_BETWEEN_ERRORS = [1.0, 3.0, 7.0, 60.0];
+
+/**
+ * LayerUpdateState is the update state of a layer, for a given object (e.g tile).
+ * It stores information to allow smart update decisions, and especially network
+ * error handling.
+ */
+function LayerUpdateState() {
+    this.state = UPDATE_STATE.IDLE;
+    this.lastErrorTimestamp = 0;
+    this.errorCount = 0;
+}
+
+LayerUpdateState.prototype.canTryUpdate = function canTryUpdate(timestamp) {
+    switch (this.state) {
+        case UPDATE_STATE.IDLE: {
+            return true;
+        }
+        case UPDATE_STATE.PENDING: {
+            return false;
+        }
+        case UPDATE_STATE.ERROR:
+        default: {
+            const errorDuration = this.secondsUntilNextTry() * 1000;
+            return errorDuration <= (timestamp - this.lastErrorTimestamp);
+        }
+    }
+};
+
+LayerUpdateState.prototype.secondsUntilNextTry = function secondsUntilNextTry() {
+    if (this.state !== UPDATE_STATE.ERROR) {
+        return 0;
+    }
+    const idx =
+        Math.max(0, Math.min(this.errorCount, PAUSE_BETWEEN_ERRORS.length) - 1);
+
+    return PAUSE_BETWEEN_ERRORS[idx];
+};
+
+LayerUpdateState.prototype.newTry = function newTry() {
+    this.state = UPDATE_STATE.PENDING;
+};
+
+LayerUpdateState.prototype.success = function success() {
+    this.lastErrorTimestamp = 0;
+    this.state = UPDATE_STATE.IDLE;
+};
+
+LayerUpdateState.prototype.failure = function failure(timestamp) {
+    this.lastErrorTimestamp = timestamp;
+    this.state = UPDATE_STATE.ERROR;
+    this.errorCount++;
+};
+
+export default LayerUpdateState;

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -20,8 +20,9 @@ function Node() {
     this.level = 0;
     this.screenSpaceError = 0.0;
     this.loaded = false;
+    // TODO: remove pendingSubdivision and use layerUpdateState instead
     this.pendingSubdivision = false;
-    this.pendingLayers = {};
+    this.layerUpdateState = {};
     this.visible = true;
     this.layer = null;
 }

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -396,11 +396,11 @@ function updateNodeElevation(scene, quadtree, node, layersConfig, force) {
                     return;
                 }
 
-                if (terrain && terrain.texture) {
+                if (terrain.texture) {
                     terrain.texture.level = (ancestor || node).level;
                 }
 
-                if (terrain && terrain.max === undefined) {
+                if (terrain.max === undefined) {
                     terrain.min = (ancestor || node).bbox.bottom();
                     terrain.max = (ancestor || node).bbox.top();
                 }

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -299,7 +299,7 @@ function updateNodeImagery(scene, quadtree, node, layersConfig, force) {
                     node.layerUpdateState[layer.id].success();
                 } else {
                     node.layerUpdateState[layer.id].failure(Date.now());
-                    scene.notifyChange(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
+                    scene.notifyChange(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000, false);
                 }
             }));
     }
@@ -412,7 +412,7 @@ function updateNodeElevation(scene, quadtree, node, layersConfig, force) {
                     node.layerUpdateState[bestLayer.id].success();
                 } else {
                     node.layerUpdateState[bestLayer.id].failure(Date.now());
-                    scene.notifyChange(node.layerUpdateState[bestLayer.id].secondsUntilNextTry() * 1000);
+                    scene.notifyChange(node.layerUpdateState[bestLayer.id].secondsUntilNextTry() * 1000, false);
                 }
             });
     }

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -12,12 +12,14 @@ import Projection from 'Core/Geographic/Projection';
 import RendererConstant from 'Renderer/RendererConstant';
 import { chooseNextLevelToFetch } from 'Scene/LayerUpdateStrategy';
 import { l_ELEVATION, l_COLOR } from 'Renderer/LayeredMaterial';
+import LayerUpdateState from 'Scene/LayerUpdateState';
+import { CancelledCommandException } from 'Core/Commander/ManagerCommands';
 
 export const SSE_SUBDIVISION_THRESHOLD = 6.0;
 
-function NodeProcess(camera, ellipsoid, bbox) {
-    // Constructor
-
+function NodeProcess(scene, camera, ellipsoid, bbox) {
+    // TODO: consider removing this.scene + replacing scene.notifyChange by an event
+    this.scene = scene;
     this.bbox = defaultValue(bbox, new BoundingBox(MathExt.PI_OV_TWO + MathExt.PI_OV_FOUR, MathExt.PI + MathExt.PI_OV_FOUR, 0, MathExt.PI_OV_TWO));
 
     this.vhMagnitudeSquared = 1.0;
@@ -181,12 +183,8 @@ NodeProcess.prototype.refineNodeLayers = function refineNodeLayers(node, camera,
     ];
 
     for (let typeLayer = 0; typeLayer < 2; typeLayer++) {
-        if (node.pendingLayers[typeLayer] === undefined && (!node.loaded || node.isLayerTypeDownscaled(typeLayer))) {
-            node.pendingLayers[typeLayer] = true;
-            layerFunctions[typeLayer](params.tree, node, params.layersConfig, !node.loaded)
-        // reset the flag, regardless of the request success/failure
-        .then(() => { node.pendingLayers[typeLayer] = undefined; },
-              () => { node.pendingLayers[typeLayer] = undefined; });
+        if (!node.loaded || node.isLayerTypeDownscaled(typeLayer)) {
+            layerFunctions[typeLayer](this.scene, params.tree, node, params.layersConfig, !node.loaded);
         }
     }
 };
@@ -217,9 +215,10 @@ function findAncestorWithValidTextureForLayer(node, layerType, layer) {
     }
 }
 
-function updateNodeImagery(quadtree, node, layersConfig, force) {
+function updateNodeImagery(scene, quadtree, node, layersConfig, force) {
     const promises = [];
 
+    const ts = Date.now();
     const colorLayers = layersConfig.getColorLayers();
     for (let i = 0; i < colorLayers.length; i++) {
         const layer = colorLayers[i];
@@ -231,6 +230,15 @@ function updateNodeImagery(quadtree, node, layersConfig, force) {
         if (!layer.tileInsideLimit(node, layer)) {
             continue;
         }
+
+        if (node.layerUpdateState[layer.id] === undefined) {
+            node.layerUpdateState[layer.id] = new LayerUpdateState();
+        }
+
+        if (!node.layerUpdateState[layer.id].canTryUpdate(ts)) {
+            continue;
+        }
+
         if (!force) {
             // does this tile needs a new texture?
             if (!node.isColorLayerDownscaled(layer.id)) {
@@ -261,6 +269,8 @@ function updateNodeImagery(quadtree, node, layersConfig, force) {
             }
         }
 
+        node.layerUpdateState[layer.id].newTry();
+
         promises.push(quadtree.interCommand.request(args, node, refinementCommandCancellationFn).then(
             (result) => {
                 const level = args.ancestor ? args.ancestor.level : node.level;
@@ -280,22 +290,32 @@ function updateNodeImagery(quadtree, node, layersConfig, force) {
                     // and stop retrying after X attempts.
                 }
 
+                node.layerUpdateState[layer.id].success();
+
                 return result;
+            },
+            (err) => {
+                if (err instanceof CancelledCommandException) {
+                    node.layerUpdateState[layer.id].success();
+                } else {
+                    node.layerUpdateState[layer.id].failure(Date.now());
+                    scene.notifyChange(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
+                }
             }));
     }
 
-    return Promise.all(promises).then(() => {
+    Promise.all(promises).then(() => {
         if (node.parent) {
             node.loadingCheck();
         }
-        return node;
     });
 }
 
-function updateNodeElevation(quadtree, node, layersConfig, force) {
+function updateNodeElevation(scene, quadtree, node, layersConfig, force) {
     // Elevation is currently handled differently from color layers.
     // This is caused by a LayeredMaterial limitation: only 1 elevation texture
     // can be used (where a tile can have N textures x M layers)
+    const ts = Date.now();
     const elevationLayers = layersConfig.getElevationLayers();
     let bestLayer = null;
     let ancestor = null;
@@ -305,7 +325,7 @@ function updateNodeElevation(quadtree, node, layersConfig, force) {
     // Step 0: currentElevevation is -1 BUT material.loadedTexturesCount[l_ELEVATION] is > 0
     // means that we already tried and failed to download an elevation texture
     if (currentElevation == -1 && node.material.loadedTexturesCount[l_ELEVATION] > 0) {
-        return Promise.resolve(node);
+        return;
     }
 
     // First step: if currentElevation is empty (level is -1), we *must* use the texture from
@@ -333,7 +353,20 @@ function updateNodeElevation(quadtree, node, layersConfig, force) {
             continue;
         }
 
+        if (node.layerUpdateState[layer.id] === undefined) {
+            node.layerUpdateState[layer.id] = new LayerUpdateState();
+        }
+
+        if (!node.layerUpdateState[layer.id].canTryUpdate(ts)) {
+            // If we'd use continue, we could have 2 parallel elevation layers updating
+            // at the same time. So we're forced to break here.
+            // TODO: if the first layer chosen ends up stalled in error we'll never try
+            // the second one...
+            break;
+        }
+
         const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node.level, currentElevation, layer.updateStrategy.options);
+
         if (targetLevel <= currentElevation) {
             continue;
         }
@@ -353,28 +386,36 @@ function updateNodeElevation(quadtree, node, layersConfig, force) {
     if (bestLayer !== null) {
         const args = { layer: bestLayer, ancestor };
 
-        return quadtree.interCommand.request(args, node, refinementCommandCancellationFn).then((terrain) => {
-            if (node.material === null) {
-                return;
-            }
+        node.layerUpdateState[bestLayer.id].newTry();
 
-            if (terrain && terrain.texture) {
-                terrain.texture.level = (ancestor || node).level;
-            }
+        quadtree.interCommand.request(args, node, refinementCommandCancellationFn).then(
+            (terrain) => {
+                node.layerUpdateState[bestLayer.id].success();
 
-            if (terrain && terrain.max === undefined) {
-                terrain.min = (ancestor || node).bbox.bottom();
-                terrain.max = (ancestor || node).bbox.top();
-            }
+                if (node.material === null) {
+                    return;
+                }
 
-            node.setTextureElevation(terrain);
+                if (terrain && terrain.texture) {
+                    terrain.texture.level = (ancestor || node).level;
+                }
 
-            return node;
-        });
+                if (terrain && terrain.max === undefined) {
+                    terrain.min = (ancestor || node).bbox.bottom();
+                    terrain.max = (ancestor || node).bbox.top();
+                }
+
+                node.setTextureElevation(terrain);
+            },
+            (err) => {
+                if (err instanceof CancelledCommandException) {
+                    node.layerUpdateState[bestLayer.id].success();
+                } else {
+                    node.layerUpdateState[bestLayer.id].failure(Date.now());
+                    scene.notifyChange(node.layerUpdateState[bestLayer.id].secondsUntilNextTry() * 1000);
+                }
+            });
     }
-
-    // No elevation texture available for this node, no need to wait for one.
-    return Promise.resolve(node);
 }
 
 

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -126,18 +126,19 @@ Scene.prototype.updateScene3D = function updateScene3D() {
  * scene itself (e.g. camera movement).
  * Using a non-0 delay allows to delay update - useful to reduce CPU load for
  * non-interactive events (e.g: texture loaded)
+ * needsRedraw param indicates if notified change requires a full scene redraw.
  */
-Scene.prototype.notifyChange = function notifyChange(delay) {
-    this.needsRedraw = true;
-
+Scene.prototype.notifyChange = function notifyChange(delay, needsRedraw) {
     if (delay) {
-        window.setTimeout(this.scheduleUpdate.bind(this), delay);
+        window.setTimeout(() => { this.scheduleUpdate(needsRedraw); }, delay);
     } else {
-        this.scheduleUpdate();
+        this.scheduleUpdate(needsRedraw);
     }
 };
 
-Scene.prototype.scheduleUpdate = function scheduleUpdate() {
+Scene.prototype.scheduleUpdate = function scheduleUpdate(forceRedraw) {
+    this.needsRedraw |= forceRedraw;
+
     if (this.renderingState !== RENDERING_ACTIVE) {
         this.renderingState = RENDERING_ACTIVE;
 
@@ -188,7 +189,6 @@ Scene.prototype.step = function step() {
             if (this.needsRedraw || executedDuringUpdate > 0) {
                 this.renderScene3D();
                 this.lastRenderTime = ts;
-                this.needsRedraw = false;
             }
         }
 
@@ -200,6 +200,7 @@ Scene.prototype.step = function step() {
  */
 Scene.prototype.renderScene3D = function renderScene3D() {
     this.gfxEngine.renderScene();
+    this.needsRedraw = false;
 };
 
 Scene.prototype.scene3D = function scene3D() {

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -130,10 +130,8 @@ Scene.prototype.updateScene3D = function updateScene3D() {
 Scene.prototype.notifyChange = function notifyChange(delay) {
     this.needsRedraw = true;
 
-    window.clearInterval(this.timer);
-
     if (delay) {
-        this.timer = window.setTimeout(this.scheduleUpdate.bind(this), delay);
+        window.setTimeout(this.scheduleUpdate.bind(this), delay);
     } else {
         this.scheduleUpdate();
     }
@@ -216,8 +214,7 @@ Scene.prototype.scene3D = function scene3D() {
 Scene.prototype.add = function add(node, nodeProcess) {
     if (node instanceof Globe) {
         this.map = node;
-        nodeProcess = nodeProcess || new NodeProcess(this.currentCamera(), node.ellipsoid);
-        // this.quadTreeRequest(node.tiles, nodeProcess);
+        nodeProcess = nodeProcess || new NodeProcess(this, this.currentCamera(), node.ellipsoid);
     }
 
     this.layers.push({


### PR DESCRIPTION
This PR implements error handling for layers loading.

It introduces a new `LayerUpdateState` object holding fetch info: error count, last error timestamp etc.
`NodeProcess` can them use this to decide if it can tries to download texture from a given layer.

Currently there's a single error strategy implemented: it simply retries after longer and longer wait period. We could later implement different strategies if needed.


