### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
+  - "lts/*"
+  - "node"
 after_success:
   - openssl aes-256-cbc -K $encrypted_d96e3d89b2d4_key -iv $encrypted_d96e3d89b2d4_iv -in deploy_key.enc -out deploy_key -d
   - bash autodeploy.sh

--- a/autodeploy.sh
+++ b/autodeploy.sh
@@ -3,8 +3,8 @@ set -xe # Verbose output and exit with nonzero exit code if anything fails
 
 # There are two npm versions used in travis (.travis.yml)
 # and only one deploy is needed
-if [ "$TRAVIS_NODE_VERSION" != "4" ]; then
-	echo "Skipping deploy for npm version != 4"
+if [ "$TRAVIS_NODE_VERSION" != "node" ]; then
+	echo "Skipping deploy for npm version != node"
 	exit 0
 fi
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\"",
     "doc": "jsdoc src/Core/Commander/Interfaces/ApiInterface/*",
-    "test": "npm run lint && npm run build",
+    "doclint": "npm run doc -- -t templates/silent",
+    "test": "npm run lint && npm run build && npm run doclint",
     "build": "webpack -p",
     "start": "webpack-dev-server -d --inline --hot"
   },
@@ -40,7 +41,7 @@
     "babel-preset-es2015": "^6.9.0",
     "eslint": "^2.5.3",
     "eslint-loader": "^1.3.0",
-    "jsdoc": "^3.4.0",
+    "jsdoc": "^3.4.3",
     "raw-loader": "^0.5.1",
     "webpack": "^1.12.12",
     "webpack-dev-server": "^1.14.1"


### PR DESCRIPTION
Use up-to-date versions of Node.js and "lint" the JSDoc as part of the build.

We could test with Node.js 4 (still supported in LTS ['til April 2017](https://github.com/nodejs/LTS/)) using versions `lts/argon` and `lts/boron` (or `4` and `6` explicitly), but then we'll have to update the build again in April to remove `lts/argon` which would then be unsupported, then in October to add the next LTS release, and repeat that dance every 6 months. I think it's enough to test on the latest LTS (and latest non-LTS).

Related to #203 