### PR TITLE
Fix race condition in the initialisation of the Scene.

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,11 @@ and open the template in the editor.
             var menuGlobe = new GuiTools(itowns.viewer,'menuDiv');
             itowns.viewer.createSceneGlobe(positionOnGlobe, viewerDiv);
 
+            let wgs84TileLayer = {
+                protocol: 'tile',
+                id: 'wgs84'
+            };
+
             var urlImageryLayersArray = ["examples/layers/JSONLayers/Ortho.json",
                                         "examples/layers/JSONLayers/OrthosCRS.json",
                                         "examples/layers/JSONLayers/ScanEX.json",
@@ -52,9 +57,14 @@ and open the template in the editor.
             var urlElevationLayersArray = [ "examples/layers/JSONLayers/IGN_MNT.json",
                                             "examples/layers/JSONLayers/IGN_MNT_HIGHRES.json"];
 
-            itowns.viewer.addImageryLayersFromJSONArray(urlImageryLayersArray).then((layersColors) => {menuGlobe.addImageryLayersGUI(layersColors);});
-            itowns.viewer.addElevationLayersFromJSONArray(urlElevationLayersArray).then((layersElevations) => {menuGlobe.addElevationLayersGUI(layersElevations);});
-            itowns.viewer.update();
+            itowns.viewer.addGeometryLayer(wgs84TileLayer);
+            let imageryPromise = itowns.viewer.addImageryLayersFromJSONArray(urlImageryLayersArray);
+            let elevationPromise = itowns.viewer.addElevationLayersFromJSONArray(urlElevationLayersArray);
+
+            imageryPromise.then((layersColors) => menuGlobe.addImageryLayersGUI(layersColors));
+            elevationPromise.then((layersElevations) => {menuGlobe.addElevationLayersGUI(layersElevations);});
+
+            Promise.all([imageryPromise, elevationPromise]).then(() => itowns.viewer.init());
 
             menuGlobe.addGUI('RealisticLighting',false,function(newValue) {itowns.viewer.setRealisticLightingOn(newValue);});
 

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -98,7 +98,7 @@ function preprocessLayer(layer, provider) {
  * Init the geometry layer of the Scene.
  */
 ApiGlobe.prototype.init = function () {
-    var map = this.scene.getMap();
+    let map = this.scene.getMap();
     map.tiles.init(map.layersConfiguration.getGeometryLayers()[0]);
 };
 
@@ -107,7 +107,7 @@ ApiGlobe.prototype.init = function () {
  */
 ApiGlobe.prototype.addGeometryLayer = function(layer) {
     preprocessLayer(layer, this.scene.managerCommand.getProtocolProvider(layer.protocol));
-    var map = this.scene.getMap();
+    let map = this.scene.getMap();
     map.layersConfiguration.addGeometryLayer(layer);
 };
 


### PR DESCRIPTION
Doing Quadtree.init with the geometry layer triggers and update of the
scene, which later causes subdivision to be made to the first 3 levels.
When this subdivision is made, we want to be absolutely sure that
LayerConfiguration is complete. Otherwise, layers textures won't be
downloaded if they are added after this initialisation.

FYI, this race conditions was triggered (most of the time) in Firefox but not in chromium.