### PR TITLE
Fix func_names linter errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 
     // TODO reactivate all the following rules
 
-    'func-names': 'off',
     'no-mixed-operators': 'off',
     'no-use-before-define': 'off',
     'no-underscore-dangle': 'off',

--- a/src/Core/Commander/Command.js
+++ b/src/Core/Commander/Command.js
@@ -28,7 +28,7 @@ Command.prototype.constructor = Command;
 
 /**
  */
-Command.prototype.instance = function () {
+Command.prototype.instance = function instance() {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/Command.js
+++ b/src/Core/Commander/Command.js
@@ -26,11 +26,4 @@ function Command() {
 
 Command.prototype.constructor = Command;
 
-/**
- */
-Command.prototype.instance = function instance() {
-    // TODO: Implement Me
-
-};
-
 export default Command;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -13,7 +13,7 @@ function InterfaceCommander(type, priorityFunction) {
     this.type = type;
 
     if (!Date.now) {
-        this.timestamp = function () {
+        this.timestamp = function timestamp() {
             return new Date().getTime();
         };
     } else {
@@ -26,12 +26,12 @@ InterfaceCommander.prototype.constructor = InterfaceCommander;
 /**
  * @return  {[object Object]}
  */
-InterfaceCommander.prototype.buildCommand = function () {
+InterfaceCommander.prototype.buildCommand = function buildCommand() {
     // TODO: Implement Me
     this._builderCommand();
 };
 
-InterfaceCommander.prototype.request = function (parameters, requester, earlyDropFunction) {
+InterfaceCommander.prototype.request = function request(parameters, requester, earlyDropFunction) {
     var command = new Command();
     command.type = this.type;
     command.requester = requester;

--- a/src/Core/Commander/InterfaceCommander.js
+++ b/src/Core/Commander/InterfaceCommander.js
@@ -11,14 +11,6 @@ function InterfaceCommander(type, priorityFunction) {
     this.managerCommands = ManagerCommands();
     this.priorityFunction = priorityFunction;
     this.type = type;
-
-    if (!Date.now) {
-        this.timestamp = function timestamp() {
-            return new Date().getTime();
-        };
-    } else {
-        this.timestamp = Date.now;
-    }
 }
 
 InterfaceCommander.prototype.constructor = InterfaceCommander;
@@ -38,7 +30,7 @@ InterfaceCommander.prototype.request = function request(parameters, requester, e
     command.paramsFunction = parameters;
     command.layer = parameters.layer;
     command.earlyDropFunction = earlyDropFunction;
-    command.timestamp = this.timestamp();
+    command.timestamp = Date.now();
 
     command.promise = new Promise((resolve, reject) => {
         command.resolve = resolve;

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -43,7 +43,7 @@ ApiGlobe.prototype.constructor = ApiGlobe;
 /**
  * @param Command
  */
-ApiGlobe.prototype.add = function (/* Command*/) {
+ApiGlobe.prototype.add = function add(/* Command*/) {
     // TODO: Implement Me
 
 };
@@ -51,19 +51,19 @@ ApiGlobe.prototype.add = function (/* Command*/) {
 /**
  * @param commandTemplate
  */
-ApiGlobe.prototype.createCommand = function (/* commandTemplate*/) {
+ApiGlobe.prototype.createCommand = function createCommand(/* commandTemplate*/) {
     // TODO: Implement Me
 
 };
 
 /**
  */
-ApiGlobe.prototype.execute = function () {
+ApiGlobe.prototype.execute = function execute() {
     // TODO: Implement Me
 
 };
 
-ApiGlobe.prototype.getProtocolProvider = function (protocol) {
+ApiGlobe.prototype.getProtocolProvider = function getProtocolProvider(protocol) {
     return this.scene.managerCommand.getProtocolProvider(protocol);
 };
 
@@ -87,7 +87,7 @@ function preprocessLayer(layer, provider) {
 /**
  * Init the geometry layer of the Scene.
  */
-ApiGlobe.prototype.init = function () {
+ApiGlobe.prototype.init = function init() {
     const map = this.scene.getMap();
     map.tiles.init(map.layersConfiguration.getGeometryLayers()[0]);
 };
@@ -95,7 +95,7 @@ ApiGlobe.prototype.init = function () {
 /**
  * Add the geometry layer to the scene.
  */
-ApiGlobe.prototype.addGeometryLayer = function (layer) {
+ApiGlobe.prototype.addGeometryLayer = function addGeometryLayer(layer) {
     preprocessLayer(layer, this.scene.managerCommand.getProtocolProvider(layer.protocol));
     const map = this.scene.getMap();
     map.layersConfiguration.addGeometryLayer(layer);
@@ -106,7 +106,7 @@ ApiGlobe.prototype.addGeometryLayer = function (layer) {
  * @constructor
  * @param {Layer} layer.
  */
-ApiGlobe.prototype.addImageryLayer = function (layer) {
+ApiGlobe.prototype.addImageryLayer = function addImageryLayer(layer) {
     preprocessLayer(layer, this.scene.managerCommand.getProtocolProvider(layer.protocol));
 
     var map = this.scene.getMap();
@@ -122,7 +122,7 @@ ApiGlobe.prototype.addImageryLayer = function (layer) {
  * @return     {layer}  The Layer.
  */
 
-ApiGlobe.prototype.addImageryLayerFromJSON = function (url) {
+ApiGlobe.prototype.addImageryLayerFromJSON = function addImageryLayerFromJSON(url) {
     return Fetcher.json(url).then((result) => {
         this.addImageryLayer(result);
     });
@@ -135,7 +135,7 @@ ApiGlobe.prototype.addImageryLayerFromJSON = function (url) {
  * @return     {layer}  The Layers.
  */
 
-ApiGlobe.prototype.addImageryLayersFromJSONArray = function (urls) {
+ApiGlobe.prototype.addImageryLayersFromJSONArray = function addImageryLayersFromJSONArray(urls) {
     var proms = [];
 
     for (var i = 0; i < urls.length; i++) {
@@ -145,13 +145,13 @@ ApiGlobe.prototype.addImageryLayersFromJSONArray = function (urls) {
     return Promise.all(proms).then(() => this.scene.getMap().layersConfiguration.getColorLayers());
 };
 
-ApiGlobe.prototype.moveLayerUp = function (layerId) {
+ApiGlobe.prototype.moveLayerUp = function moveLayerUp(layerId) {
     this.scene.getMap().layersConfiguration.moveLayerUp(layerId);
     this.scene.getMap().updateLayersOrdering();
     this.scene.renderScene3D();
 };
 
-ApiGlobe.prototype.moveLayerDown = function (layerId) {
+ApiGlobe.prototype.moveLayerDown = function moveLayerDown(layerId) {
     this.scene.getMap().layersConfiguration.moveLayerDown(layerId);
     this.scene.getMap().updateLayersOrdering();
     this.scene.renderScene3D();
@@ -163,7 +163,7 @@ ApiGlobe.prototype.moveLayerDown = function (layerId) {
  * @param      {string}  layerId   The layer's idendifiant
  * @param      {number}  newIndex   The new index
  */
-ApiGlobe.prototype.moveLayerToIndex = function (layerId, newIndex) {
+ApiGlobe.prototype.moveLayerToIndex = function moveLayerToIndex(layerId, newIndex) {
     this.scene.getMap().layersConfiguration.moveLayerToIndex(layerId, newIndex);
     this.scene.getMap().updateLayersOrdering();
     this.scene.renderScene3D();
@@ -178,7 +178,7 @@ ApiGlobe.prototype.moveLayerToIndex = function (layerId, newIndex) {
  * @param      {string}   id      The identifier
  * @return     {boolean}  { description_of_the_return_value }
  */
-ApiGlobe.prototype.removeImageryLayer = function (id) {
+ApiGlobe.prototype.removeImageryLayer = function removeImageryLayer(id) {
     if (this.scene.getMap().layersConfiguration.removeColorLayer(id)) {
         this.scene.getMap().removeColorLayer(id);
         this.scene.renderScene3D();
@@ -200,7 +200,7 @@ ApiGlobe.prototype.removeImageryLayer = function (id) {
  * @param {Layer} layer.
  */
 
-ApiGlobe.prototype.addElevationLayer = function (layer) {
+ApiGlobe.prototype.addElevationLayer = function addElevationLayer(layer) {
     preprocessLayer(layer, this.scene.managerCommand.getProtocolProvider(layer.protocol));
 
     var map = this.scene.getMap();
@@ -220,7 +220,7 @@ ApiGlobe.prototype.addElevationLayer = function (layer) {
 * @return     {layer}  The Layers.
  */
 
-ApiGlobe.prototype.addElevationLayersFromJSON = function (url) {
+ApiGlobe.prototype.addElevationLayersFromJSON = function addElevationLayersFromJSON(url) {
     return Fetcher.json(url).then((result) => {
         this.addElevationLayer(result);
     });
@@ -238,7 +238,7 @@ ApiGlobe.prototype.addElevationLayersFromJSON = function (url) {
  * @return     {layer}  The Layers.
  */
 
-ApiGlobe.prototype.addElevationLayersFromJSONArray = function (urls) {
+ApiGlobe.prototype.addElevationLayersFromJSONArray = function addElevationLayersFromJSONArray(urls) {
     var proms = [];
 
     for (var i = 0; i < urls.length; i++) {
@@ -255,7 +255,7 @@ ApiGlobe.prototype.addElevationLayersFromJSONArray = function (urls) {
  * @param {index} index - The index of the layer.
  * @return     {number}  The min of the level.
  */
-ApiGlobe.prototype.getMinZoomLevel = function (index) {
+ApiGlobe.prototype.getMinZoomLevel = function getMinZoomLevel(index) {
     var layer = this.getImageryLayers()[index];
     if (layer && layer.zoom) {
         return layer.zoom.min;
@@ -278,7 +278,7 @@ ApiGlobe.prototype.getMinZoomLevel = function (index) {
  * @param {index} index - The index of the layer.
  * @return     {number}  The max of the level.
  */
-ApiGlobe.prototype.getMaxZoomLevel = function (index) {
+ApiGlobe.prototype.getMaxZoomLevel = function getMaxZoomLevel(index) {
     var layer = this.getImageryLayers()[index];
     if (layer && layer.zoom) {
         return layer.zoom.max;
@@ -299,7 +299,7 @@ ApiGlobe.prototype.getMaxZoomLevel = function (index) {
  * @constructor
  * @return     {layer}  The Layers.
  */
-ApiGlobe.prototype.getImageryLayers = function () {
+ApiGlobe.prototype.getImageryLayers = function getImageryLayers() {
     var map = this.scene.getMap();
     return map.layersConfiguration.getColorLayers();
 };
@@ -313,7 +313,7 @@ ApiGlobe.prototype.getImageryLayers = function () {
  * @params {Div} string.
  */
 
-ApiGlobe.prototype.createSceneGlobe = function (coordCarto, viewerDiv) {
+ApiGlobe.prototype.createSceneGlobe = function createSceneGlobe(coordCarto, viewerDiv) {
     // TODO: Normalement la creation de scene ne doit pas etre ici....
     // Deplacer plus tard
 
@@ -362,11 +362,11 @@ ApiGlobe.prototype.createSceneGlobe = function (coordCarto, viewerDiv) {
     return this.scene;
 };
 
-ApiGlobe.prototype.update = function () {
+ApiGlobe.prototype.update = function update() {
     this.scene.notifyChange();
 };
 
-// ApiGlobe.prototype.setLayerAtLevel = function(baseurl,layer/*,level*/) {
+// ApiGlobe.prototype.setLayerAtLevel = functionsetLayerAtLevel(baseurl,layer/*,level*/) {
 //     // TODO CLEAN AND GENERIC
 //     var wmtsProvider = new WMTS_Provider({url:baseurl, layer:layer});
 //     this.scene.managerCommand.providerMap[4] = wmtsProvider;
@@ -376,12 +376,12 @@ ApiGlobe.prototype.update = function () {
 //     this.scene.renderScene3D();
 // };
 
-ApiGlobe.prototype.showClouds = function (value, satelliteAnimation) {
+ApiGlobe.prototype.showClouds = function showClouds(value, satelliteAnimation) {
     this.scene.getMap().showClouds(value, satelliteAnimation);
     this.scene.renderScene3D();
 };
 
-ApiGlobe.prototype.setRealisticLightingOn = function (value) {
+ApiGlobe.prototype.setRealisticLightingOn = function setRealisticLightingOn(value) {
     this.scene.setLightingPos();
     this.scene.gfxEngine.setLightingOn(value);
     this.scene.getMap().setRealisticLightingOn(value);
@@ -396,7 +396,7 @@ ApiGlobe.prototype.setRealisticLightingOn = function (value) {
  * @params {visible} boolean.
  */
 
-ApiGlobe.prototype.setLayerVisibility = function (id, visible) {
+ApiGlobe.prototype.setLayerVisibility = function setLayerVisibility(id, visible) {
     this.scene.getMap().setLayerVisibility(id, visible);
     this.update();
     eventLayerChangedVisible.layerId = id;
@@ -404,11 +404,11 @@ ApiGlobe.prototype.setLayerVisibility = function (id, visible) {
     this.viewerDiv.dispatchEvent(eventLayerChangedVisible);
 };
 
-ApiGlobe.prototype.animateTime = function (value) {
+ApiGlobe.prototype.animateTime = function animateTime(value) {
     this.scene.animateTime(value);
 };
 
-ApiGlobe.prototype.orbit = function (value) {
+ApiGlobe.prototype.orbit = function orbit(value) {
     this.scene.orbit(value);
 };
 
@@ -419,7 +419,7 @@ ApiGlobe.prototype.orbit = function (value) {
  * @params {visible} boolean.
  */
 
-ApiGlobe.prototype.setLayerOpacity = function (id, opacity) {
+ApiGlobe.prototype.setLayerOpacity = function setLayerOpacity(id, opacity) {
     this.scene.getMap().setLayerOpacity(id, opacity);
     this.scene.renderScene3D();
     eventLayerChangedOpacity.layerId = id;
@@ -427,7 +427,7 @@ ApiGlobe.prototype.setLayerOpacity = function (id, opacity) {
     this.viewerDiv.dispatchEvent(eventLayerChangedOpacity);
 };
 
-ApiGlobe.prototype.setStreetLevelImageryOn = function (value) {
+ApiGlobe.prototype.setStreetLevelImageryOn = function setStreetLevelImageryOn(value) {
     this.scene.setStreetLevelImageryOn(value);
 };
 
@@ -436,7 +436,7 @@ ApiGlobe.prototype.setStreetLevelImageryOn = function (value) {
  * <iframe width="100%" height="400" src="//jsfiddle.net/iTownsIGN/okfj460p/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
  * @constructor
  */
-ApiGlobe.prototype.getCameraOrientation = function () {
+ApiGlobe.prototype.getCameraOrientation = function getCameraOrientation() {
     var tiltCam = this.scene.currentControls().getTilt();
     var headingCam = this.scene.currentControls().getHeading();
     return [tiltCam, headingCam];
@@ -449,7 +449,7 @@ ApiGlobe.prototype.getCameraOrientation = function () {
  * @return {Position} position
  */
 
-ApiGlobe.prototype.getCameraLocation = function () {
+ApiGlobe.prototype.getCameraLocation = function getCameraLocation() {
     var cam = this.scene.currentCamera().camera3D;
     return this.projection.cartesianToGeo(cam.position);
 };
@@ -461,7 +461,7 @@ ApiGlobe.prototype.getCameraLocation = function () {
  * @return {Position} position
  */
 
-ApiGlobe.prototype.getCenter = function () {
+ApiGlobe.prototype.getCenter = function getCenter() {
     var controlCam = this.scene.currentControls();
     return this.projection.cartesianToGeo(controlCam.getTargetCameraPosition());
 };
@@ -473,7 +473,7 @@ ApiGlobe.prototype.getCenter = function () {
  * @param {Orientation} Param - The angle of the rotation in degrees.
  */
 
-ApiGlobe.prototype.setCameraOrientation = function (orientation /* param,pDisableAnimationopt*/) {
+ApiGlobe.prototype.setCameraOrientation = function setCameraOrientation(orientation /* param,pDisableAnimationopt*/) {
     this.setHeading(orientation.heading);
     this.setTilt(orientation.tilt);
     this.viewerDiv.dispatchEvent(eventOrientation);
@@ -486,7 +486,7 @@ ApiGlobe.prototype.setCameraOrientation = function (orientation /* param,pDisabl
  * @param {number | undefined} y - The y-position inside the Globe element.
  * @return {Position} postion
  */
-ApiGlobe.prototype.pickPosition = function (mouse, y) {
+ApiGlobe.prototype.pickPosition = function pickPosition(mouse, y) {
     if (mouse)
         { if (mouse.clientX) {
             mouse.x = mouse.clientX;
@@ -510,7 +510,7 @@ ApiGlobe.prototype.pickPosition = function (mouse, y) {
  * @return {Angle} number - The angle of the rotation in degrees.
  */
 
-ApiGlobe.prototype.getTilt = function () {
+ApiGlobe.prototype.getTilt = function getTilt() {
     var tiltCam = this.scene.currentControls().getTilt();
     return tiltCam;
 };
@@ -522,7 +522,7 @@ ApiGlobe.prototype.getTilt = function () {
  * @return {Angle} number - The angle of the rotation in degrees.
  */
 
-ApiGlobe.prototype.getHeading = function () {
+ApiGlobe.prototype.getHeading = function getHeading() {
     var headingCam = this.scene.currentControls().getHeading();
     return headingCam;
 };
@@ -534,11 +534,11 @@ ApiGlobe.prototype.getHeading = function () {
  * @return {Number} number
  */
 
-ApiGlobe.prototype.getRange = function () {
+ApiGlobe.prototype.getRange = function getRange() {
     return this.scene.currentControls().getRange();
 };
 
-ApiGlobe.prototype.getRangeFromEllipsoid = function () {
+ApiGlobe.prototype.getRangeFromEllipsoid = function getRangeFromEllipsoid() {
     // TODO: error is distance is big with ellipsoid.intersection(ray) because d < 0
     var controlCam = this.scene.currentControls();
     var ellipsoid = this.scene.getEllipsoid();
@@ -558,7 +558,7 @@ ApiGlobe.prototype.getRangeFromEllipsoid = function () {
  * @param {Boolean} [pDisableAnimation] - Used to force the non use of animation if its enable.
  */
 
-ApiGlobe.prototype.setTilt = function (tilt /* , bool*/) {
+ApiGlobe.prototype.setTilt = function setTilt(tilt /* , bool*/) {
     eventOrientation.oldTilt = this.getTilt();
     this.scene.currentControls().setTilt(tilt);
     this.viewerDiv.dispatchEvent(eventOrientation);
@@ -572,7 +572,7 @@ ApiGlobe.prototype.setTilt = function (tilt /* , bool*/) {
  * @param {Boolean} [pDisableAnimation] - Used to force the non use of animation if its enable.
  */
 
-ApiGlobe.prototype.setHeading = function (heading /* , bool*/) {
+ApiGlobe.prototype.setHeading = function setHeading(heading /* , bool*/) {
     eventOrientation.oldHeading = this.getHeading();
     this.scene.currentControls().setHeading(heading);
     this.viewerDiv.dispatchEvent(eventOrientation);
@@ -584,7 +584,7 @@ ApiGlobe.prototype.setHeading = function (heading /* , bool*/) {
  * @param {Boolean} [pDisableAnimation] - Used to force the non use of animation if its enable.
  */
 
-ApiGlobe.prototype.resetTilt = function (/* bool*/) {
+ApiGlobe.prototype.resetTilt = function resetTilt(/* bool*/) {
     this.scene.currentControls().setTilt(0);
     this.viewerDiv.dispatchEvent(eventOrientation);
 };
@@ -595,7 +595,7 @@ ApiGlobe.prototype.resetTilt = function (/* bool*/) {
  * @param {Boolean} [pDisableAnimation] - Used to force the non use of animation if its enable.
  */
 
-ApiGlobe.prototype.resetHeading = function (/* bool*/) {
+ApiGlobe.prototype.resetHeading = function resetHeading(/* bool*/) {
     this.scene.currentControls().setHeading(0);
     this.viewerDiv.dispatchEvent(eventOrientation);
 };
@@ -609,7 +609,7 @@ ApiGlobe.prototype.resetHeading = function (/* bool*/) {
  * @return {Number} distance
  */
 
-ApiGlobe.prototype.computeDistance = function (p1, p2) {
+ApiGlobe.prototype.computeDistance = function computeDistance(p1, p2) {
     return this.scene.getEllipsoid().computeDistance(new GeoCoordinate().copy(p1), new GeoCoordinate().copy(p2));
 };
 
@@ -619,7 +619,7 @@ ApiGlobe.prototype.computeDistance = function (p1, p2) {
  * @constructor
  * @param {coordinates} coordinates - Properties : longitude and latitude
  */
-ApiGlobe.prototype.setCenter = function (coordinates) {
+ApiGlobe.prototype.setCenter = function setCenter(coordinates) {
     eventCenter.oldCenter = this.getCenter();
     var position3D = this.scene.getEllipsoid().cartographicToCartesian(new GeoCoordinate(coordinates.longitude, coordinates.latitude, 0, UNIT.DEGREE));
     this.scene.currentControls().setCenter(position3D);
@@ -637,14 +637,14 @@ ApiGlobe.prototype.setCenter = function (coordinates) {
  * @param {Boolean} [pDisableAnimation] - Used to force the non use of animation if its enable.
  */
 
-ApiGlobe.prototype.setCenterAdvanced = function (pPosition /* , pDisableAnimationopt*/) {
+ApiGlobe.prototype.setCenterAdvanced = function setCenterAdvanced(pPosition /* , pDisableAnimationopt*/) {
     this.setCenter(pPosition.position);
     this.setRange(pPosition.range);
     this.setHeading(pPosition.heading);
     this.setTilt(pPosition.tilt);
 };
 
-var updateTargetCamera = function (api) {
+var updateTargetCamera = function updateTargetCamera(api) {
     api.scene.currentControls().updateCameraTransformation();
     api.viewerDiv.dispatchEvent(eventRange);
     api.removeEventListener('globe-loaded', updateTargetCamera);
@@ -656,7 +656,7 @@ var updateTargetCamera = function (api) {
  * @param {Number} pRange - The camera altitude.
  * @param {Boolean} [pDisableAnimation] - Used to force the non use of animation if its enable.
  */
-ApiGlobe.prototype.setRange = function (pRange /* , bool anim*/) {
+ApiGlobe.prototype.setRange = function setRange(pRange /* , bool anim*/) {
     eventRange.oldRange = this.getRange();
     loaded = false;
     this.scene.currentControls().setRange(pRange);
@@ -669,7 +669,7 @@ ApiGlobe.prototype.setRange = function (pRange /* , bool anim*/) {
  * @constructor
  * @param      {vector}  pVector  The vector
  */
-ApiGlobe.prototype.pan = function (pVector) {
+ApiGlobe.prototype.pan = function pan(pVector) {
     this.scene.currentControls().pan(pVector.x, pVector.y);
 };
 
@@ -678,7 +678,7 @@ ApiGlobe.prototype.pan = function (pVector) {
  * @constructor
  * @return     {number}  The zoom level.
  */
-ApiGlobe.prototype.getZoomLevel = function () {
+ApiGlobe.prototype.getZoomLevel = function getZoomLevel() {
     return this.scene.getMap().getZoomLevel();
 };
 
@@ -689,7 +689,7 @@ ApiGlobe.prototype.getZoomLevel = function () {
  * @constructor
  * @param      {number}  zoom    The zoom
  */
-ApiGlobe.prototype.setZoomLevel = function (zoom) {
+ApiGlobe.prototype.setZoomLevel = function setZoomLevel(zoom) {
     zoom = Math.max(this.getMinZoomLevel(), zoom);
     zoom = Math.min(this.getMaxZoomLevel(), zoom);
     const distance = this.scene.getMap().computeDistanceForZoomLevel(zoom, this.scene.currentCamera());
@@ -703,7 +703,7 @@ ApiGlobe.prototype.setZoomLevel = function (zoom) {
  * @param      {number}  pitch   Screen pitch, in millimeters ; 0.28 by default
  * @return     {number}  The zoom scale.
  */
-ApiGlobe.prototype.getZoomScale = function (pitch) {
+ApiGlobe.prototype.getZoomScale = function getZoomScale(pitch) {
     // TODO: Why error div size height in Chrome?
     // Screen pitch, in millimeters
     pitch = (pitch || 0.28) / 1000;
@@ -758,7 +758,7 @@ ApiGlobe.prototype.getZoomScale = function (pitch) {
  * @param      {number}  zoomScale  The zoom scale
  * @param      {number}  pitch      The pitch
  */
-ApiGlobe.prototype.setZoomScale = function (zoomScale, pitch) {
+ApiGlobe.prototype.setZoomScale = function setZoomScale(zoomScale, pitch) {
     // Screen pitch, in millimeters
     pitch = (pitch || 0.28) / 1000;
 
@@ -811,7 +811,7 @@ ApiGlobe.prototype.setZoomScale = function (zoomScale, pitch) {
  * @param {callback} Callback - The callback that is called when the event is heard.
  */
 
-ApiGlobe.prototype.addEventListener = function (eventname, callback) {
+ApiGlobe.prototype.addEventListener = function addEventListenerProto(eventname, callback) {
     if (eventname == 'layerchanged') {
         this.viewerDiv.addEventListener('layerchanged', callback, false);
         this.addEventListenerLayerChanged();
@@ -820,13 +820,13 @@ ApiGlobe.prototype.addEventListener = function (eventname, callback) {
     }
 };
 
-ApiGlobe.prototype.addEventListenerLayerChanged = function () {
+ApiGlobe.prototype.addEventListenerLayerChanged = function addEventListenerLayerChanged() {
     this.viewerDiv.addEventListener('layerchanged:visible', this.callbackLayerChanged, false);
     this.viewerDiv.addEventListener('layerchanged:opacity', this.callbackLayerChanged, false);
     this.viewerDiv.addEventListener('layerchanged:index', this.callbackLayerChanged, false);
 };
 
-ApiGlobe.prototype.callbackLayerChanged = function () {
+ApiGlobe.prototype.callbackLayerChanged = function callbackLayerChanged() {
     this.dispatchEvent(eventLayerChanged);
 };
 
@@ -837,7 +837,7 @@ ApiGlobe.prototype.callbackLayerChanged = function () {
  * @param {callback} Callback - The callback that is called when the event is heard.
  */
 
-ApiGlobe.prototype.removeEventListener = function (eventname, callback) {
+ApiGlobe.prototype.removeEventListener = function removeEventListenerProto(eventname, callback) {
     if (eventname == 'layerchanged') {
         this.viewerDiv.removeEventListener('layerchanged', callback, false);
         this.removeEventListenerLayerChanged();
@@ -846,13 +846,13 @@ ApiGlobe.prototype.removeEventListener = function (eventname, callback) {
     }
 };
 
-ApiGlobe.prototype.removeEventListenerLayerChanged = function () {
+ApiGlobe.prototype.removeEventListenerLayerChanged = function removeEventListenerLayerChanged() {
     this.viewerDiv.removeEventListener('layerchanged:visible', this.callbackLayerChanged, false);
     this.viewerDiv.removeEventListener('layerchanged:opacity', this.callbackLayerChanged, false);
     this.viewerDiv.removeEventListener('layerchanged:index', this.callbackLayerChanged, false);
 };
 
-ApiGlobe.prototype.launchCommandApi = function () {
+ApiGlobe.prototype.launchCommandApi = function launchCommandApi() {
 
     // this.removeImageryLayer('ScanEX');
 
@@ -892,14 +892,14 @@ ApiGlobe.prototype.launchCommandApi = function () {
     //        this.setCenterAdvanced({position:p2, /*range:10000,*/ heading:180, tilt:70});
 };
 
-//    ApiGlobe.prototype.testTilt = function (){
+//    ApiGlobe.prototype.testTilt = function testTilt(){
 //        this.setTilt(45);
 //        console.log(this.getTilt());
 //        this.resetTilt();
 //        console.log(this.getTilt());
 //    };
 //
-//    ApiGlobe.prototype.testHeading = function (){
+//    ApiGlobe.prototype.testHeading = function testHeading(){
 //        this.setHeading(90);
 //        console.log(this.getHeading());
 //        this.resetHeading();
@@ -907,19 +907,19 @@ ApiGlobe.prototype.launchCommandApi = function () {
 //    };
 
 
-ApiGlobe.prototype.selectNodeById = function (id) {
+ApiGlobe.prototype.selectNodeById = function selectNodeById(id) {
     this.scene.selectNodeId(id);
     this.scene.update();
     this.scene.renderScene3D();
 };
 
-ApiGlobe.prototype.showKML = function (value) {
+ApiGlobe.prototype.showKML = function showKML(value) {
     this.scene.getMap().showKML(value);
     this.scene.renderScene3D();
 };
 
 
-ApiGlobe.prototype.loadGPX = function (url) {
+ApiGlobe.prototype.loadGPX = function loadGPX(url) {
     loadGpx(url, this.scene.getEllipsoid()).then((gpx) => {
         if (gpx) {
             this.scene.getMap().gpxTracks.children[0].add(gpx);

--- a/src/Core/Commander/Interfaces/EventsManager.js
+++ b/src/Core/Commander/Interfaces/EventsManager.js
@@ -17,16 +17,16 @@ function EventsManager() {
  * @param pevent {[object Object]}
  * @param com {[object Object]}
  */
-EventsManager.prototype.connect = function (/* pevent, com*/) {
+EventsManager.prototype.connect = function connect(/* pevent, com*/) {
     // TODO: Implement Me
 
 };
 
-EventsManager.prototype.command = function () {
+EventsManager.prototype.command = function command() {
 
 };
 
-EventsManager.prototype.wait = function () {
+EventsManager.prototype.wait = function wait() {
     var waitTime = 250;
     if (this.timer === null) {
         this.timer = window.setTimeout(this.command, waitTime);

--- a/src/Core/Commander/Interfaces/Times/Timeline.js
+++ b/src/Core/Commander/Interfaces/Times/Timeline.js
@@ -18,7 +18,7 @@ Timeline.prototype = new EventsManager();
  * @documentation: Cette classe est un conteneur et gestionnaire de triggeurs
  *
  */
-Timeline.prototype.update = function () {
+Timeline.prototype.update = function update() {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/Interfaces/Times/Timer.js
+++ b/src/Core/Commander/Interfaces/Times/Timer.js
@@ -13,7 +13,7 @@ function Timer() {
 
 /**
  */
-Timer.prototype.getTime = function () {
+Timer.prototype.getTime = function getTime() {
     // TODO: Implement Me
 
 };
@@ -21,7 +21,7 @@ Timer.prototype.getTime = function () {
 
 /**
  */
-Timer.prototype.stop = function () {
+Timer.prototype.stop = function stopTimer() {
     // TODO: Implement Me
 
 };
@@ -29,7 +29,7 @@ Timer.prototype.stop = function () {
 
 /**
  */
-Timer.prototype.start = function () {
+Timer.prototype.start = function start() {
     // TODO: Implement Me
 
 };
@@ -37,7 +37,7 @@ Timer.prototype.start = function () {
 
 /**
  */
-Timer.prototype.pause = function () {
+Timer.prototype.pause = function pause() {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/Interfaces/Times/Trigger.js
+++ b/src/Core/Commander/Interfaces/Times/Trigger.js
@@ -15,7 +15,7 @@ function Trigger() {
 
 /**
  */
-Trigger.prototype.executeChildrenCommand = function () {
+Trigger.prototype.executeChildrenCommand = function executeChildrenCommand() {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/ManagerCommands.js
+++ b/src/Core/Commander/ManagerCommands.js
@@ -72,7 +72,7 @@ function ManagerCommands(scene) {
 
 ManagerCommands.prototype.constructor = ManagerCommands;
 
-ManagerCommands.prototype.runCommand = function (command, queue, executingCounterUpToDate) {
+ManagerCommands.prototype.runCommand = function runCommand(command, queue, executingCounterUpToDate) {
     var provider = this.providers[command.layer.protocol];
 
     if (!provider) {
@@ -96,7 +96,7 @@ ManagerCommands.prototype.runCommand = function (command, queue, executingCounte
     });
 };
 
-ManagerCommands.prototype.addCommand = function (command) {
+ManagerCommands.prototype.addCommand = function addCommand(command) {
     // parse host
     const layer = command.layer;
 
@@ -114,7 +114,7 @@ ManagerCommands.prototype.addCommand = function (command) {
         // increment before
         q.counters.executing++;
 
-        var runNow = function () {
+        var runNow = function runNow() {
             this.runCommand(command, q, true);
         }.bind(this);
 
@@ -128,15 +128,15 @@ ManagerCommands.prototype.addCommand = function (command) {
 };
 
 
-ManagerCommands.prototype.addProtocolProvider = function (protocol, provider) {
+ManagerCommands.prototype.addProtocolProvider = function addProtocolProvider(protocol, provider) {
     this.providers[protocol] = provider;
 };
 
-ManagerCommands.prototype.getProtocolProvider = function (protocol) {
+ManagerCommands.prototype.getProtocolProvider = function getProtocolProvider(protocol) {
     return this.providers[protocol];
 };
 
-ManagerCommands.prototype.commandsWaitingExecutionCount = function () {
+ManagerCommands.prototype.commandsWaitingExecutionCount = function commandsWaitingExecutionCount() {
     let sum = this.defaultQueue.storage.length + this.defaultQueue.counters.executing;
     for (var q of this.hostQueues) {
         sum += q[1].storage.length + q[1].counters.executing;
@@ -144,7 +144,7 @@ ManagerCommands.prototype.commandsWaitingExecutionCount = function () {
     return sum;
 };
 
-ManagerCommands.prototype.commandsRunningCount = function () {
+ManagerCommands.prototype.commandsRunningCount = function commandsRunningCount() {
     let sum = this.defaultQueue.counters.executing;
 
     for (var q of this.hostQueues) {
@@ -153,7 +153,7 @@ ManagerCommands.prototype.commandsRunningCount = function () {
     return sum;
 };
 
-ManagerCommands.prototype.resetCommandsCount = function (type) {
+ManagerCommands.prototype.resetCommandsCount = function resetCommandsCount(type) {
     let sum = this.defaultQueue.counters[type];
     this.defaultQueue.counters[type] = 0;
     for (var q of this.hostQueues) {
@@ -163,7 +163,7 @@ ManagerCommands.prototype.resetCommandsCount = function (type) {
     return sum;
 };
 
-ManagerCommands.prototype.getProviders = function () {
+ManagerCommands.prototype.getProviders = function getProviders() {
     var p = [];
 
     for (var protocol in this.providers) {
@@ -174,7 +174,7 @@ ManagerCommands.prototype.getProviders = function () {
 
 /**
  */
-ManagerCommands.prototype.deQueue = function (queue) {
+ManagerCommands.prototype.deQueue = function deQueue(queue) {
     var st = queue.storage;
     while (st.length > 0) {
         var cmd = st.dequeue();
@@ -192,7 +192,7 @@ ManagerCommands.prototype.deQueue = function (queue) {
 
 /**
  */
-ManagerCommands.prototype.wait = function () {
+ManagerCommands.prototype.wait = function wait() {
     this.eventsManager.wait();
 };
 

--- a/src/Core/Commander/Providers/BuildingBox_Provider.js
+++ b/src/Core/Commander/Providers/BuildingBox_Provider.js
@@ -43,7 +43,7 @@ BuildingBox_Provider.prototype.constructor = BuildingBox_Provider;
  * @param {type} coWMTS : coord WMTS
  * @returns {Object@call;create.url.url|String}
  */
-BuildingBox_Provider.prototype.url = function (longitude, latitude, radius) {
+BuildingBox_Provider.prototype.url = function url(longitude, latitude, radius) {
     // var key    = "wmybzw30d6zg563hjlq8eeqb";
     // var key    = coWMTS.zoom > 11 ? "va5orxd0pgzvq3jxutqfuy0b" : "wmybzw30d6zg563hjlq8eeqb"; // clef pro va5orxd0pgzvq3jxutqfuy0b
 
@@ -63,14 +63,14 @@ BuildingBox_Provider.prototype.url = function (longitude, latitude, radius) {
     return url;
 };
 
-BuildingBox_Provider.prototype.getData = function (bbox, altitude) {
+BuildingBox_Provider.prototype.getData = function getData(bbox, altitude) {
     return this.WFS_Provider.getData(bbox).then((data) => {
         this.generateMesh(data, bbox, altitude); // console.log(data);
         return this.geometry;
     });
 };
 
-BuildingBox_Provider.prototype.generateMesh = function (elements, bbox, altitude) {
+BuildingBox_Provider.prototype.generateMesh = function generateMesh(elements, bbox, altitude) {
     // console.log(elements);
 
     var _geometry = new THREE.Geometry(); // for the walls
@@ -187,7 +187,7 @@ BuildingBox_Provider.prototype.generateMesh = function (elements, bbox, altitude
 };
 
 
-BuildingBox_Provider.prototype.addRoad = function (geometry, bbox, altitude_road, ellipsoid) {
+BuildingBox_Provider.prototype.addRoad = function addRoad(geometry, bbox, altitude_road, ellipsoid) {
     // Version using SIMPLE PLANE ROAD for Click and Go
     var ratio = 0.2;
     var roadWidth = (bbox.east() - bbox.west()) * ratio;

--- a/src/Core/Commander/Providers/CacheRessource.js
+++ b/src/Core/Commander/Providers/CacheRessource.js
@@ -16,11 +16,11 @@ function CacheRessource() {
 /**
  * @param url
  */
-CacheRessource.prototype.getRessource = function (url) {
+CacheRessource.prototype.getRessource = function getRessource(url) {
     return this.cacheObjects[url];
 };
 
-CacheRessource.prototype.addRessource = function (url, ressource) {
+CacheRessource.prototype.addRessource = function addRessource(url, ressource) {
     this.cacheObjects[url] = ressource;
 };
 
@@ -28,7 +28,7 @@ CacheRessource.prototype.addRessource = function (url, ressource) {
 /**
  * @param id
  */
-CacheRessource.prototype.getRessourceByID = function (/* id*/) {
+CacheRessource.prototype.getRessourceByID = function getRessourceByID(/* id*/) {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/Providers/IoDriver.js
+++ b/src/Core/Commander/Providers/IoDriver.js
@@ -17,7 +17,7 @@ IoDriver.prototype.constructor = IoDriver;
 /**
  * @param url
  */
-IoDriver.prototype.load = function (/* url*/) {
+IoDriver.prototype.load = function load(/* url*/) {
     // TODO: Implement Me
 
 };
@@ -27,7 +27,7 @@ IoDriver.prototype.load = function (/* url*/) {
  * @param url
  * @param inputObject {Object}
  */
-IoDriver.prototype.write = function (/* url, inputObject*/) {
+IoDriver.prototype.write = function write(/* url, inputObject*/) {
     // TODO: Implement Me
 
 };
@@ -36,7 +36,7 @@ IoDriver.prototype.write = function (/* url, inputObject*/) {
 /**
  * @param url
  */
-IoDriver.prototype.readAsync = function (/* url*/) {
+IoDriver.prototype.readAsync = function readAsync(/* url*/) {
     // TODO: Implement Me
 
 };
@@ -45,7 +45,7 @@ IoDriver.prototype.readAsync = function (/* url*/) {
 /**
  * @param url
  */
-IoDriver.prototype.writeAsync = function (/* url*/) {
+IoDriver.prototype.writeAsync = function writeAsync(/* url*/) {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/Providers/IoDriver_XBIL.js
+++ b/src/Core/Commander/Providers/IoDriver_XBIL.js
@@ -7,7 +7,7 @@
 import IoDriver from 'Core/Commander/Providers/IoDriver';
 
 
-var portableXBIL = function (buffer) {
+var portableXBIL = function portableXBIL(buffer) {
     this.floatArray = new Float32Array(buffer);
     this.max = -1000000;
     this.min = 1000000;
@@ -25,7 +25,7 @@ IoDriver_XBIL.prototype = Object.create(IoDriver.prototype);
 
 IoDriver_XBIL.prototype.constructor = IoDriver_XBIL;
 
-IoDriver_XBIL.prototype.computeMinMaxElevation = function (buffer, width, height, offsetScale) {
+IoDriver_XBIL.prototype.computeMinMaxElevation = function computeMinMaxElevation(buffer, width, height, offsetScale) {
     let min = 1000000;
     let max = -1000000;
 
@@ -53,7 +53,7 @@ IoDriver_XBIL.prototype.computeMinMaxElevation = function (buffer, width, height
     return { min, max };
 };
 
-IoDriver_XBIL.prototype.parseXBil = function (buffer, url) {
+IoDriver_XBIL.prototype.parseXBil = function parseXBil(buffer, url) {
     if (!buffer) {
         throw new Error('Error processing XBIL');
     }
@@ -75,7 +75,7 @@ IoDriver_XBIL.prototype.parseXBil = function (buffer, url) {
 };
 
 
-IoDriver_XBIL.prototype.read = function (url) {
+IoDriver_XBIL.prototype.read = function read(url) {
     return fetch(url).then((response) => {
         if (response.status < 200 || response.status >= 300) {
             throw new Error(`Error loading ${url}: status ${response.status}`);

--- a/src/Core/Commander/Providers/ItownsLine.js
+++ b/src/Core/Commander/Providers/ItownsLine.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import ItownsLineMaterial from 'Renderer/ItownsLineMaterial';
 
-var ItownsLine = function (options) {
+var ItownsLine = function ItownsLine(options) {
     THREE.Mesh.call(this);
 
     this.positions = [];
@@ -20,7 +20,7 @@ var ItownsLine = function (options) {
 ItownsLine.prototype = Object.create(THREE.Mesh.prototype);
 ItownsLine.prototype.constructor = ItownsLine;
 
-ItownsLine.prototype.setGeometry = function (g, c) {
+ItownsLine.prototype.setGeometry = function setGeometry(g, c) {
     this.widthCallback = c;
     this.positions = [];
 
@@ -48,25 +48,25 @@ ItownsLine.prototype.setGeometry = function (g, c) {
     this.process();
 };
 
-ItownsLine.prototype.addPoint = function (v) {
+ItownsLine.prototype.addPoint = function addPoint(v) {
     if (v instanceof THREE.Vector3) {
         this.positions.push(v.x, v.y, v.z);
         this.positions.push(v.x, v.y, v.z);
     }
 };
 
-ItownsLine.prototype.compareV3 = function (a, b) {
+ItownsLine.prototype.compareV3 = function compareV3(a, b) {
     var aa = a * 6;
     var ab = b * 6;
     return (this.positions[aa] === this.positions[ab]) && (this.positions[aa + 1] === this.positions[ab + 1]) && (this.positions[aa + 2] === this.positions[ab + 2]);
 };
 
-ItownsLine.prototype.copyV3 = function (a) {
+ItownsLine.prototype.copyV3 = function copyV3(a) {
     var aa = a * 6;
     return [this.positions[aa], this.positions[aa + 1], this.positions[aa + 2]];
 };
 
-ItownsLine.prototype.process = function () {
+ItownsLine.prototype.process = function process() {
     var l = this.positions.length / 6;
 
     this.previous = [];
@@ -144,7 +144,7 @@ ItownsLine.prototype.process = function () {
     this.geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(this.indices_array), 1));
 };
 
-ItownsLine.prototype.createQuad = function (pt1, pt2) {
+ItownsLine.prototype.createQuad = function createQuad(pt1, pt2) {
 		// Définition propre a chaque géométrie
     var geometry = new THREE.BufferGeometry();
 
@@ -194,7 +194,7 @@ ItownsLine.prototype.createQuad = function (pt1, pt2) {
     return geometry;
 };
 
-ItownsLine.prototype.createSegments = function (pt1, pt2, pt3) {
+ItownsLine.prototype.createSegments = function createSegments(pt1, pt2, pt3) {
 		// Définition propre a chaque géométrie
     var geometry = new THREE.BufferGeometry();
     var point1 = new Float32Array([

--- a/src/Core/Commander/Providers/ItownsPoint.js
+++ b/src/Core/Commander/Providers/ItownsPoint.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import ItownsPointMaterial from 'Renderer/ItownsPointMaterial';
 
 
-var ItownsPoint = function (options) {
+var ItownsPoint = function ItownsPoint(options) {
     THREE.Points.call(this);
 
     if (options === undefined)
@@ -18,7 +18,7 @@ var ItownsPoint = function (options) {
 ItownsPoint.prototype = Object.create(THREE.Points.prototype);
 ItownsPoint.prototype.constructor = ItownsPoint;
 
-ItownsPoint.prototype.addPoint = function (v, c, s) {
+ItownsPoint.prototype.addPoint = function addPoint(v, c, s) {
     if (v instanceof THREE.Vector3) {
         this.positions.push(v.x, v.y, v.z);
 
@@ -29,7 +29,7 @@ ItownsPoint.prototype.addPoint = function (v, c, s) {
     }
 };
 
-ItownsPoint.prototype.process = function () {
+ItownsPoint.prototype.process = function process() {
     this.geometry.addAttribute('position', new THREE.BufferAttribute(new Float32Array(this.positions), 3));
     this.geometry.addAttribute('customColor', new THREE.BufferAttribute(new Float32Array(this.colors), 3));
     this.geometry.addAttribute('size', new THREE.BufferAttribute(new Float32Array(this.sizes), 1));

--- a/src/Core/Commander/Providers/KML_Provider.js
+++ b/src/Core/Commander/Providers/KML_Provider.js
@@ -23,11 +23,11 @@ KML_Provider.prototype = Object.create(Provider.prototype);
 
 KML_Provider.prototype.constructor = KML_Provider;
 
-KML_Provider.prototype.loadKMZCenterInBBox = function (/* bbox*/) {
+KML_Provider.prototype.loadKMZCenterInBBox = function loadKMZCenterInBBox(/* bbox*/) {
 
 };
 
-KML_Provider.prototype.loadKMZ = function (longitude, latitude) {
+KML_Provider.prototype.loadKMZ = function loadKMZ(longitude, latitude) {
     return this.getUrlCollada(longitude, latitude).then((result) => {
         if (result === undefined)
             { return undefined; }
@@ -50,7 +50,7 @@ KML_Provider.prototype.loadKMZ = function (longitude, latitude) {
             child.updateMatrix();
             child.visible = false;
 
-            var changeMaterial = function (object3D) {
+            var changeMaterial = function changeMaterial(object3D) {
                 if (object3D.material instanceof THREE.MultiMaterial) {
                     object3D.material = new BasicMaterial(object3D.material.materials[0].color);
                 } else if (object3D.material)
@@ -66,7 +66,7 @@ KML_Provider.prototype.loadKMZ = function (longitude, latitude) {
     });
 };
 
-KML_Provider.prototype.parseKML = function (urlFile, longitude, latitude) {
+KML_Provider.prototype.parseKML = function parseKML(urlFile, longitude, latitude) {
     /* var longitude = 48.87;
     var south = 48.875;
     var east = -3.4900000000000046;
@@ -114,7 +114,7 @@ KML_Provider.prototype.parseKML = function (urlFile, longitude, latitude) {
 };
 
 
-KML_Provider.prototype.getUrlCollada = function (longitude, latitude) {
+KML_Provider.prototype.getUrlCollada = function getUrlCollada(longitude, latitude) {
     return Fetcher.xml('http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/vecteurtuile3d/BATI3D/BU.Building.kml').then((/* result_0*/) => {
         // get href's node value
         // var kml_0 = result_0.getElementsByTagName("href");

--- a/src/Core/Commander/Providers/PanoramicProvider.js
+++ b/src/Core/Commander/Providers/PanoramicProvider.js
@@ -44,7 +44,7 @@ PanoramicProvider.prototype = Object.create(Provider.prototype);
 PanoramicProvider.prototype.constructor = PanoramicProvider;
 
 
-PanoramicProvider.prototype.init = function (options) {
+PanoramicProvider.prototype.init = function init(options) {
     _urlPano = options.pano;
     _urlImage = options.url;
     _urlCam = options.cam;
@@ -57,14 +57,14 @@ PanoramicProvider.prototype.init = function (options) {
  * @param {type} distance
  * @returns {Promise}
  */
-PanoramicProvider.prototype.getMetaDataFromPos = function (longitude, latitude) {
+PanoramicProvider.prototype.getMetaDataFromPos = function getMetaDataFromPos(longitude, latitude) {
     if (_panoramicsMetaDataPromise == null) {
         var requestURL = _urlPano; // TODO : string_format
         _panoramicsMetaDataPromise = new Promise((resolve, reject) => {
             var req = new XMLHttpRequest();
             req.open('GET', requestURL);
 
-            req.onload = function () {
+            req.onload = function onloadFn() {
                 if (req.status === 200) {
                     resolve(JSON.parse(req.response));
                 } else {
@@ -72,7 +72,7 @@ PanoramicProvider.prototype.getMetaDataFromPos = function (longitude, latitude) 
                 }
             };
 
-            req.onerror = function () {
+            req.onerror = function onerrorFn() {
                 reject(Error('Network Error'));
             };
 
@@ -96,7 +96,7 @@ PanoramicProvider.prototype.getMetaDataFromPos = function (longitude, latitude) 
     });
 };
 
-PanoramicProvider.prototype.getTextureMaterial = function (panoInfo, pivot) {
+PanoramicProvider.prototype.getTextureMaterial = function getTextureMaterial(panoInfo, pivot) {
     return ProjectiveTexturingMaterial.init(_options, panoInfo, pivot); // Initialize itself Ori
 
     // ProjectiveTexturingMaterial.createShaderMat(_options);
@@ -104,12 +104,12 @@ PanoramicProvider.prototype.getTextureMaterial = function (panoInfo, pivot) {
 };
 
 
-PanoramicProvider.prototype.updateTextureMaterial = function (panoInfo, pivot) {
+PanoramicProvider.prototype.updateTextureMaterial = function updateTextureMaterial(panoInfo, pivot) {
     ProjectiveTexturingMaterial.updateUniforms(panoInfo, pivot);
 };
 
 
-PanoramicProvider.prototype.getGeometry = function (longitude, latitude, altitude) {
+PanoramicProvider.prototype.getGeometry = function getGeometry(longitude, latitude, altitude) {
     var w = 0.003;
     var bbox = {
         minCarto: {
@@ -143,14 +143,14 @@ PanoramicProvider.prototype.getGeometry = function (longitude, latitude, altitud
 // - Get Pano closest to lon lat (panoramic metadata)
 // - Get sensors informations (camera calibration)
 // - Get Building boxes from WFS
-PanoramicProvider.prototype.getTextureProjectiveMesh = function (longitude, latitude, distance) {
+PanoramicProvider.prototype.getTextureProjectiveMesh = function getTextureProjectiveMesh(longitude, latitude, distance) {
     return this.getMetaDataFromPos(longitude, latitude, distance).then(panoInfo => this.getGeometry(panoInfo.longitude, panoInfo.latitude, panoInfo.altitude)).then((data) => {
         this.geometry = data.geometry;
         this.absoluteCenter = data.pivot; // pivot in fact here, not absoluteCenter
         this.geometryRoof = data.roof;
 
         return this.getTextureMaterial(this.panoInfo, this.absoluteCenter);
-    }).then(function (shaderMaterial) {
+    }).then(function thenCb(shaderMaterial) {
         this.material = shaderMaterial; // new THREE.MeshBasicMaterial({color: 0xffffff, transparent: true, opacity: 0.8});
         // this.projectiveTexturedMesh = new THREE.Mesh(this.geometry, this.material);
         this.panoramicMesh = new PanoramicMesh(this.geometry, this.material, this.absoluteCenter);
@@ -169,7 +169,7 @@ PanoramicProvider.prototype.getTextureProjectiveMesh = function (longitude, lati
 };
 
 // Update existing panoramic mesh with new images look for the closest to parameters position
-PanoramicProvider.prototype.updateMaterialImages = function (longitude, latitude, distance) {
+PanoramicProvider.prototype.updateMaterialImages = function updateMaterialImages(longitude, latitude, distance) {
     return this.getMetaDataFromPos(longitude, latitude, distance).then((panoInfo) => {
         this.updateTextureMaterial(panoInfo, this.absoluteCenter);
         return panoInfo;
@@ -177,15 +177,15 @@ PanoramicProvider.prototype.updateMaterialImages = function (longitude, latitude
 };
 
 
-PanoramicProvider.prototype.getUrlImageFile = function () {
+PanoramicProvider.prototype.getUrlImageFile = function getUrlImageFile() {
     return _urlImage;
 };
 
-PanoramicProvider.prototype.getMetaDataSensorURL = function () {
+PanoramicProvider.prototype.getMetaDataSensorURL = function getMetaDataSensorURL() {
     return _urlCam;
 };
 
-PanoramicProvider.prototype.getMetaDataSensor = function () {
+PanoramicProvider.prototype.getMetaDataSensor = function getMetaDataSensor() {
 
 
 };

--- a/src/Core/Commander/Providers/Provider.js
+++ b/src/Core/Commander/Providers/Provider.js
@@ -16,7 +16,7 @@ Provider.prototype.constructor = Provider;
 /**
  * @param url
  */
-Provider.prototype.get = function (/* url*/) {
+Provider.prototype.get = function get(/* url*/) {
     // TODO: Implement Me
 
 };
@@ -25,14 +25,14 @@ Provider.prototype.get = function (/* url*/) {
  * preprocessLayer will be called each time a layer is added.
  * Allows the Provider to perform precomputations on the layer
  */
-Provider.prototype.preprocessLayer = function (/* layer*/) {
+Provider.prototype.preprocessLayer = function preprocessLayer(/* layer*/) {
 
 };
 
 /**
  * @param url
  */
-Provider.prototype.getInCache = function (/* url*/) {
+Provider.prototype.getInCache = function getInCache(/* url*/) {
     // TODO: Implement Me
 
 };

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -36,11 +36,11 @@ TileProvider.prototype = Object.create(Provider.prototype);
 
 TileProvider.prototype.constructor = TileProvider;
 
-TileProvider.prototype.preprocessLayer = function (/* layer*/) {
+TileProvider.prototype.preprocessLayer = function preprocessLayer(/* layer*/) {
     /* no-op */
 };
 
-TileProvider.prototype.getGeometry = function (bbox, cooWMTS) {
+TileProvider.prototype.getGeometry = function getGeometry(bbox, cooWMTS) {
     var geometry;
     var n = Math.pow(2, cooWMTS.zoom + 1);
     var part = Math.PI * 2.0 / n;
@@ -63,7 +63,7 @@ TileProvider.prototype.getGeometry = function (bbox, cooWMTS) {
 };
 
 
-TileProvider.prototype.executeCommand = function (command) {
+TileProvider.prototype.executeCommand = function executeCommand(command) {
     var bbox = command.paramsFunction.bbox;
 
     // TODO not generic

--- a/src/Core/Commander/Providers/WFS_Provider.js
+++ b/src/Core/Commander/Providers/WFS_Provider.js
@@ -39,7 +39,7 @@ WFS_Provider.prototype.constructor = WFS_Provider;
  * &REQUEST=GetFeature&typeName=BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie
  * &bbox=2.325,48.855,2.335,48.865,epsg:4326&outputFormat=json
  */
-WFS_Provider.prototype.url = function (bbox) {
+WFS_Provider.prototype.url = function url(bbox) {
     var url = `${this.baseUrl
         }SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature` +
         `&typeName=${this.typename}&BBOX=${
@@ -53,7 +53,7 @@ WFS_Provider.prototype.url = function (bbox) {
 /*
  * Return Data as Object (JSON parsed)
  */
-WFS_Provider.prototype.getData = function (bbox) {
+WFS_Provider.prototype.getData = function getData(bbox) {
     var url = this.url(bbox);
     return Fetcher.json(url);
 };

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -28,7 +28,7 @@ function WMS_Provider(/* options*/) {
     this.cache = CacheRessource();
     this.projection = new Projection();
 
-    this.getTextureFloat = function (buffer) {
+    this.getTextureFloat = function getTextureFloat(buffer) {
         // Start float to RGBA uint8
         var texture = new THREE.DataTexture(buffer, 256, 256, THREE.AlphaFormat, THREE.FloatType);
 
@@ -41,11 +41,11 @@ WMS_Provider.prototype = Object.create(Provider.prototype);
 
 WMS_Provider.prototype.constructor = WMS_Provider;
 
-WMS_Provider.prototype.url = function (bbox, layer) {
+WMS_Provider.prototype.url = function url(bbox, layer) {
     return this.customUrl(layer.customUrl, bbox);
 };
 
-WMS_Provider.prototype.customUrl = function (url, bbox) {
+WMS_Provider.prototype.customUrl = function customUrl(url, bbox) {
     var bboxDegS = `${bbox.south(UNIT.DEGREE)},${
                     bbox.west(UNIT.DEGREE)},${
                     bbox.north(UNIT.DEGREE)},${
@@ -56,7 +56,7 @@ WMS_Provider.prototype.customUrl = function (url, bbox) {
     return urld;
 };
 
-WMS_Provider.prototype.preprocessDataLayer = function (layer) {
+WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer) {
     if (!layer.name)
         { throw new Error('layerName is required.'); }
 
@@ -86,11 +86,11 @@ WMS_Provider.prototype.preprocessDataLayer = function (layer) {
                   }&HEIGHT=${layer.width}`;
 };
 
-WMS_Provider.prototype.tileInsideLimit = function (tile, layer) {
+WMS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) {
     return tile.level > 2 && layer.bbox.intersect(tile.bbox);
 };
 
-WMS_Provider.prototype.getColorTexture = function (tile, layer, bbox, pitch) {
+WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, bbox, pitch) {
     if (!this.tileInsideLimit(tile, layer) || tile.material === null) {
         return Promise.resolve();
     }
@@ -119,7 +119,7 @@ WMS_Provider.prototype.getColorTexture = function (tile, layer, bbox, pitch) {
     });
 };
 
-WMS_Provider.prototype.getXbilTexture = function (tile, layer, bbox, pitch) {
+WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, bbox, pitch) {
     var url = this.url(bbox, layer);
 
     // TODO: this is not optimal: if called again before the IoDriver resolves, it'll load the XBIL again
@@ -165,7 +165,7 @@ WMS_Provider.prototype.getXbilTexture = function (tile, layer, bbox, pitch) {
     });
 };
 
-WMS_Provider.prototype.executeCommand = function (command) {
+WMS_Provider.prototype.executeCommand = function executeCommand(command) {
     var layer = command.paramsFunction.layer;
     var tile = command.requester;
     var ancestor = command.paramsFunction.ancestor;
@@ -200,7 +200,7 @@ WMS_Provider.prototype.executeCommand = function (command) {
  * @param {BoundingBox} bbox: requested bounding box
  * @returns {WMS_Provider_L15.WMS_Provider.prototype@pro;_IoDriver@call;read@call;then}
  */
-WMS_Provider.prototype.getTexture = function (bbox) {
+WMS_Provider.prototype.getTexture = function getTexture(bbox) {
     if (bbox === undefined)
         { return Promise.resolve(-2); }
 

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -23,11 +23,11 @@ function WMTS_Provider(options) {
     this.getTextureFloat = null;
 
     if (this.support)
-        { this.getTextureFloat = function () {
+        { this.getTextureFloat = function getTextureFloat() {
             return new THREE.Texture();
         }; }
     else
-        { this.getTextureFloat = function (buffer) {
+        { this.getTextureFloat = function getTextureFloat(buffer) {
             // Start float to RGBA uint8
             // var bufferUint = new Uint8Array(buffer.buffer);
             // var texture = new THREE.DataTexture(bufferUint, 256, 256);
@@ -43,7 +43,7 @@ WMTS_Provider.prototype = Object.create(Provider.prototype);
 
 WMTS_Provider.prototype.constructor = WMTS_Provider;
 
-WMTS_Provider.prototype.customUrl = function (layer, url, tilematrix, row, col) {
+WMTS_Provider.prototype.customUrl = function customUrl(layer, url, tilematrix, row, col) {
     const tm = Math.min(layer.zoom.max, tilematrix);
 
     let urld = url.replace('%TILEMATRIX', tm.toString());
@@ -53,11 +53,11 @@ WMTS_Provider.prototype.customUrl = function (layer, url, tilematrix, row, col) 
     return urld;
 };
 
-WMTS_Provider.prototype.removeLayer = function (/* idLayer*/) {
+WMTS_Provider.prototype.removeLayer = function removeLayer(/* idLayer*/) {
 
 };
 
-WMTS_Provider.prototype.preprocessDataLayer = function (layer) {
+WMTS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer) {
     layer.fx = layer.fx || 0.0;
     if (layer.protocol === 'wmtsc') {
         layer.zoom = {
@@ -98,7 +98,7 @@ WMTS_Provider.prototype.preprocessDataLayer = function (layer) {
  * @param {type} coWMTS
  * @returns {Object@call;create.urlOrtho.url|String}
  */
-WMTS_Provider.prototype.url = function (coWMTS, layer) {
+WMTS_Provider.prototype.url = function url(coWMTS, layer) {
     return this.customUrl(layer, layer.customUrl, coWMTS.zoom, coWMTS.row, coWMTS.col);
 };
 
@@ -107,7 +107,7 @@ WMTS_Provider.prototype.url = function (coWMTS, layer) {
  * @param {type} coWMTS : coord WMTS
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
  */
-WMTS_Provider.prototype.getXbilTexture = function (tile, layer, parameters) {
+WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, parameters) {
     var cooWMTS = tile.matrixSet[layer.options.tileMatrixSet][0];
     var pitch = new THREE.Vector3(0.0, 0.0, 1.0);
 
@@ -186,7 +186,7 @@ WMTS_Provider.prototype.getXbilTexture = function (tile, layer, parameters) {
  * @param {type} id
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;ioDriverImage@call;read@call;then}
  */
-WMTS_Provider.prototype.getColorTexture = function (coWMTS, pitch, layer) {
+WMTS_Provider.prototype.getColorTexture = function getColorTexture(coWMTS, pitch, layer) {
     var result = {
         pitch,
     };
@@ -213,7 +213,7 @@ WMTS_Provider.prototype.getColorTexture = function (coWMTS, pitch, layer) {
     });
 };
 
-WMTS_Provider.prototype.executeCommand = function (command) {
+WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
     var layer = command.paramsFunction.layer;
     var tile = command.requester;
 
@@ -233,7 +233,7 @@ WMTS_Provider.prototype.executeCommand = function (command) {
 };
 
 
-WMTS_Provider.prototype.computeLevelToDownload = function (tile, ancestor, layer) {
+WMTS_Provider.prototype.computeLevelToDownload = function computeLevelToDownload(tile, ancestor, layer) {
     // Use ancestor's level if valid, else fallback on tile's level
     var lvl = ancestor ? ancestor.level : tile.level;
 
@@ -244,14 +244,14 @@ WMTS_Provider.prototype.computeLevelToDownload = function (tile, ancestor, layer
             lvl));
 };
 
-WMTS_Provider.prototype.tileInsideLimit = function (tile, layer) {
+WMTS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) {
     // This layer provides data starting at level = layer.zoom.min
     // (the zoom.max property is used when building the url to make
     //  sure we don't use invalid levels)
     return layer.zoom.min <= tile.level;
 };
 
-WMTS_Provider.prototype.getColorTextures = function (tile, layer, parameters) {
+WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer, parameters) {
     var promises = [];
     if (tile.material === null) {
         return Promise.resolve();

--- a/src/Core/Commander/TemplatesCommand.js
+++ b/src/Core/Commander/TemplatesCommand.js
@@ -13,7 +13,7 @@ function TemplatesCommand() {
 
 /**
  */
-TemplatesCommand.prototype.xmlToCommands = function () {
+TemplatesCommand.prototype.xmlToCommands = function xmlToCommands() {
     // TODO: Implement Me
 
 };
@@ -21,7 +21,7 @@ TemplatesCommand.prototype.xmlToCommands = function () {
 
 /**
  */
-TemplatesCommand.prototype.specifiesCommand = function () {
+TemplatesCommand.prototype.specifiesCommand = function specifiesCommand() {
     // TODO: Implement Me
 
 };

--- a/src/Core/Geographic/CoordWMTS.js
+++ b/src/Core/Geographic/CoordWMTS.js
@@ -27,11 +27,11 @@ function CoordWMTS(zoom, row, col) {
 
 CoordWMTS.prototype.constructor = CoordWMTS;
 
-CoordWMTS.prototype.clone = function () {
+CoordWMTS.prototype.clone = function cloneCoord() {
     return new CoordWMTS(this.zoom, this.row, this.col);
 };
 
-CoordWMTS.prototype.isInside = function (limit) {
+CoordWMTS.prototype.isInside = function isInside(limit) {
     return this.row >= limit.minTileRow && this.row <= limit.maxTileRow && this.col <= limit.maxTileCol && this.col >= limit.minTileCol;
 };
 

--- a/src/Core/Geographic/GeoCoordinate.js
+++ b/src/Core/Geographic/GeoCoordinate.js
@@ -23,7 +23,7 @@ export const UNIT = {
     METER: 2,
 };
 
-var getCoordinateValue = function (unit, coord, id)
+var getCoordinateValue = function getCoordinateValue(unit, coord, id)
 {
     unit = defaultValue(unit, UNIT.RADIAN);
 
@@ -36,7 +36,7 @@ var getCoordinateValue = function (unit, coord, id)
   { return mE.radToDeg(coord[id]); }
 };
 
-var setCoordinateValue = function (unit, coord, id, value)
+var setCoordinateValue = function setCoordinateValue(unit, coord, id, value)
 {
     unit = defaultValue(unit, UNIT.RADIAN);
 
@@ -49,7 +49,7 @@ var setCoordinateValue = function (unit, coord, id, value)
   { return coord[id] = mE.degToRad(value); }
 };
 
-var setCoordinate = function (coordinate, longitude, latitude, altitude, unit) {
+var setCoordinate = function setCoordinate(coordinate, longitude, latitude, altitude, unit) {
     unit = defaultValue(unit, UNIT.RADIAN);
 
     setCoordinateValue(unit, coordinate, COORD.LONG, longitude);
@@ -66,45 +66,45 @@ function GeoCoordinate(longitude, latitude, altitude, unit) {
 
 GeoCoordinate.prototype.constructor = GeoCoordinate;
 
-GeoCoordinate.prototype.longitude = function (unit) {
+GeoCoordinate.prototype.longitude = function longitude(unit) {
     return getCoordinateValue(unit, this.coordinate, COORD.LONG);
 };
 
-GeoCoordinate.prototype.setLongitude = function (longitude, unit) {
+GeoCoordinate.prototype.setLongitude = function setLongitude(longitude, unit) {
     setCoordinateValue(unit, this.coordinate, COORD.LONG, longitude);
 };
 
-GeoCoordinate.prototype.latitude = function (unit) {
+GeoCoordinate.prototype.latitude = function latitude(unit) {
     return getCoordinateValue(unit, this.coordinate, COORD.LAT);
 };
 
-GeoCoordinate.prototype.setLatitude = function (latitude, unit) {
+GeoCoordinate.prototype.setLatitude = function setLatitude(latitude, unit) {
     setCoordinateValue(unit, this.coordinate, COORD.LAT, latitude);
 };
 
-GeoCoordinate.prototype.altitude = function () {
+GeoCoordinate.prototype.altitude = function altitude() {
     return this.coordinate[COORD.ALT];
 };
 
-GeoCoordinate.prototype.setAltitude = function (altitude) {
+GeoCoordinate.prototype.setAltitude = function setAltitude(altitude) {
     this.coordinate[COORD.ALT] = altitude;
 };
 
 
-GeoCoordinate.prototype.set = function (longitude, latitude, altitude, unit) {
+GeoCoordinate.prototype.set = function set(longitude, latitude, altitude, unit) {
     setCoordinate(this.coordinate, longitude, latitude, altitude, unit);
 
     return this;
 };
 
-GeoCoordinate.prototype.copy = function (coordinate, unit) {
+GeoCoordinate.prototype.copy = function copyCoordinate(coordinate, unit) {
     if (coordinate instanceof GeoCoordinate)
 		{ return this.set(coordinate.longitude(), coordinate.latitude(), coordinate.altitude(), unit); }
     else
 		{ return this.set(coordinate.longitude, coordinate.latitude, coordinate.altitude, unit); }
 };
 
-GeoCoordinate.prototype.clone = function () {
+GeoCoordinate.prototype.clone = function cloneCoordinate() {
     return new GeoCoordinate().copy(this);
 };
 

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -15,15 +15,15 @@ function Projection() {
 
 }
 
-Projection.prototype.WGS84ToY = function (latitude) {
+Projection.prototype.WGS84ToY = function WGS84ToY(latitude) {
     return 0.5 - Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
 };
 
-Projection.prototype.WGS84ToOneSubY = function (latitude) {
+Projection.prototype.WGS84ToOneSubY = function WGS84ToOneSubY(latitude) {
     return 0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
 };
 
-Projection.prototype.WGS84LatitudeClamp = function (latitude) {
+Projection.prototype.WGS84LatitudeClamp = function WGS84LatitudeClamp(latitude) {
     // var min = -68.1389  / 180 * Math.PI;
     var min = -86 / 180 * Math.PI;
     var max = 84 / 180 * Math.PI;
@@ -35,14 +35,14 @@ Projection.prototype.WGS84LatitudeClamp = function (latitude) {
 };
 
 
-Projection.prototype.getCoordWMTS_WGS84 = function (tileCoord, bbox, tileMatrixSet) {
+Projection.prototype.getCoordWMTS_WGS84 = function getCoordWMTS_WGS84(tileCoord, bbox, tileMatrixSet) {
     if (tileMatrixSet === 'PM')
         { return this.WMTS_WGS84ToWMTS_PM(tileCoord, bbox); }
     else if (tileMatrixSet === 'WGS84G')
         { return [tileCoord, tileCoord]; }
 };
 
-Projection.prototype.getAllCoordsWMTS = function (tileCoord, bbox, tileMatrixSets) {
+Projection.prototype.getAllCoordsWMTS = function getAllCoordsWMTS(tileCoord, bbox, tileMatrixSets) {
     var tilesMT = [];
 
     for (var key in tileMatrixSets)
@@ -52,7 +52,7 @@ Projection.prototype.getAllCoordsWMTS = function (tileCoord, bbox, tileMatrixSet
     return tilesMT;
 };
 
-Projection.prototype.getCoordsWMTS = function (tileCoord, bbox, tileMatrixSet) {
+Projection.prototype.getCoordsWMTS = function getCoordsWMTS(tileCoord, bbox, tileMatrixSet) {
     var box = this.getCoordWMTS_WGS84(tileCoord, bbox, tileMatrixSet);
     var tilesMT = [];
 
@@ -71,7 +71,7 @@ Projection.prototype.getCoordsWMTS = function (tileCoord, bbox, tileMatrixSet) {
  * @param {type} bbox
  * @returns {Array} coord WMTS array in pseudo mercator
  */
-Projection.prototype.WMTS_WGS84ToWMTS_PM = function (cWMTS, bbox) {
+Projection.prototype.WMTS_WGS84ToWMTS_PM = function WMTS_WGS84ToWMTS_PM(cWMTS, bbox) {
     var wmtsBox = [];
     var level = cWMTS.zoom + 1;
     var nbRow = Math.pow(2, level);
@@ -105,7 +105,7 @@ Projection.prototype.WMTS_WGS84ToWMTS_PM = function (cWMTS, bbox) {
     return wmtsBox;
 };
 
-Projection.prototype.WMTS_WGS84Parent = function (cWMTS, levelParent, pitch) {
+Projection.prototype.WMTS_WGS84Parent = function WMTS_WGS84Parent(cWMTS, levelParent, pitch) {
     var diffLevel = cWMTS.zoom - levelParent;
     var diff = Math.pow(2, diffLevel);
     var invDiff = 1 / diff;
@@ -120,7 +120,7 @@ Projection.prototype.WMTS_WGS84Parent = function (cWMTS, levelParent, pitch) {
     return new CoordWMTS(levelParent, r, c);
 };
 
-Projection.prototype.WMS_WGS84Parent = function (bbox, bboxParent) {
+Projection.prototype.WMS_WGS84Parent = function WMS_WGS84Parent(bbox, bboxParent) {
     var scale = bbox.dimension.x / bboxParent.dimension.x;
 
     var x =
@@ -135,7 +135,7 @@ Projection.prototype.WMS_WGS84Parent = function (bbox, bboxParent) {
     return new THREE.Vector3(x, y, scale);
 };
 
-Projection.prototype.WGS84toWMTS = function (bbox) {
+Projection.prototype.WGS84toWMTS = function WGS84toWMTS(bbox) {
     var zoom = Math.floor(Math.log(MathExt.PI / bbox.dimension.y) / MathExt.LOG_TWO + 0.5);
 
     var nY = Math.pow(2, zoom);
@@ -150,15 +150,15 @@ Projection.prototype.WGS84toWMTS = function (bbox) {
     return new CoordWMTS(zoom, row, col);
 };
 
-Projection.prototype.UnitaryToLongitudeWGS84 = function (u, projection, bbox) {
+Projection.prototype.UnitaryToLongitudeWGS84 = function UnitaryToLongitudeWGS84(u, projection, bbox) {
     projection.setLongitude(bbox.west() + u * bbox.dimension.x);
 };
 
-Projection.prototype.UnitaryToLatitudeWGS84 = function (v, projection, bbox) {
+Projection.prototype.UnitaryToLatitudeWGS84 = function UnitaryToLatitudeWGS84(v, projection, bbox) {
     projection.setLatitude(bbox.south() + v * bbox.dimension.y);
 };
 
-Projection.prototype.cartesianToGeo = function (position) {
+Projection.prototype.cartesianToGeo = function cartesianToGeo(position) {
     // TODO: warning switch coord
     var p = position.clone();
     p.x = position.x;
@@ -186,7 +186,7 @@ Projection.prototype.cartesianToGeo = function (position) {
     return new GeoCoordinate(-theta, phi, h);
 };
 
-Projection.prototype.wgs84_to_lambert93 = function (latitude, longitude) // , x93, y93)
+Projection.prototype.wgs84_to_lambert93 = function wgs84_to_lambert93(latitude, longitude) // , x93, y93)
     {
         /*
         rfrences :
@@ -202,7 +202,7 @@ Projection.prototype.wgs84_to_lambert93 = function (latitude, longitude) // , x9
     var e = 0.08181919106; // premire excentricit de l'ellipsoide
 
 
-    var deg2rad = function () {};
+    var deg2rad = function deg2rad() {};
 
         // paramtres de projections
         // var l0 =deg2rad(3);

--- a/src/Core/Geographic/Quad.js
+++ b/src/Core/Geographic/Quad.js
@@ -13,7 +13,7 @@ function Quad(bbox) {
     this.southEast = new BoundingBox(bbox.center.x, bbox.east(), bbox.south(), bbox.center.y);
 }
 
-Quad.prototype.array = function () {
+Quad.prototype.array = function array() {
     var subdiv = [];
 
     subdiv.push(this.northWest);

--- a/src/Core/Math/Binary.js
+++ b/src/Core/Math/Binary.js
@@ -6,17 +6,17 @@ var Binary = {};
 // Unsigned right-shifting is simple: just move the bits,
 // while shifting in zeros from the left.
 // The sign is not preserved, the result is always a Uint32
-Binary.ToUint32 = function (x) {
+Binary.ToUint32 = function ToUint32(x) {
     return x >>> 0;
 };
 
-Binary.ToInt32 = function (x) {
+Binary.ToInt32 = function ToInt32(x) {
     return x >> 0;
 };
 
 
 // Convert flag to char
-Binary.toChar = function (nMask) {
+Binary.toChar = function toChar(nMask) {
     var nFlag,
         nShifted = nMask,
         sMask = '';

--- a/src/Core/Math/CVML.js
+++ b/src/Core/Math/CVML.js
@@ -10,13 +10,13 @@ var CVML = CVML || {
 CVML.epsilon = 2.220446049250313e-16;
 // Point
 
-CVML.Point2D = function (x, y) {
+CVML.Point2D = function Point2D(x, y) {
     this.x = x;
     this.y = y;
 };
 
 
-var PointError = function (message, points) {
+var PointError = function PointError(message, points) {
     this.name = 'PointError';
     this.points = points = points || [];
     this.message = message || 'Invalid Points!';
@@ -33,7 +33,7 @@ PointError.prototype.constructor = PointError;
  * @param {Number} x    coordinate (0 if undefined)
  * @param {Number} y    coordinate (0 if undefined)
  */
-var Point = function (x, y) {
+var Point = function Point(x, y) {
     this.x = +x || 0;
     this.y = +y || 0;
 
@@ -47,7 +47,7 @@ var Point = function (x, y) {
 /**
  * For pretty printing ex. "(5;42)"
  */
-Point.prototype.toString = function () {
+Point.prototype.toString = function toStringFn() {
     return (`(${this.x};${this.y})`);
 };
 
@@ -55,14 +55,14 @@ Point.prototype.toString = function () {
  * Creates a copy of this Point object.
  * @returns Point
  */
-Point.prototype.clone = function () {
+Point.prototype.clone = function clone() {
     return new Point(this.x, this.y);
 };
 
 /**
  * Set this Point instance to the origo. (0; 0)
  */
-Point.prototype.set_zero = function () {
+Point.prototype.set_zero = function set_zero() {
     this.x = 0.0;
     this.y = 0.0;
     return this; // for chaining
@@ -73,7 +73,7 @@ Point.prototype.set_zero = function () {
  * @param   x   number.
  * @param   y   number;
  */
-Point.prototype.set = function (x, y) {
+Point.prototype.set = function set(x, y) {
     this.x = +x || 0;
     this.y = +y || 0;
     return this; // for chaining
@@ -82,7 +82,7 @@ Point.prototype.set = function (x, y) {
 /**
  * Negate this Point instance. (component-wise)
  */
-Point.prototype.negate = function () {
+Point.prototype.negate = function negate() {
     this.x = -this.x;
     this.y = -this.y;
     return this; // for chaining
@@ -92,7 +92,7 @@ Point.prototype.negate = function () {
  * Add another Point object to this instance. (component-wise)
  * @param   n   Point object.
  */
-Point.prototype.add = function (n) {
+Point.prototype.add = function add(n) {
     this.x += n.x;
     this.y += n.y;
     return this; // for chaining
@@ -102,7 +102,7 @@ Point.prototype.add = function (n) {
  * Subtract this Point instance with another point given. (component-wise)
  * @param   n   Point object.
  */
-Point.prototype.sub = function (n) {
+Point.prototype.sub = function sub(n) {
     this.x -= n.x;
     this.y -= n.y;
     return this; // for chaining
@@ -112,7 +112,7 @@ Point.prototype.sub = function (n) {
  * Multiply this Point instance by a scalar. (component-wise)
  * @param   s   scalar.
  */
-Point.prototype.mul = function (s) {
+Point.prototype.mul = function mul(s) {
     this.x *= s;
     this.y *= s;
     return this; // for chaining
@@ -121,7 +121,7 @@ Point.prototype.mul = function (s) {
 /**
  * Return the distance of this Point instance from the origo.
  */
-Point.prototype.length = function () {
+Point.prototype.length = function length() {
     return Math.sqrt(this.x * this.x + this.y * this.y);
 };
 
@@ -129,7 +129,7 @@ Point.prototype.length = function () {
  * Normalize this Point instance (as a vector).
  * @return The original distance of this instance from the origo.
  */
-Point.prototype.normalize = function () {
+Point.prototype.normalize = function normalize() {
     var len = this.length();
     this.x /= len;
     this.y /= len;
@@ -141,7 +141,7 @@ Point.prototype.normalize = function () {
  * @param   p   any "Point like" object with {x,y} (duck typing)
  * @return True if this == p, false otherwise.
  */
-Point.prototype.equals = function (p) {
+Point.prototype.equals = function equals(p) {
     return this.x === p.x && this.y === p.y;
 };
 
@@ -151,7 +151,7 @@ Point.prototype.equals = function (p) {
  * @param   p   Point object.
  * @return the resulting Point object.
  */
-Point.negate = function (p) {
+Point.negate = function negate(p) {
     return new Point(-p.x, -p.y);
 };
 
@@ -161,7 +161,7 @@ Point.negate = function (p) {
  * @param   b   Point object.
  * @return the resulting Point object.
  */
-Point.add = function (a, b) {
+Point.add = function add(a, b) {
     return new Point(a.x + b.x, a.y + b.y);
 };
 
@@ -171,7 +171,7 @@ Point.add = function (a, b) {
  * @param   b   Point object.
  * @return the resulting Point object.
  */
-Point.sub = function (a, b) {
+Point.sub = function sub(a, b) {
     return new Point(a.x - b.x, a.y - b.y);
 };
 
@@ -181,7 +181,7 @@ Point.sub = function (a, b) {
  * @param   p   Point object.
  * @return the resulting Point object.
  */
-Point.mul = function (s, p) {
+Point.mul = function mul(s, p) {
     return new Point(s * p.x, s * p.y);
 };
 
@@ -194,7 +194,7 @@ Point.mul = function (s, p) {
  * @param   b   Point object or scalar.
  * @return  a   Point object or a number, depending on the parameters.
  */
-Point.cross = function (a, b) {
+Point.cross = function cross(a, b) {
     if (typeof (a) === 'number') {
         if (typeof (b) === 'number') {
             return a * b;
@@ -215,14 +215,14 @@ Point.cross = function (a, b) {
  * @param   p   any "Point like" object with {x,y}
  * @returns {String}
  */
-Point.toString = function (p) {
+Point.toString = function toStringFn(p) {
     // Try a custom toString first, and fallback to Point.prototype.toString if none
     var s = p.toString();
     return (s === '[object Object]' ? Point.prototype.toString.call(p) : s);
 };
 
 
-Point.compare = function (a, b) {
+Point.compare = function compare(a, b) {
     if (a.y === b.y) {
         return a.x - b.x;
     } else {
@@ -231,7 +231,7 @@ Point.compare = function (a, b) {
 };
 Point.cmp = Point.compare; // backward compatibility
 
-Point.equals = function (a, b) {
+Point.equals = function equals(a, b) {
     return a.x === b.x && a.y === b.y;
 };
 
@@ -240,11 +240,11 @@ Point.equals = function (a, b) {
  * @param   a,b   any "Point like" objects with {x,y}
  * @return The dot product (as a number).
  */
-Point.dot = function (a, b) {
+Point.dot = function dot(a, b) {
     return a.x * b.x + a.y * b.y;
 };
 
-Point.prototype.distanceTo = function (v) {
+Point.prototype.distanceTo = function distanceTo(v) {
     var dx = this.x - v.x;
     var dy = this.y - v.y;
     return Math.sqrt(dx * dx + dy * dy);
@@ -256,7 +256,7 @@ Point.prototype.distanceTo = function (v) {
  * @param {Point} p1
  * @param {Point} p2
  */
-var Edge = function (p1, p2) {
+var Edge = function Edge(p1, p2) {
     this.p = p1;
     this.q = p2;
 
@@ -288,7 +288,7 @@ var Edge = function (p1, p2) {
  *
  * @param   a,b,c   any "Point like" objects with {x,y} (duck typing)
  */
-var Triangle = function (a, b, c) {
+var Triangle = function Triangle(a, b, c) {
     // Triangle points
     this.points_ = [a, b, c];
     // Neighbor list
@@ -302,23 +302,23 @@ var Triangle = function (a, b, c) {
 };
 
 
-Triangle.prototype.toString = function () {
+Triangle.prototype.toString = function toStringFn() {
     var p2s = Point.toString;
     return (`[${p2s(this.points_[0])}${p2s(this.points_[1])}${p2s(this.points_[2])}]`);
 };
 
-Triangle.prototype.getPoint = function (index) {
+Triangle.prototype.getPoint = function getPoint(index) {
     return this.points_[index];
 };
 // for backward compatibility
 Triangle.prototype.GetPoint = Triangle.prototype.getPoint;
 
-Triangle.prototype.getNeighbor = function (index) {
+Triangle.prototype.getNeighbor = function getNeighbor(index) {
     return this.neighbors_[index];
 };
 
 
-Triangle.prototype.containsPoint = function (point) {
+Triangle.prototype.containsPoint = function containsPoint(point) {
     var points = this.points_;
     // Here we are comparing point references, not values
     return (point === points[0] || point === points[1] || point === points[2]);
@@ -330,18 +330,18 @@ Triangle.prototype.containsPoint = function (point) {
  * @return True if the Edge object is of the Triangle's bounding
  *         edges, false otherwise.
  */
-Triangle.prototype.containsEdge = function (edge) {
+Triangle.prototype.containsEdge = function containsEdge(edge) {
     return this.containsPoint(edge.p) && this.containsPoint(edge.q);
 };
-Triangle.prototype.containsPoints = function (p1, p2) {
+Triangle.prototype.containsPoints = function containsPoints(p1, p2) {
     return this.containsPoint(p1) && this.containsPoint(p2);
 };
 
 
-Triangle.prototype.isInterior = function () {
+Triangle.prototype.isInterior = function isInterior() {
     return this.interior_;
 };
-Triangle.prototype.setInterior = function (interior) {
+Triangle.prototype.setInterior = function setInterior(interior) {
     this.interior_ = interior;
     return this;
 };
@@ -352,7 +352,7 @@ Triangle.prototype.setInterior = function (interior) {
  * @param {Point} p2 Point object.
  * @param {Triangle} t Triangle object.
  */
-Triangle.prototype.markNeighborPointers = function (p1, p2, t) {
+Triangle.prototype.markNeighborPointers = function markNeighborPointers(p1, p2, t) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if ((p1 === points[2] && p2 === points[1]) || (p1 === points[1] && p2 === points[2])) {
@@ -370,7 +370,7 @@ Triangle.prototype.markNeighborPointers = function (p1, p2, t) {
  * Exhaustive search to update neighbor pointers
  * @param {Triangle} t
  */
-Triangle.prototype.markNeighbor = function (t) {
+Triangle.prototype.markNeighbor = function markNeighbor(t) {
     var points = this.points_;
     if (t.containsPoints(points[1], points[2])) {
         this.neighbors_[0] = t;
@@ -385,13 +385,13 @@ Triangle.prototype.markNeighbor = function (t) {
 };
 
 
-Triangle.prototype.clearNeigbors = function () {
+Triangle.prototype.clearNeigbors = function clearNeigbors() {
     this.neighbors_[0] = null;
     this.neighbors_[1] = null;
     this.neighbors_[2] = null;
 };
 
-Triangle.prototype.clearDelunayEdges = function () {
+Triangle.prototype.clearDelunayEdges = function clearDelunayEdges() {
     this.delaunay_edge[0] = false;
     this.delaunay_edge[1] = false;
     this.delaunay_edge[2] = false;
@@ -400,7 +400,7 @@ Triangle.prototype.clearDelunayEdges = function () {
 /**
  * Returns the point clockwise to the given point.
  */
-Triangle.prototype.pointCW = function (p) {
+Triangle.prototype.pointCW = function pointCW(p) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if (p === points[0]) {
@@ -417,7 +417,7 @@ Triangle.prototype.pointCW = function (p) {
 /**
  * Returns the point counter-clockwise to the given point.
  */
-Triangle.prototype.pointCCW = function (p) {
+Triangle.prototype.pointCCW = function pointCCW(p) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if (p === points[0]) {
@@ -434,7 +434,7 @@ Triangle.prototype.pointCCW = function (p) {
 /**
  * Returns the neighbor clockwise to given point.
  */
-Triangle.prototype.neighborCW = function (p) {
+Triangle.prototype.neighborCW = function neighborCW(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.neighbors_[1];
@@ -448,7 +448,7 @@ Triangle.prototype.neighborCW = function (p) {
 /**
  * Returns the neighbor counter-clockwise to given point.
  */
-Triangle.prototype.neighborCCW = function (p) {
+Triangle.prototype.neighborCCW = function neighborCCW(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.neighbors_[2];
@@ -459,7 +459,7 @@ Triangle.prototype.neighborCCW = function (p) {
     }
 };
 
-Triangle.prototype.getConstrainedEdgeCW = function (p) {
+Triangle.prototype.getConstrainedEdgeCW = function getConstrainedEdgeCW(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.constrained_edge[1];
@@ -470,7 +470,7 @@ Triangle.prototype.getConstrainedEdgeCW = function (p) {
     }
 };
 
-Triangle.prototype.getConstrainedEdgeCCW = function (p) {
+Triangle.prototype.getConstrainedEdgeCCW = function getConstrainedEdgeCCW(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.constrained_edge[2];
@@ -481,7 +481,7 @@ Triangle.prototype.getConstrainedEdgeCCW = function (p) {
     }
 };
 
-Triangle.prototype.setConstrainedEdgeCW = function (p, ce) {
+Triangle.prototype.setConstrainedEdgeCW = function setConstrainedEdgeCW(p, ce) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         this.constrained_edge[1] = ce;
@@ -492,7 +492,7 @@ Triangle.prototype.setConstrainedEdgeCW = function (p, ce) {
     }
 };
 
-Triangle.prototype.setConstrainedEdgeCCW = function (p, ce) {
+Triangle.prototype.setConstrainedEdgeCCW = function setConstrainedEdgeCCW(p, ce) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         this.constrained_edge[2] = ce;
@@ -503,7 +503,7 @@ Triangle.prototype.setConstrainedEdgeCCW = function (p, ce) {
     }
 };
 
-Triangle.prototype.getDelaunayEdgeCW = function (p) {
+Triangle.prototype.getDelaunayEdgeCW = function getDelaunayEdgeCW(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.delaunay_edge[1];
@@ -514,7 +514,7 @@ Triangle.prototype.getDelaunayEdgeCW = function (p) {
     }
 };
 
-Triangle.prototype.getDelaunayEdgeCCW = function (p) {
+Triangle.prototype.getDelaunayEdgeCCW = function getDelaunayEdgeCCW(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.delaunay_edge[2];
@@ -525,7 +525,7 @@ Triangle.prototype.getDelaunayEdgeCCW = function (p) {
     }
 };
 
-Triangle.prototype.setDelaunayEdgeCW = function (p, e) {
+Triangle.prototype.setDelaunayEdgeCW = function setDelaunayEdgeCW(p, e) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         this.delaunay_edge[1] = e;
@@ -536,7 +536,7 @@ Triangle.prototype.setDelaunayEdgeCW = function (p, e) {
     }
 };
 
-Triangle.prototype.setDelaunayEdgeCCW = function (p, e) {
+Triangle.prototype.setDelaunayEdgeCCW = function setDelaunayEdgeCCW(p, e) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         this.delaunay_edge[2] = e;
@@ -550,7 +550,7 @@ Triangle.prototype.setDelaunayEdgeCCW = function (p, e) {
 /**
  * The neighbor across to given point.
  */
-Triangle.prototype.neighborAcross = function (p) {
+Triangle.prototype.neighborAcross = function neighborAcross(p) {
     // Here we are comparing point references, not values
     if (p === this.points_[0]) {
         return this.neighbors_[0];
@@ -561,7 +561,7 @@ Triangle.prototype.neighborAcross = function (p) {
     }
 };
 
-Triangle.prototype.oppositePoint = function (t, p) {
+Triangle.prototype.oppositePoint = function oppositePoint(t, p) {
     var cw = t.pointCW(p);
     return this.pointCW(cw);
 };
@@ -571,7 +571,7 @@ Triangle.prototype.oppositePoint = function (t, p) {
  * @param {Point} opoint
  * @param {Point} npoint
  */
-Triangle.prototype.legalize = function (opoint, npoint) {
+Triangle.prototype.legalize = function legalize(opoint, npoint) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if (opoint === points[0]) {
@@ -597,7 +597,7 @@ Triangle.prototype.legalize = function (opoint, npoint) {
  * @param {Point} p Point object
  * @returns {Number} index 0, 1 or 2
  */
-Triangle.prototype.index = function (p) {
+Triangle.prototype.index = function index(p) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if (p === points[0]) {
@@ -611,7 +611,7 @@ Triangle.prototype.index = function (p) {
     }
 };
 
-Triangle.prototype.edgeIndex = function (p1, p2) {
+Triangle.prototype.edgeIndex = function edgeIndex(p1, p2) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if (p1 === points[0]) {
@@ -641,13 +641,13 @@ Triangle.prototype.edgeIndex = function (p1, p2) {
  * This method takes either 1 parameter (an edge index or an Edge instance) or
  * 2 parameters (two Point instances defining the edge of the triangle).
  */
-Triangle.prototype.markConstrainedEdgeByIndex = function (index) {
+Triangle.prototype.markConstrainedEdgeByIndex = function markConstrainedEdgeByIndex(index) {
     this.constrained_edge[index] = true;
 };
-Triangle.prototype.markConstrainedEdgeByEdge = function (edge) {
+Triangle.prototype.markConstrainedEdgeByEdge = function markConstrainedEdgeByEdge(edge) {
     this.markConstrainedEdgeByPoints(edge.p, edge.q);
 };
-Triangle.prototype.markConstrainedEdgeByPoints = function (p, q) {
+Triangle.prototype.markConstrainedEdgeByPoints = function markConstrainedEdgeByPoints(p, q) {
     var points = this.points_;
     // Here we are comparing point references, not values
     if ((q === points[0] && p === points[1]) || (q === points[1] && p === points[0])) {
@@ -719,7 +719,7 @@ function inScanArea(pa, pb, pc, pd) {
     return true;
 }
 
-var Node = function (p, t) {
+var Node = function Node(p, t) {
     this.point = p;
     this.triangle = t || null;
 
@@ -729,42 +729,42 @@ var Node = function (p, t) {
     this.value = p.x;
 };
 
-var AdvancingFront = function (head, tail) {
+var AdvancingFront = function AdvancingFront(head, tail) {
     this.head_ = head; // Node
     this.tail_ = tail; // Node
     this.search_node_ = head; // Node
 };
 
-AdvancingFront.prototype.head = function () {
+AdvancingFront.prototype.head = function head() {
     return this.head_;
 };
 
-AdvancingFront.prototype.setHead = function (node) {
+AdvancingFront.prototype.setHead = function setHead(node) {
     this.head_ = node;
 };
 
-AdvancingFront.prototype.tail = function () {
+AdvancingFront.prototype.tail = function tail() {
     return this.tail_;
 };
 
-AdvancingFront.prototype.setTail = function (node) {
+AdvancingFront.prototype.setTail = function setTail(node) {
     this.tail_ = node;
 };
 
-AdvancingFront.prototype.search = function () {
+AdvancingFront.prototype.search = function search() {
     return this.search_node_;
 };
 
-AdvancingFront.prototype.setSearch = function (node) {
+AdvancingFront.prototype.setSearch = function setSearch(node) {
     this.search_node_ = node;
 };
 
-AdvancingFront.prototype.findSearchNode = function (/* x*/) {
+AdvancingFront.prototype.findSearchNode = function findSearchNode(/* x*/) {
     // TODO: implement BST index
     return this.search_node_;
 };
 
-AdvancingFront.prototype.locateNode = function (x) {
+AdvancingFront.prototype.locateNode = function locateNode(x) {
     var node = this.search_node_;
 
     /* jshint boss:true */
@@ -786,7 +786,7 @@ AdvancingFront.prototype.locateNode = function (x) {
     return null;
 };
 
-AdvancingFront.prototype.locatePoint = function (point) {
+AdvancingFront.prototype.locatePoint = function locatePoint(point) {
     var px = point.x;
     var node = this.findSearchNode(px);
     var nx = node.point.x;
@@ -825,7 +825,7 @@ AdvancingFront.prototype.locatePoint = function (point) {
 };
 
 // ----------Basin
-var Basin = function () {
+var Basin = function Basin() {
     this.left_node = null; // Node
     this.bottom_node = null; // Node
     this.right_node = null; // Node
@@ -833,7 +833,7 @@ var Basin = function () {
     this.left_highest = false;
 };
 
-Basin.prototype.clear = function () {
+Basin.prototype.clear = function clear() {
     this.left_node = null;
     this.bottom_node = null;
     this.right_node = null;
@@ -842,7 +842,7 @@ Basin.prototype.clear = function () {
 };
 
 // ----------EdgeEvent
-var EdgeEvent = function () {
+var EdgeEvent = function EdgeEvent() {
     this.constrained_edge = null; // Edge
     this.right = false;
 };
@@ -859,7 +859,7 @@ var EdgeEvent = function () {
  * @param {Array} contour  array of "Point like" objects with {x,y} (duck typing)
  * @param {Object} options  constructor options
  */
-var SweepContext = function (contour, options) {
+var SweepContext = function SweepContext(contour, options) {
     options = options || {};
     this.triangles_ = [];
     this.map_ = [];
@@ -892,7 +892,7 @@ var SweepContext = function (contour, options) {
  * Add a hole to the constraints
  * @param {Array} polyline  array of "Point like" objects with {x,y} (duck typing)
  */
-SweepContext.prototype.addHole = function (polyline) {
+SweepContext.prototype.addHole = function addHole(polyline) {
     this.initEdges(polyline);
     var i,
         len = polyline.length;
@@ -909,7 +909,7 @@ SweepContext.prototype.AddHole = SweepContext.prototype.addHole;
  * Add a Steiner point to the constraints
  * @param {Point} point     any "Point like" object with {x,y} (duck typing)
  */
-SweepContext.prototype.addPoint = function (point) {
+SweepContext.prototype.addPoint = function addPoint(point) {
     this.points_.push(point);
     return this; // for chaining
 };
@@ -917,59 +917,59 @@ SweepContext.prototype.addPoint = function (point) {
 SweepContext.prototype.AddPoint = SweepContext.prototype.addPoint;
 
 
-SweepContext.prototype.addPoints = function (points) {
+SweepContext.prototype.addPoints = function addPoints(points) {
     this.points_ = this.points_.concat(points);
     return this; // for chaining
 };
 
-SweepContext.prototype.triangulate = function () {
+SweepContext.prototype.triangulate = function triangulate() {
     Sweep.triangulate(this);
     return this; // for chaining
 };
 
-SweepContext.prototype.getBoundingBox = function () {
+SweepContext.prototype.getBoundingBox = function getBoundingBox() {
     return {
         min: this.pmin_,
         max: this.pmax_,
     };
 };
 
-SweepContext.prototype.getTriangles = function () {
+SweepContext.prototype.getTriangles = function getTriangles() {
     return this.triangles_;
 };
 // Backward compatibility
 SweepContext.prototype.GetTriangles = SweepContext.prototype.getTriangles;
 
 
-SweepContext.prototype.front = function () {
+SweepContext.prototype.front = function front() {
     return this.front_;
 };
 
-SweepContext.prototype.pointCount = function () {
+SweepContext.prototype.pointCount = function pointCount() {
     return this.points_.length;
 };
 
-SweepContext.prototype.head = function () {
+SweepContext.prototype.head = function head() {
     return this.head_;
 };
 
-SweepContext.prototype.setHead = function (p1) {
+SweepContext.prototype.setHead = function setHead(p1) {
     this.head_ = p1;
 };
 
-SweepContext.prototype.tail = function () {
+SweepContext.prototype.tail = function tail() {
     return this.tail_;
 };
 
-SweepContext.prototype.setTail = function (p1) {
+SweepContext.prototype.setTail = function setTail(p1) {
     this.tail_ = p1;
 };
 
-SweepContext.prototype.getMap = function () {
+SweepContext.prototype.getMap = function getMap() {
     return this.map_;
 };
 
-SweepContext.prototype.initTriangulation = function () {
+SweepContext.prototype.initTriangulation = function initTriangulation() {
     var xmax = this.points_[0].x;
     var xmin = this.points_[0].x;
     var ymax = this.points_[0].y;
@@ -998,7 +998,7 @@ SweepContext.prototype.initTriangulation = function () {
     this.points_.sort(Point.compare);
 };
 
-SweepContext.prototype.initEdges = function (polyline) {
+SweepContext.prototype.initEdges = function initEdges(polyline) {
     var i,
         len = polyline.length;
     for (i = 0; i < len; ++i) {
@@ -1006,19 +1006,19 @@ SweepContext.prototype.initEdges = function (polyline) {
     }
 };
 
-SweepContext.prototype.getPoint = function (index) {
+SweepContext.prototype.getPoint = function getPoint(index) {
     return this.points_[index];
 };
 
-SweepContext.prototype.addToMap = function (triangle) {
+SweepContext.prototype.addToMap = function addToMap(triangle) {
     this.map_.push(triangle);
 };
 
-SweepContext.prototype.locateNode = function (point) {
+SweepContext.prototype.locateNode = function locateNode(point) {
     return this.front_.locateNode(point.x);
 };
 
-SweepContext.prototype.createAdvancingFront = function () {
+SweepContext.prototype.createAdvancingFront = function createAdvancingFront() {
     var head;
     var middle;
     var tail;
@@ -1039,12 +1039,12 @@ SweepContext.prototype.createAdvancingFront = function () {
     tail.prev = middle;
 };
 
-SweepContext.prototype.removeNode = function (/* node*/) {
+SweepContext.prototype.removeNode = function removeNode(/* node*/) {
     // do nothing
     /* jshint unused:false */
 };
 
-SweepContext.prototype.mapTriangleToNodes = function (t) {
+SweepContext.prototype.mapTriangleToNodes = function mapTriangleToNodes(t) {
     for (var i = 0; i < 3; ++i) {
         if (!t.getNeighbor(i)) {
             var n = this.front_.locatePoint(t.pointCW(t.getPoint(i)));
@@ -1055,7 +1055,7 @@ SweepContext.prototype.mapTriangleToNodes = function (t) {
     }
 };
 
-SweepContext.prototype.removeFromMap = function (triangle) {
+SweepContext.prototype.removeFromMap = function removeFromMap(triangle) {
     var i,
         map = this.map_,
         len = map.length;
@@ -1067,7 +1067,7 @@ SweepContext.prototype.removeFromMap = function (triangle) {
     }
 };
 
-SweepContext.prototype.meshClean = function (triangle) {
+SweepContext.prototype.meshClean = function meshClean(triangle) {
     // New implementation avoids recursive calls and use a loop instead.
     // Cf. issues # 57, 65 and 69.
     var triangles = [triangle],
@@ -1092,7 +1092,7 @@ SweepContext.prototype.meshClean = function (triangle) {
 
 var Sweep = {};
 
-Sweep.triangulate = function (tcx) {
+Sweep.triangulate = function triangulate(tcx) {
     tcx.initTriangulation();
     tcx.createAdvancingFront();
     // Sweep points; build mesh
@@ -1101,7 +1101,7 @@ Sweep.triangulate = function (tcx) {
     Sweep.finalizationPolygon(tcx);
 };
 
-Sweep.sweepPoints = function (tcx) {
+Sweep.sweepPoints = function sweepPoints(tcx) {
     var i,
         len = tcx.pointCount();
     for (i = 1; i < len; ++i) {
@@ -1114,7 +1114,7 @@ Sweep.sweepPoints = function (tcx) {
     }
 };
 
-Sweep.finalizationPolygon = function (tcx) {
+Sweep.finalizationPolygon = function finalizationPolygon(tcx) {
     // Get an Internal triangle to start with
     var t = tcx.front().head().next.triangle;
     var p = tcx.front().head().next.point;
@@ -1126,7 +1126,7 @@ Sweep.finalizationPolygon = function (tcx) {
     tcx.meshClean(t);
 };
 
-Sweep.pointEvent = function (tcx, point) {
+Sweep.pointEvent = function pointEvent(tcx, point) {
     var node = tcx.locateNode(point);
     var new_node = Sweep.newFrontTriangle(tcx, point, node);
 
@@ -1142,7 +1142,7 @@ Sweep.pointEvent = function (tcx, point) {
     return new_node;
 };
 
-Sweep.edgeEventByEdge = function (tcx, edge, node) {
+Sweep.edgeEventByEdge = function edgeEventByEdge(tcx, edge, node) {
     tcx.edge_event.constrained_edge = edge;
     tcx.edge_event.right = (edge.p.x > edge.q.x);
 
@@ -1157,7 +1157,7 @@ Sweep.edgeEventByEdge = function (tcx, edge, node) {
     Sweep.edgeEventByPoints(tcx, edge.p, edge.q, node.triangle, edge.q);
 };
 
-Sweep.edgeEventByPoints = function (tcx, ep, eq, triangle, point) {
+Sweep.edgeEventByPoints = function edgeEventByPoints(tcx, ep, eq, triangle, point) {
     if (Sweep.isEdgeSideOfTriangle(triangle, ep, eq)) {
         return;
     }
@@ -1191,7 +1191,7 @@ Sweep.edgeEventByPoints = function (tcx, ep, eq, triangle, point) {
     }
 };
 
-Sweep.isEdgeSideOfTriangle = function (triangle, ep, eq) {
+Sweep.isEdgeSideOfTriangle = function isEdgeSideOfTriangle(triangle, ep, eq) {
     var index = triangle.edgeIndex(ep, eq);
     if (index !== -1) {
         triangle.markConstrainedEdgeByIndex(index);
@@ -1204,7 +1204,7 @@ Sweep.isEdgeSideOfTriangle = function (triangle, ep, eq) {
     return false;
 };
 
-Sweep.newFrontTriangle = function (tcx, point, node) {
+Sweep.newFrontTriangle = function newFrontTriangle(tcx, point, node) {
     var triangle = new Triangle(point, node.point, node.next.point);
 
     triangle.markNeighbor(node.triangle);
@@ -1223,7 +1223,7 @@ Sweep.newFrontTriangle = function (tcx, point, node) {
     return new_node;
 };
 
-Sweep.fill = function (tcx, node) {
+Sweep.fill = function fill(tcx, node) {
     var triangle = new Triangle(node.prev.point, node.point, node.next.point);
 
     // TODO: should copy the constrained_edge value from neighbor triangles
@@ -1247,7 +1247,7 @@ Sweep.fill = function (tcx, node) {
 };
 
 
-Sweep.fillAdvancingFront = function (tcx, n) {
+Sweep.fillAdvancingFront = function fillAdvancingFront(tcx, n) {
     // Fill right holes
     var node = n.next;
     var angle;
@@ -1280,7 +1280,7 @@ Sweep.fillAdvancingFront = function (tcx, n) {
     }
 };
 
-Sweep.basinAngle = function (node) {
+Sweep.basinAngle = function basinAngle(node) {
     var ax = node.point.x - node.next.next.point.x;
     var ay = node.point.y - node.next.next.point.y;
     return Math.atan2(ay, ax);
@@ -1291,7 +1291,7 @@ Sweep.basinAngle = function (node) {
  * @param node - middle node
  * @return the angle between 3 front nodes
  */
-Sweep.holeAngle = function (node) {
+Sweep.holeAngle = function holeAngle(node) {
     /* Complex plane
      * ab = cosA +i*sinA
      * ab = (ax + ay*i)(bx + by*i) = (ax*bx + ay*by) + i(ax*by-ay*bx)
@@ -1310,7 +1310,7 @@ Sweep.holeAngle = function (node) {
 /**
  * Returns true if triangle was legalized
  */
-Sweep.legalize = function (tcx, t) {
+Sweep.legalize = function legalize(tcx, t) {
     // To legalize a triangle we start by finding if any of the three edges
     // violate the Delaunay condition
     for (var i = 0; i < 3; ++i) {
@@ -1368,7 +1368,7 @@ Sweep.legalize = function (tcx, t) {
     return false;
 };
 
-Sweep.inCircle = function (pa, pb, pc, pd) {
+Sweep.inCircle = function inCircle(pa, pb, pc, pd) {
     var adx = pa.x - pd.x;
     var ady = pa.y - pd.y;
     var bdx = pb.x - pd.x;
@@ -1402,7 +1402,7 @@ Sweep.inCircle = function (pa, pb, pc, pd) {
     return det > 0;
 };
 
-Sweep.rotateTrianglePair = function (t, p, ot, op) {
+Sweep.rotateTrianglePair = function rotateTrianglePair(t, p, ot, op) {
     var n1,
         n2,
         n3,
@@ -1467,7 +1467,7 @@ Sweep.rotateTrianglePair = function (t, p, ot, op) {
     t.markNeighbor(ot);
 };
 
-Sweep.fillBasin = function (tcx, node) {
+Sweep.fillBasin = function fillBasin(tcx, node) {
     if (orient2d(node.point, node.next.point, node.next.next.point) === Orientation.CCW) {
         tcx.basin.left_node = node.next.next;
     } else {
@@ -1505,7 +1505,7 @@ Sweep.fillBasin = function (tcx, node) {
  * @param tcx
  * @param node - bottom_node
  */
-Sweep.fillBasinReq = function (tcx, node) {
+Sweep.fillBasinReq = function fillBasinReq(tcx, node) {
     // if shallow stop filling
     if (Sweep.isShallow(tcx, node)) {
         return;
@@ -1540,7 +1540,7 @@ Sweep.fillBasinReq = function (tcx, node) {
     Sweep.fillBasinReq(tcx, node);
 };
 
-Sweep.isShallow = function (tcx, node) {
+Sweep.isShallow = function isShallow(tcx, node) {
     var height;
     if (tcx.basin.left_highest) {
         height = tcx.basin.left_node.point.y - node.point.y;
@@ -1555,7 +1555,7 @@ Sweep.isShallow = function (tcx, node) {
     return false;
 };
 
-Sweep.fillEdgeEvent = function (tcx, edge, node) {
+Sweep.fillEdgeEvent = function fillEdgeEvent(tcx, edge, node) {
     if (tcx.edge_event.right) {
         Sweep.fillRightAboveEdgeEvent(tcx, edge, node);
     } else {
@@ -1563,7 +1563,7 @@ Sweep.fillEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillRightAboveEdgeEvent = function (tcx, edge, node) {
+Sweep.fillRightAboveEdgeEvent = function fillRightAboveEdgeEvent(tcx, edge, node) {
     while (node.next.point.x < edge.p.x) {
         // Check if next node is below the edge
         if (orient2d(edge.q, node.next.point, edge.p) === Orientation.CCW) {
@@ -1574,7 +1574,7 @@ Sweep.fillRightAboveEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillRightBelowEdgeEvent = function (tcx, edge, node) {
+Sweep.fillRightBelowEdgeEvent = function fillRightBelowEdgeEvent(tcx, edge, node) {
     if (node.point.x < edge.p.x) {
         if (orient2d(node.point, node.next.point, node.next.next.point) === Orientation.CCW) {
             // Concave
@@ -1588,7 +1588,7 @@ Sweep.fillRightBelowEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillRightConcaveEdgeEvent = function (tcx, edge, node) {
+Sweep.fillRightConcaveEdgeEvent = function fillRightConcaveEdgeEvent(tcx, edge, node) {
     Sweep.fill(tcx, node.next);
     if (node.next.point !== edge.p) {
         // Next above or below edge?
@@ -1605,7 +1605,7 @@ Sweep.fillRightConcaveEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillRightConvexEdgeEvent = function (tcx, edge, node) {
+Sweep.fillRightConvexEdgeEvent = function fillRightConvexEdgeEvent(tcx, edge, node) {
     // Next concave or convex?
     if (orient2d(node.next.point, node.next.next.point, node.next.next.next.point) === Orientation.CCW) {
         // Concave
@@ -1623,7 +1623,7 @@ Sweep.fillRightConvexEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillLeftAboveEdgeEvent = function (tcx, edge, node) {
+Sweep.fillLeftAboveEdgeEvent = function fillLeftAboveEdgeEvent(tcx, edge, node) {
     while (node.prev.point.x > edge.p.x) {
         // Check if next node is below the edge
         if (orient2d(edge.q, node.prev.point, edge.p) === Orientation.CW) {
@@ -1634,7 +1634,7 @@ Sweep.fillLeftAboveEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillLeftBelowEdgeEvent = function (tcx, edge, node) {
+Sweep.fillLeftBelowEdgeEvent = function fillLeftBelowEdgeEvent(tcx, edge, node) {
     if (node.point.x > edge.p.x) {
         if (orient2d(node.point, node.prev.point, node.prev.prev.point) === Orientation.CW) {
             // Concave
@@ -1648,7 +1648,7 @@ Sweep.fillLeftBelowEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillLeftConvexEdgeEvent = function (tcx, edge, node) {
+Sweep.fillLeftConvexEdgeEvent = function fillLeftConvexEdgeEvent(tcx, edge, node) {
     // Next concave or convex?
     if (orient2d(node.prev.point, node.prev.prev.point, node.prev.prev.prev.point) === Orientation.CW) {
         // Concave
@@ -1666,7 +1666,7 @@ Sweep.fillLeftConvexEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.fillLeftConcaveEdgeEvent = function (tcx, edge, node) {
+Sweep.fillLeftConcaveEdgeEvent = function fillLeftConcaveEdgeEvent(tcx, edge, node) {
     Sweep.fill(tcx, node.prev);
     if (node.prev.point !== edge.p) {
         // Next above or below edge?
@@ -1683,7 +1683,7 @@ Sweep.fillLeftConcaveEdgeEvent = function (tcx, edge, node) {
     }
 };
 
-Sweep.flipEdgeEvent = function (tcx, ep, eq, t, p) {
+Sweep.flipEdgeEvent = function flipEdgeEvent(tcx, ep, eq, t, p) {
     var ot = t.neighborAcross(p);
     if (!ot) {
         // If we want to integrate the fillEdgeEvent do it here
@@ -1725,7 +1725,7 @@ Sweep.flipEdgeEvent = function (tcx, ep, eq, t, p) {
     }
 };
 
-Sweep.nextFlipTriangle = function (tcx, o, t, ot, p, op) {
+Sweep.nextFlipTriangle = function nextFlipTriangle(tcx, o, t, ot, p, op) {
     var edge_index;
     if (o === Orientation.CCW) {
         // ot is not crossing edge after flip
@@ -1745,7 +1745,7 @@ Sweep.nextFlipTriangle = function (tcx, o, t, ot, p, op) {
     return ot;
 };
 
-Sweep.nextFlipPoint = function (ep, eq, ot, op) {
+Sweep.nextFlipPoint = function nextFlipPoint(ep, eq, ot, op) {
     var o2d = orient2d(eq, op, ep);
     if (o2d === Orientation.CW) {
         // Right
@@ -1758,7 +1758,7 @@ Sweep.nextFlipPoint = function (ep, eq, ot, op) {
     }
 };
 
-Sweep.flipScanEdgeEvent = function (tcx, ep, eq, flip_triangle, t, p) {
+Sweep.flipScanEdgeEvent = function flipScanEdgeEvent(tcx, ep, eq, flip_triangle, t, p) {
     var ot = t.neighborAcross(p);
     if (!ot) {
         // If we want to integrate the fillEdgeEvent do it here
@@ -1798,40 +1798,40 @@ var Delaunay = {
 
 };
 
-CVML.newPoint = function (x, y) {
+CVML.newPoint = function newPoint(x, y) {
     return new Delaunay._Point(x, y);
 };
 
-CVML.TriangulatePoly = function (arr) {
+CVML.TriangulatePoly = function TriangulatePoly(arr) {
     var swctx = new Delaunay._SweepContext(arr);
     swctx.triangulate();
     return swctx.getTriangles();
 };
 
-CVML.initSweepContext = function (arr) {
+CVML.initSweepContext = function initSweepContext(arr) {
     return new Delaunay._SweepContext(arr);
 };
 
 // Line
-CVML.Line = function (a, b) { // y = ax + b
+CVML.Line = function Line(a, b) { // y = ax + b
     this.a = a;
     this.b = b;
 };
 
-CVML.Line.prototype.copy = function (line) {
+CVML.Line.prototype.copy = function copy(line) {
     this.a = line.a;
     this.b = line.b;
 };
 
 
-CVML.RobustLineFitting = function (points, threshold) {
+CVML.RobustLineFitting = function RobustLineFitting(points, threshold) {
     return new CVML.Ransac(new CVML.LineFitting(), points, threshold);
 };
 
-CVML.LineFitting = function () {
+CVML.LineFitting = function LineFitting() {
     this.nbSampleNeeded = 2;
 
-    this.estimateModel = function (points, sample, model) {
+    this.estimateModel = function estimateModel(points, sample, model) {
         var counter = 0;
         for (var i in sample) {
             _samplePoints[counter] = points[i];
@@ -1845,14 +1845,14 @@ CVML.LineFitting = function () {
         model.b = p1.y - model.a * p1.x;
     };
 
-    this.estimateError = function (points, index, model) {
+    this.estimateError = function estimateError(points, index, model) {
         return Math.abs(points[index].y - model.a * points[index].x - model.b) / Math.sqrt(1 + model.a * model.a);
     };
 
     var _samplePoints = new Array(this.nbSampleNeeded);
 };
 
-CVML.Ransac = function (fittingProblem, points, threshold) {
+CVML.Ransac = function Ransac(fittingProblem, points, threshold) {
     var _points = points;
     var _threshold = threshold;
     var _problem = fittingProblem;
@@ -1886,7 +1886,7 @@ CVML.Ransac = function (fittingProblem, points, threshold) {
     }
 
 
-    // this.next = function() {
+    // this.next = functionnext() {
     for (var _iterationCounter = 0; _iterationCounter < _nbIters; _iterationCounter++) {
         var _currentInliers = [];
 
@@ -1945,7 +1945,7 @@ CVML.dim = function dim(x) {
     return [];
 };
 
-CVML.sdim = function (A, ret, k) {
+CVML.sdim = function sdim(A, ret, k) {
     if (typeof ret === 'undefined') {
         ret = [];
     }
@@ -1964,7 +1964,7 @@ CVML.sdim = function (A, ret, k) {
     return ret;
 };
 
-CVML.clone = function (A, k, n) {
+CVML.clone = function cloneFn(A, k, n) {
     if (typeof k === 'undefined') {
         k = 0;
     }
@@ -2008,7 +2008,7 @@ CVML.rep = function rep(s, v, k) {
     return ret;
 };
 
-CVML.transpose = function (A) {
+CVML.transpose = function transpose(A) {
     var ret = [],
         /* n = A.length,*/
         i,
@@ -2028,7 +2028,7 @@ CVML.transpose = function (A) {
     return ret;
 };
 
-CVML.minVP = function (svd) {
+CVML.minVP = function minVP(svd) {
     var ind = 0;
     for (var i = 0; i < svd.S.length - 1; i++) {
         if (svd.S[i + 1] < svd.S[i]) ind = i + 1;
@@ -2036,7 +2036,7 @@ CVML.minVP = function (svd) {
     return svd.U[ind];
 };
 
-CVML.maxVP = function (svd) {
+CVML.maxVP = function maxVP(svd) {
     var ind = 0;
     for (var i = 0; i < svd.S.length - 1; i++) {
         if (svd.S[i + 1] > svd.S[i]) ind = i + 1;
@@ -2044,7 +2044,7 @@ CVML.maxVP = function (svd) {
     return svd.U[ind];
 };
 
-CVML.subVec = function (vec, vec1) {
+CVML.subVec = function subVec(vec, vec1) {
     var ret = new Array(vec.length);
     if (vec.length === vec1.length) {
         for (var i = 0; i < vec.length; i++)
@@ -2053,7 +2053,7 @@ CVML.subVec = function (vec, vec1) {
     return ret;
 };
 
-CVML.addVec = function (vec, vec1) {
+CVML.addVec = function addVec(vec, vec1) {
     var ret = new Array(vec.length);
     if (vec.length === vec1.length) {
         for (var i = 0; i < vec.length; i++)
@@ -2063,7 +2063,7 @@ CVML.addVec = function (vec, vec1) {
 };
 
 
-CVML.dotMV = function (A, x) {
+CVML.dotMV = function dotMV(A, x) {
     var p = A.length,
         Ai,
         i,
@@ -2355,7 +2355,7 @@ CVML.svd = function svd(A) {
         V: v,
     };
 };
-CVML.dotMMsmall = function (x, y) {
+CVML.dotMMsmall = function dotMMsmall(x, y) {
     var i,
         j,
         k,
@@ -2389,7 +2389,7 @@ CVML.dotMMsmall = function (x, y) {
     }
     return ret;
 };
-CVML._getCol = function (A, j, x) {
+CVML._getCol = function _getCol(A, j, x) {
     var n = A.length,
         i;
     for (i = n - 1; i > 0; --i) {
@@ -2399,7 +2399,7 @@ CVML._getCol = function (A, j, x) {
     }
     if (i === 0) x[0] = A[0][j];
 };
-CVML.dotMMbig = function (x, y) {
+CVML.dotMMbig = function dotMMbig(x, y) {
     var gc = CVML._getCol,
         p = y.length,
         v = Array(p);
@@ -2425,7 +2425,7 @@ CVML.dotMMbig = function (x, y) {
     return A;
 };
 
-CVML.dotMV = function (x, y) {
+CVML.dotMV = function dotMV(x, y) {
     var p = x.length; // , q = y.length,i;
     var ret = Array(p),
         dotVV = CVML.dotVV;
@@ -2435,7 +2435,7 @@ CVML.dotMV = function (x, y) {
     return ret;
 };
 
-CVML.dotVM = function (x, y) {
+CVML.dotVM = function dotVM(x, y) {
     var /* i,*/ j,
         k,
         p,
@@ -2460,7 +2460,7 @@ CVML.dotVM = function (x, y) {
     return ret;
 };
 
-CVML.dotVV = function (x, y) {
+CVML.dotVV = function dotVV(x, y) {
     var i,
         n = x.length,
         i1,
@@ -2498,7 +2498,7 @@ CVML.dot = function dot(x, y) {
     }
 };
 
-CVML.div = function (A, m) {
+CVML.div = function div(A, m) {
     var ret = new Array(A.length);
     for (var i = 0; i < A.length; i++) {
         var Ai = A[i];
@@ -2510,7 +2510,7 @@ CVML.div = function (A, m) {
 };
 
 // prends une matrice Nx3 and subtract to vector 3x1
-CVML.subMV = function (A, v) {
+CVML.subMV = function subMV(A, v) {
     if (A[0].length !== v.length)
         { throw new Error('vector and matrice elements must have same length'); }
     var ret = new Array(A.length);
@@ -2524,7 +2524,7 @@ CVML.subMV = function (A, v) {
     return ret;
 };
 
-CVML.pca = function (A, mV) {
+CVML.pca = function pca(A, mV) {
     var m = A.length;
     var A_norm = CVML.subMV(A, mV);
     var sigma = CVML.div(CVML.dot(CVML.transpose(A_norm), A_norm), m);

--- a/src/Core/Math/Ellipsoid.js
+++ b/src/Core/Math/Ellipsoid.js
@@ -20,7 +20,7 @@ function Ellipsoid(size) {
     this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
 }
 
-Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function (coordCarto) {
+Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function geodeticSurfaceNormalCartographic(coordCarto) {
     var longitude = Math.PI * 2 - coordCarto.longitude();
     var latitude = coordCarto.latitude();
     var cosLatitude = Math.cos(latitude);
@@ -34,7 +34,7 @@ Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function (coordCarto) {
     return result.normalize();
 };
 
-Ellipsoid.prototype.setSize = function (size) {
+Ellipsoid.prototype.setSize = function setSize(size) {
     this.rayon_1 = size.x;
     this.rayon_2 = size.y;
     this.rayon_3 = size.z;
@@ -43,7 +43,7 @@ Ellipsoid.prototype.setSize = function (size) {
 };
 
 
-Ellipsoid.prototype.cartographicToCartesian = function (coordCarto) {
+Ellipsoid.prototype.cartographicToCartesian = function cartographicToCartesian(coordCarto) {
     // var n;
     var k = new THREE.Vector3();
     var n = this.geodeticSurfaceNormalCartographic(coordCarto);
@@ -61,7 +61,7 @@ Ellipsoid.prototype.cartographicToCartesian = function (coordCarto) {
     return k.add(n);
 };
 
-Ellipsoid.prototype.cartographicToCartesianArray = function (coordCartoArray) {
+Ellipsoid.prototype.cartographicToCartesianArray = function cartographicToCartesianArray(coordCartoArray) {
     var cartesianArray = [];
     for (var i = 0; i < coordCartoArray.length; i++) {
         cartesianArray.push(this.cartographicToCartesian(coordCartoArray[i]));
@@ -70,7 +70,7 @@ Ellipsoid.prototype.cartographicToCartesianArray = function (coordCartoArray) {
     return cartesianArray;
 };
 
-Ellipsoid.prototype.intersection = function (ray) {
+Ellipsoid.prototype.intersection = function intersection(ray) {
     var EPSILON = 0.0001;
     var O_C = ray.origin;
     var dir = ray.direction;
@@ -123,7 +123,7 @@ Ellipsoid.prototype.intersection = function (ray) {
     */
 };
 
-Ellipsoid.prototype.computeDistance = function (coordCarto1, coordCarto2) {
+Ellipsoid.prototype.computeDistance = function computeDistance(coordCarto1, coordCarto2) {
     var longitude1 = coordCarto1.longitude() * Math.PI / 180;
     var latitude1 = coordCarto1.latitude() * Math.PI / 180;
     var longitude2 = coordCarto2.longitude() * Math.PI / 180;

--- a/src/Core/Math/MathExtented.js
+++ b/src/Core/Math/MathExtented.js
@@ -48,15 +48,15 @@ MathExt.RADTODEG = 180.0 / MathExt.PI;
 
 MathExt.DEGTORAD = MathExt.PI / 180.0;
 
-MathExt.radToDeg = function (rad) {
+MathExt.radToDeg = function radToDeg(rad) {
     return rad * MathExt.RADTODEG;
 };
 
-MathExt.degToRad = function (deg) {
+MathExt.degToRad = function degToRad(deg) {
     return deg * MathExt.DEGTORAD;
 };
 
-MathExt.arrayDegToRad = function (arrayDeg) {
+MathExt.arrayDegToRad = function arrayDegToRad(arrayDeg) {
     if (arrayDeg) {
         for (var i = 0; i < arrayDeg.length; i++) {
             arrayDeg[i] = MathExt.degToRad(arrayDeg[i]);
@@ -64,7 +64,7 @@ MathExt.arrayDegToRad = function (arrayDeg) {
     }
 };
 
-MathExt.arrayRadToDeg = function (arrayDeg) {
+MathExt.arrayRadToDeg = function arrayRadToDeg(arrayDeg) {
     if (arrayDeg) {
         for (var i = 0; i < arrayDeg.length; i++) {
             arrayDeg[i] = MathExt.radToDeg(arrayDeg[i]);
@@ -73,7 +73,7 @@ MathExt.arrayRadToDeg = function (arrayDeg) {
 };
 
 // TODO: Function in test :
-MathExt.step = function (val, stepVal) {
+MathExt.step = function step(val, stepVal) {
     if (val < stepVal) {
         return 0.0;
     }
@@ -82,7 +82,7 @@ MathExt.step = function (val, stepVal) {
     }
 };
 
-MathExt.exp2 = function (expo) {
+MathExt.exp2 = function exp2(expo) {
     return Math.pow(2, expo);
 };
 

--- a/src/Core/Math/Rectangle.js
+++ b/src/Core/Math/Rectangle.js
@@ -12,25 +12,25 @@ function Rectangle(options) {
     this._north = defaultValue(options.north(), 0);
 }
 
-Rectangle.prototype.getWest = function () {
+Rectangle.prototype.getWest = function getWest() {
     return this._west;
 };
 
-Rectangle.prototype.getSouth = function () {
+Rectangle.prototype.getSouth = function getSouth() {
     return this._south;
 };
 
-Rectangle.prototype.getEast = function () {
+Rectangle.prototype.getEast = function getEast() {
     return this._east;
 };
 
-Rectangle.prototype.getNorth = function () {
+Rectangle.prototype.getNorth = function getNorth() {
     return this._north;
 };
 
 // if Right2 < Right1 && Left2 > Left1 && Top2 < Top1 && Bottom2 > Bottom1
 // this is correct only for coordinate positive
-Rectangle.prototype.intersects = function (rect) {
+Rectangle.prototype.intersects = function intersects(rect) {
     if (rect.getEast() < this._west) return false;
     if (rect.getWest() > this._east) return false;
     if (rect.getNorth() < this._south) return false;
@@ -39,7 +39,7 @@ Rectangle.prototype.intersects = function (rect) {
     return true;
 };
 
-Rectangle.prototype.containsPoint = function (v) {
+Rectangle.prototype.containsPoint = function containsPoint(v) {
     if (!v) {
         throw new Error('point is required.');
     }

--- a/src/Core/Math/Sphere.js
+++ b/src/Core/Math/Sphere.js
@@ -7,18 +7,18 @@ function Sphere(center, radius) {
 
 Sphere.prototype.constructor = Sphere;
 
-Sphere.prototype.setCenter = function (center) {
+Sphere.prototype.setCenter = function setCenter(center) {
     this.center.copy(center);
 };
 
-Sphere.prototype.setRadius = function (radius) {
+Sphere.prototype.setRadius = function setRadius(radius) {
     this.radius = radius;
 };
 
 var vector = new THREE.Vector3();
 
 //
-Sphere.prototype.intersectWithRayNoMiss = function (ray) {
+Sphere.prototype.intersectWithRayNoMiss = function intersectWithRayNoMiss(ray) {
     let pc = ray.closestPointToPoint(this.center);
     let a = pc.length(),
         d,

--- a/src/Core/System/Capabilities.js
+++ b/src/Core/System/Capabilities.js
@@ -13,7 +13,7 @@ function Capabilities() {
 
 /**
  */
-Capabilities.prototype.getSystemCapabilities = function () {
+Capabilities.prototype.getSystemCapabilities = function getSystemCapabilities() {
     // TODO: Implement Me
     /*
     var memory = window.performance.memory;
@@ -24,7 +24,7 @@ Capabilities.prototype.getSystemCapabilities = function () {
 
 /**
  */
-Capabilities.prototype.getGpuCapabilities = function () {
+Capabilities.prototype.getGpuCapabilities = function getGpuCapabilities() {
     // TODO: Implement Me
 
 };
@@ -32,16 +32,16 @@ Capabilities.prototype.getGpuCapabilities = function () {
 
 /**
  */
-Capabilities.prototype.ioFile = function () {
+Capabilities.prototype.ioFile = function ioFile() {
     // TODO: Implement Me
 
 };
 
-Capabilities.prototype.isInternetExplorer = function () {
+Capabilities.prototype.isInternetExplorer = function isInternetExplorer() {
     return /* @cc_on!@*/ false || !!document.documentMode;
 };
 /*
-    Capabilities.prototype.checkVersion = function()
+    Capabilities.prototype.checkVersion = functioncheckVersion()
     {
       var msg = "You're not using Internet Explorer.";
       var ver = getInternetExplorerVersion();

--- a/src/Core/System/JavaTools.js
+++ b/src/Core/System/JavaTools.js
@@ -12,7 +12,7 @@ function JavaTools() {
 
 JavaTools.prototype.constructor = JavaTools;
 
-JavaTools.prototype.freeArray = function (sourceArray) {
+JavaTools.prototype.freeArray = function freeArray(sourceArray) {
     var arr = sourceArray.slice();
 
     while (arr.length > 0) {

--- a/src/Core/defaultValue.js
+++ b/src/Core/defaultValue.js
@@ -7,7 +7,7 @@
 
 import { Vector3 } from 'three';
 
-var defaultValue = function (value, def) {
+var defaultValue = function defaultValue(value, def) {
     return value === undefined ? def : value;
 };
 

--- a/src/Globe/Atmosphere.js
+++ b/src/Globe/Atmosphere.js
@@ -282,7 +282,7 @@ function Atmosphere(ellipsoid) {
 Atmosphere.prototype = Object.create(NodeMesh.prototype);
 Atmosphere.prototype.constructor = Atmosphere;
 
-Atmosphere.prototype.setRealisticOn = function (bool) {
+Atmosphere.prototype.setRealisticOn = function setRealisticOn(bool) {
     this.realistic = bool;
     this.material.visible = !this.realistic;
     this.atmosphereIN.visible = !this.realistic;
@@ -294,7 +294,7 @@ Atmosphere.prototype.setRealisticOn = function (bool) {
     // this.sphereSun.visible     = this.realistic;
 };
 
-Atmosphere.prototype.updateLightingPos = function (pos) {
+Atmosphere.prototype.updateLightingPos = function updateLightingPos(pos) {
     this.ground.material.uniforms.v3LightPosition.value = pos.clone().normalize();
     this.sky.material.uniforms.v3LightPosition.value = pos.clone().normalize();
     //  this.sphereSun.position.copy(pos);

--- a/src/Globe/BuilderEllipsoidTile.js
+++ b/src/Globe/BuilderEllipsoidTile.js
@@ -11,7 +11,7 @@ BuilderEllipsoidTile.prototype.constructor = BuilderEllipsoidTile;
 
 // prepare params
 // init projected object -> params.projected
-BuilderEllipsoidTile.prototype.Prepare = function (params) {
+BuilderEllipsoidTile.prototype.Prepare = function Prepare(params) {
     params.nbRow = Math.pow(2.0, params.zoom + 1.0);
 
     var st1 = this.projector.WGS84ToOneSubY(params.bbox.south());
@@ -31,34 +31,34 @@ BuilderEllipsoidTile.prototype.Prepare = function (params) {
 
 
 // get center tile in cartesian 3D
-BuilderEllipsoidTile.prototype.Center = function (params) {
+BuilderEllipsoidTile.prototype.Center = function Center(params) {
     params.center = this.ellipsoid.cartographicToCartesian(new GeoCoordinate(params.bbox.center.x, params.bbox.center.y, 0));
     return params.center;
 };
 
 // get position 3D cartesian
-BuilderEllipsoidTile.prototype.VertexPosition = function (params) {
+BuilderEllipsoidTile.prototype.VertexPosition = function VertexPosition(params) {
     params.cartesianPosition = this.ellipsoid.cartographicToCartesian(params.projected);
     return params.cartesianPosition;
 };
 
 // get normal for last vertex
-BuilderEllipsoidTile.prototype.VertexNormal = function (params) {
+BuilderEllipsoidTile.prototype.VertexNormal = function VertexNormal(params) {
     return params.cartesianPosition.clone().normalize();
 };
 
 // coord u tile to projected
-BuilderEllipsoidTile.prototype.uProjecte = function (u, params) {
+BuilderEllipsoidTile.prototype.uProjecte = function uProjecte(u, params) {
     this.projector.UnitaryToLongitudeWGS84(u, params.projected, params.bbox);
 };
 
 // coord v tile to projected
-BuilderEllipsoidTile.prototype.vProjecte = function (v, params) {
+BuilderEllipsoidTile.prototype.vProjecte = function vProjecte(v, params) {
     this.projector.UnitaryToLatitudeWGS84(v, params.projected, params.bbox);
 };
 
 // Compute uv 1, if isn't defined the uv1 isn't computed
-BuilderEllipsoidTile.prototype.getUV_PM = function (params) {
+BuilderEllipsoidTile.prototype.getUV_PM = function getUV_PM(params) {
     var t = this.projector.WGS84ToOneSubY(params.projected.latitude()) * params.nbRow;
 
     if (!isFinite(t))
@@ -68,7 +68,7 @@ BuilderEllipsoidTile.prototype.getUV_PM = function (params) {
 };
 
 // get oriented bounding box of tile
-BuilderEllipsoidTile.prototype.OBB = function (params) {
+BuilderEllipsoidTile.prototype.OBB = function OBBFn(params) {
     var cardinals = [];
 
     var normal = params.center.clone().normalize();

--- a/src/Globe/Clouds.js
+++ b/src/Globe/Clouds.js
@@ -62,7 +62,7 @@ Clouds.prototype = Object.create(NodeMesh.prototype);
 Clouds.prototype.constructor = Clouds;
 
 
-Clouds.prototype.generate = function (satelliteAnimation) {
+Clouds.prototype.generate = function generate(satelliteAnimation) {
     this.satelliteAnimation = satelliteAnimation;
     if (!satelliteAnimation) {
         this.live = true;
@@ -98,16 +98,16 @@ Clouds.prototype.generate = function (satelliteAnimation) {
 };
 
 
-Clouds.prototype.animate = function () {
+Clouds.prototype.animate = function animate() {
     if (!this.satelliteAnimation) this.material.uniforms.time.value += 0.01;
     requestAnimationFrame(this.animate.bind(this));
 };
 
-Clouds.prototype.setLightingOn = function (enable) {
+Clouds.prototype.setLightingOn = function setLightingOn(enable) {
     this.material.uniforms.lightingOn.value = enable;
 };
 
-Clouds.prototype.updateLightingPos = function (pos) {
+Clouds.prototype.updateLightingPos = function updateLightingPos(pos) {
     this.material.uniforms.lightPosition.value = pos.clone().normalize();
 };
 

--- a/src/Globe/Globe.js
+++ b/src/Globe/Globe.js
@@ -114,12 +114,12 @@ Globe.prototype.constructor = Globe;
  * @documentation: Rafrachi les materiaux en fonction du quadTree ORTHO
  *
  */
-Globe.prototype.QuadTreeToMaterial = function () {
+Globe.prototype.QuadTreeToMaterial = function QuadTreeToMaterial() {
     // TODO: Implement Me
 
 };
 
-Globe.prototype.SchemeTileWMTS = function (type) {
+Globe.prototype.SchemeTileWMTS = function SchemeTileWMTS(type) {
     if (type === 0) {
         // bbox longitude(0,360),latitude(-90,90)
         const schemeT = new SchemeTile();
@@ -140,33 +140,33 @@ Globe.prototype.SchemeTileWMTS = function (type) {
     }
 };
 
-Globe.prototype.showAtmosphere = function (show) {
+Globe.prototype.showAtmosphere = function showAtmosphere(show) {
     if (this.atmosphere !== undefined)
       { this.atmosphere.visible = show; }
 };
 
-Globe.prototype.showClouds = function (show, satelliteAnimation) {
+Globe.prototype.showClouds = function showClouds(show, satelliteAnimation) {
     if (/* this.clouds.live === false && */ show) {
         this.clouds.generate(satelliteAnimation);
     }
     this.clouds.visible = show;
 };
 
-Globe.prototype.showKML = function (show) {
+Globe.prototype.showKML = function showKML(show) {
     this.batiments.visible = show;
 
     this.batiments.children[0].visible = show;
 };
 
-Globe.prototype.updateLightingPos = function (pos) {
+Globe.prototype.updateLightingPos = function updateLightingPos(pos) {
     this.atmosphere.updateLightingPos(pos);
     this.clouds.updateLightingPos(pos);
 };
 
-Globe.prototype.setLayerOpacity = function (id, opacity) {
+Globe.prototype.setLayerOpacity = function setLayerOpacity(id, opacity) {
     this.layersConfiguration.setLayerOpacity(id, opacity);
 
-    var cO = function (object) {
+    var cO = function cO(object) {
         if (object.material.setLayerOpacity) {
             object.material.setLayerOpacity(object.getIndexLayerColor(id), opacity);
         }
@@ -176,10 +176,10 @@ Globe.prototype.setLayerOpacity = function (id, opacity) {
     this.tiles.children[0].traverse(cO);
 };
 
-Globe.prototype.setLayerVisibility = function (id, visible) {
+Globe.prototype.setLayerVisibility = function setLayerVisibility(id, visible) {
     this.layersConfiguration.setLayerVisibility(id, visible);
 
-    var cO = function (object) {
+    var cO = function cO(object) {
         if (object.material.setLayerOpacity) {
             object.material.setLayerVisibility(object.getIndexLayerColor(id), visible);
         }
@@ -189,10 +189,10 @@ Globe.prototype.setLayerVisibility = function (id, visible) {
     this.tiles.children[0].traverse(cO);
 };
 
-Globe.prototype.updateLayersOrdering = function () {
+Globe.prototype.updateLayersOrdering = function updateLayersOrdering() {
     var sequence = this.layersConfiguration.getColorLayersIdOrderedBySequence();
 
-    var cO = function (object) {
+    var cO = function cO(object) {
         if (object.changeSequenceLayers)
             { object.changeSequenceLayers(sequence); }
     };
@@ -200,8 +200,8 @@ Globe.prototype.updateLayersOrdering = function () {
     this.tiles.children[0].traverse(cO);
 };
 
-Globe.prototype.removeColorLayer = function (layer) {
-    var cO = function (object) {
+Globe.prototype.removeColorLayer = function removeColorLayer(layer) {
+    var cO = function cO(object) {
         if (object.removeColorLayer) {
             object.removeColorLayer(layer);
         }
@@ -210,10 +210,10 @@ Globe.prototype.removeColorLayer = function (layer) {
     this.tiles.children[0].traverse(cO);
 };
 
-Globe.prototype.getZoomLevel = function () {
-    var cO = (function () {
+Globe.prototype.getZoomLevel = function getZoomLevel() {
+    var cO = (function getCOFn() {
         var zoom = 0;
-        return function (object) {
+        return function cO(object) {
             if (object) {
                 zoom = Math.max(zoom, object.level);
             }
@@ -226,15 +226,15 @@ Globe.prototype.getZoomLevel = function () {
 };
 
 
-Globe.prototype.computeDistanceForZoomLevel = function (zoom, camera) {
+Globe.prototype.computeDistanceForZoomLevel = function computeDistanceForZoomLevel(zoom, camera) {
     return camera.preSSE * Math.pow(this.tiles.minLevel, (this.tiles.maxLevel - zoom + 1)) / SSE_SUBDIVISION_THRESHOLD;
 };
 
-Globe.prototype.getTile = function (coordinate) {
+Globe.prototype.getTile = function getTile(coordinate) {
     return this.tiles.getTile(coordinate);
 };
 
-Globe.prototype.setRealisticLightingOn = function (bool) {
+Globe.prototype.setRealisticLightingOn = function setRealisticLightingOn(bool) {
     this.atmosphere.setRealisticOn(bool);
     this.clouds.setLightingOn(bool);
 };

--- a/src/Globe/Star.js
+++ b/src/Globe/Star.js
@@ -10,7 +10,7 @@ import StarGeometry from 'Renderer/ThreeExtented/StarGeometry';
 import * as THREE from 'three';
 
 
-var Star = function () {
+var Star = function Star() {
     NodeMesh.call(this);
 
     var geom = new StarGeometry();

--- a/src/Globe/TileGeometry.js
+++ b/src/Globe/TileGeometry.js
@@ -76,7 +76,7 @@ TileGeometry.prototype = Object.create(THREE.BufferGeometry.prototype);
 
 TileGeometry.prototype.constructor = TileGeometry;
 
-TileGeometry.prototype.computeBuffers = function (params, builder) {
+TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder) {
     var javToo = new JavaTools();
     // Create output buffers.
     var outBuffers = new Buffers(params.segment);
@@ -115,18 +115,18 @@ TileGeometry.prototype.computeBuffers = function (params, builder) {
 
     builder.Prepare(params);
 
-    var UV_WGS84 = function () {};
-    var UV_PM = function () {};
+    var UV_WGS84 = function UV_WGS84() {};
+    var UV_PM = function UV_PM() {};
 
     // Define UV computation functions if needed
     if (outBuffers.uv.wgs84 === null) {
-        UV_WGS84 = function (out, id, u, v) {
+        UV_WGS84 = function UV_WGS84(out, id, u, v) {
             out.uv.wgs84[id * 2 + 0] = u;
             out.uv.wgs84[id * 2 + 1] = v;
         };
     }
     if (outBuffers.uv.pm === null && builder.getUV_PM) {
-        UV_PM = function (out, id, u) {
+        UV_PM = function UV_PM(out, id, u) {
             out.uv.pm[id] = u;
         };
     }
@@ -224,17 +224,17 @@ TileGeometry.prototype.computeBuffers = function (params, builder) {
 
     const r = 5 * ((20 - params.zoom) + 10);
 
-    var buildIndexSkirt = function () {};
-    var buildUVSkirt = function () {};
+    var buildIndexSkirt = function buildIndexSkirt() {};
+    var buildUVSkirt = function buildUVSkirt() {};
 
     if (outBuffers.index === null) {
-        buildIndexSkirt = function (id, v1, v2, v3, v4) {
+        buildIndexSkirt = function buildIndexSkirt(id, v1, v2, v3, v4) {
             id = bufferize(v1, v2, v3, id);
             id = bufferize(v1, v3, v4, id);
             return id;
         };
 
-        buildUVSkirt = function () {
+        buildUVSkirt = function buildUVSkirt() {
             scratchBuffers.uv.wgs84[idVertex * 2 + 0] = scratchBuffers.uv.wgs84[id * 2 + 0];
             scratchBuffers.uv.wgs84[idVertex * 2 + 1] = scratchBuffers.uv.wgs84[id * 2 + 1];
         };

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -74,7 +74,7 @@ TileMesh.prototype = Object.create(NodeMesh.prototype);
 
 TileMesh.prototype.constructor = TileMesh;
 
-TileMesh.prototype.buildHelper = function () {
+TileMesh.prototype.buildHelper = function buildHelper() {
     // TODO Dispose HELPER!!!
     var text = (this.level + 1).toString();
 
@@ -96,7 +96,7 @@ TileMesh.prototype.buildHelper = function () {
     this.link.add(this.helper);
 };
 
-TileMesh.prototype.dispose = function () {
+TileMesh.prototype.dispose = function dispose() {
     // TODO à mettre dans node mesh
     this.material.dispose();
     this.geometry.dispose();
@@ -104,17 +104,17 @@ TileMesh.prototype.dispose = function () {
     this.material = null;
 };
 
-TileMesh.prototype.setUuid = function (uuid) {
+TileMesh.prototype.setUuid = function setUuid(uuid) {
     this.id = uuid;
     this.materials[RendererConstant.FINAL].setUuid(uuid);
     this.materials[RendererConstant.ID].setUuid(uuid);
 };
 
-TileMesh.prototype.getUuid = function (uuid) {
+TileMesh.prototype.getUuid = function getUuid(uuid) {
     return this.materials[RendererConstant.ID].getUuid(uuid);
 };
 
-TileMesh.prototype.setColorLayerParameters = function (paramsTextureColor) {
+TileMesh.prototype.setColorLayerParameters = function setColorLayerParameters(paramsTextureColor) {
     if (!this.loaded) {
         this.materials[RendererConstant.FINAL].setColorLayerParameters(paramsTextureColor);
     }
@@ -122,7 +122,7 @@ TileMesh.prototype.setColorLayerParameters = function (paramsTextureColor) {
 /**
  *
  * @returns {undefined}     */
-TileMesh.prototype.disposeChildren = function () {
+TileMesh.prototype.disposeChildren = function disposeChildren() {
     this.pendingSubdivision = false;
 
     while (this.children.length > 0) {
@@ -132,7 +132,7 @@ TileMesh.prototype.disposeChildren = function () {
     }
 };
 
-TileMesh.prototype.setDisplayed = function (show) {
+TileMesh.prototype.setDisplayed = function setDisplayed(show) {
     for (var key in this.materials) {
         this.materials[key].visible = show;
     }
@@ -146,12 +146,12 @@ TileMesh.prototype.setDisplayed = function (show) {
     }
 };
 
-TileMesh.prototype.enableRTC = function (enable) {
+TileMesh.prototype.enableRTC = function enableRTC(enable) {
     this.materials[RendererConstant.FINAL].enableRTC(enable);
 };
 
 // switch material in function of state
-TileMesh.prototype.changeState = function (state) {
+TileMesh.prototype.changeState = function changeState(state) {
     if (state !== RendererConstant.FINAL) {
         this.materials[state].visible = this.materials[RendererConstant.FINAL].visible;
     }
@@ -159,25 +159,25 @@ TileMesh.prototype.changeState = function (state) {
     this.material = this.materials[state];
 };
 
-TileMesh.prototype.setFog = function (fog) {
+TileMesh.prototype.setFog = function setFog(fog) {
     this.materials[RendererConstant.FINAL].setFogDistance(fog);
 };
 
-TileMesh.prototype.setMatrixRTC = function (rtc) {
+TileMesh.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
     for (var key in this.materials) {
         this.materials[key].setMatrixRTC(rtc);
     }
 };
 
-TileMesh.prototype.setDebug = function (enable) {
+TileMesh.prototype.setDebug = function setDebug(enable) {
     this.materials[RendererConstant.FINAL].setDebug(enable);
 };
 
-TileMesh.prototype.setSelected = function (select) {
+TileMesh.prototype.setSelected = function setSelected(select) {
     this.materials[RendererConstant.FINAL].setSelected(select);
 };
 
-TileMesh.prototype.setTextureElevation = function (elevation) {
+TileMesh.prototype.setTextureElevation = function setTextureElevation(elevation) {
     if (this.materials[RendererConstant.FINAL] === null) {
         return;
     }
@@ -198,7 +198,7 @@ TileMesh.prototype.setTextureElevation = function (elevation) {
     this.loadingCheck();
 };
 
-TileMesh.prototype.setBBoxZ = function (min, max) {
+TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
     if (Math.floor(min) !== Math.floor(this.bbox.bottom()) || Math.floor(max) !== Math.floor(this.bbox.top())) {
         this.bbox.setBBoxZ(min, max);
         var delta = this.geometry.OBB.addHeight(this.bbox);
@@ -218,7 +218,7 @@ TileMesh.prototype.setBBoxZ = function (min, max) {
     }
 };
 
-TileMesh.prototype.setTexturesLayer = function (textures, layerType, layer) {
+TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layer) {
     if (this.material === null) {
         return;
     }
@@ -228,52 +228,52 @@ TileMesh.prototype.setTexturesLayer = function (textures, layerType, layer) {
     this.loadingCheck();
 };
 
-TileMesh.prototype.isColorLayerDownscaled = function (layer) {
+TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layer) {
     var mat = this.materials[RendererConstant.FINAL];
     return mat.isColorLayerDownscaled(layer, this.level);
 };
 
-TileMesh.prototype.isLayerTypeDownscaled = function (layerType) {
+TileMesh.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType) {
     var mat = this.materials[RendererConstant.FINAL];
     return mat.isLayerTypeDownscaled(layerType, this.level);
 };
 
-TileMesh.prototype.normals = function () {
+TileMesh.prototype.normals = function normals() {
     return this.geometry.normals;
 };
 
-TileMesh.prototype.fourCorners = function () {
+TileMesh.prototype.fourCorners = function fourCorners() {
     return this.geometry.fourCorners;
 };
 
-TileMesh.prototype.normal = function () {
+TileMesh.prototype.normal = function normal() {
     return this.geometry.normal;
 };
 
-TileMesh.prototype.center = function () {
+TileMesh.prototype.center = function center() {
     return this.geometry.center;
 };
 
-TileMesh.prototype.OBB = function () {
+TileMesh.prototype.OBB = function OBB() {
     return this.geometry.OBB;
 };
 
-TileMesh.prototype.allTexturesAreLoaded = function () {
+TileMesh.prototype.allTexturesAreLoaded = function allTexturesAreLoaded() {
     return this.texturesNeeded === this.materials[RendererConstant.FINAL].getLoadedTexturesCount();
 };
 
-TileMesh.prototype.loadingCheck = function () {
+TileMesh.prototype.loadingCheck = function loadingCheck() {
     if (this.allTexturesAreLoaded()) {
         this.loaded = true;
         this.parent.childrenLoaded();
     }
 };
 
-TileMesh.prototype.getIndexLayerColor = function (idLayer) {
+TileMesh.prototype.getIndexLayerColor = function getIndexLayerColor(idLayer) {
     return this.materials[RendererConstant.FINAL].indexOfColorLayer(idLayer);
 };
 
-TileMesh.prototype.removeColorLayer = function (idLayer) {
+TileMesh.prototype.removeColorLayer = function removeColorLayer(idLayer) {
     const index = this.materials[RendererConstant.FINAL].indexOfColorLayer(idLayer);
     const texturesCount = this.materials[RendererConstant.FINAL].getTextureCountByLayerIndex(index);
     this.materials[RendererConstant.FINAL].removeColorLayer(idLayer);
@@ -281,7 +281,7 @@ TileMesh.prototype.removeColorLayer = function (idLayer) {
     this.loadingCheck();
 };
 
-TileMesh.prototype.changeSequenceLayers = function (sequence) {
+TileMesh.prototype.changeSequenceLayers = function changeSequenceLayers(sequence) {
     var layerCount = this.materials[RendererConstant.FINAL].getColorLayersCount();
 
     // Quit if there is only one layer

--- a/src/MobileMapping/GeometryProj.js
+++ b/src/MobileMapping/GeometryProj.js
@@ -14,24 +14,24 @@ function GeometryProj() {
 GeometryProj.prototype = Object.create(THREE.BufferGeometry.prototype);
 GeometryProj.prototype.constructor = GeometryProj;
 
-GeometryProj.prototype.enableRTC = function (enable) {
+GeometryProj.prototype.enableRTC = function enableRTC(enable) {
     this.material.enableRTC(enable);
 };
 
 
-GeometryProj.prototype.setFog = function (fog) {
+GeometryProj.prototype.setFog = function setFog(fog) {
     this.material.setFogDistance(fog);
 };
 
-GeometryProj.prototype.setMatrixRTC = function (rtc) {
+GeometryProj.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
     this.material.setMatrixRTC(rtc);
 };
 
-GeometryProj.prototype.setDebug = function (enable) {
+GeometryProj.prototype.setDebug = function setDebug(enable) {
     this.material.setDebug(enable);
 };
 
-GeometryProj.prototype.setSelected = function (select) {
+GeometryProj.prototype.setSelected = function setSelected(select) {
     this.material.setSelected(select);
 };
 

--- a/src/MobileMapping/MobileMappingLayer.js
+++ b/src/MobileMapping/MobileMappingLayer.js
@@ -43,7 +43,7 @@ MobileMappingLayer.prototype = Object.create(Layer.prototype);
 MobileMappingLayer.prototype.constructor = MobileMappingLayer;
 
 
-MobileMappingLayer.prototype.initiatePanoramic = function (imageOpt) {
+MobileMappingLayer.prototype.initiatePanoramic = function initiatePanoramic(imageOpt) {
     var imagesOptions = imageOpt || this.getDefaultOptions();
     // console.log(this.defaultOptions);
     // Create and add the MobileMappingLayer with Panoramic imagery
@@ -65,7 +65,7 @@ MobileMappingLayer.prototype.initiatePanoramic = function (imageOpt) {
 };
 
 
-MobileMappingLayer.prototype.updateData = function () {
+MobileMappingLayer.prototype.updateData = function updateData() {
     var pos = gfxEngine().controls.getPickingPosition();
     var posWGS84 = new Projection().cartesianToGeo(pos);
     var lonDeg = posWGS84.longitude / Math.PI * 180;
@@ -85,7 +85,7 @@ MobileMappingLayer.prototype.updateData = function () {
 };
 
 
-MobileMappingLayer.prototype.moveCameraToScanPosition = function (pos) {
+MobileMappingLayer.prototype.moveCameraToScanPosition = function moveCameraToScanPosition(pos) {
     var speedMove = 0.1;
     var currentPos = gfxEngine().camera.camera3D.position.clone();
 
@@ -104,7 +104,7 @@ MobileMappingLayer.prototype.moveCameraToScanPosition = function (pos) {
       }, 20); }
 };
 
-MobileMappingLayer.prototype.getDefaultOptions = function () {
+MobileMappingLayer.prototype.getDefaultOptions = function getDefaultOptions() {
     var o = {
         // HTTP access to itowns sample datasets
         // url : "../{lod}/images/{YYMMDD}/Paris-{YYMMDD}_0740-{cam.cam}-00001_{pano.pano:07}.jpg",

--- a/src/MobileMapping/Sensor.js
+++ b/src/MobileMapping/Sensor.js
@@ -7,7 +7,7 @@
 import * as THREE from 'three';
 
 
-var Sensor = function (infos) {
+var Sensor = function Sensor(infos) {
     this.infos = infos;
     this.position = new THREE.Vector3().fromArray(infos.position);
     this.rotation = new THREE.Matrix3().fromArray(infos.rotation);
@@ -39,7 +39,7 @@ var Sensor = function (infos) {
 };
 
 
-Sensor.prototype.getDistortion_r2max = function (disto) {
+Sensor.prototype.getDistortion_r2max = function getDistortion_r2max(disto) {
     // returned the square of the smallest positive root of the derivativeof the distortion polynomial
     // which tells where the distortion might no longer be bijective.
     var roots = this.cardan_cubic_roots(7 * disto.z, 5 * disto.y, 3 * disto.x, 1);
@@ -52,7 +52,7 @@ Sensor.prototype.getDistortion_r2max = function (disto) {
 
 
 // rotation * Photogram_JMM * getMatOrientationCapteur * photgramme_image
-Sensor.prototype.getMatOrientationTotal = function () {
+Sensor.prototype.getMatOrientationTotal = function getMatOrientationTotal() {
     var out = this.rotation.clone();
     out = new THREE.Matrix3().multiplyMatrices(out.clone(), this.Photogram_JMM.clone());
 
@@ -63,7 +63,7 @@ Sensor.prototype.getMatOrientationTotal = function () {
     return out;
 };
 
-Sensor.prototype.getMatOrientationCapteur = function () {
+Sensor.prototype.getMatOrientationCapteur = function getMatOrientationCapteur() {
     var ori0 = new THREE.Matrix3().set(0, -1, 0,
         1, 0, 0,
         0, 0, 1);
@@ -92,9 +92,9 @@ Sensor.prototype.getMatOrientationCapteur = function () {
 };
 
 
-Sensor.prototype.cardan_cubic_roots = function (a, b, c, d) {
+Sensor.prototype.cardan_cubic_roots = function cardan_cubic_roots(a, b, c, d) {
     // http://fr.wikipedia.org/wiki/Methode_de_Cardan  Thanks Bredif
-    var cardan_cubic_roots = function (a, b, c, d) {
+    var cardan_cubic_roots = function cardan_cubic_roots(a, b, c, d) {
         if (a === 0) return quadratic_roots(b, c, d);
         var vt = -b / (3 * a);
         var a2 = a * a;
@@ -132,7 +132,7 @@ Sensor.prototype.cardan_cubic_roots = function (a, b, c, d) {
         }
     };
 
-    var quadratic_roots = function (a, b, c) {
+    var quadratic_roots = function quadratic_roots(a, b, c) {
         var delta = b * b - 4 * a * c;
         if (delta < 0) return [];
         var x0 = -b / (2 * a);
@@ -141,11 +141,11 @@ Sensor.prototype.cardan_cubic_roots = function (a, b, c, d) {
         return [x0 - sqr_delta_2a, x0 + sqr_delta_2a];
     };
 
-    var sgn = function (x) {
+    var sgn = function sgn(x) {
         return (x > 0) - (x < 0);
     };
 
-    var cubic_root = function (x) {
+    var cubic_root = function cubic_root(x) {
         return sgn(x) * Math.pow(Math.abs(x), 1 / 3);
     };
 

--- a/src/MobileMapping/Shader.js
+++ b/src/MobileMapping/Shader.js
@@ -80,7 +80,7 @@ var Shader = {
             var request = new XMLHttpRequest();
             request.open('GET', currentShaderURL, true);
 
-            request.onload = function () {
+            request.onload = function onloadFn() {
                 if (request.status >= 200 && request.status < 400) {
                     // Success!
                     partialLoading(request.responseText, currentShaderURL.substr(currentShaderURL.lastIndexOf('/') + 1));
@@ -89,7 +89,7 @@ var Shader = {
                 }
             };
 
-            request.onerror = function () {
+            request.onerror = function onerrorFn() {
                 // console.error("no  connection, Unable to load shader from file" + currentShaderURL);
             };
 

--- a/src/Renderer/BasicMaterial.js
+++ b/src/Renderer/BasicMaterial.js
@@ -59,35 +59,35 @@ function BasicMaterial(color) {
 BasicMaterial.prototype = Object.create(THREE.RawShaderMaterial.prototype);
 BasicMaterial.prototype.constructor = BasicMaterial;
 
-BasicMaterial.prototype.enableRTC = function (enable) {
+BasicMaterial.prototype.enableRTC = function enableRTC(enable) {
     this.uniforms.useRTC.value = enable;
 };
 
-BasicMaterial.prototype.setDebug = function (debug_value) {
+BasicMaterial.prototype.setDebug = function setDebug(debug_value) {
     this.uniforms.debug.value = debug_value;
 };
 
-BasicMaterial.prototype.setMatrixRTC = function (rtc) {
+BasicMaterial.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
     this.uniforms.mVPMatRTC.value = rtc;
 };
 
-BasicMaterial.prototype.getMatrixRTC = function () {
+BasicMaterial.prototype.getMatrixRTC = function getMatrixRTC() {
     return this.uniforms.mVPMatRTC.value;
 };
 
-BasicMaterial.prototype.setUuid = function (uuid) {
+BasicMaterial.prototype.setUuid = function setUuid(uuid) {
     this.uniforms.uuid.value = uuid;
 };
 
-BasicMaterial.prototype.getUuid = function () {
+BasicMaterial.prototype.getUuid = function getUuid() {
     return this.uniforms.uuid.value;
 };
 
-BasicMaterial.prototype.setFogDistance = function (df) {
+BasicMaterial.prototype.setFogDistance = function setFogDistance(df) {
     this.uniforms.distanceFog.value = df;
 };
 
-BasicMaterial.prototype.setSelected = function (selected) {
+BasicMaterial.prototype.setSelected = function setSelected(selected) {
     this.uniforms.selected.value = selected;
 };
 

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -41,15 +41,15 @@ Camera.prototype.constructor = Camera;
 
 /**
  */
-Camera.prototype.position = function () {
+Camera.prototype.position = function position() {
     return this.camera3D.position;
 };
 
-Camera.prototype.camHelper = function () {
+Camera.prototype.camHelper = function camHelper() {
     return this.cameraHelper;
 };
 
-Camera.prototype.updatePreSSE = function () {
+Camera.prototype.updatePreSSE = function updatePreSSE() {
     this.Hypotenuse = Math.sqrt(this.width * this.width + this.height * this.height);
     var radAngle = this.FOV * Math.PI / 180;
 
@@ -68,7 +68,7 @@ Camera.prototype.updatePreSSE = function () {
     */
 };
 
-Camera.prototype.createCamHelper = function () {
+Camera.prototype.createCamHelper = function createCamHelper() {
     this.cameraHelper = new THREE.CameraHelper(this.camera3D);
 
     var dir = new THREE.Vector3(0, 0, -1);
@@ -84,11 +84,11 @@ Camera.prototype.createCamHelper = function () {
     this.cameraHelper.add(this.arrowHelper);
 };
 
-Camera.prototype.matrixWorldInverse = function () {
+Camera.prototype.matrixWorldInverse = function matrixWorldInverse() {
     return this.camera3D.matrixWorldInverse;
 };
 
-Camera.prototype.resize = function (width, height) {
+Camera.prototype.resize = function resize(width, height) {
     this.width = width;
     this.height = height;
     this.ratio = width / height;
@@ -109,7 +109,7 @@ Camera.prototype.resize = function (width, height) {
     }
 };
 
-Camera.prototype.computeNodeSSE = function (node) {
+Camera.prototype.computeNodeSSE = function computeNodeSSE(node) {
     var boundingSphere = node.geometry.boundingSphere;
     var distance = Math.max(0.0, (this.camera3D.position.distanceTo(node.centerSphere) - boundingSphere.radius));
 
@@ -129,7 +129,7 @@ Camera.prototype.computeNodeSSE = function (node) {
     return SSE;
 };
 
-Camera.prototype.update = function () {
+Camera.prototype.update = function update() {
     var vector = new THREE.Vector3(0, 0, 1);
 
     this.direction = vector.applyQuaternion(this.camera3D.quaternion);
@@ -137,32 +137,32 @@ Camera.prototype.update = function () {
     this.frustum.setFromMatrix(new THREE.Matrix4().multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse));
 };
 
-Camera.prototype.updateMatrixWorld = function () {
+Camera.prototype.updateMatrixWorld = function updateMatrixWorld() {
     this.camera3D.updateMatrix();
     this.camera3D.updateMatrixWorld(true);
     this.camera3D.matrixWorldInverse.getInverse(this.camera3D.matrixWorld);
 };
 
-Camera.prototype.getDistanceFromOrigin = function () {
+Camera.prototype.getDistanceFromOrigin = function getDistanceFromOrigin() {
     return this.camera3D.position.length();
 };
 
-Camera.prototype.setPosition = function (position) {
+Camera.prototype.setPosition = function setPosition(position) {
     this.camera3D.position.copy(position);
 };
 
-Camera.prototype.setRotation = function (rotation) {
+Camera.prototype.setRotation = function setRotation(rotation) {
     this.camera3D.quaternion.copy(rotation);
 };
 
-Camera.prototype.getFrustum = function () {
+Camera.prototype.getFrustum = function getFrustum() {
     this.updateMatrixWorld();
     this.frustum.setFromMatrix(new THREE.Matrix4().multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse));
 
     return this.frustum;
 };
 
-Camera.prototype.getFrustumLocalSpace = function (position, quaternion) {
+Camera.prototype.getFrustumLocalSpace = function getFrustumLocalSpace(position, quaternion) {
     var m = new THREE.Matrix4();
 
     m.makeRotationFromQuaternion(quaternion.inverse());

--- a/src/Renderer/GlobeDepthMaterial.js
+++ b/src/Renderer/GlobeDepthMaterial.js
@@ -3,7 +3,7 @@ import BasicMaterial from 'Renderer/BasicMaterial';
 import GlobeDepthFS from 'Renderer/Shader/GlobeDepthFS.glsl';
 import GlobeDepthVS from 'Renderer/Shader/GlobeDepthVS.glsl';
 
-var GlobeDepthMaterial = function (otherMaterial) {
+var GlobeDepthMaterial = function GlobeDepthMaterial(otherMaterial) {
     BasicMaterial.call(this);
 
     this.vertexShader = this.vertexShaderHeader + GlobeDepthVS;

--- a/src/Renderer/ItownsLineMaterial.js
+++ b/src/Renderer/ItownsLineMaterial.js
@@ -9,7 +9,7 @@ import BasicMaterial from 'Renderer/BasicMaterial';
 import LineVS from 'Renderer/Shader/LineVS.glsl';
 import LineFS from 'Renderer/Shader/LineFS.glsl';
 
-var ItownsLineMaterial = function (options) {
+var ItownsLineMaterial = function ItownsLineMaterial(options) {
     BasicMaterial.call(this);
 
     if (options === undefined)

--- a/src/Renderer/ItownsPointMaterial.js
+++ b/src/Renderer/ItownsPointMaterial.js
@@ -3,7 +3,7 @@ import BasicMaterial from 'Renderer/BasicMaterial';
 import PointVS from 'Renderer/Shader/PointVS.glsl';
 import PointFS from 'Renderer/Shader/PointFS.glsl';
 
-var ItownsPointMaterial = function (options) {
+var ItownsPointMaterial = function ItownsPointMaterial(options) {
     BasicMaterial.call(this);
 
     if (options === undefined)

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -25,7 +25,7 @@ var fooTexture;
 export const l_ELEVATION = 0;
 export const l_COLOR = 1;
 
-var getColorAtIdUv = function (nbTex) {
+var getColorAtIdUv = function getColorAtIdUv(nbTex) {
     if (!fooTexture) {
         fooTexture = 'vec4 colorAtIdUv(sampler2D dTextures[TEX_UNITS],vec3 offsetScale[TEX_UNITS],int id, vec2 uv){\n';
         fooTexture += ' if (id == 0) return texture2D(dTextures[0],  pitUV(uv,offsetScale[0]));\n';
@@ -42,17 +42,17 @@ var getColorAtIdUv = function (nbTex) {
 };
 
 // Array not suported in IE
-var fillArray = function (array, remp) {
+var fillArray = function fillArray(array, remp) {
     for (var i = 0; i < array.length; i++)
         { array[i] = remp; }
 };
 
-var moveElementArray = function (array, old_index, new_index)
+var moveElementArray = function moveElementArray(array, old_index, new_index)
 {
     array.splice(new_index, 0, array.splice(old_index, 1)[0]);
 };
 
-var moveElementsArray = function (array, index, howMany, toIndex) {
+var moveElementsArray = function moveElementsArray(array, index, howMany, toIndex) {
     if ((toIndex > index) && (toIndex <= index + howMany)) {
         toIndex = index + howMany;
     }
@@ -61,7 +61,7 @@ var moveElementsArray = function (array, index, howMany, toIndex) {
 };
 
 /* eslint-disable */
-var moveElementsArraySafe = function (array,index, howMany, toIndex) {
+var moveElementsArraySafe = function moveElementsArraySafe(array,index, howMany, toIndex) {
     index = parseInt(index) || 0;
     index = index < 0 ? array.length + index : index;
     toIndex = parseInt(toIndex) || 0;
@@ -76,7 +76,7 @@ var moveElementsArraySafe = function (array,index, howMany, toIndex) {
 };
 /* eslint-enable */
 
-var LayeredMaterial = function (id) {
+var LayeredMaterial = function LayeredMaterial(id) {
     BasicMaterial.call(this);
 
     const maxTexturesUnits = gfxEngine().glParams.maxTexturesUnits;
@@ -158,7 +158,7 @@ var LayeredMaterial = function (id) {
 LayeredMaterial.prototype = Object.create(BasicMaterial.prototype);
 LayeredMaterial.prototype.constructor = LayeredMaterial;
 
-LayeredMaterial.prototype.dispose = function () {
+LayeredMaterial.prototype.dispose = function dispose() {
     // TODO: WARNING  verify if textures to dispose aren't attached with ancestor
 
     this.dispatchEvent({
@@ -182,7 +182,7 @@ LayeredMaterial.prototype.dispose = function () {
     jT.freeArray(this.uniforms.dTextures_01.value);
 };
 
-LayeredMaterial.prototype.setSequence = function (sequenceLayer) {
+LayeredMaterial.prototype.setSequence = function setSequence(sequenceLayer) {
     let offsetLayer = 0;
     let offsetTexture = 0;
 
@@ -213,7 +213,7 @@ LayeredMaterial.prototype.setSequence = function (sequenceLayer) {
     this.uniforms.colorLayersCount.value = this.getColorLayersCount();
 };
 
-LayeredMaterial.prototype.removeColorLayer = function (layer) {
+LayeredMaterial.prototype.removeColorLayer = function removeColorLayer(layer) {
     const layerIndex = this.indexOfColorLayer(layer);
 
     if (layerIndex === -1) {
@@ -268,7 +268,7 @@ LayeredMaterial.prototype.removeColorLayer = function (layer) {
     this.uniforms.dTextures_01.value = this.textures[l_COLOR];
 };
 
-LayeredMaterial.prototype.setTexturesLayer = function (textures, layerType, layer) {
+LayeredMaterial.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layer) {
     const index = this.indexOfColorLayer(layer);
     const slotOffset = this.getTextureOffsetByLayerIndex(index);
     for (let i = 0, max = textures.length; i < max; i++) {
@@ -283,7 +283,7 @@ LayeredMaterial.prototype.setTexturesLayer = function (textures, layerType, laye
     }
 };
 
-LayeredMaterial.prototype.setTexture = function (texture, layerType, slot, offsetScale) {
+LayeredMaterial.prototype.setTexture = function setTexture(texture, layerType, slot, offsetScale) {
     if (this.textures[layerType][slot] === undefined || this.textures[layerType][slot].image === undefined) {
         this.loadedTexturesCount[layerType] += 1;
     }
@@ -293,7 +293,7 @@ LayeredMaterial.prototype.setTexture = function (texture, layerType, slot, offse
     this.offsetScale[layerType][slot] = offsetScale ? offsetScale : new THREE.Vector3(0.0, 0.0, 1.0);
 };
 
-LayeredMaterial.prototype.setColorLayerParameters = function (params) {
+LayeredMaterial.prototype.setColorLayerParameters = function setColorLayerParameters(params) {
     if (this.getColorLayersCount() === 0) {
         for (let l = 0; l < params.length; l++) {
             this.pushLayer(params[l]);
@@ -301,7 +301,7 @@ LayeredMaterial.prototype.setColorLayerParameters = function (params) {
     }
 };
 
-LayeredMaterial.prototype.pushLayer = function (param) {
+LayeredMaterial.prototype.pushLayer = function pushLayer(param) {
     const newIndex = this.getColorLayersCount();
     const offset = newIndex === 0 ? 0 : this.getTextureOffsetByLayerIndex(newIndex - 1) + this.getTextureCountByLayerIndex(newIndex - 1);
 
@@ -318,65 +318,65 @@ LayeredMaterial.prototype.pushLayer = function (param) {
     this.uniforms.colorLayersCount.value = this.getColorLayersCount();
 };
 
-LayeredMaterial.prototype.indexOfColorLayer = function (layer) {
+LayeredMaterial.prototype.indexOfColorLayer = function indexOfColorLayer(layer) {
     return this.colorLayersId.indexOf(layer);
 };
 
-LayeredMaterial.prototype.getColorLayersCount = function () {
+LayeredMaterial.prototype.getColorLayersCount = function getColorLayersCount() {
     return this.colorLayersId.length;
 };
 
-LayeredMaterial.prototype.getTextureOffsetByLayerIndex = function (index) {
+LayeredMaterial.prototype.getTextureOffsetByLayerIndex = function getTextureOffsetByLayerIndex(index) {
     return this.uniforms.paramLayers.value[index].x;
 };
 
-LayeredMaterial.prototype.getTextureCountByLayerIndex = function (index) {
+LayeredMaterial.prototype.getTextureCountByLayerIndex = function getTextureCountByLayerIndex(index) {
     return this.layerTexturesCount[index];
 };
 
-LayeredMaterial.prototype.getLayerTextureOffset = function (layer) {
+LayeredMaterial.prototype.getLayerTextureOffset = function getLayerTextureOffset(layer) {
     const index = this.indexOfColorLayer(layer);
     return index > -1 ? this.getTextureOffsetByLayerIndex(index) : -1;
 };
 
-LayeredMaterial.prototype.setLightingOn = function (enable) {
+LayeredMaterial.prototype.setLightingOn = function setLightingOn(enable) {
     this.uniforms.lightingOn.value = enable;
 };
 
-LayeredMaterial.prototype.setLayerFx = function (index, fx) {
+LayeredMaterial.prototype.setLayerFx = function setLayerFx(index, fx) {
     this.uniforms.paramLayers.value[index].z = fx;
 };
 
-LayeredMaterial.prototype.setTextureOffsetByLayerIndex = function (index, offset) {
+LayeredMaterial.prototype.setTextureOffsetByLayerIndex = function setTextureOffsetByLayerIndex(index, offset) {
     this.uniforms.paramLayers.value[index].x = offset;
 };
 
-LayeredMaterial.prototype.setLayerUV = function (index, idUV) {
+LayeredMaterial.prototype.setLayerUV = function setLayerUV(index, idUV) {
     this.uniforms.paramLayers.value[index].y = idUV;
 };
 
-LayeredMaterial.prototype.setLayerOpacity = function (index, opacity) {
+LayeredMaterial.prototype.setLayerOpacity = function setLayerOpacity(index, opacity) {
     if (this.uniforms.paramLayers.value[index])
         { this.uniforms.paramLayers.value[index].w = opacity; }
 };
 
-LayeredMaterial.prototype.setLayerVisibility = function (index, visible) {
+LayeredMaterial.prototype.setLayerVisibility = function setLayerVisibility(index, visible) {
     this.uniforms.visibility.value[index] = visible;
 };
 
-LayeredMaterial.prototype.setLayerTexturesCount = function (index, count) {
+LayeredMaterial.prototype.setLayerTexturesCount = function setLayerTexturesCount(index, count) {
     this.layerTexturesCount[index] = count;
 };
 
-LayeredMaterial.prototype.getLoadedTexturesCount = function () {
+LayeredMaterial.prototype.getLoadedTexturesCount = function getLoadedTexturesCount() {
     return this.loadedTexturesCount[l_ELEVATION] + this.loadedTexturesCount[l_COLOR];
 };
 
-LayeredMaterial.prototype.isColorLayerDownscaled = function (layer, level) {
+LayeredMaterial.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layer, level) {
     return this.textures[l_COLOR][this.getLayerTextureOffset(layer)].level < level;
 };
 
-LayeredMaterial.prototype.isLayerTypeDownscaled = function (layerType, level) {
+LayeredMaterial.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType, level) {
     if (layerType === l_ELEVATION) {
         if (this.textures[l_ELEVATION][0].level < 0) {
             return false;
@@ -395,7 +395,7 @@ LayeredMaterial.prototype.isLayerTypeDownscaled = function (layerType, level) {
     return false;
 };
 
-LayeredMaterial.prototype.getColorLayerLevelById = function (colorLayerId) {
+LayeredMaterial.prototype.getColorLayerLevelById = function getColorLayerLevelById(colorLayerId) {
     let index = this.indexOfColorLayer(colorLayerId);
     // TODO: hiding the "colorLayerId is invalid", it's problem, needs new PR
     if (index === -1) {
@@ -407,11 +407,11 @@ LayeredMaterial.prototype.getColorLayerLevelById = function (colorLayerId) {
     return level;
 };
 
-LayeredMaterial.prototype.getElevationLayerLevel = function () {
+LayeredMaterial.prototype.getElevationLayerLevel = function getElevationLayerLevel() {
     return this.textures[l_ELEVATION][0].level;
 };
 
-LayeredMaterial.prototype.getLayerLevel = function (layerType, layer) {
+LayeredMaterial.prototype.getLayerLevel = function getLayerLevel(layerType, layer) {
     if (layerType == l_ELEVATION) {
         return this.getElevationLayerLevel();
     } else {

--- a/src/Renderer/MatteIdsMaterial.js
+++ b/src/Renderer/MatteIdsMaterial.js
@@ -13,7 +13,7 @@ import GlobeDepthVS from 'Renderer/Shader/GlobeDepthVS.glsl';
 // This material renders the id in RGBA Color
 // Warning the RGBA contains id in float pack in 4 unsigned char
 
-var MatteIdsMaterial = function (otherMaterial) {
+var MatteIdsMaterial = function MatteIdsMaterial(otherMaterial) {
     BasicMaterial.call(this);
 
     this.vertexShader = this.vertexShaderHeader + GlobeDepthVS;
@@ -30,7 +30,7 @@ var MatteIdsMaterial = function (otherMaterial) {
 MatteIdsMaterial.prototype = Object.create(BasicMaterial.prototype);
 MatteIdsMaterial.prototype.constructor = MatteIdsMaterial;
 
-MatteIdsMaterial.prototype.setMatrixRTC = function (rtc) {
+MatteIdsMaterial.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
     this.uniforms.mVPMatRTC.value = rtc;
 };
 

--- a/src/Renderer/NodeMesh.js
+++ b/src/Renderer/NodeMesh.js
@@ -9,7 +9,7 @@ import Node from 'Scene/Node';
 import * as THREE from 'three';
 
 
-var NodeMesh = function () {
+var NodeMesh = function NodeMesh() {
     // Constructor
 
     Node.call(this);
@@ -24,18 +24,18 @@ NodeMesh.prototype = Object.create(THREE.Mesh.prototype);
 
 NodeMesh.prototype.constructor = NodeMesh;
 
-NodeMesh.prototype.enableRTC = function () {};
+NodeMesh.prototype.enableRTC = function enableRTC() {};
 
-NodeMesh.prototype.showHelper = function (show) {
+NodeMesh.prototype.showHelper = function showHelper(show) {
     if (this.helper !== undefined)
         { this.helper.visible = show; }
 };
 
-NodeMesh.prototype.isVisible = function () {
+NodeMesh.prototype.isVisible = function isVisible() {
     return this.visible;
 };
 
-NodeMesh.prototype.setVisibility = function (show) {
+NodeMesh.prototype.setVisibility = function setVisibility(show) {
     this.visible = show;
     this.showHelper(show);
 
@@ -43,7 +43,7 @@ NodeMesh.prototype.setVisibility = function (show) {
         { this.content.visible = show; }
 };
 
-NodeMesh.prototype.setDisplayed = function (show) {
+NodeMesh.prototype.setDisplayed = function setDisplayed(show) {
     this.material.visible = show;
     if (this.helper !== undefined)
         { this.helper.setMaterialVisibility(show); }
@@ -52,7 +52,7 @@ NodeMesh.prototype.setDisplayed = function (show) {
         { this.content.visible = true; }
 };
 
-NodeMesh.prototype.isDisplayed = function () {
+NodeMesh.prototype.isDisplayed = function isDisplayed() {
     return this.material.visible;
 };
 

--- a/src/Renderer/PanoramicMesh.js
+++ b/src/Renderer/PanoramicMesh.js
@@ -9,7 +9,7 @@
 import NodeMesh from 'Renderer/NodeMesh';
 
 
-var PanoramicMesh = function (geom, mat, absC) {
+var PanoramicMesh = function PanoramicMesh(geom, mat, absC) {
     NodeMesh.call(this);
 
     this.matrixAutoUpdate = false;
@@ -30,28 +30,28 @@ PanoramicMesh.prototype = Object.create(NodeMesh.prototype);
 PanoramicMesh.prototype.constructor = PanoramicMesh;
 
 
-PanoramicMesh.prototype.setGeometry = function (geom) {
+PanoramicMesh.prototype.setGeometry = function setGeometry(geom) {
     this.geometry = geom;
 };
 
-PanoramicMesh.prototype.setMaterial = function (mat) {
+PanoramicMesh.prototype.setMaterial = function setMaterial(mat) {
     this.material = mat;
 };
 
-PanoramicMesh.prototype.setMatrixRTC = function (rtc) {
+PanoramicMesh.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
     //  console.log(this.material);
     this.material.uniforms.mVPMatRTC.value = rtc;
 };
 
-PanoramicMesh.prototype.enableRTC = function () {
+PanoramicMesh.prototype.enableRTC = function enableRTC() {
     //  this.material.enableRTC(enable);
 };
 
-PanoramicMesh.prototype.setFog = function () {
+PanoramicMesh.prototype.setFog = function setFog() {
     //  this.material.setFogDistance(fog);
 };
 
-PanoramicMesh.prototype.setSelected = function () {
+PanoramicMesh.prototype.setSelected = function setSelected() {
     //  this.material.setSelected(select);
 };
 

--- a/src/Renderer/ProjectiveTexturingMaterial.js
+++ b/src/Renderer/ProjectiveTexturingMaterial.js
@@ -14,13 +14,13 @@ import url from 'url';
 import Ellipsoid from 'Core/Math/Ellipsoid';
 import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
 
-window.requestAnimSelectionAlpha = (function () {
+window.requestAnimSelectionAlpha = (function getRequestAnimSelectionAlphaFn() {
     return window.requestAnimationFrame ||
         window.webkitRequestAnimationFrame ||
         window.mozRequestAnimationFrame ||
         window.oRequestAnimationFrame ||
         window.msRequestAnimationFrame ||
-        function (callback) {
+        function requestAnimSelectionAlpha(callback) {
             window.setTimeout(callback, 1000 / 60);
         };
 }());
@@ -35,7 +35,7 @@ var ProjectiveTexturingMaterial = {
 
     init(infos, panoInfo, pivot) {
         if (_initPromise == null) {
-            _initPromise = Ori.init(infos).then(function () {
+            _initPromise = Ori.init(infos).then(function thenCb() {
                 // compute Camera Frame Rotation
                 var matRotationFrame = this.getCameraFrameRotation(panoInfo);
                 this.createShaderMat(panoInfo, matRotationFrame, pivot);
@@ -131,7 +131,7 @@ var ProjectiveTexturingMaterial = {
         src = src.format(infos); // console.log("src: ",src);
         var img = new Image();
         img.crossOrigin = 'anonymous';
-        img.onload = function () {
+        img.onload = function onLoad() {
             var tex = new THREE.Texture(this, THREE.UVMapping,
                 THREE.RepeatWrapping, THREE.RepeatWrapping, THREE.LinearFilter, THREE.LinearFilter, THREE.RGBFormat);
             tex.needsUpdate = true;

--- a/src/Renderer/ThreeExtented/GlobeControls.js
+++ b/src/Renderer/ThreeExtented/GlobeControls.js
@@ -135,7 +135,7 @@ function SnapCamera(camera) {
     this.projectionMatrix.elements = new Float64Array(16);
     this.invProjectionMatrix.elements = new Float64Array(16);
 
-    this.init = function (camera)
+    this.init = function init(camera)
     {
         this.matrixWorld.elements.set(camera.matrixWorld.elements);
         this.projectionMatrix.elements.set(camera.projectionMatrix.elements);
@@ -145,7 +145,7 @@ function SnapCamera(camera) {
 
     this.init(camera);
 
-    this.shot = function (objectToSnap)
+    this.shot = function shot(objectToSnap)
     {
         objectToSnap.updateMatrixWorld();
         this.matrixWorld.elements.set(objectToSnap.matrixWorld.elements);
@@ -155,7 +155,7 @@ function SnapCamera(camera) {
     var matrix = new THREE.Matrix4();
     matrix.elements = new Float64Array(16);
 
-    this.updateRay = function (ray, mouse)
+    this.updateRay = function updateRay(ray, mouse)
     {
         ray.origin.copy(this.position);
         ray.direction.set(mouse.x, mouse.y, 0.5);
@@ -258,28 +258,28 @@ function GlobeControls(camera, domElement, engine) {
 
 
     //
-    this.updateCamera = function (camera) {
+    this.updateCamera = function updateCamera(camera) {
         snapShotCamera.init(camera.camera3D);
         sizeRendering.width = camera.width;
         sizeRendering.height = camera.height;
     };
 
-    this.getAutoRotationAngle = function () {
+    this.getAutoRotationAngle = function getAutoRotationAngle() {
         return 2 * Math.PI / 60 / 60 * this.autoRotateSpeed;
     };
 
-    this.getZoomScale = function () {
+    this.getZoomScale = function getZoomScale() {
         return Math.pow(0.95, this.zoomSpeed);
     };
 
-    this.rotateLeft = function (angle) {
+    this.rotateLeft = function rotateLeft(angle) {
         if (angle === undefined) {
             angle = this.getAutoRotationAngle();
         }
         sphericalDelta.theta -= angle;
     };
 
-    this.rotateUp = function (angle) {
+    this.rotateUp = function rotateUp(angle) {
         if (angle === undefined) {
             angle = this.getAutoRotationAngle();
         }
@@ -288,7 +288,7 @@ function GlobeControls(camera, domElement, engine) {
     };
 
     // pass in distance in world space to move left
-    this.panLeft = function (distance) {
+    this.panLeft = function panLeft(distance) {
         var te = this.camera.matrix.elements;
 
         // get X column of matrix
@@ -299,7 +299,7 @@ function GlobeControls(camera, domElement, engine) {
     };
 
     // pass in distance in world space to move up
-    this.panUp = function (distance) {
+    this.panUp = function panUp(distance) {
         var te = this.camera.matrix.elements;
 
         // get Y column of matrix
@@ -311,7 +311,7 @@ function GlobeControls(camera, domElement, engine) {
 
     // pass in x,y of change desired in pixel space,
     // right and down are positive
-    this.mouseToPan = function (deltaX, deltaY) {
+    this.mouseToPan = function mouseToPan(deltaX, deltaY) {
         var element = this.domElement === document ? this.domElement.body : this.domElement;
 
         if (this.camera instanceof THREE.PerspectiveCamera) {
@@ -341,7 +341,7 @@ function GlobeControls(camera, domElement, engine) {
         }
     };
 
-    this.dollyIn = function (dollyScale) {
+    this.dollyIn = function dollyIn(dollyScale) {
         if (dollyScale === undefined) {
             dollyScale = this.getZoomScale();
         }
@@ -359,7 +359,7 @@ function GlobeControls(camera, domElement, engine) {
         }
     };
 
-    this.dollyOut = function (dollyScale) {
+    this.dollyOut = function dollyOut(dollyScale) {
         if (dollyScale === undefined) {
             dollyScale = this.getZoomScale();
         }
@@ -377,11 +377,11 @@ function GlobeControls(camera, domElement, engine) {
         }
     };
 
-    var getPickingPosition = (function () {
+    var getPickingPosition = (function getGetPickingPositionFn() {
         var engineGfx = engine;
         var position;
 
-        return function (coords)
+        return function getPickingPosition(coords)
         {
             position = engineGfx.getPickingPositionFromDepth(coords);
             engineGfx.renderScene();
@@ -393,7 +393,7 @@ function GlobeControls(camera, domElement, engine) {
     // introduction collision
     // Not use for the moment
     // eslint-disable-next-line
-    var collision = function(position)
+    var collision = function collision(position)
     {
         if (scene.getMap())
         {
@@ -419,7 +419,7 @@ function GlobeControls(camera, domElement, engine) {
 
     // /////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    var update = function () {
+    var update = function update() {
         // MOVE_GLOBE
         // Rotate globe with mouse
         if (state === CONTROL_STATE.MOVE_GLOBE) {
@@ -505,20 +505,20 @@ function GlobeControls(camera, domElement, engine) {
         }
     }.bind(this);
 
-    this.getSpace = function () {
+    this.getSpace = function getSpace() {
         return space;
     };
 
 
-    this.getSphericalDelta = function () {
+    this.getSphericalDelta = function getSphericalDelta() {
         return sphericalDelta;
     };
 
     // Position object on globe
-    var positionObject = (function ()
+    var positionObject = (function getPositionObjectFn()
     {
         var quaterionX = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 2);
-        return function (newPosition, object)
+        return function positionObject(newPosition, object)
         {
             object.position.copy(newPosition);
             object.lookAt(newPosition.clone().multiplyScalar(1.1));
@@ -528,7 +528,7 @@ function GlobeControls(camera, domElement, engine) {
     }());
 
     // set new globe target
-    var setGlobleTarget = function (newPosition) {
+    var setGlobleTarget = function setGlobleTarget(newPosition) {
  // Compute the new target center position
 
         positionObject(newPosition, globeTarget);
@@ -538,7 +538,7 @@ function GlobeControls(camera, domElement, engine) {
 
     var cT = new THREE.Vector3();
     // update globe target
-    var updateGlobeTarget = function () {
+    var updateGlobeTarget = function updateGlobeTarget() {
         // Get distance camera DME
         var pickingPosition = getPickingPosition();
 
@@ -563,22 +563,22 @@ function GlobeControls(camera, domElement, engine) {
     };
 
     // Update helper
-    var updateHelper = enableTargetHelper ? function (position, helper) {
+    var updateHelper = enableTargetHelper ? function updateHelper(position, helper) {
         positionObject(position, helper);
         this.dispatchEvent(this.changeEvent);
-    } : function () {};
+    } : function empty() {};
 
-    this.getPickingPositionOnSphere = function () {
+    this.getPickingPositionOnSphere = function getPickingPositionOnSphere() {
         return tSphere.picking.position;
     };
 
     // Update radius's sphere : the sphere must cross the point
     // Return intersection with mouse and sphere
-    var updateSpherePicking = (function () {
+    var updateSpherePicking = (function getUpdateSpherePicking() {
         var mouse = new THREE.Vector2();
         var ray = new THREE.Ray();
 
-        return function (point, screenCoord) {
+        return function updateSpherePicking(point, screenCoord) {
             tSphere.setRadius(point.length());
 
             mouse.x = (screenCoord.x / sizeRendering.width) * 2 - 1;
@@ -593,11 +593,11 @@ function GlobeControls(camera, domElement, engine) {
         };
     }());
 
-    var onMouseMove = (function () {
+    var onMouseMove = (function getOnMouseMoveFn() {
         var ray = new THREE.Ray();
         var mouse = new THREE.Vector2();
 
-        return function (event)
+        return function onMouseMove(event)
         {
             if (this.enabled === false) return;
 
@@ -662,7 +662,7 @@ function GlobeControls(camera, domElement, engine) {
         };
     }());
 
-    var onMouseDown = function (event) {
+    var onMouseDown = function onMouseDown(event) {
         if (this.enabled === false) return;
         event.preventDefault();
 
@@ -719,7 +719,7 @@ function GlobeControls(camera, domElement, engine) {
         }
     };
 
-    var onDblClick = function ()
+    var onDblClick = function onDblClick()
     {
         // state = CONTROL_STATE.ORBIT;
         // scale = 0.3333;
@@ -727,7 +727,7 @@ function GlobeControls(camera, domElement, engine) {
         // state = CONTROL_STATE.NONE;
     };
 
-    var onMouseUp = function (/* event */) {
+    var onMouseUp = function onMouseUp(/* event */) {
         if (this.enabled === false) return;
 
         this.domElement.removeEventListener('mousemove', _handlerMouseMove, false);
@@ -738,7 +738,7 @@ function GlobeControls(camera, domElement, engine) {
         state = CONTROL_STATE.NONE;
     };
 
-    var onMouseWheel = function (event) {
+    var onMouseWheel = function onMouseWheel(event) {
         if (this.enabled === false || this.enableZoom === false || state !== CONTROL_STATE.NONE) return;
 
         event.preventDefault();
@@ -768,7 +768,7 @@ function GlobeControls(camera, domElement, engine) {
         this.dispatchEvent(this.endEvent);
     };
 
-    var onKeyUp = function (/* event*/) {
+    var onKeyUp = function onKeyUp(/* event*/) {
         if (this.enabled === false || this.enableKeys === false || this.enablePan === false) return;
 
 
@@ -783,7 +783,7 @@ function GlobeControls(camera, domElement, engine) {
         keyS = false;
     };
 
-    var onKeyDown = function (event) {
+    var onKeyDown = function onKeyDown(event) {
         if (this.enabled === false || this.enableKeys === false || this.enablePan === false) return;
         keyCtrl = false;
         keyShift = false;
@@ -831,7 +831,7 @@ function GlobeControls(camera, domElement, engine) {
         }
     };
 
-    var onTouchStart = function (event) {
+    var onTouchStart = function onTouchStart(event) {
         if (this.enabled === false) return;
 
         switch (event.touches.length) {
@@ -875,7 +875,7 @@ function GlobeControls(camera, domElement, engine) {
         if (state !== CONTROL_STATE.NONE) this.dispatchEvent(this.startEvent);
     };
 
-    var onTouchMove = function (event) {
+    var onTouchMove = function onTouchMove(event) {
         if (this.enabled === false) return;
 
         event.preventDefault();
@@ -948,7 +948,7 @@ function GlobeControls(camera, domElement, engine) {
         }
     };
 
-    var onTouchEnd = function (/* event */) {
+    var onTouchEnd = function onTouchEnd(/* event */) {
         if (this.enabled === false) return;
 
         this.dispatchEvent(this.endEvent);
@@ -959,7 +959,7 @@ function GlobeControls(camera, domElement, engine) {
     };
 
     // update object camera position
-    this.updateCameraTransformation = function (controlState)
+    this.updateCameraTransformation = function updateCameraTransformation(controlState)
     {
         state = controlState || CONTROL_STATE.ORBIT;
         update();
@@ -967,7 +967,7 @@ function GlobeControls(camera, domElement, engine) {
         updateGlobeTarget.bind(this)();
     };
 
-    this.dispose = function () {
+    this.dispose = function dispose() {
         // this.domElement.removeEventListener( 'contextmenu', onContextMenu, false );
         this.domElement.removeEventListener('mousedown', onMouseDown, false);
         this.domElement.removeEventListener('mousewheel', onMouseWheel, false);
@@ -1032,12 +1032,12 @@ GlobeControls.prototype.constructor = GlobeControls;
 // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 // API Function
 
-GlobeControls.prototype.setTilt = function (tilt) {
+GlobeControls.prototype.setTilt = function setTilt(tilt) {
     sphericalDelta.phi = (tilt * Math.PI / 180 - this.getTiltRad());
     this.updateCameraTransformation();
 };
 
-GlobeControls.prototype.setHeading = function (heading) {
+GlobeControls.prototype.setHeading = function setHeading(heading) {
     sphericalDelta.theta = (heading * Math.PI / 180 - this.getHeadingRad());
     this.updateCameraTransformation();
 };
@@ -1047,11 +1047,11 @@ GlobeControls.prototype.setHeading = function (heading) {
  *
  * @return     {Vecto3}
  */
-GlobeControls.prototype.getTargetCameraPosition = function () {
+GlobeControls.prototype.getTargetCameraPosition = function getTargetCameraPosition() {
     return globeTarget.position;
 };
 
-GlobeControls.prototype.setCenter = function (position) {
+GlobeControls.prototype.setCenter = function setCenter(position) {
     var center = this.getTargetCameraPosition();
 
     snapShotCamera.shot(this.camera);
@@ -1066,17 +1066,17 @@ GlobeControls.prototype.setCenter = function (position) {
     this.updateCameraTransformation(CONTROL_STATE.MOVE_GLOBE);
 };
 
-GlobeControls.prototype.setRange = function (pRange) {
+GlobeControls.prototype.setRange = function setRange(pRange) {
     scale = pRange / this.getTargetCameraPosition().distanceTo(this.camera.position);
     this.updateCameraTransformation();
 };
 
-GlobeControls.prototype.getRange = function () {
+GlobeControls.prototype.getRange = function getRange() {
     return this.getTargetCameraPosition().distanceTo(this.camera.position);
 };
 
 // TODO idea : remove this? used in API
-GlobeControls.prototype.getRay = function () {
+GlobeControls.prototype.getRay = function getRay() {
     var direction = new THREE.Vector3(0, 0, 1);
     this.camera.localToWorld(direction);
     direction.sub(this.camera.position).negate().normalize();
@@ -1087,37 +1087,37 @@ GlobeControls.prototype.getRay = function () {
     };
 };
 
-GlobeControls.prototype.getTilt = function () {
+GlobeControls.prototype.getTilt = function getTilt() {
     return spherical.phi * 180 / Math.PI;
 };
 
-GlobeControls.prototype.getHeading = function () {
+GlobeControls.prototype.getHeading = function getHeading() {
     return spherical.theta * 180 / Math.PI;
 };
 
 // Same functions
 
-GlobeControls.prototype.getTiltRad = function () {
+GlobeControls.prototype.getTiltRad = function getTiltRad() {
     return spherical.phi;
 };
 
-GlobeControls.prototype.getHeadingRad = function () {
+GlobeControls.prototype.getHeadingRad = function getHeadingRad() {
     return spherical.theta;
 };
 
-GlobeControls.prototype.getPolarAngle = function () {
+GlobeControls.prototype.getPolarAngle = function getPolarAngle() {
     return spherical.phi;
 };
 
-GlobeControls.prototype.getAzimuthalAngle = function () {
+GlobeControls.prototype.getAzimuthalAngle = function getAzimuthalAngle() {
     return spherical.theta;
 };
 
-GlobeControls.prototype.moveTarget = function () {
+GlobeControls.prototype.moveTarget = function moveTarget() {
     return movingGlobeTarget;
 };
 
-GlobeControls.prototype.pan = function (deltaX, deltaY) {
+GlobeControls.prototype.pan = function pan(deltaX, deltaY) {
     this.mouseToPan(deltaX, deltaY);
     this.updateCameraTransformation(CONTROL_STATE.PAN);
 };
@@ -1125,7 +1125,7 @@ GlobeControls.prototype.pan = function (deltaX, deltaY) {
 // End API functions
 // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-GlobeControls.prototype.reset = function () {
+GlobeControls.prototype.reset = function reset() {
     // TODO not reset target globe
 
     state = CONTROL_STATE.NONE;

--- a/src/Renderer/ThreeExtented/KMZLoader.js
+++ b/src/Renderer/ThreeExtented/KMZLoader.js
@@ -16,7 +16,7 @@ KMZLoader.prototype = Object.create(KMZLoader.prototype);
 
 KMZLoader.prototype.constructor = KMZLoader;
 
-KMZLoader.prototype.parseCollada = function (buffer) {
+KMZLoader.prototype.parseCollada = function parseCollada(buffer) {
     var zip = new JSZip(buffer);
     var collada;
     var coordCarto;
@@ -40,7 +40,7 @@ KMZLoader.prototype.parseCollada = function (buffer) {
     return collada;
 };
 
-KMZLoader.prototype.load = function (url) {
+KMZLoader.prototype.load = function load(url) {
     return fetch(url).then((response) => {
         if (response.status < 200 || response.status >= 300) {
             throw new Error(`Error loading ${url}: status ${response.status}`);

--- a/src/Renderer/ThreeExtented/OBB.js
+++ b/src/Renderer/ThreeExtented/OBB.js
@@ -38,7 +38,7 @@ function OBB(min, max, lookAt, translate) {
 OBB.prototype = Object.create(THREE.Object3D.prototype);
 OBB.prototype.constructor = OBB;
 
-OBB.prototype.update = function () {
+OBB.prototype.update = function update() {
     this.updateMatrix();
     this.updateMatrixWorld();
 
@@ -47,11 +47,11 @@ OBB.prototype.update = function () {
     this.pointsWorld = this.cPointsWorld(this.points());
 };
 
-OBB.prototype.quadInverse = function () {
+OBB.prototype.quadInverse = function quadInverse() {
     return this.quaInv;
 };
 
-OBB.prototype.addHeight = function (bbox) {
+OBB.prototype.addHeight = function addHeight(bbox) {
     var depth = Math.abs(this.natBox.min.z - this.natBox.max.z);
     //
     this.box3D.min.z = this.natBox.min.z + bbox.bottom();
@@ -77,7 +77,7 @@ OBB.prototype.addHeight = function (bbox) {
     // TODO <---- à vérifier
 };
 
-OBB.prototype.points = function () {
+OBB.prototype.points = function points() {
     var points = [
         new THREE.Vector3(),
         new THREE.Vector3(),
@@ -101,7 +101,7 @@ OBB.prototype.points = function () {
     return points;
 };
 
-OBB.prototype.cPointsWorld = function (points) {
+OBB.prototype.cPointsWorld = function cPointsWorld(points) {
     var m = this.matrixWorld;
 
     for (var i = 0, max = points.length; i < max; i++) {

--- a/src/Renderer/ThreeExtented/OBBHelper.js
+++ b/src/Renderer/ThreeExtented/OBBHelper.js
@@ -50,12 +50,12 @@ function OBBHelper(OBB, text) {
 OBBHelper.prototype = Object.create(THREE.LineSegments.prototype);
 OBBHelper.prototype.constructor = OBBHelper;
 
-OBBHelper.prototype.setMaterialVisibility = function (show) {
+OBBHelper.prototype.setMaterialVisibility = function setMaterialVisibility(show) {
     this.material.visible = show;
     this.textMesh.material.visible = show;
 };
 
-OBBHelper.prototype.update = function (OBB) {
+OBBHelper.prototype.update = function update(OBB) {
     var box = OBB.box3D;
     var min = box.min;
     var max = box.max;

--- a/src/Renderer/ThreeExtented/SphereHelper.js
+++ b/src/Renderer/ThreeExtented/SphereHelper.js
@@ -21,7 +21,7 @@ function SphereHelper(radius) {
 SphereHelper.prototype = Object.create(THREE.Mesh.prototype);
 SphereHelper.prototype.constructor = SphereHelper;
 
-SphereHelper.prototype.update = function (radius) {
+SphereHelper.prototype.update = function update(radius) {
     this.geometry.dispose();
     this.geometry = new THREE.SphereGeometry(radius, 8, 8);
 };

--- a/src/Renderer/ThreeExtented/threeExt.js
+++ b/src/Renderer/ThreeExtented/threeExt.js
@@ -9,7 +9,7 @@ import * as THREE from 'three';
 // mbredif: extend THREE.Matrix3 prototype to with some THREE.Matrix4 functionalities
 THREE.Matrix3.prototype.fromArray = THREE.Matrix4.prototype.fromArray;
 
-THREE.Matrix3.prototype.multiplyMatrices = function (a, b) {
+THREE.Matrix3.prototype.multiplyMatrices = function multiplyMatrices(a, b) {
     var ae = a.elements;
     var be = b.elements;
     var te = this.elements;
@@ -49,7 +49,7 @@ THREE.Matrix3.prototype.multiplyMatrices = function (a, b) {
     return this;
 };
 
-THREE.Matrix3.prototype.flattenToArray = function (flat) {
+THREE.Matrix3.prototype.flattenToArray = function flattenToArray(flat) {
     var te = this.elements;
     flat[0] = te[0];
     flat[1] = te[1];
@@ -64,7 +64,7 @@ THREE.Matrix3.prototype.flattenToArray = function (flat) {
     return flat;
 };
 
-THREE.Matrix3.prototype.flattenToArrayOffset = function (flat, offset) {
+THREE.Matrix3.prototype.flattenToArrayOffset = function flattenToArrayOffset(flat, offset) {
     var te = this.elements;
     flat[offset] = te[0];
     flat[offset + 1] = te[1];
@@ -81,7 +81,7 @@ THREE.Matrix3.prototype.flattenToArrayOffset = function (flat, offset) {
     return flat;
 };
 
-THREE.Matrix3.prototype.makeRotationFromQuaternion = function (q) {
+THREE.Matrix3.prototype.makeRotationFromQuaternion = function makeRotationFromQuaternion(q) {
     var te = this.elements;
 
     var x = q.x,
@@ -116,7 +116,7 @@ THREE.Matrix3.prototype.makeRotationFromQuaternion = function (q) {
     return this;
 };
 
-THREE.Matrix3.prototype.fromMatrix4 = function (m) {
+THREE.Matrix3.prototype.fromMatrix4 = function fromMatrix4(m) {
     // var out = this.elements;
     var c = m.elements;
 

--- a/src/Renderer/WebGLTools/GenericBufferObject.js
+++ b/src/Renderer/WebGLTools/GenericBufferObject.js
@@ -12,7 +12,7 @@ function GenericBufferObject() {
 
 /**
  */
-GenericBufferObject.prototype.computeVertex = function () {
+GenericBufferObject.prototype.computeVertex = function computeVertex() {
     // TODO: Implement Me
 
 };

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -51,7 +51,7 @@ function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
     this.pickingTexture.texture.generateMipmaps = false;
     this.pickingTexture.depthBuffer = true;
 
-    this.renderScene = function () {
+    this.renderScene = function renderScene() {
         if (this.camera.camHelper())
             { this.camera.camHelper().visible = false; }
 
@@ -83,13 +83,13 @@ function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
         }
     }.bind(this);
 
-    this.update = function () {
+    this.update = function update() {
         this.camera.update();
         this.updateControl();
         this.scene.notifyChange();
     }.bind(this);
 
-    this.onWindowResize = function () {
+    this.onWindowResize = function onWindowResize() {
         this.width = this.viewerDiv.clientWidth * (this.debug ? 0.5 : 1);
         this.height = this.viewerDiv.clientHeight;
         this.camera.resize(this.width, this.height);
@@ -199,7 +199,7 @@ function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
  * update control parameter in function of distance of globe
  * @returns {undefined}
  */
-c3DEngine.prototype.updateControl = function () {
+c3DEngine.prototype.updateControl = function updateControl() {
     var len = this.camera.position().length();
     var lim = this.size * 1.1;
 
@@ -211,7 +211,7 @@ c3DEngine.prototype.updateControl = function () {
         { this.renderer.setClearColor(0x030508); }
 };
 
-c3DEngine.prototype.enableRTC = function (enable) {
+c3DEngine.prototype.enableRTC = function enableRTC(enable) {
     for (var x = 0; x < this.scene3D.children.length; x++) {
         var node = this.scene3D.children[x];
 
@@ -227,10 +227,10 @@ c3DEngine.prototype.enableRTC = function (enable) {
  * @param {type} state new state to apply
  * @returns {undefined}
  */
-c3DEngine.prototype.changeStateNodesScene = function (state) {
+c3DEngine.prototype.changeStateNodesScene = function changeStateNodesScene(state) {
     // build traverse function
-    var changeStateFunction = (function () {
-        return function (object3D) {
+    var changeStateFunction = (function getChangeStateFunctionFn() {
+        return function changeStateFunction(object3D) {
             object3D.changeState(state);
         };
     }());
@@ -250,12 +250,12 @@ c3DEngine.prototype.changeStateNodesScene = function (state) {
     }
 };
 
-c3DEngine.prototype.rtcOn = function (obj3D) {
+c3DEngine.prototype.rtcOn = function rtcOn(obj3D) {
     obj3D.enableRTC(true);
     obj3D.matrixAutoUpdate = false;
 };
 
-c3DEngine.prototype.rtcOff = function (obj3D) {
+c3DEngine.prototype.rtcOff = function rtcOff(obj3D) {
     obj3D.enableRTC(false);
     obj3D.matrixWorldNeedsUpdate = true;
     obj3D.matrixAutoUpdate = true;
@@ -263,7 +263,7 @@ c3DEngine.prototype.rtcOff = function (obj3D) {
 
 /**
  */
-c3DEngine.prototype.style2Engine = function () {
+c3DEngine.prototype.style2Engine = function style2Engine() {
     // TODO: Implement Me
 
 };
@@ -274,7 +274,7 @@ c3DEngine.prototype.style2Engine = function () {
  * @param {type} texture
  * @returns {undefined}
  */
-c3DEngine.prototype.setTexture = function (mesh, texture) {
+c3DEngine.prototype.setTexture = function setTexture(mesh, texture) {
     // TODO: Implement Me
     mesh.material = new THREE.MeshBasicMaterial({
         color: 0xffffff,
@@ -287,7 +287,7 @@ c3DEngine.prototype.setTexture = function (mesh, texture) {
  * @param {type} node
  * @returns {undefined}
  */
-c3DEngine.prototype.add3DScene = function (node) {
+c3DEngine.prototype.add3DScene = function add3DScene(node) {
     if (Array.isArray(node))
 
         { this.scene3D.add.apply(this.scene3D, node); }
@@ -298,13 +298,13 @@ c3DEngine.prototype.add3DScene = function (node) {
 };
 
 
-c3DEngine.prototype.removeAll = function () {
+c3DEngine.prototype.removeAll = function removeAll() {
     this.scene3D.children = [];
 };
 
 /**
  */
-c3DEngine.prototype.precision = function () {
+c3DEngine.prototype.precision = function precision() {
     // TODO: Implement Me
 
 };
@@ -312,7 +312,7 @@ c3DEngine.prototype.precision = function () {
 /*
  * return
  */
-c3DEngine.prototype.getWindowSize = function () {
+c3DEngine.prototype.getWindowSize = function getWindowSize() {
     return new THREE.Vector2(this.width, this.height);
 };
 
@@ -320,11 +320,11 @@ c3DEngine.prototype.getWindowSize = function () {
  * return renderer THREE.js
  * @returns {undefined|c3DEngine_L7.THREE.WebGLRenderer}
  */
-c3DEngine.prototype.getRenderer = function () {
+c3DEngine.prototype.getRenderer = function getRenderer() {
     return this.renderer;
 };
 
-c3DEngine.prototype.setStateRender = function (stateRender) {
+c3DEngine.prototype.setStateRender = function setStateRender(stateRender) {
     if (this.stateRender !== stateRender) {
         this.stateRender = stateRender;
 
@@ -332,7 +332,7 @@ c3DEngine.prototype.setStateRender = function (stateRender) {
     }
 };
 
-c3DEngine.prototype.renderTobuffer = function (x, y, width, height, mode) {
+c3DEngine.prototype.renderTobuffer = function renderTobuffer(x, y, width, height, mode) {
     // TODO Deallocate render texture
     var originalState = this.stateRender;
     this.setStateRender(mode);
@@ -352,7 +352,7 @@ c3DEngine.prototype.renderTobuffer = function (x, y, width, height, mode) {
     return pixelBuffer;
 };
 
-c3DEngine.prototype.bufferToImage = function (pixelBuffer, width, height) {
+c3DEngine.prototype.bufferToImage = function bufferToImage(pixelBuffer, width, height) {
     var canvas = document.createElement('canvas');
     var ctx = canvas.getContext('2d');
 
@@ -374,13 +374,13 @@ c3DEngine.prototype.bufferToImage = function (pixelBuffer, width, height) {
     return image;
 };
 
-c3DEngine.prototype.updatePositionBuffer = function () {
+c3DEngine.prototype.updatePositionBuffer = function updatePositionBuffer() {
     this.camera.camera3D.updateMatrixWorld();
     this.positionBuffer = this.renderTobuffer(0, 0, this.width, this.height, RendererConstant.DEPTH);
     this.renderScene(); // TODO debug to remove white screen, but why?
 };
 
-c3DEngine.prototype.pickingInPositionBuffer = function (mouse, scene) {
+c3DEngine.prototype.pickingInPositionBuffer = function pickingInPositionBuffer(mouse, scene) {
     if (this.positionBuffer === null)
         { this.updatePositionBuffer(); }
 
@@ -407,7 +407,7 @@ c3DEngine.prototype.pickingInPositionBuffer = function (mouse, scene) {
  * @param {type} scene
  * @returns THREE.Vector3 position cartesien in world space
  * */
-c3DEngine.prototype.getPickingPosition = function (mouse, scene) {
+c3DEngine.prototype.getPickingPosition = function getPickingPosition(mouse, scene) {
     if (mouse === undefined)
         { mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2)); }
 
@@ -430,7 +430,7 @@ c3DEngine.prototype.getPickingPosition = function (mouse, scene) {
     return worldPosition;
 };
 
-var unpack1K = function (color, factor) {
+var unpack1K = function unpack1K(color, factor) {
     var bitSh = new THREE.Vector4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
     return bitSh.dot(color) * factor;
 };
@@ -440,7 +440,7 @@ var unpack1K = function (color, factor) {
  * @param {Vecto2D} mouse : mouse position on screen in pixel
  * @returns {int} uuid's node
  * */
-c3DEngine.prototype.screenCoordsToNodeId = function (mouse) {
+c3DEngine.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {
     var camera = this.camera.camera3D;
 
     camera.updateMatrixWorld();
@@ -461,11 +461,11 @@ c3DEngine.prototype.screenCoordsToNodeId = function (mouse) {
  * @param {Vecto2D} mouse : mouse position on screen in pixel
  * Select node under mouse
  **/
-c3DEngine.prototype.selectNodeAt = function (mouse) {
+c3DEngine.prototype.selectNodeAt = function selectNodeAt(mouse) {
     this.scene.selectNodeId(this.screenCoordsToNodeId(mouse));
 };
 
-c3DEngine.prototype.getPickingPositionFromDepth = (function () {
+c3DEngine.prototype.getPickingPositionFromDepth = (function getGetPickingPosFromDepthFn() {
     var matrix = new THREE.Matrix4();
     matrix.elements = new Float64Array(16); // /!\ WARNING Matrix JS are in Float32Array
     var raycaster = new THREE.Raycaster();
@@ -474,7 +474,7 @@ c3DEngine.prototype.getPickingPositionFromDepth = (function () {
     var ray = new THREE.Ray();
     var depthRGBA = new THREE.Vector4();
 
-    return function (mouse) {
+    return function getPickingPositionFromDepth(mouse) {
         if (mouse === undefined)
             { mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2)); }
 
@@ -520,7 +520,7 @@ c3DEngine.prototype.getPickingPositionFromDepth = (function () {
     };
 }());
 
-c3DEngine.prototype.placeDummy = function (dummy, position) {
+c3DEngine.prototype.placeDummy = function placeDummy(dummy, position) {
     dummy.position.copy(position);
     var size = position.clone().sub(this.camera.position()).length() / 200; // TODO distance
     dummy.scale.copy(new THREE.Vector3(size, size, size));
@@ -531,7 +531,7 @@ c3DEngine.prototype.placeDummy = function (dummy, position) {
     dummy.updateMatrixWorld();
 };
 
-c3DEngine.prototype.getRTCMatrixFromCenter = function (center, camera) {
+c3DEngine.prototype.getRTCMatrixFromCenter = function getRTCMatrixFromCenter(center, camera) {
     var position = new THREE.Vector3().subVectors(camera.camera3D.position, center);
     var quaternion = new THREE.Quaternion().copy(camera.camera3D.quaternion);
     var matrix = new THREE.Matrix4().compose(position, quaternion, new THREE.Vector3(1, 1, 1));
@@ -541,7 +541,7 @@ c3DEngine.prototype.getRTCMatrixFromCenter = function (center, camera) {
     return new THREE.Matrix4().multiplyMatrices(camera.camera3D.projectionMatrix, mvc);
 };
 
-c3DEngine.prototype.getRTCMatrixFromNode = function (node, camera) {
+c3DEngine.prototype.getRTCMatrixFromNode = function getRTCMatrixFromNode(node, camera) {
     var camera3D = camera.camera3D;
     // var position = new THREE.Vector3().subVectors(camera3D.position, node.position);
     var positionWorld = new THREE.Vector3().setFromMatrixPosition(node.matrixWorld);
@@ -557,7 +557,7 @@ c3DEngine.prototype.getRTCMatrixFromNode = function (node, camera) {
     return new THREE.Matrix4().multiplyMatrices(camera3D.projectionMatrix, mvc);
 };
 
-c3DEngine.prototype.setLightingOn = function (value) {
+c3DEngine.prototype.setLightingOn = function setLightingOn(value) {
     this.lightingOn = value;
 };
 

--- a/src/Scene/BoundingBox.js
+++ b/src/Scene/BoundingBox.js
@@ -34,27 +34,27 @@ function BoundingBox(west, east, south, north, minAltitude, maxAltitude, unit) {
     this.size = Math.sqrt(this.dimension.x * this.dimension.x + this.dimension.y * this.dimension.y);
 }
 
-BoundingBox.prototype.west = function (unit) {
+BoundingBox.prototype.west = function west(unit) {
     return this.minCoordinate.longitude(unit);
 };
 
-BoundingBox.prototype.east = function (unit) {
+BoundingBox.prototype.east = function east(unit) {
     return this.maxCoordinate.longitude(unit);
 };
 
-BoundingBox.prototype.north = function (unit) {
+BoundingBox.prototype.north = function north(unit) {
     return this.maxCoordinate.latitude(unit);
 };
 
-BoundingBox.prototype.south = function (unit) {
+BoundingBox.prototype.south = function south(unit) {
     return this.minCoordinate.latitude(unit);
 };
 
-BoundingBox.prototype.top = function () {
+BoundingBox.prototype.top = function top() {
     return this.maxCoordinate.altitude();
 };
 
-BoundingBox.prototype.bottom = function () {
+BoundingBox.prototype.bottom = function bottom() {
     return this.minCoordinate.altitude();
 };
 
@@ -63,15 +63,15 @@ BoundingBox.prototype.bottom = function () {
  *
  * @param point {[object Object]}
  */
-BoundingBox.prototype.isInside = function (point) {
+BoundingBox.prototype.isInside = function isInside(point) {
     return point.x <= this.east() && point.x >= this.west() && point.y <= this.north() && point.y >= this.south();
 };
 
-BoundingBox.prototype.BBoxIsInside = function (bbox) {
+BoundingBox.prototype.BBoxIsInside = function BBoxIsInside(bbox) {
     return bbox.east() <= this.east() && bbox.west() >= this.west() && bbox.north() <= this.north() && bbox.south() >= this.south();
 };
 
-BoundingBox.prototype.offsetScale = function (bbox) {
+BoundingBox.prototype.offsetScale = function offsetScale(bbox) {
     var pitX = Math.abs(bbox.west() - this.west()) / this.dimension.x;
     var pitY = Math.abs(bbox.north() - this.north()) / this.dimension.y;
     var scale = bbox.dimension.x / this.dimension.x;
@@ -84,7 +84,7 @@ BoundingBox.prototype.offsetScale = function (bbox) {
  * @param {type} halfDimension : half dimension of box
  * @returns {undefined}
  */
-BoundingBox.prototype.set = function (center, halfDimension) {
+BoundingBox.prototype.set = function set(center, halfDimension) {
     this.halfDimension = halfDimension;
     this.center = center;
 };
@@ -95,7 +95,7 @@ BoundingBox.prototype.set = function (center, halfDimension) {
  * @param {type} max : maximum altitude
  * @returns {undefined}
  */
-BoundingBox.prototype.setBBoxZ = function (min, max) {
+BoundingBox.prototype.setBBoxZ = function setBBoxZ(min, max) {
     this.minCoordinate.setAltitude(min);
     this.maxCoordinate.setAltitude(max);
 };
@@ -105,7 +105,7 @@ BoundingBox.prototype.setBBoxZ = function (min, max) {
  * @param {type} bbox
  * @returns {Boolean}
  */
-BoundingBox.prototype.intersect = function (bbox) {
+BoundingBox.prototype.intersect = function intersect(bbox) {
     return !(this.west() >= bbox.east() || this.east() <= bbox.west() || this.south() >= bbox.north() || this.north() <= bbox.south());
 };
 

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -18,23 +18,23 @@ function BrowseTree(engine) {
     this.selectedNodeId = -1;
     this.selectedNode = null;
 
-    this.selectNode = function (node) {
+    this.selectNode = function selectNode(node) {
         this._selectNode(node);
     };
 }
 
-BrowseTree.prototype.addNodeProcess = function (nodeProcess) {
+BrowseTree.prototype.addNodeProcess = function addNodeProcess(nodeProcess) {
     this.nodeProcess = nodeProcess;
 };
 
-BrowseTree.prototype.NodeProcess = function () {
+BrowseTree.prototype.NodeProcess = function NodeProcess() {
     return this.nodeProcess;
 };
 
-BrowseTree.prototype.uniformsProcess = (function () {
+BrowseTree.prototype.uniformsProcess = (function getUniformsProcessFn() {
     var positionWorld = new THREE.Vector3();
 
-    return function (node, camera) {
+    return function uniformsProcess(node, camera) {
         node.setMatrixRTC(this.gfxEngine.getRTCMatrixFromCenter(positionWorld.setFromMatrixPosition(node.matrixWorld), camera));
         node.setFog(this.fogDistance);
 
@@ -42,7 +42,7 @@ BrowseTree.prototype.uniformsProcess = (function () {
     };
 }());
 
-BrowseTree.prototype._selectNode = function (node) {
+BrowseTree.prototype._selectNode = function _selectNode(node) {
     if (node.id === this.selectedNodeId) {
         node.setSelected(node.visible && node.material.visible);
         if (this.selectedNode !== node) {
@@ -68,7 +68,7 @@ function applyFunctionToChildren(func, node) {
  * @param {type} optional   : optional process
  * @returns {undefined}
  */
-BrowseTree.prototype.browse = function (tree, camera, process, layersConfig) {
+BrowseTree.prototype.browse = function browse(tree, camera, process, layersConfig) {
     this.tree = tree;
 
     camera.updateMatrixWorld();
@@ -94,7 +94,7 @@ BrowseTree.prototype.browse = function (tree, camera, process, layersConfig) {
  * @param {type} optional   : optional process
  * @returns {undefined}
  */
-BrowseTree.prototype._browseDisplayableNode = function (node, camera, process, params) {
+BrowseTree.prototype._browseDisplayableNode = function _browseDisplayableNode(node, camera, process, params) {
     if (node.parent.isVisible() && process.processNode(node, camera, params)) {
         if (node.isDisplayed()) {
             this.uniformsProcess(node, camera);
@@ -110,7 +110,7 @@ BrowseTree.prototype._browseDisplayableNode = function (node, camera, process, p
     }
 };
 
-BrowseTree.prototype._browseNonDisplayableNode = function (node, level, process, camera, params) {
+BrowseTree.prototype._browseNonDisplayableNode = function _browseNonDisplayableNode(node, level, process, camera, params) {
     // update node's sse value
     node.sse = camera.computeNodeSSE(node);
     node.setDisplayed(false);
@@ -152,12 +152,12 @@ BrowseTree.prototype._browseNonDisplayableNode = function (node, level, process,
  * @documentation: Recursive traverse tree to update a material specific uniform
  * @returns {undefined}
  */
-BrowseTree.prototype.updateMaterialUniform = function (uniformName, value) {
+BrowseTree.prototype.updateMaterialUniform = function updateMaterialUniform(uniformName, value) {
     for (var a = 0; a < this.tree.children.length; ++a) {
         var root = this.tree.children[a];
         for (var c = 0; c < root.children.length; c++) {
             var node = root.children[c];
-            var lookMaterial = function (obj) {
+            var lookMaterial = function lookMaterial(obj) {
                 obj.material.uniforms[uniformName].value = value;
             };
 
@@ -167,7 +167,7 @@ BrowseTree.prototype.updateMaterialUniform = function (uniformName, value) {
     }
 };
 
-BrowseTree.prototype.updateLayer = function (layer, camera) {
+BrowseTree.prototype.updateLayer = function updateLayer(layer, camera) {
     if (!layer.visible)
         { return; }
 
@@ -176,10 +176,10 @@ BrowseTree.prototype.updateLayer = function (layer, camera) {
     for (var c = 0; c < root.children.length; c++) {
         var node = root.children[c];
 
-        var cRTC = function () {
+        var cRTC = function getCRtcFn() {
             var mRTC = this.gfxEngine.getRTCMatrixFromNode(node, camera);
 
-            return function (obj) {
+            return function cRTC(obj) {
                 if (obj.setMatrixRTC)
                   { obj.setMatrixRTC(mRTC); }
             };
@@ -189,7 +189,7 @@ BrowseTree.prototype.updateLayer = function (layer, camera) {
     }
 };
 
-BrowseTree.prototype.updateMobileMappingLayer = function (layer, camera) {
+BrowseTree.prototype.updateMobileMappingLayer = function updateMobileMappingLayer(layer, camera) {
     if (!layer.visible)
         { return; }
 
@@ -201,7 +201,7 @@ BrowseTree.prototype.updateMobileMappingLayer = function (layer, camera) {
     }
 };
 
-BrowseTree.prototype.updateQuadtree = function (layer, layersConfiguration, camera) {
+BrowseTree.prototype.updateQuadtree = function updateQuadtree(layer, layersConfiguration, camera) {
     var quadtree = layer.node.tiles;
 
     this.browse(quadtree, camera, layer.process, layersConfiguration);

--- a/src/Scene/Description/DescriptionManager.js
+++ b/src/Scene/Description/DescriptionManager.js
@@ -13,7 +13,7 @@ function DescriptionManager() {
 
 /**
  */
-DescriptionManager.prototype.descriptionToContent = function () {
+DescriptionManager.prototype.descriptionToContent = function descriptionToContent() {
     // TODO: Implement Me
 
 };

--- a/src/Scene/Description/Style.js
+++ b/src/Scene/Description/Style.js
@@ -34,11 +34,11 @@ PaintingTool.prototype = Object.create(PaintingTool.prototype);
 
 PaintingTool.prototype.constructor = PaintingTool;
 
-PaintingTool.prototype.setTexture = function (texture) {
+PaintingTool.prototype.setTexture = function setTexture(texture) {
     this.texture = texture;
 };
 
-PaintingTool.prototype.addEffect = function (effect) {
+PaintingTool.prototype.addEffect = function addEffect(effect) {
     this.effects.push(effect);
 };
 
@@ -141,7 +141,7 @@ Style.prototype = Object.create(Style.prototype);
 
 Style.prototype.constructor = Style;
 
-Style.prototype.applyPalette = function (palette) {
+Style.prototype.applyPalette = function applyPalette(palette) {
     this.line.color = palette.colorLine;
     this.surface.color = palette.colorLine;
     this.surface.pen.color = palette.colorLineSurface;

--- a/src/Scene/Description/StyleManager.js
+++ b/src/Scene/Description/StyleManager.js
@@ -14,24 +14,24 @@ StyleManager.prototype = Object.create(StyleManager.prototype);
 
 StyleManager.prototype.constructor = StyleManager;
 
-StyleManager.prototype.getStyles = function () {
+StyleManager.prototype.getStyles = function getStyles() {
     return this.styles;
 };
 
-StyleManager.prototype.addStyle = function (style) {
+StyleManager.prototype.addStyle = function addStyle(style) {
     if (style instanceof Style)
 		{ this.styles.push(style); }
 };
 
-StyleManager.prototype.getStyle = function (idStyle) {
+StyleManager.prototype.getStyle = function getStyle(idStyle) {
     return this.styles.filter(element => element.name === idStyle).pop();
 };
 
-StyleManager.prototype.removeStyle = function (idStyle) {
+StyleManager.prototype.removeStyle = function removeStyle(idStyle) {
     this.styles = this.styles.filter(element => element.name === idStyle);
 };
 
-StyleManager.prototype.updateStyle = function () {
+StyleManager.prototype.updateStyle = function updateStyle() {
 
 
 };

--- a/src/Scene/Layer.js
+++ b/src/Scene/Layer.js
@@ -34,7 +34,7 @@ Layer.prototype = Object.create(Node.prototype);
 Layer.prototype.constructor = Layer;
 
 // Should be plural as it return an array of meshes
-Layer.prototype.getMesh = function () {
+Layer.prototype.getMesh = function getMesh() {
     var meshs = [];
 
     for (var i = 0; i < this.children.length; i++) {

--- a/src/Scene/LayersConfiguration.js
+++ b/src/Scene/LayersConfiguration.js
@@ -41,22 +41,22 @@ function defaultState(seq) {
     };
 }
 
-LayersConfiguration.prototype.addElevationLayer = function (layer) {
+LayersConfiguration.prototype.addElevationLayer = function addElevationLayer(layer) {
     this.elevationLayers.push(layer);
     this.layersState[layer.id] = defaultState();
 };
 
-LayersConfiguration.prototype.addColorLayer = function (layer) {
+LayersConfiguration.prototype.addColorLayer = function addColorLayer(layer) {
     this.colorLayers.push(layer);
     this.layersState[layer.id] = defaultState(this.colorLayers.length - 1);
 };
 
-LayersConfiguration.prototype.addGeometryLayer = function (layer) {
+LayersConfiguration.prototype.addGeometryLayer = function addGeometryLayer(layer) {
     this.geometryLayers.push(layer);
     this.layersState[layer.id] = defaultState();
 };
 
-LayersConfiguration.prototype.removeColorLayer = function (id) {
+LayersConfiguration.prototype.removeColorLayer = function removeColorLayer(id) {
     if (this.layersState[id]) {
         this.colorLayers = this.colorLayers.filter(l => l.id != id);
         delete this.layersState[id];
@@ -65,54 +65,54 @@ LayersConfiguration.prototype.removeColorLayer = function (id) {
     return false;
 };
 
-LayersConfiguration.prototype.getColorLayers = function () {
+LayersConfiguration.prototype.getColorLayers = function getColorLayers() {
     return this.colorLayers;
 };
 
-LayersConfiguration.prototype.getColorLayersId = function () {
+LayersConfiguration.prototype.getColorLayersId = function getColorLayersId() {
     return this.colorLayers.map(l => l.id);
 };
 
-LayersConfiguration.prototype.getGeometryLayers = function () {
+LayersConfiguration.prototype.getGeometryLayers = function getGeometryLayers() {
     return this.geometryLayers;
 };
 
-LayersConfiguration.prototype.getElevationLayers = function () {
+LayersConfiguration.prototype.getElevationLayers = function getElevationLayers() {
     return this.elevationLayers;
 };
 
-LayersConfiguration.prototype.setLayerOpacity = function (id, opacity) {
+LayersConfiguration.prototype.setLayerOpacity = function setLayerOpacity(id, opacity) {
     if (this.layersState[id]) {
         this.layersState[id].opacity = opacity;
     }
 };
 
-LayersConfiguration.prototype.setLayerVisibility = function (id, visible) {
+LayersConfiguration.prototype.setLayerVisibility = function setLayerVisibility(id, visible) {
     if (this.layersState[id]) {
         this.layersState[id].visible = visible;
     }
 };
 
-LayersConfiguration.prototype.isColorLayerVisible = function (id) {
+LayersConfiguration.prototype.isColorLayerVisible = function isColorLayerVisible(id) {
     return this.layersState[id].visible;
 };
 
-LayersConfiguration.prototype.getColorLayerOpacity = function (id) {
+LayersConfiguration.prototype.getColorLayerOpacity = function getColorLayerOpacity(id) {
     return this.layersState[id].opacity;
 };
 
-LayersConfiguration.prototype.setLayerFreeze = function (id, frozen) {
+LayersConfiguration.prototype.setLayerFreeze = function setLayerFreeze(id, frozen) {
     if (this.layersState[id]) {
         this.layersState[id].frozen = frozen;
     }
 };
 
-LayersConfiguration.prototype.isLayerFrozen = function (id) {
+LayersConfiguration.prototype.isLayerFrozen = function isLayerFrozen(id) {
     return this.layersState[id].frozen;
 };
 
 
-LayersConfiguration.prototype.moveLayerToIndex = function (id, new_index) {
+LayersConfiguration.prototype.moveLayerToIndex = function moveLayerToIndex(id, new_index) {
     if (this.layersState[id]) {
         var old_index = this.layersState[id].sequence;
         for (var i in this.layersState) {
@@ -128,19 +128,19 @@ LayersConfiguration.prototype.moveLayerToIndex = function (id, new_index) {
     }
 };
 
-LayersConfiguration.prototype.moveLayerDown = function (id) {
+LayersConfiguration.prototype.moveLayerDown = function moveLayerDown(id) {
     if (this.layersState[id] && this.layersState[id].sequence > 0) {
         this.moveLayerToIndex(id, this.layersState[id].sequence - 1);
     }
 };
 
-LayersConfiguration.prototype.moveLayerUp = function (id) {
+LayersConfiguration.prototype.moveLayerUp = function moveLayerUp(id) {
     if (this.layersState[id] && this.layersState[id].sequence < this.colorLayers.length - 1) {
         this.moveLayerToIndex(id, this.layersState[id].sequence + 1);
     }
 };
 
-LayersConfiguration.prototype.getColorLayersIdOrderedBySequence = function () {
+LayersConfiguration.prototype.getColorLayersIdOrderedBySequence = function getColorLayersIdOrderedBySequence() {
     var seq = this.colorLayers.map(l => l.id);
     seq.sort((a, b) => this.layersState[a].sequence - this.layersState[b].sequence);
     return seq;

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -27,11 +27,11 @@ function Node() {
 }
 
 
-Node.prototype.setVisibility = function (show) {
+Node.prototype.setVisibility = function setVisibility(show) {
     this.visible = show;
 };
 
-Node.prototype.setDisplayed = function (/* show*/) {
+Node.prototype.setDisplayed = function setDisplayed(/* show*/) {
     // The default node has nothing to display
 };
 
@@ -40,15 +40,15 @@ Node.prototype.setDisplayed = function (/* show*/) {
  *
  * @return  {int}
  */
-Node.prototype.childrenCount = function () {
+Node.prototype.childrenCount = function childrenCount() {
     return this.children.length;
 };
 
-Node.prototype.noChild = function () {
+Node.prototype.noChild = function noChild() {
     return this.children.length === 0;
 };
 
-Node.prototype.childrenLoaded = function () {
+Node.prototype.childrenLoaded = function childrenLoaded() {
     // TODO: '4' is specific to Quadtree
     var fourChildren = this.children.length == 4;
 
@@ -74,7 +74,7 @@ Node.prototype.childrenLoaded = function () {
  * @documentation: Rafraichi le Node si le contenu ou  le style a été modifié.
  *
  */
-Node.prototype.update = function () {
+Node.prototype.update = function update() {
     // TODO: Implement Me
 
 };
@@ -84,7 +84,7 @@ Node.prototype.update = function () {
  * @param {type} level
  * @returns {undefined}
  */
-Node.prototype.getNodeAtLevel = function (level) {
+Node.prototype.getNodeAtLevel = function getNodeAtLevel(level) {
     if (level === this.level) {
         return this;
     }
@@ -102,7 +102,7 @@ Node.prototype.getNodeAtLevel = function (level) {
  *param
  * @return  {[object Object]}
  */
-Node.prototype.hydrate = function () {
+Node.prototype.hydrate = function hydrate() {
     // TODO: Implement Me
 
 };
@@ -113,7 +113,7 @@ Node.prototype.hydrate = function () {
  *
  * @param mem {[object Object]}
  */
-Node.prototype.dehydrate = function (/* mem*/) {
+Node.prototype.dehydrate = function dehydrate(/* mem*/) {
     // TODO: Implement Me
 
 };
@@ -123,7 +123,7 @@ Node.prototype.dehydrate = function (/* mem*/) {
  *
  * @param child {[object Object]}
  */
-Node.prototype.add = function (child) {
+Node.prototype.add = function add(child) {
     // TODO: Implement Me
     this.children.push(child);
     child.parent = this;
@@ -136,7 +136,7 @@ Node.prototype.add = function (child) {
  *
  * @param child {[object Object]}
  */
-Node.prototype.remove = function (/* child*/) {
+Node.prototype.remove = function remove(/* child*/) {
     // TODO: Implement Me
 
 };
@@ -148,7 +148,7 @@ Node.prototype.remove = function (/* child*/) {
  * @param childClass {Object}
  */
 
-Node.extend = function (childClass) {
+Node.extend = function extend(childClass) {
     function propName(prop, value) {
         for (var i in prop) {
             if (prop[i] === value) {

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -33,7 +33,7 @@ function NodeProcess(camera, ellipsoid, bbox) {
  * @param {type} camera : camera for the culling
  * @returns {Boolean}
  */
-NodeProcess.prototype.backFaceCulling = function (node, camera) {
+NodeProcess.prototype.backFaceCulling = function backFaceCulling(node, camera) {
     var normal = camera.direction;
     for (var n = 0; n < node.normals().length; n++) {
         var dot = normal.dot(node.normals()[n]);
@@ -54,7 +54,7 @@ NodeProcess.prototype.backFaceCulling = function (node, camera) {
  * @param  {type} camera: the camera used for culling
  * @return {Boolean}      the culling attempt's result
  */
-NodeProcess.prototype.isCulled = function (node, camera) {
+NodeProcess.prototype.isCulled = function isCulled(node, camera) {
     return !(this.frustumCullingOBB(node, camera) && this.horizonCulling(node, camera));
 };
 
@@ -64,17 +64,17 @@ NodeProcess.prototype.isCulled = function (node, camera) {
  * @param {type} camera : camera for culling
  * @returns {unresolved}
  */
-NodeProcess.prototype.frustumCulling = function (node, camera) {
+NodeProcess.prototype.frustumCulling = function frustumCulling(node, camera) {
     var frustum = camera.frustum;
 
     return frustum.intersectsObject(node);
 };
 
-NodeProcess.prototype.checkNodeSSE = function (node) {
+NodeProcess.prototype.checkNodeSSE = function checkNodeSSE(node) {
     return SSE_SUBDIVISION_THRESHOLD < node.sse || node.level <= 2;
 };
 
-NodeProcess.prototype.subdivideNode = function (node, camera, params) {
+NodeProcess.prototype.subdivideNode = function subdivideNode(node, camera, params) {
     if (!node.pendingSubdivision && node.noChild()) {
         var bboxes = params.tree.subdivideNode(node);
         node.pendingSubdivision = true;
@@ -169,7 +169,7 @@ function refinementCommandCancellationFn(cmd) {
         cmd.requester.level >= 2;
 }
 
-NodeProcess.prototype.refineNodeLayers = function (node, camera, params) {
+NodeProcess.prototype.refineNodeLayers = function refineNodeLayers(node, camera, params) {
     // Elevation and Imagery updates require separate functions (for now):
     //   * a node can only have 1 elevation texture
     //   * a node inherits elevation texture from parent, even if tileInsideLimit(node)
@@ -191,7 +191,7 @@ NodeProcess.prototype.refineNodeLayers = function (node, camera, params) {
     }
 };
 
-NodeProcess.prototype.hideNodeChildren = function (node) {
+NodeProcess.prototype.hideNodeChildren = function hideNodeChildren(node) {
     for (var i = 0; i < node.children.length; i++) {
         var child = node.children[i];
         child.setDisplayed(false);
@@ -378,7 +378,7 @@ function updateNodeElevation(quadtree, node, layersConfig, force) {
 }
 
 
-NodeProcess.prototype.processNode = function (node, camera, params) {
+NodeProcess.prototype.processNode = function processNode(node, camera, params) {
     node.setDisplayed(false);
     node.setSelected(false);
 
@@ -419,7 +419,7 @@ NodeProcess.prototype.processNode = function (node, camera, params) {
 
 var quaternion = new THREE.Quaternion();
 
-NodeProcess.prototype.frustumCullingOBB = function (node, camera) {
+NodeProcess.prototype.frustumCullingOBB = function frustumCullingOBB(node, camera) {
     // position in local space
     var position = node.OBB().worldToLocal(camera.position().clone());
     position.z -= node.distance;
@@ -435,7 +435,7 @@ NodeProcess.prototype.frustumCullingOBB = function (node, camera) {
  * @param {type} camera
  * @returns {unresolved}
  */
-NodeProcess.prototype.frustumBB = function (node /* , camera*/) {
+NodeProcess.prototype.frustumBB = function frustumBB(node /* , camera*/) {
     return node.bbox.intersect(this.bbox);
 };
 
@@ -443,7 +443,7 @@ NodeProcess.prototype.frustumBB = function (node /* , camera*/) {
  * @documentation: Pre-computing for the upcoming processes
  * @param  {type} camera
  */
-NodeProcess.prototype.prepare = function (camera) {
+NodeProcess.prototype.prepare = function prepare(camera) {
     this.preHorizonCulling(camera);
 };
 
@@ -452,7 +452,7 @@ NodeProcess.prototype.prepare = function (camera) {
  * @param {type} camera
  * @returns {undefined}
  */
-NodeProcess.prototype.preHorizonCulling = function (camera) {
+NodeProcess.prototype.preHorizonCulling = function preHorizonCulling(camera) {
     this.cV.copy(camera.position()).divide(this.r);
     this.vhMagnitudeSquared = this.cV.lengthSq() - 1.0;
 };
@@ -462,7 +462,7 @@ NodeProcess.prototype.preHorizonCulling = function (camera) {
  * @param {type} pt
  * @returns {Boolean}
  */
-NodeProcess.prototype.pointHorizonCulling = function (pt) {
+NodeProcess.prototype.pointHorizonCulling = function pointHorizonCulling(pt) {
     var vT = pt.divide(this.r).sub(this.cV);
 
     var vtMagnitudeSquared = vT.lengthSq();
@@ -483,7 +483,7 @@ NodeProcess.prototype.pointHorizonCulling = function (pt) {
  */
 var point = new THREE.Vector3();
 
-NodeProcess.prototype.horizonCulling = function (node) {
+NodeProcess.prototype.horizonCulling = function horizonCulling(node) {
     // horizonCulling Oriented bounding box
     var points = node.OBB().pointsWorld;
     var isVisible = false;

--- a/src/Scene/NodeProvider.js
+++ b/src/Scene/NodeProvider.js
@@ -17,7 +17,7 @@ NodeProvider.prototype = new Provider();
 /**
  * @param type {int}
  */
-NodeProvider.prototype.createObject = function (/* type*/) {
+NodeProvider.prototype.createObject = function createObject(/* type*/) {
     // TODO: Implement Me
 
 };

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -54,7 +54,7 @@ function Quadtree(type, schemeTile, link) {
 
     rootNode.link = this.link;
 
-    rootNode.changeState = function () {
+    rootNode.changeState = function changeState() {
         return true;
     };
 
@@ -65,7 +65,7 @@ Quadtree.prototype = Object.create(Layer.prototype);
 
 Quadtree.prototype.constructor = Quadtree;
 
-Quadtree.prototype.init = function (geometryLayer) {
+Quadtree.prototype.init = function init(geometryLayer) {
     var rootNode = this.children[0];
 
     for (var i = 0; i < this.schemeTile.rootCount(); i++) {
@@ -73,23 +73,23 @@ Quadtree.prototype.init = function (geometryLayer) {
     }
 };
 
-Quadtree.prototype.northWest = function (node) {
+Quadtree.prototype.northWest = function northWest(node) {
     return node.children[0];
 };
 
-Quadtree.prototype.northEast = function (node) {
+Quadtree.prototype.northEast = function northEast(node) {
     return node.children[1];
 };
 
-Quadtree.prototype.southWest = function (node) {
+Quadtree.prototype.southWest = function southWest(node) {
     return node.children[2];
 };
 
-Quadtree.prototype.southEast = function (node) {
+Quadtree.prototype.southEast = function southEast(node) {
     return node.children[3];
 };
 
-Quadtree.prototype.requestNewTile = function (geometryLayer, bbox, parent) {
+Quadtree.prototype.requestNewTile = function requestNewTile(geometryLayer, bbox, parent) {
     var params = {
         layer: geometryLayer,
         bbox,
@@ -98,7 +98,7 @@ Quadtree.prototype.requestNewTile = function (geometryLayer, bbox, parent) {
     this.interCommand.request(params, parent);
 };
 
-Quadtree.prototype.canSubdivideNode = function (node) {
+Quadtree.prototype.canSubdivideNode = function canSubdivideNode(node) {
     return node.level < this.maxLevel;
 };
 
@@ -107,7 +107,7 @@ Quadtree.prototype.canSubdivideNode = function (node) {
  * @param {type} node
  * @returns {Array} an array of four bounding boxex
  */
-Quadtree.prototype.subdivideNode = function (node) {
+Quadtree.prototype.subdivideNode = function subdivideNode(node) {
     if (node.pendingSubdivision || !this.canSubdivideNode(node)) {
         return [];
     }
@@ -117,17 +117,17 @@ Quadtree.prototype.subdivideNode = function (node) {
     return [quad.northWest, quad.northEast, quad.southWest, quad.southEast];
 };
 
-Quadtree.prototype.traverse = function (foo, node)
+Quadtree.prototype.traverse = function traverse(foo, node)
 {
     if (foo(node))
       { for (var i = 0; i < node.children.length; i++)
         { this.traverse(foo, node.children[i]); } }
 };
 
-Quadtree.prototype.getTile = function (coordinate) {
+Quadtree.prototype.getTile = function getTile(coordinate) {
     var point = { x: coordinate.longitude(), y: coordinate.latitude() };
 
-    var gT = function (tile)
+    var gT = function gT(tile)
     {
         var inside = tile.bbox ? tile.bbox.isInside(point) : true;
 

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -73,7 +73,7 @@ function Scene(coordinate, ellipsoid, viewerDiv, debugMode, gLDebug) {
 Scene.prototype.constructor = Scene;
 /**
  */
-Scene.prototype.updateCommand = function () {
+Scene.prototype.updateCommand = function updateCommand() {
     // TODO: Implement Me
 
 };
@@ -82,35 +82,35 @@ Scene.prototype.updateCommand = function () {
  * @documentation: return current camera
  * @returns {Scene_L7.Scene.gfxEngine.camera}
  */
-Scene.prototype.currentCamera = function () {
+Scene.prototype.currentCamera = function currentCamera() {
     return this.gfxEngine.camera;
 };
 
-Scene.prototype.currentControls = function () {
+Scene.prototype.currentControls = function currentControls() {
     return this.gfxEngine.controls;
 };
 
-Scene.prototype.getPickPosition = function (mouse) {
+Scene.prototype.getPickPosition = function getPickPosition(mouse) {
     return this.gfxEngine.getPickingPositionFromDepth(mouse);
 };
 
-Scene.prototype.getStyle = function (name) {
+Scene.prototype.getStyle = function getStyle(name) {
     return this.stylesManager.getStyle(name);
 };
 
-Scene.prototype.removeStyle = function (name) {
+Scene.prototype.removeStyle = function removeStyle(name) {
     return this.stylesManager.removeStyle(name);
 };
 
-Scene.prototype.getStyles = function () {
+Scene.prototype.getStyles = function getStyles() {
     return this.stylesManager.getStyles();
 };
 
-Scene.prototype.getEllipsoid = function () {
+Scene.prototype.getEllipsoid = function getEllipsoid() {
     return this.ellipsoid;
 };
 
-Scene.prototype.size = function () {
+Scene.prototype.size = function size() {
     return this.ellipsoid.size;
 };
 
@@ -118,7 +118,7 @@ Scene.prototype.size = function () {
  *
  * @returns {undefined}
  */
-Scene.prototype.updateScene3D = function () {
+Scene.prototype.updateScene3D = function updateScene3D() {
     this.gfxEngine.update();
 };
 
@@ -129,7 +129,7 @@ Scene.prototype.updateScene3D = function () {
  * Using a non-0 delay allows to delay update - useful to reduce CPU load for
  * non-interactive events (e.g: texture loaded)
  */
-Scene.prototype.notifyChange = function (delay) {
+Scene.prototype.notifyChange = function notifyChange(delay) {
     this.needsRedraw = true;
 
     window.clearInterval(this.timer);
@@ -141,7 +141,7 @@ Scene.prototype.notifyChange = function (delay) {
     }
 };
 
-Scene.prototype.scheduleUpdate = function () {
+Scene.prototype.scheduleUpdate = function scheduleUpdate() {
     if (this.renderingState !== RENDERING_ACTIVE) {
         this.renderingState = RENDERING_ACTIVE;
 
@@ -149,7 +149,7 @@ Scene.prototype.scheduleUpdate = function () {
     }
 };
 
-Scene.prototype.update = function () {
+Scene.prototype.update = function update() {
     for (var l = 0; l < this.layers.length; l++) {
         var layer = this.layers[l].node;
 
@@ -167,7 +167,7 @@ Scene.prototype.update = function () {
     }
 };
 
-Scene.prototype.step = function () {
+Scene.prototype.step = function step() {
     // update data-structure
     this.update();
 
@@ -202,11 +202,11 @@ Scene.prototype.step = function () {
 
 /**
  */
-Scene.prototype.renderScene3D = function () {
+Scene.prototype.renderScene3D = function renderScene3D() {
     this.gfxEngine.renderScene();
 };
 
-Scene.prototype.scene3D = function () {
+Scene.prototype.scene3D = function scene3D() {
     return this.gfxEngine.scene3D;
 };
 
@@ -215,7 +215,7 @@ Scene.prototype.scene3D = function () {
  *
  * @param node {[object Object]}
  */
-Scene.prototype.add = function (node, nodeProcess) {
+Scene.prototype.add = function add(node, nodeProcess) {
     if (node instanceof Globe) {
         this.map = node;
         nodeProcess = nodeProcess || new NodeProcess(this.currentCamera(), node.ellipsoid);
@@ -229,7 +229,7 @@ Scene.prototype.add = function (node, nodeProcess) {
     this.gfxEngine.add3DScene(node.getMesh());
 };
 
-Scene.prototype.getMap = function () {
+Scene.prototype.getMap = function getMap() {
     return this.map;
 };
 
@@ -238,7 +238,7 @@ Scene.prototype.getMap = function () {
  *
  * @param layer {[object Object]}
  */
-Scene.prototype.remove = function (/* layer*/) {
+Scene.prototype.remove = function remove(/* layer*/) {
     // TODO: Implement Me
 
 };
@@ -247,16 +247,16 @@ Scene.prototype.remove = function (/* layer*/) {
 /**
  * @param layers {[object Object]}
  */
-Scene.prototype.select = function (/* layers*/) {
+Scene.prototype.select = function select(/* layers*/) {
     // TODO: Implement Me
 
 };
 
-Scene.prototype.selectNodeId = function (id) {
+Scene.prototype.selectNodeId = function selectNodeId(id) {
     this.browserScene.selectedNodeId = id;
 };
 
-Scene.prototype.setStreetLevelImageryOn = function (value) {
+Scene.prototype.setStreetLevelImageryOn = function setStreetLevelImageryOn(value) {
     if (value) {
         if (this.layers[1]) {
             this.layers[1].node.visible = true;
@@ -277,7 +277,7 @@ Scene.prototype.setStreetLevelImageryOn = function (value) {
     this.updateScene3D();
 };
 
-Scene.prototype.setLightingPos = function (pos) {
+Scene.prototype.setLightingPos = function setLightingPos(pos) {
     if (pos)
         { this.lightingPos = pos; }
     else {
@@ -292,7 +292,7 @@ Scene.prototype.setLightingPos = function (pos) {
 };
 
 // Should be moved in time module: A single loop update registered object every n millisec
-Scene.prototype.animateTime = function (value) {
+Scene.prototype.animateTime = function animateTime(value) {
     if (value) {
         this.time += 4000;
 
@@ -318,7 +318,7 @@ Scene.prototype.animateTime = function (value) {
         { window.cancelAnimationFrame(this.rAF); }
 };
 
-Scene.prototype.orbit = function (value) {
+Scene.prototype.orbit = function orbit(value) {
     // this.gfxEngine.controls = null;
     this.orbitOn = value;
 };

--- a/src/Scene/SchemeTile.js
+++ b/src/Scene/SchemeTile.js
@@ -22,16 +22,16 @@ function SchemeTile() {
  * @returns {SchemeTile_L8.SchemeTile.prototype@pro;schemeBB@call;push}
  */
 
-SchemeTile.prototype.add = function (minLo, maxLo, minLa, maxLa) {
+SchemeTile.prototype.add = function add(minLo, maxLo, minLa, maxLa) {
     return this.schemeBB.push(new BoundingBox(minLo, maxLo, minLa, maxLa));
 };
 
 
-SchemeTile.prototype.rootCount = function () {
+SchemeTile.prototype.rootCount = function rootCount() {
     return this.schemeBB.length;
 };
 
-SchemeTile.prototype.getRoot = function (id) {
+SchemeTile.prototype.getRoot = function getRoot(id) {
     return this.schemeBB[id];
 };
 

--- a/src/Scene/SpatialHash.js
+++ b/src/Scene/SpatialHash.js
@@ -14,7 +14,7 @@ function SpatialHash() {
 /**
  * @param boundingBox
  */
-SpatialHash.prototype.hash = function (/* boundingBox*/) {
+SpatialHash.prototype.hash = function hash(/* boundingBox*/) {
     // TODO: Implement Me
 
 };
@@ -23,7 +23,7 @@ SpatialHash.prototype.hash = function (/* boundingBox*/) {
 /**
  * @param boundingBoxs
  */
-SpatialHash.prototype.hashNode = function (/* boundingBoxs*/) {
+SpatialHash.prototype.hashNode = function hashNode(/* boundingBoxs*/) {
     // TODO: Implement Me
 
 };
@@ -31,7 +31,7 @@ SpatialHash.prototype.hashNode = function (/* boundingBoxs*/) {
 
 /**
  */
-SpatialHash.prototype.buildRoot = function () {
+SpatialHash.prototype.buildRoot = function buildRoot() {
     // TODO: Implement Me
 
 };


### PR DESCRIPTION
Having some time, I took upon myself to correct one linter error this Monday. I hope I'll be able to do this once a week.

 This was more or less automatic, except for one important point: naming functions add names to the current scope. Therefore we need to be careful not to shadow any existing declaration by mistake. For local names, I guess it's not a problem because the linter would detect it (as the other declaration won't be used any more). However global names, for instance those attached to the `window` object can still be shadowed. I have been careful of those, but I might have missed something so please double-check! 

Pinging @iTowns/reviewers 