### PR TITLE
Style: enable guard-for-in eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,6 @@ module.exports = {
     'camelcase': 'off',
     'no-bitwise': 'off',
     'no-restricted-syntax': 'off',
-    'guard-for-in': 'off',
     'consistent-return': 'off',
     'brace-style': 'off',
     'new-cap': 'off',

--- a/src/Core/Commander/Scheduler.js
+++ b/src/Core/Commander/Scheduler.js
@@ -176,12 +176,7 @@ Scheduler.prototype.resetCommandsCount = function resetCommandsCount(type) {
 };
 
 Scheduler.prototype.getProviders = function getProviders() {
-    var p = [];
-
-    for (var protocol in this.providers) {
-        p.push(this.providers[protocol]);
-    }
-    return p;
+    return this.providers.slice();
 };
 
 /**

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -50,7 +50,9 @@ Projection.prototype.getAllCoordsWMTS = function getAllCoordsWMTS(tileCoord, bbo
     var tilesMT = [];
 
     for (var key in tileMatrixSets) {
-        tilesMT[key] = this.getCoordsWMTS(tileCoord, bbox, key);
+        if (Object.prototype.hasOwnProperty.call(tileMatrixSets, key)) {
+            tilesMT[key] = this.getCoordsWMTS(tileCoord, bbox, key);
+        }
     }
 
     return tilesMT;

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -131,8 +131,8 @@ TileMesh.prototype.disposeChildren = function disposeChildren() {
 };
 
 TileMesh.prototype.setDisplayed = function setDisplayed(show) {
-    for (var key in this.materials) {
-        this.materials[key].visible = show;
+    for (var material of this.materials) {
+        material.visible = show;
     }
 
     if (this.helper !== undefined) {
@@ -158,8 +158,8 @@ TileMesh.prototype.setFog = function setFog(fog) {
 };
 
 TileMesh.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
-    for (var key in this.materials) {
-        this.materials[key].setMatrixRTC(rtc);
+    for (var material of this.materials) {
+        material.setMatrixRTC(rtc);
     }
 };
 

--- a/src/Scene/LayersConfiguration.js
+++ b/src/Scene/LayersConfiguration.js
@@ -116,11 +116,13 @@ LayersConfiguration.prototype.moveLayerToIndex = function moveLayerToIndex(id, n
     if (this.layersState[id]) {
         var oldIndex = this.layersState[id].sequence;
         for (var i in this.layersState) {
-            var state = this.layersState[i];
-            if (state.sequence === newIndex) {
-                state.sequence = oldIndex;
-                this.layersState[id].sequence = newIndex;
-                break;
+            if (Object.prototype.hasOwnProperty.call(this.layersState, i)) {
+                var state = this.layersState[i];
+                if (state.sequence === newIndex) {
+                    state.sequence = oldIndex;
+                    this.layersState[id].sequence = newIndex;
+                    break;
+                }
             }
         }
 

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -147,21 +147,10 @@ Node.prototype.remove = function remove(/* child*/) {
  */
 
 Node.extend = function extend(childClass) {
-    function propName(prop, value) {
-        for (var i in prop) {
-            if (prop[i] === value) {
-                return i;
-            }
-        }
-        return false;
-    }
-
-    for (var p in Node.prototype) {
-        var protoName = propName(Node.prototype, Node.prototype[p]);
-
-
-        if (protoName !== 'add' && protoName !== 'remove' & protoName !== 'setVisibility' && protoName !== 'setDisplayed') {
-            childClass.prototype[protoName] = Node.prototype[p];
+    const membersToIgnore = ['add', 'remove', 'setVisibility', 'setDisplayed'];
+    for (const p in Node.prototype) {
+        if (Object.prototype.hasOwnProperty.call(Node.prototype, p) && !membersToIgnore.includes(p)) {
+            childClass.prototype[p] = Node.prototype[p];
         }
     }
 };


### PR DESCRIPTION
This should make itowns works nicely with all apps that adds properties to `Array.prototype`. @iTowns/reviewers please r?