### PR TITLE
Widget class

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*	text=auto
+*   text=auto
 *.js eol=lf
 *.css eol=lf
 *.glsl eol=lf

--- a/examples/widgets/Widget.js
+++ b/examples/widgets/Widget.js
@@ -1,0 +1,104 @@
+/**
+ * Generated On: 2016-11-22
+ * Class: Controls
+ * Description: Create a widget.
+ */
+
+function Widget(pName, pElement, options) {
+    this.pName = pName;
+    this.pElement = pElement;
+    this.options = options;
+    this._map = null;
+}
+
+/**
+ * Return the name of the widget.
+ * @constructor
+ * @return     {name}  The name.
+ */
+
+Widget.prototype.getName = function getName() {
+    return this.pName;
+};
+
+/*
+ * Return the element used by the widget to display its GUI.
+ * @constructor
+ * @return     {element}  The element.
+*/
+
+Widget.prototype.getElement = function getElement() {
+    return this.pElement;
+};
+
+/**
+ * Return the options of the widget.
+ * @constructor
+ * @return     {object}  Object.
+ */
+
+Widget.prototype.getOptions = function getOptions() {
+    this.options = this.options || {};
+    return this.options;
+};
+
+/**
+ * Change the options of the widget.
+ * @constructor
+ * @param {object} pOptions - The new options of the conrtol.
+ */
+
+Widget.prototype.setOptions = function setOptions(pOptions) {
+    this.pName = pOptions.name;
+    this.pElement = pOptions.element;
+    this.options = pOptions.options;
+};
+
+/**
+ * Listen to an event linked to the map.
+ * @constructor
+ * @param {string} Eventname - The name of the event.
+ * @param {callback} Callback - The callback that is called when the event is heard.
+ */
+
+Widget.prototype.listenToMap = function listenToMap(pEventName, pCallback) {
+    document.getElementById('viewerDiv').addEventListener(pEventName, pCallback, false);
+};
+
+/**
+ * Remove an event linked to the map.
+ * @constructor
+ * @param {string} Eventname - The name of the event.
+ * @param {callback} Callback - The callback that is called when the event is heard.
+ */
+
+Widget.prototype.removeFromMap = function removeFromMap(pEventName, pCallback) {
+    document.getElementById('viewerDiv').removeEventListener(pEventName, pCallback, false);
+};
+
+/**
+ * Get the Map associated with the widget. Undefined if the widget is not added to a map.
+ * @constructor
+ */
+
+Widget.prototype.getMap = function getMap() {
+    return this._map;
+};
+
+/**
+ * Associate a map to a widget.
+ * @constructor
+ */
+
+Widget.prototype.setMap = function setMap(map) {
+    if (this._map) {
+        this.options.div.removeChild(this.pElement);
+    }
+    this._map = map;
+    if (this._map) {
+        var element = this.pElement;
+        this.options.div.appendChild(element);
+    }
+};
+
+/* export default Widget; */

--- a/examples/widgets/pickPositionWidget.js
+++ b/examples/widgets/pickPositionWidget.js
@@ -1,0 +1,37 @@
+/* global itowns */
+/* global Widget */
+/* global widgetTab */
+
+const pickWidget = document.createElement('div');
+pickWidget.id = 'pickWidget';
+
+const widgetsP = document.getElementById('widgets');
+
+widgetsP.appendChild(pickWidget);
+
+const widget = new Widget(
+    'Pick',
+    document.getElementById('pickWidget'),
+    {
+        div: widgetsP,
+    });
+
+const callback = function () {
+    widgetTab.addWidget(widget);
+    if (document.getElementById('pickList')) {
+        document.getElementById(widget.pElement.id).removeChild(document.getElementById('pickList'));
+    }
+    const tab = ['longitude', 'latitude', 'altitude'];
+    const coords = itowns.viewer.pickPosition().coordinate;
+    const list = document.createElement('ul');
+    list.id = 'pickList';
+    for (var j = 0; j < coords.length; j++) {
+        var item = document.createElement('li');
+        item.id = tab[j];
+        item.innerHTML = `${tab[j]} : ${coords[j]}`;
+        list.appendChild(item);
+    }
+    document.getElementById(widget.pElement.id).appendChild(list);
+};
+
+widget.listenToMap('mousedown', callback);

