### PR TITLE
WMSOptions default values in WMS_Providers (corrections)

### DIFF
--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -71,14 +71,6 @@ WMS_Provider.prototype.preprocessDataLayer = function(layer){
         layer.bbox = new BoundingBox(layer.bbox[0],layer.bbox[2],layer.bbox[1],layer.bbox[3]);
     }
 
-    /*layer.format = defaultValue(layer.options.mimetype, "image/png"),
-    layer.crs = defaultValue(layer.projection, "EPSG:4326"),
-    layer.width = defaultValue(layer.heightMapWidth, 256),
-    layer.version = defaultValue(layer.version, "1.3.0"),
-    layer.style = defaultValue(layer.style, "normal"),
-    layer.transparent = defaultValue(layer.transparent, false),
-    layer.bbox = defaultValue(layer.bbox,new BoundingBox());*/
-
     layer.format = layer.options.mimetype || "image/png";
     layer.crs = layer.projection || "EPSG:4326";
     layer.width = layer.heightMapWidth || 256;

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -71,18 +71,26 @@ WMS_Provider.prototype.preprocessDataLayer = function(layer){
         layer.bbox = new BoundingBox(layer.bbox[0],layer.bbox[2],layer.bbox[1],layer.bbox[3]);
     }
 
+    /*layer.format = defaultValue(layer.options.mimetype, "image/png"),
+    layer.crs = defaultValue(layer.projection, "EPSG:4326"),
+    layer.width = defaultValue(layer.heightMapWidth, 256),
+    layer.version = defaultValue(layer.version, "1.3.0"),
+    layer.style = defaultValue(layer.style, "normal"),
+    layer.transparent = defaultValue(layer.transparent, false),
+    layer.bbox = defaultValue(layer.bbox,new BoundingBox());*/
+
     layer.format = layer.options.mimetype || "image/png";
     layer.crs = layer.projection || "EPSG:4326";
     layer.width = layer.heightMapWidth || 256;
     layer.version = layer.version || "1.3.0";
-    layer.style = layer.style || "normal";
+    layer.style = layer.style || "";
     layer.transparent = layer.transparent || false;
     layer.bbox = layer.bbox || new BoundingBox();
 
     layer.customUrl = layer.url +
                   '?SERVICE=WMS&REQUEST=GetMap&LAYERS=' + layer.name +
                   '&VERSION=' + layer.version +
-                  '&STYLES=' + layer.styleName +
+                  '&STYLES=' + layer.style +
                   '&FORMAT=' + layer.format +
                   '&TRANSPARENT=' + layer.transparent +
                   '&BBOX=%bbox'  +


### PR DESCRIPTION
layer.format = layer.options.mimetype || "image/png";
layer.crs = layer.projection || "EPSG:4326";
layer.width = layer.heightMapWidth || 256;
layer.version = layer.version || "1.3.0";
layer.style = layer.style || "";
layer.transparent = layer.transparent || false;
layer.bbox = layer.bbox || new BoundingBox();