--- a/examples/widgets/rangeWidget.js
+++ b/examples/widgets/rangeWidget.js
@@ -1,0 +1,31 @@
+/* global itowns */
+/* global Widget */
+/* global widgetTab */
+
+const rangeWidget = document.createElement('div');
+rangeWidget.id = 'rangeWidget';
+
+const widgetsR = document.getElementById('widgets');
+
+widgetsR.appendChild(rangeWidget);
+
+const widgetR = new Widget(
+    'Range',
+    document.getElementById('rangeWidget'),
+    { div: widgetsR });
+
+const callbackR = function () {
+    widgetTab.addWidget(widgetR);
+    if (document.getElementById('rangeList')) {
+        document.getElementById(widgetR.pElement.id).removeChild(document.getElementById('rangeList'));
+    }
+    const coords = itowns.viewer.getRange();
+    const list = document.createElement('ul');
+    list.id = 'rangeList';
+    const item = document.createElement('li');
+    item.innerHTML = `range : ${coords}`;
+    list.appendChild(item);
+    document.getElementById(widgetR.pElement.id).appendChild(list);
+};
+
+widgetR.listenToMap('mousedown', callbackR);

--- a/examples/widgets/widgetAPI.js
+++ b/examples/widgets/widgetAPI.js
@@ -1,0 +1,34 @@
+/* global Widget */
+/* global itowns */
+
+function widgetAPI() {
+    this.widgets = new Set();
+}
+
+/**
+ * Add a widget.
+ */
+
+widgetAPI.prototype.addWidget = function addWidget(widget) {
+    widget.setMap(itowns.viewer.scene.getMap());
+    this.widgets.add(widget);
+};
+
+/**
+ * Returns all widgets.
+ * @return     {array}  The array of widgets.
+ */
+
+widgetAPI.prototype.getWidgets = function getWidget() {
+    return this.widgets;
+};
+
+/**
+ * Remove a widget.
+ * @param {object} Widget - The Widget object.
+ */
+
+widgetAPI.prototype.removeWidget = function removeWidget(widget) {
+    widget.setMap();
+    this.widgets.delete(widget);
+};

--- a/examples/widgets/widgets.css
+++ b/examples/widgets/widgets.css
@@ -1,0 +1,10 @@
+#widgets {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      width: 20rem;
+      box-shadow: 1px 1px 10px #555;
+      font: 11px Lucida Grande,sans-serif;
+      color: #eee;
+      padding: 0.5rem;
+}

--- a/index.html
+++ b/index.html
@@ -8,29 +8,41 @@ and open the template in the editor.
     <head>
         <title>Globe</title>
 
-    <style type="text/css">
+    	<style type="text/css">
             html {height: 100%}
-        body { margin: 0; overflow:hidden; height:100%}
+
+    	    body {
+                margin: 0;
+                overflow:hidden;
+                height:100%
+            }
 
             #viewerDiv {
                 margin : auto auto;
                 width: 100%;
                 height: 100%;
                 padding: 0;
+                position: relative;
                 /*margin-top: 50vh;
                 transform: translateY(-50%);*/
             }
-            #menuDiv {position: absolute; top:0px; margin-left: 0px;}
-
-
+            #menuDiv {
+                position: absolute;
+                top:0px;
+                margin-left: 0px;
+            }
         </style>
         <meta charset="UTF-8">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.1/dat.gui.min.js"></script>
+        <script src="examples/widgets/Widget.js"></script>
     </head>
     <body>
-        <div id="viewerDiv"></div>
+        <div id="viewerDiv">
+            <div id="widgets"></div>
+        </div>
+
         <script src="examples/GUI/GuiTools.js"></script>
         <script src="dist/itowns.js"></script>
         <script type="text/javascript">
@@ -42,6 +54,7 @@ and open the template in the editor.
             // iTowns namespace defined here
             const viewerDiv = document.getElementById('viewerDiv');
             const menuGlobe = new GuiTools(itowns.viewer, 'menuDiv');
+
             itowns.viewer.createSceneGlobe(positionOnGlobe, viewerDiv);
 
             const wgs84TileLayer = {
@@ -76,7 +89,6 @@ and open the template in the editor.
                 // eslint-disable-next-line no-console
                 console.info('Globe Loaded');
             });
-
 </script>
     </body>
 </html>


### PR DESCRIPTION
Adding Widget class in example

Widget class with constructor and method (Widget.js)

In Widget.js
- getName()
- getElement()
- getOptions()
- setOptions(pOptions)
- listenToMap(pEventName, pCallback)
- getGlobe()
- setGlobe(map)

Method in widgetAPI.js
- addWidget(widget)
- getWidgets()
- removeWidget(widget)

To make the examples work : put the following lines in index.html :
- < link rel="stylesheet" href="examples/widgets/widget.css" > in the 'head' tag
- <script src="examples/widgets/pickPositionWidget.js"> </script>
  <script src="examples/widgets/rangeWidget.js"> </script> 
  Right before the closure of the 'body' tag
- <script src="examples/widgets/Widget.js"> </script>
  <script src="examples/widgets/widgetAPI.js"> </script>
  Just after the line <script src="dist/itowns.js"></script>
- const widgetTab = new widgetAPI();