### PR TITLE
Remove ancestor

### DIFF
--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -243,6 +243,10 @@ ApiGlobe.prototype.removeImageryLayer = function removeImageryLayer(id) {
  */
 
 ApiGlobe.prototype.addElevationLayer = function addElevationLayer(layer) {
+    if (layer.protocol === 'wmts' && layer.options.tileMatrixSet !== 'WGS84G') {
+        throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
+    }
+
     preprocessLayer(layer, this.scene.scheduler.getProtocolProvider(layer.protocol));
     const map = this.scene.getMap();
     if (this.getLayerById(layer.id)) {

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -147,13 +147,15 @@ ApiGlobe.prototype.addGeometryLayer = function addGeometryLayer(layer) {
 
 ApiGlobe.prototype.addImageryLayer = function addImageryLayer(layer) {
     preprocessLayer(layer, this.scene.scheduler.getProtocolProvider(layer.protocol));
-    const map = this.scene.getMap();
     if (this.getLayerById(layer.id)) {
-      // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console
         console.error(`Error : id "${layer.id}" already exist, WARNING your layer isn't added`);
     } else {
-        map.layersConfiguration.addColorLayer(layer);
-        this.viewerDiv.dispatchEvent(eventLayerAdded);
+        this.scene.getMap().layersConfiguration.addColorLayer(layer);
+        this.scene.notifyChange(1, true);
+        this.setSceneLoaded().then(() => {
+            this.viewerDiv.dispatchEvent(eventLayerAdded);
+        });
     }
 };
 
@@ -248,13 +250,15 @@ ApiGlobe.prototype.addElevationLayer = function addElevationLayer(layer) {
     }
 
     preprocessLayer(layer, this.scene.scheduler.getProtocolProvider(layer.protocol));
-    const map = this.scene.getMap();
     if (this.getLayerById(layer.id)) {
       // eslint-disable-next-line no-console
         console.error(`Error : id "${layer.id}" already exist, WARNING your layer isn't added`);
     } else {
-        map.layersConfiguration.addElevationLayer(layer);
-        this.viewerDiv.dispatchEvent(eventLayerAdded);
+        this.scene.getMap().layersConfiguration.addElevationLayer(layer);
+        this.scene.notifyChange(1, true);
+        this.setSceneLoaded().then(() => {
+            this.viewerDiv.dispatchEvent(eventLayerAdded);
+        });
     }
 };
 

--- a/src/Core/Commander/Providers/OGCWebServiceHelper.js
+++ b/src/Core/Commander/Providers/OGCWebServiceHelper.js
@@ -1,0 +1,84 @@
+import * as THREE from 'three';
+import Fetcher from './Fetcher';
+import CacheRessource from './CacheRessource';
+import IoDriver_XBIL from './IoDriver_XBIL';
+import Projection from '../../Geographic/Projection';
+
+
+export const SIZE_TEXTURE_TILE = 256;
+
+// CacheRessource is necessary for neighboring PM textures
+// The PM textures overlap several tiles WGS84, it is to avoid net requests
+// Info : THREE.js have cache image https://github.com/mrdoob/three.js/blob/master/src/loaders/ImageLoader.js#L25
+const cache = CacheRessource();
+const ioDXBIL = new IoDriver_XBIL();
+const projection = new Projection();
+
+const getTextureFloat = function getTextureFloat(buffer) {
+    const texture = new THREE.DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, THREE.AlphaFormat, THREE.FloatType);
+    texture.needsUpdate = true;
+    return texture;
+};
+
+export default {
+    ioDXBIL,
+    getColorTextureByUrl(url) {
+        const cachedTexture = cache.getRessource(url);
+
+        if (cachedTexture) {
+            return Promise.resolve(cachedTexture);
+        }
+
+        const { texture, promise } = Fetcher.texture(url);
+
+        texture.generateMipmaps = false;
+        texture.magFilter = THREE.LinearFilter;
+        texture.minFilter = THREE.LinearFilter;
+        texture.anisotropy = 16;
+
+        return promise.then(() => {
+            cache.addRessource(url, texture);
+            return texture;
+        });
+    },
+    getXBilTextureByUrl(url, pitch) {
+        const textureCache = cache.getRessource(url);
+
+        if (textureCache !== undefined) {
+            const { min, max } = ioDXBIL.computeMinMaxElevation(
+                textureCache.image.data,
+                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                pitch);
+            return Promise.resolve({ pitch, textureCache, min, max });
+        }
+
+        return ioDXBIL.read(url).then((result) => {
+            // TODO  RGBA is needed for navigator with no support in texture float
+            // In RGBA elevation texture LinearFilter give some errors with nodata value.
+            // need to rewrite sample function in shader
+            result.texture = getTextureFloat(result.floatArray);
+            result.texture.generateMipmaps = false;
+            result.texture.magFilter = THREE.LinearFilter;
+            result.texture.minFilter = THREE.LinearFilter;
+            result.pitch = pitch;
+
+            cache.addRessource(url, result.texture);
+
+            return result;
+        });
+    },
+    computeTileMatrixSetCoordinates(tile, layer) {
+        // Are WMTS coordinates ready?
+        if (!tile.wmtsCoords) {
+            tile.wmtsCoords = {};
+        }
+
+        const tileMatrixSet = layer.options.tileMatrixSet || 'WGS84G';
+        if (!(tileMatrixSet in tile.wmtsCoords)) {
+            const tileCoord = projection.WGS84toWMTS(tile.bbox);
+
+            tile.wmtsCoords[tileMatrixSet] =
+                projection.getCoordWMTS_WGS84(tileCoord, tile.bbox, tileMatrixSet);
+        }
+    },
+};

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -17,6 +17,8 @@ import Provider from './Provider';
 import Projection from '../../Geographic/Projection';
 import BuilderEllipsoidTile from '../../../Globe/BuilderEllipsoidTile';
 import TileGeometry from '../../../Globe/TileGeometry';
+import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from './OGCWebServiceHelper';
+import { EMPTY_TEXTURE_ZOOM, l_ELEVATION } from '../../../Renderer/LayeredMaterial';
 
 function TileProvider() {
     Provider.call(this, null);
@@ -41,6 +43,8 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
         bbox,
         level: (command.level === undefined) ? (parent.level + 1) : command.level,
         segment: 16,
+        parentMaterial: parent.material,
+        parentWmtsCoords: parent.wmtsCoords,
     };
 
     const geometry = new TileGeometry(params, this.builder);
@@ -61,6 +65,19 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
     tile.updateMatrixWorld();
     tile.OBB().parent = tile;   // TODO: we should use tile.add(tile.OBB())
     tile.OBB().update();
+
+    // update bbox if node herits texture elevation from parent
+    if (tile.material.getElevationLayerLevel() > EMPTY_TEXTURE_ZOOM) {
+        const textureElevation = tile.material.getLayerTextures(l_ELEVATION)[0];
+        const { min, max } = OGCWebServiceHelper.ioDXBIL.computeMinMaxElevation(
+                textureElevation.image.data,
+                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                tile.material.offsetScale[0][0]);
+
+        if (min && max) {
+            tile.setBBoxZ(min, max);
+        }
+    }
 
     return Promise.resolve(tile);
 };

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -6,12 +6,8 @@
 
 
 import * as THREE from 'three';
-import Provider from './Provider';
-import IoDriver_XBIL from './IoDriver_XBIL';
-import Fetcher from './Fetcher';
-import Projection from '../../Geographic/Projection';
-import CacheRessource from './CacheRessource';
 import BoundingBox from '../../../Scene/BoundingBox';
+import WMTS_Provider, { computeTileWMTSCoordinates } from './WMTS_Provider';
 
 /**
  * Return url wmts MNT
@@ -20,22 +16,11 @@ import BoundingBox from '../../../Scene/BoundingBox';
  * @param {String} options.format: image format (default: format/jpeg)
  * @returns {Object@call;create.url.url|String}
  */
-function WMS_Provider(/* options*/) {
-    // Constructor
-    Provider.call(this, new IoDriver_XBIL());
-    this.cache = CacheRessource();
-    this.projection = new Projection();
-
-    this.getTextureFloat = function getTextureFloat(buffer) {
-        // Start float to RGBA uint8
-        const texture = new THREE.DataTexture(buffer, 256, 256, THREE.AlphaFormat, THREE.FloatType);
-
-        texture.needsUpdate = true;
-        return texture;
-    };
+function WMS_Provider(options) {
+    WMTS_Provider.call(this, options);
 }
 
-WMS_Provider.prototype = Object.create(Provider.prototype);
+WMS_Provider.prototype = Object.create(WMTS_Provider.prototype);
 
 WMS_Provider.prototype.constructor = WMS_Provider;
 
@@ -93,21 +78,6 @@ WMS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) {
     return tile.level > 2 && layer.bbox.intersect(tile.bbox);
 };
 
-function computeTileWMTSCoordinates(tile, wmtsLayer, projection) {
-    // Are WMTS coordinates ready?
-    if (!tile.wmtsCoords) {
-        tile.wmtsCoords = {};
-    }
-
-    const tileMatrixSet = wmtsLayer.options.tileMatrixSet;
-    if (!(tileMatrixSet in tile.wmtsCoords)) {
-        const tileCoord = projection.WGS84toWMTS(tile.bbox);
-
-        tile.wmtsCoords[tileMatrixSet] =
-            projection.getCoordWMTS_WGS84(tileCoord, tile.bbox, tileMatrixSet);
-    }
-}
-
 WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, bbox, pitch) {
     if (!this.tileInsideLimit(tile, layer) || tile.material === null) {
         return Promise.resolve();
@@ -116,56 +86,18 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, b
     const url = this.url(bbox.as('EPSG:4326'), layer);
     const result = { pitch };
 
-    result.texture = this.cache.getRessource(url);
-
-    if (result.texture !== undefined) {
-        return Promise.resolve(result);
-    }
-
-    const { texture, promise } = Fetcher.texture(url);
-    result.texture = texture;
-
-    result.texture.generateMipmaps = false;
-    result.texture.magFilter = THREE.LinearFilter;
-    result.texture.minFilter = THREE.LinearFilter;
-    result.texture.anisotropy = 16;
-    result.texture.coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
-    result.texture.bbox = bbox;
-
-    return promise.then(() => {
-        this.cache.addRessource(url, result.texture);
-        result.texture.needsUpdate = true;
+    return this.getColorTextureByUrl(url).then((texture) => {
+        result.texture = texture;
+        result.texture.coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
+        result.texture.bbox = bbox;
         return result;
     });
 };
 
 WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, bbox, pitch) {
     const url = this.url(bbox, layer);
-
-    // TODO: this is not optimal: if called again before the IoDriver resolves, it'll load the XBIL again
-    const textureCache = this.cache.getRessource(url);
-
-    if (textureCache !== undefined) {
-        return Promise.resolve({
-            pitch,
-            texture: textureCache.texture,
-            min: textureCache.min,
-            max: textureCache.max,
-        });
-    }
-
-    return this._IoDriver.read(url).then((result) => {
-        result.texture = this.getTextureFloat(result.floatArray);
-        result.texture.generateMipmaps = false;
-        result.texture.magFilter = THREE.LinearFilter;
-        result.texture.minFilter = THREE.LinearFilter;
+    return this.getXBilTextureByUrl(url, pitch).then((result) => {
         result.texture.coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
-        result.pitch = pitch;
-
-        // In RGBA elevation texture LinearFilter give some errors with nodata value.
-        // need to rewrite sample function in shader
-        this.cache.addRessource(url, result);
-
         return result;
     });
 };

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -8,24 +8,6 @@
 import * as THREE from 'three';
 import BoundingBox from '../../../Scene/BoundingBox';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
-import { UNIT } from '../../Geographic/Coordinates';
-
-const WMS_WGS84Parent = function WMS_WGS84Parent(bbox, bboxParent) {
-    const dim = bbox.dimensions(UNIT.RADIAN);
-    const dimParent = bboxParent.dimensions(UNIT.RADIAN);
-    const scale = dim.x / dimParent.x;
-
-    const x =
-        Math.abs(bbox.west(UNIT.RADIAN) - bboxParent.west(UNIT.RADIAN)) /
-        dimParent.x;
-    const y =
-        Math.abs(
-            bbox.south(UNIT.RADIAN) + dim.y -
-            (bboxParent.south(UNIT.RADIAN) + dimParent.y)) /
-        dimParent.y;
-
-    return new THREE.Vector3(x, y, scale);
-};
 
 /**
  * Return url wmts MNT
@@ -113,14 +95,7 @@ WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
 };
 
 WMS_Provider.prototype.executeCommand = function executeCommand(command) {
-    const parentTextures = command.parentTextures;
     const tile = command.requester;
-
-    if (parentTextures) {
-        const texture = parentTextures[0];
-        const pitch = WMS_WGS84Parent(tile.bbox, texture.bbox);
-        return Promise.resolve({ pitch, texture });
-    }
 
     const layer = command.layer;
     const supportedFormats = {

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -7,7 +7,25 @@
 
 import * as THREE from 'three';
 import BoundingBox from '../../../Scene/BoundingBox';
-import WMTS_Provider, { computeTileWMTSCoordinates } from './WMTS_Provider';
+import OGCWebServiceHelper from './OGCWebServiceHelper';
+import { UNIT } from '../../Geographic/Coordinates';
+
+const WMS_WGS84Parent = function WMS_WGS84Parent(bbox, bboxParent) {
+    const dim = bbox.dimensions(UNIT.RADIAN);
+    const dimParent = bboxParent.dimensions(UNIT.RADIAN);
+    const scale = dim.x / dimParent.x;
+
+    const x =
+        Math.abs(bbox.west(UNIT.RADIAN) - bboxParent.west(UNIT.RADIAN)) /
+        dimParent.x;
+    const y =
+        Math.abs(
+            bbox.south(UNIT.RADIAN) + dim.y -
+            (bboxParent.south(UNIT.RADIAN) + dimParent.y)) /
+        dimParent.y;
+
+    return new THREE.Vector3(x, y, scale);
+};
 
 /**
  * Return url wmts MNT
@@ -16,13 +34,8 @@ import WMTS_Provider, { computeTileWMTSCoordinates } from './WMTS_Provider';
  * @param {String} options.format: image format (default: format/jpeg)
  * @returns {Object@call;create.url.url|String}
  */
-function WMS_Provider(options) {
-    WMTS_Provider.call(this, options);
+function WMS_Provider() {
 }
-
-WMS_Provider.prototype = Object.create(WMTS_Provider.prototype);
-
-WMS_Provider.prototype.constructor = WMS_Provider;
 
 WMS_Provider.prototype.url = function url(bbox, layer) {
     const box = bbox.as(layer.projection);
@@ -46,6 +59,9 @@ WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer)
     if (!layer.bbox) {
         throw new Error('bbox is required');
     }
+    if (!layer.projection) {
+        throw new Error('projection is required');
+    }
 
     layer.bbox = new BoundingBox(
         layer.projection,
@@ -58,9 +74,6 @@ WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer)
     layer.version = layer.version || '1.3.0';
     layer.style = layer.style || '';
     layer.transparent = layer.transparent || false;
-    layer.bbox = layer.bbox || new BoundingBox();
-    layer.options = {};
-    layer.options.tileMatrixSet = layer.tileMatrixSet || 'WGS84G';
 
     layer.customUrl = `${layer.url
                   }?SERVICE=WMS&REQUEST=GetMap&LAYERS=${layer.name
@@ -83,24 +96,20 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer) {
         return Promise.resolve();
     }
 
-    const url = this.url(tile.bbox.as('EPSG:4326'), layer);
+    const url = this.url(tile.bbox.as(layer.projection), layer);
     const pitch = new THREE.Vector3(0, 0, 1);
     const result = { pitch };
 
-    return this.getColorTextureByUrl(url).then((texture) => {
+    return OGCWebServiceHelper.getColorTextureByUrl(url).then((texture) => {
         result.texture = texture;
-        result.texture.coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
         result.texture.bbox = tile.bbox;
         return result;
     });
 };
 
 WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
-    const url = this.url(tile.bbox, layer);
-    return this.getXBilTextureByUrl(url, new THREE.Vector3(0, 0, 1)).then((result) => {
-        result.texture.coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
-        return result;
-    });
+    const url = this.url(tile.bbox.as(layer.projection), layer);
+    return this.getXBilTextureByUrl(url, new THREE.Vector3(0, 0, 1));
 };
 
 WMS_Provider.prototype.executeCommand = function executeCommand(command) {
@@ -109,14 +118,11 @@ WMS_Provider.prototype.executeCommand = function executeCommand(command) {
 
     if (parentTextures) {
         const texture = parentTextures[0];
-        const pitch = this.projection.WMS_WGS84Parent(tile.bbox, texture.bbox);
+        const pitch = WMS_WGS84Parent(tile.bbox, texture.bbox);
         return Promise.resolve({ pitch, texture });
     }
 
     const layer = command.layer;
-
-    computeTileWMTSCoordinates(tile, layer, this.projection);
-
     const supportedFormats = {
         'image/png': this.getColorTexture.bind(this),
         'image/jpg': this.getColorTexture.bind(this),
@@ -132,6 +138,5 @@ WMS_Provider.prototype.executeCommand = function executeCommand(command) {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.format}`));
     }
 };
-
 
 export default WMS_Provider;

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -15,10 +15,26 @@ import CacheRessource from './CacheRessource';
 
 const SIZE_TEXTURE_TILE = 256;
 
-function WMTS_Provider(options) {
-    // Constructor
+export function computeTileWMTSCoordinates(tile, wmtsLayer, projection) {
+    // Are WMTS coordinates ready?
+    if (!tile.wmtsCoords) {
+        tile.wmtsCoords = {};
+    }
 
+    const tileMatrixSet = wmtsLayer.options.tileMatrixSet;
+    if (!(tileMatrixSet in tile.wmtsCoords)) {
+        const tileCoord = projection.WGS84toWMTS(tile.bbox);
+
+        tile.wmtsCoords[tileMatrixSet] =
+            projection.getCoordWMTS_WGS84(tileCoord, tile.bbox, tileMatrixSet);
+    }
+}
+
+function WMTS_Provider(options) {
     Provider.call(this, new IoDriver_XBIL());
+
+    // CacheRessource is necessary for neighboring PM textures
+    // Info : THREE.js have cache image https://github.com/mrdoob/three.js/blob/master/src/loaders/ImageLoader.js#L25
     this.cache = CacheRessource();
     this.projection = new Projection();
     this.support = options.support || false;
@@ -33,9 +49,7 @@ function WMTS_Provider(options) {
             // Start float to RGBA uint8
             // var bufferUint = new Uint8Array(buffer.buffer);
             // var texture = new THREE.DataTexture(bufferUint, 256, 256);
-
             const texture = new THREE.DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, THREE.AlphaFormat, THREE.FloatType);
-
             texture.needsUpdate = true;
             return texture;
         }; }
@@ -51,10 +65,6 @@ WMTS_Provider.prototype.customUrl = function customUrl(layer, url, tilematrix, r
     urld = urld.replace('%COL', col.toString());
 
     return urld;
-};
-
-WMTS_Provider.prototype.removeLayer = function removeLayer(/* idLayer*/) {
-
 };
 
 WMTS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer) {
@@ -104,6 +114,21 @@ WMTS_Provider.prototype.url = function url(coWMTS, layer) {
     return this.customUrl(layer, layer.customUrl, coWMTS.zoom, coWMTS.row, coWMTS.col);
 };
 
+
+WMTS_Provider.prototype.cropXbilTexture = function cropXbilTexture(texture, pitch) {
+    const minmax = this._IoDriver.computeMinMaxElevation(
+                texture.image.data,
+                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                pitch);
+    return Promise.resolve(
+        {
+            pitch,
+            texture,
+            min: minmax.min,
+            max: minmax.max,
+        });
+};
+
 /**
  * return texture float alpha THREE.js of MNT
  * @param {type} coWMTS : coord WMTS
@@ -121,47 +146,37 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
                 coordWMTS,
                 Math.max(layer.zoom.min, parentZoom),
                 pitch);
-            const texture = tile.parent.material.textures[0][0];
-            const minmax = this._IoDriver.computeMinMaxElevation(
-                texture.image.data,
-                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-                pitch);
-            return Promise.resolve(
-                {
-                    pitch,
-                    texture,
-                    min: minmax.min,
-                    max: minmax.max,
-                });
+            const texture = tile.parent.material.getLayerTextures(layer.type)[0];
+            return this.cropXbilTexture(texture, pitch);
         }
     }
 
     const url = this.url(coordWMTS, layer);
 
+    return this.getXBilTextureByUrl(url, pitch).then((result) => {
+        result.texture.coordWMTS = coordWMTS;
+        return result;
+    });
+};
+
+WMTS_Provider.prototype.getXBilTextureByUrl = function getXBilTextureByUrl(url, pitch) {
     const textureCache = this.cache.getRessource(url);
 
     if (textureCache !== undefined) {
-        const minmax = this._IoDriver.computeMinMaxElevation(
-            textureCache.floatArray,
-            SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-            pitch);
-        return Promise.resolve(
-            {
-                pitch,
-                texture: textureCache.texture,
-                min: minmax.min,
-                max: minmax.max,
-            });
+        return this.cropXbilTexture(textureCache, pitch);
     }
 
     return this._IoDriver.read(url).then((result) => {
-        result.pitch = pitch;
+        // RGBA is needed for navigator with no support in texture float
+        // In RGBA elevation texture LinearFilter give some errors with nodata value.
+        // need to rewrite sample function in shader
         result.texture = this.getTextureFloat(result.floatArray);
         result.texture.generateMipmaps = false;
         result.texture.magFilter = THREE.LinearFilter;
         result.texture.minFilter = THREE.LinearFilter;
-        result.texture.coordWMTS = coordWMTS;
-        this.cache.addRessource(url, { texture: result.texture, floatArray: result.floatArray });
+        result.pitch = pitch;
+
+        this.cache.addRessource(url, result.texture);
 
         return result;
     });
@@ -178,44 +193,35 @@ WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, pi
     const result = {
         pitch,
     };
+
     const url = this.url(coordWMTS, layer);
 
-    result.texture = this.cache.getRessource(url);
-
-    if (result.texture !== undefined) {
-        return Promise.resolve(result);
-    }
-
-    const { texture, promise } = Fetcher.texture(url);
-
-    result.texture = texture;
-    result.texture.generateMipmaps = false;
-    result.texture.magFilter = THREE.LinearFilter;
-    result.texture.minFilter = THREE.LinearFilter;
-    result.texture.anisotropy = 16;
-    result.texture.coordWMTS = coordWMTS;
-
-    return promise.then(() => {
-        this.cache.addRessource(url, result.texture);
-        result.texture.needsUpdate = true;
+    return this.getColorTextureByUrl(url).then((texture) => {
+        result.texture = texture;
+        result.texture.coordWMTS = coordWMTS;
         return result;
     });
 };
 
-function computeTileWMTSCoordinates(tile, wmtsLayer, projection) {
-    // Are WMTS coordinates ready?
-    if (!tile.wmtsCoords) {
-        tile.wmtsCoords = {};
+WMTS_Provider.prototype.getColorTextureByUrl = function getColorTextureByUrl(url) {
+    const textureCached = this.cache.getRessource(url);
+
+    if (textureCached !== undefined) {
+        return Promise.resolve(textureCached);
     }
 
-    const tileMatrixSet = wmtsLayer.options.tileMatrixSet;
-    if (!(tileMatrixSet in tile.wmtsCoords)) {
-        const tileCoord = projection.WGS84toWMTS(tile.bbox);
+    const { texture, promise } = Fetcher.texture(url);
 
-        tile.wmtsCoords[tileMatrixSet] =
-            projection.getCoordWMTS_WGS84(tileCoord, tile.bbox, tileMatrixSet);
-    }
-}
+    texture.generateMipmaps = false;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+    texture.anisotropy = 16;
+
+    return promise.then(() => {
+        this.cache.addRessource(url, texture);
+        return texture;
+    });
+};
 
 WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
     const layer = command.layer;

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -134,21 +134,16 @@ WMTS_Provider.prototype.cropXbilTexture = function cropXbilTexture(texture, pitc
  * @param {type} coWMTS : coord WMTS
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
  */
-WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
+WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, parentTextures) {
     let coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
     const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
-    const searchInParent = tile.material.getElevationLayerLevel() < 0;
 
-    if (searchInParent || coordWMTS.zoom > layer.zoom.max) {
-        const parentZoom = tile.parent.material.getElevationLayerLevel();
-        if (parentZoom > -1) {
-            coordWMTS = this.projection.WMTS_WGS84Parent(
-                coordWMTS,
-                Math.max(layer.zoom.min, parentZoom),
-                pitch);
-            const texture = tile.parent.material.getLayerTextures(layer.type)[0];
-            return this.cropXbilTexture(texture, pitch);
-        }
+    if (parentTextures) {
+        coordWMTS = this.projection.WMTS_WGS84Parent(
+            coordWMTS,
+            parentTextures[0].coordWMTS.zoom,
+            pitch);
+        return this.cropXbilTexture(parentTextures[0], pitch);
     }
 
     const url = this.url(coordWMTS, layer);
@@ -189,16 +184,14 @@ WMTS_Provider.prototype.getXBilTextureByUrl = function getXBilTextureByUrl(url, 
  * @param {type} id
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;ioDriverImage@call;read@call;then}
  */
-WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, pitch, layer) {
-    const result = {
-        pitch,
-    };
-
+WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, layer) {
     const url = this.url(coordWMTS, layer);
-
     return this.getColorTextureByUrl(url).then((texture) => {
+        const result = {};
         result.texture = texture;
         result.texture.coordWMTS = coordWMTS;
+        result.pitch = new THREE.Vector3(0, 0, 1);
+
         return result;
     });
 };
@@ -226,6 +219,7 @@ WMTS_Provider.prototype.getColorTextureByUrl = function getColorTextureByUrl(url
 WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
     const layer = command.layer;
     const tile = command.requester;
+    const parentTextures = command.parentTextures;
 
     computeTileWMTSCoordinates(tile, layer, this.projection);
 
@@ -238,7 +232,7 @@ WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
 
     const func = supportedFormats[layer.options.mimetype];
     if (func) {
-        return func(tile, layer);
+        return func(tile, layer, parentTextures);
     } else {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.options.mimetype}`));
     }
@@ -258,7 +252,7 @@ WMTS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) 
     return layer.options.zoom.min <= tile.level;
 };
 
-WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer) {
+WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer, parentTextures) {
     const promises = [];
     if (tile.material === null) {
         return Promise.resolve();
@@ -267,30 +261,18 @@ WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer
     // Request parent's texture if no texture at all
     if (this.tileInsideLimit(tile, layer)) {
         const bcoord = tile.wmtsCoords[layer.options.tileMatrixSet];
-        let parentZoom = layer.zoom.min;
-        let searchInParent = tile.material.getColorLayerLevelById(layer.id) < 0;
-        let texturesParent;
-
-        if (searchInParent) {
-            parentZoom = tile.parent.material.getColorLayerLevelById(layer.id);
-            if (parentZoom < 0) {
-                searchInParent = false;
-            } else {
-                texturesParent = tile.parent.material.getLayerTextures(layer.type, layer.id);
-            }
-        }
 
         for (let row = bcoord[1].row; row >= bcoord[0].row; row--) {
             let coordWMTS = new CoordWMTS(bcoord[0].zoom, row, bcoord[0].col);
-            const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
 
-            if (searchInParent) {
-                coordWMTS = this.projection.WMTS_WGS84Parent(coordWMTS, parentZoom, pitch);
+            if (parentTextures) {
+                const pitch = new THREE.Vector3();
+                coordWMTS = this.projection.WMTS_WGS84Parent(coordWMTS, parentTextures[0].coordWMTS.zoom, pitch);
                 promises.push(Promise.resolve({ pitch,
-                    texture: texturesParent.find(texture => texture.coordWMTS.equals(coordWMTS)),
+                    texture: parentTextures.find(texture => texture.coordWMTS.equals(coordWMTS)),
                 }));
             } else {
-                promises.push(this.getColorTexture(coordWMTS, pitch, layer));
+                promises.push(this.getColorTexture(coordWMTS, layer));
             }
         }
     }

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -34,7 +34,7 @@ function WMTS_Provider(options) {
             // var bufferUint = new Uint8Array(buffer.buffer);
             // var texture = new THREE.DataTexture(bufferUint, 256, 256);
 
-            var texture = new THREE.DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, THREE.AlphaFormat, THREE.FloatType);
+            const texture = new THREE.DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, THREE.AlphaFormat, THREE.FloatType);
 
             texture.needsUpdate = true;
             return texture;
@@ -109,25 +109,36 @@ WMTS_Provider.prototype.url = function url(coWMTS, layer) {
  * @param {type} coWMTS : coord WMTS
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
  */
-WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, parameters) {
-    var cooWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
-    var pitch = new THREE.Vector3(0.0, 0.0, 1.0);
+WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
+    let coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
+    const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
+    const searchInParent = tile.material.getElevationLayerLevel() < 0;
 
-    if (parameters.ancestor) {
-        // account for possible level offset between coords and tile level
-        // (e.g for PM texture cooWMTS.level = tile.level + 1)
-        var levelOffset = cooWMTS.zoom - tile.level;
-
-        cooWMTS = this.projection.WMTS_WGS84Parent(
-            cooWMTS,
-            this.computeLevelToDownload(tile, parameters.ancestor, layer) + levelOffset,
-            pitch);
+    if (searchInParent || coordWMTS.zoom > layer.zoom.max) {
+        const parentZoom = tile.parent.material.getElevationLayerLevel();
+        if (parentZoom > -1) {
+            coordWMTS = this.projection.WMTS_WGS84Parent(
+                coordWMTS,
+                Math.max(layer.zoom.min, parentZoom),
+                pitch);
+            const texture = tile.parent.material.textures[0][0];
+            const minmax = this._IoDriver.computeMinMaxElevation(
+                texture.image.data,
+                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                pitch);
+            return Promise.resolve(
+                {
+                    pitch,
+                    texture,
+                    min: minmax.min,
+                    max: minmax.max,
+                });
+        }
     }
 
-    var url = this.url(cooWMTS, layer);
+    const url = this.url(coordWMTS, layer);
 
-    // TODO: this is not optimal: if called again before the IoDriver resolves, it'll load the XBIL again
-    var textureCache = this.cache.getRessource(url);
+    const textureCache = this.cache.getRessource(url);
 
     if (textureCache !== undefined) {
         const minmax = this._IoDriver.computeMinMaxElevation(
@@ -143,22 +154,13 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, pa
             });
     }
 
-
-    // bug #74
-    // var limits = layer.tileMatrixSetLimits[coWMTS.zoom];
-    // if (!limits || !coWMTS.isInside(limits)) {
-    //     var texture = -1;
-    //     this.cache.addRessource(url, texture);
-    //     return Promise.resolve(texture);
-    // }
-    // -> bug #74
-
     return this._IoDriver.read(url).then((result) => {
         result.pitch = pitch;
         result.texture = this.getTextureFloat(result.floatArray);
         result.texture.generateMipmaps = false;
         result.texture.magFilter = THREE.LinearFilter;
         result.texture.minFilter = THREE.LinearFilter;
+        result.texture.coordWMTS = coordWMTS;
         this.cache.addRessource(url, { texture: result.texture, floatArray: result.floatArray });
 
         return result;
@@ -168,15 +170,15 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, pa
 /**
  * Return texture RGBA THREE.js of orthophoto
  * TODO : RGBA --> RGB remove alpha canal
- * @param {type} coWMTS
+ * @param {type} coordWMTS
  * @param {type} id
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;ioDriverImage@call;read@call;then}
  */
-WMTS_Provider.prototype.getColorTexture = function getColorTexture(coWMTS, pitch, layer) {
-    var result = {
+WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, pitch, layer) {
+    const result = {
         pitch,
     };
-    var url = this.url(coWMTS, layer);
+    const url = this.url(coordWMTS, layer);
 
     result.texture = this.cache.getRessource(url);
 
@@ -185,12 +187,13 @@ WMTS_Provider.prototype.getColorTexture = function getColorTexture(coWMTS, pitch
     }
 
     const { texture, promise } = Fetcher.texture(url);
-    result.texture = texture;
 
+    result.texture = texture;
     result.texture.generateMipmaps = false;
     result.texture.magFilter = THREE.LinearFilter;
     result.texture.minFilter = THREE.LinearFilter;
     result.texture.anisotropy = 16;
+    result.texture.coordWMTS = coordWMTS;
 
     return promise.then(() => {
         this.cache.addRessource(url, result.texture);
@@ -215,36 +218,24 @@ function computeTileWMTSCoordinates(tile, wmtsLayer, projection) {
 }
 
 WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
-    var layer = command.layer;
-    var tile = command.requester;
+    const layer = command.layer;
+    const tile = command.requester;
 
     computeTileWMTSCoordinates(tile, layer, this.projection);
 
-    var supportedFormats = {
+    const supportedFormats = {
         'image/png': this.getColorTextures.bind(this),
         'image/jpg': this.getColorTextures.bind(this),
         'image/jpeg': this.getColorTextures.bind(this),
         'image/x-bil;bits=32': this.getXbilTexture.bind(this),
     };
 
-    var func = supportedFormats[layer.options.mimetype];
+    const func = supportedFormats[layer.options.mimetype];
     if (func) {
-        return func(tile, layer, command);
+        return func(tile, layer);
     } else {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.options.mimetype}`));
     }
-};
-
-
-WMTS_Provider.prototype.computeLevelToDownload = function computeLevelToDownload(tile, ancestor, layer) {
-    // Use ancestor's level if valid, else fallback on tile's level
-    var lvl = ancestor ? ancestor.level : tile.level;
-
-    return Math.min(
-        layer.options.zoom.max,
-        Math.max(
-            layer.options.zoom.min,
-            lvl));
 };
 
 WMTS_Provider.prototype.tileTextureCount = function tileTextureCount(tile, layer) {
@@ -261,32 +252,40 @@ WMTS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) 
     return layer.options.zoom.min <= tile.level;
 };
 
-WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer, parameters) {
-    var promises = [];
+WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer) {
+    const promises = [];
     if (tile.material === null) {
         return Promise.resolve();
     }
+
     // Request parent's texture if no texture at all
     if (this.tileInsideLimit(tile, layer)) {
-        var bcoord = tile.wmtsCoords[layer.options.tileMatrixSet];
+        const bcoord = tile.wmtsCoords[layer.options.tileMatrixSet];
+        let parentZoom = layer.zoom.min;
+        let searchInParent = tile.material.getColorLayerLevelById(layer.id) < 0;
+        let texturesParent;
 
-        // WARNING the direction textures is important
-        for (var row = bcoord[1].row; row >= bcoord[0].row; row--) {
-            var cooWMTS = new CoordWMTS(bcoord[0].zoom, row, bcoord[0].col);
-            var pitch = new THREE.Vector3(0.0, 0.0, 1.0);
-
-            if (parameters.ancestor) {
-                // account for possible level offset between coords and tile level
-                // (e.g for PM texture cooWMTS.level = tile.level + 1)
-                var levelOffset = cooWMTS.zoom - tile.level;
-
-                cooWMTS = this.projection.WMTS_WGS84Parent(
-                    cooWMTS,
-                    this.computeLevelToDownload(tile, parameters.ancestor, layer) + levelOffset,
-                    pitch);
+        if (searchInParent) {
+            parentZoom = tile.parent.material.getColorLayerLevelById(layer.id);
+            if (parentZoom < 0) {
+                searchInParent = false;
+            } else {
+                texturesParent = tile.parent.material.getLayerTextures(layer.type, layer.id);
             }
+        }
 
-            promises.push(this.getColorTexture(cooWMTS, pitch, layer));
+        for (let row = bcoord[1].row; row >= bcoord[0].row; row--) {
+            let coordWMTS = new CoordWMTS(bcoord[0].zoom, row, bcoord[0].col);
+            const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
+
+            if (searchInParent) {
+                coordWMTS = this.projection.WMTS_WGS84Parent(coordWMTS, parentZoom, pitch);
+                promises.push(Promise.resolve({ pitch,
+                    texture: texturesParent.find(texture => texture.coordWMTS.equals(coordWMTS)),
+                }));
+            } else {
+                promises.push(this.getColorTexture(coordWMTS, pitch, layer));
+            }
         }
     }
 

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -4,60 +4,27 @@
  * Description: Fournisseur de données à travers un flux WMTS
  */
 
-
 import * as THREE from 'three';
-import Provider from './Provider';
-import Projection from '../../Geographic/Projection';
 import CoordWMTS from '../../Geographic/CoordWMTS';
-import IoDriver_XBIL from './IoDriver_XBIL';
-import Fetcher from './Fetcher';
-import CacheRessource from './CacheRessource';
+import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from './OGCWebServiceHelper';
 
-const SIZE_TEXTURE_TILE = 256;
+const WMTS_WGS84Parent = function WMTS_WGS84Parent(cWMTS, levelParent, pitch) {
+    const diffLevel = cWMTS.zoom - levelParent;
+    const diff = Math.pow(2, diffLevel);
+    const invDiff = 1 / diff;
 
-export function computeTileWMTSCoordinates(tile, wmtsLayer, projection) {
-    // Are WMTS coordinates ready?
-    if (!tile.wmtsCoords) {
-        tile.wmtsCoords = {};
-    }
+    const r = (cWMTS.row - (cWMTS.row % diff)) * invDiff;
+    const c = (cWMTS.col - (cWMTS.col % diff)) * invDiff;
 
-    const tileMatrixSet = wmtsLayer.options.tileMatrixSet;
-    if (!(tileMatrixSet in tile.wmtsCoords)) {
-        const tileCoord = projection.WGS84toWMTS(tile.bbox);
+    pitch.x = cWMTS.col * invDiff - c;
+    pitch.y = cWMTS.row * invDiff - r;
+    pitch.z = invDiff;
 
-        tile.wmtsCoords[tileMatrixSet] =
-            projection.getCoordWMTS_WGS84(tileCoord, tile.bbox, tileMatrixSet);
-    }
+    return new CoordWMTS(levelParent, r, c);
+};
+
+function WMTS_Provider() {
 }
-
-function WMTS_Provider(options) {
-    Provider.call(this, new IoDriver_XBIL());
-
-    // CacheRessource is necessary for neighboring PM textures
-    // Info : THREE.js have cache image https://github.com/mrdoob/three.js/blob/master/src/loaders/ImageLoader.js#L25
-    this.cache = CacheRessource();
-    this.projection = new Projection();
-    this.support = options.support || false;
-    this.getTextureFloat = null;
-
-    if (this.support)
-        { this.getTextureFloat = function getTextureFloat() {
-            return new THREE.Texture();
-        }; }
-    else
-        { this.getTextureFloat = function getTextureFloat(buffer) {
-            // Start float to RGBA uint8
-            // var bufferUint = new Uint8Array(buffer.buffer);
-            // var texture = new THREE.DataTexture(bufferUint, 256, 256);
-            const texture = new THREE.DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, THREE.AlphaFormat, THREE.FloatType);
-            texture.needsUpdate = true;
-            return texture;
-        }; }
-}
-
-WMTS_Provider.prototype = Object.create(Provider.prototype);
-
-WMTS_Provider.prototype.constructor = WMTS_Provider;
 
 WMTS_Provider.prototype.customUrl = function customUrl(layer, url, tilematrix, row, col) {
     let urld = url.replace('%TILEMATRIX', tilematrix.toString());
@@ -114,65 +81,31 @@ WMTS_Provider.prototype.url = function url(coWMTS, layer) {
     return this.customUrl(layer, layer.customUrl, coWMTS.zoom, coWMTS.row, coWMTS.col);
 };
 
-
-WMTS_Provider.prototype.cropXbilTexture = function cropXbilTexture(texture, pitch) {
-    const minmax = this._IoDriver.computeMinMaxElevation(
-                texture.image.data,
-                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-                pitch);
-    return Promise.resolve(
-        {
-            pitch,
-            texture,
-            min: minmax.min,
-            max: minmax.max,
-        });
-};
-
 /**
  * return texture float alpha THREE.js of MNT
  * @param {type} coWMTS : coord WMTS
  * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
  */
 WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, parentTextures) {
-    let coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
+    const coordWMTS = tile.wmtsCoords[layer.options.tileMatrixSet][0];
     const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
 
     if (parentTextures) {
-        coordWMTS = this.projection.WMTS_WGS84Parent(
+        WMTS_WGS84Parent(
             coordWMTS,
             parentTextures[0].coordWMTS.zoom,
             pitch);
-        return this.cropXbilTexture(parentTextures[0], pitch);
+        const { min, max } = OGCWebServiceHelper.ioDXBIL.computeMinMaxElevation(
+                parentTextures[0].image.data,
+                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                pitch);
+        return Promise.resolve({ pitch, texture: parentTextures[0], min, max });
     }
 
     const url = this.url(coordWMTS, layer);
 
-    return this.getXBilTextureByUrl(url, pitch).then((result) => {
+    return OGCWebServiceHelper.getXBilTextureByUrl(url, pitch).then((result) => {
         result.texture.coordWMTS = coordWMTS;
-        return result;
-    });
-};
-
-WMTS_Provider.prototype.getXBilTextureByUrl = function getXBilTextureByUrl(url, pitch) {
-    const textureCache = this.cache.getRessource(url);
-
-    if (textureCache !== undefined) {
-        return this.cropXbilTexture(textureCache, pitch);
-    }
-
-    return this._IoDriver.read(url).then((result) => {
-        // RGBA is needed for navigator with no support in texture float
-        // In RGBA elevation texture LinearFilter give some errors with nodata value.
-        // need to rewrite sample function in shader
-        result.texture = this.getTextureFloat(result.floatArray);
-        result.texture.generateMipmaps = false;
-        result.texture.magFilter = THREE.LinearFilter;
-        result.texture.minFilter = THREE.LinearFilter;
-        result.pitch = pitch;
-
-        this.cache.addRessource(url, result.texture);
-
         return result;
     });
 };
@@ -186,7 +119,7 @@ WMTS_Provider.prototype.getXBilTextureByUrl = function getXBilTextureByUrl(url, 
  */
 WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, layer) {
     const url = this.url(coordWMTS, layer);
-    return this.getColorTextureByUrl(url).then((texture) => {
+    return OGCWebServiceHelper.getColorTextureByUrl(url).then((texture) => {
         const result = {};
         result.texture = texture;
         result.texture.coordWMTS = coordWMTS;
@@ -196,33 +129,10 @@ WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, la
     });
 };
 
-WMTS_Provider.prototype.getColorTextureByUrl = function getColorTextureByUrl(url) {
-    const textureCached = this.cache.getRessource(url);
-
-    if (textureCached !== undefined) {
-        return Promise.resolve(textureCached);
-    }
-
-    const { texture, promise } = Fetcher.texture(url);
-
-    texture.generateMipmaps = false;
-    texture.magFilter = THREE.LinearFilter;
-    texture.minFilter = THREE.LinearFilter;
-    texture.anisotropy = 16;
-
-    return promise.then(() => {
-        this.cache.addRessource(url, texture);
-        return texture;
-    });
-};
-
 WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
     const layer = command.layer;
     const tile = command.requester;
     const parentTextures = command.parentTextures;
-
-    computeTileWMTSCoordinates(tile, layer, this.projection);
-
     const supportedFormats = {
         'image/png': this.getColorTextures.bind(this),
         'image/jpg': this.getColorTextures.bind(this),
@@ -239,8 +149,6 @@ WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
 };
 
 WMTS_Provider.prototype.tileTextureCount = function tileTextureCount(tile, layer) {
-    computeTileWMTSCoordinates(tile, layer, this.projection);
-
     const tileMatrixSet = layer.options.tileMatrixSet;
     return tile.wmtsCoords[tileMatrixSet][1].row - tile.wmtsCoords[tileMatrixSet][0].row + 1;
 };
@@ -267,7 +175,7 @@ WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer
 
             if (parentTextures) {
                 const pitch = new THREE.Vector3();
-                coordWMTS = this.projection.WMTS_WGS84Parent(coordWMTS, parentTextures[0].coordWMTS.zoom, pitch);
+                coordWMTS = WMTS_WGS84Parent(coordWMTS, parentTextures[0].coordWMTS.zoom, pitch);
                 promises.push(Promise.resolve({ pitch,
                     texture: parentTextures.find(texture => texture.coordWMTS.equals(coordWMTS)),
                 }));

--- a/src/Core/Geographic/CoordWMTS.js
+++ b/src/Core/Geographic/CoordWMTS.js
@@ -21,4 +21,8 @@ CoordWMTS.prototype.isInside = function isInside(limit) {
     return this.row >= limit.minTileRow && this.row <= limit.maxTileRow && this.col <= limit.maxTileCol && this.col >= limit.minTileCol;
 };
 
+CoordWMTS.prototype.equals = function equals(coordWMTS) {
+    return this.row === coordWMTS.row && this.zoom === coordWMTS.zoom && this.col === coordWMTS.col;
+};
+
 export default CoordWMTS;

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -3,7 +3,6 @@
  * Class: Projection
  * Description: Outils de projections cartographiques et de convertion
  */
-import * as THREE from 'three';
 import CoordWMTS from './CoordWMTS';
 import MathExt from '../Math/MathExtended';
 import { UNIT } from './Coordinates';
@@ -32,7 +31,6 @@ Projection.prototype.WGS84LatitudeClamp = function WGS84LatitudeClamp(latitude) 
 
     return latitude;
 };
-
 
 Projection.prototype.getCoordWMTS_WGS84 = function getCoordWMTS_WGS84(tileCoord, bbox, tileMatrixSet) {
     // TODO: PM, WGS84G are hard-coded reference to IGN's TileMatrixSet
@@ -104,38 +102,6 @@ Projection.prototype.WMTS_WGS84ToWMTS_PM = function WMTS_WGS84ToWMTS_PM(cWMTS, b
     wmtsBox.push(new CoordWMTS(level, maxRow, maxCol));
 
     return wmtsBox;
-};
-
-Projection.prototype.WMTS_WGS84Parent = function WMTS_WGS84Parent(cWMTS, levelParent, pitch) {
-    var diffLevel = cWMTS.zoom - levelParent;
-    var diff = Math.pow(2, diffLevel);
-    var invDiff = 1 / diff;
-
-    var r = (cWMTS.row - (cWMTS.row % diff)) * invDiff;
-    var c = (cWMTS.col - (cWMTS.col % diff)) * invDiff;
-
-    pitch.x = cWMTS.col * invDiff - c;
-    pitch.y = cWMTS.row * invDiff - r;
-    pitch.z = invDiff;
-
-    return new CoordWMTS(levelParent, r, c);
-};
-
-Projection.prototype.WMS_WGS84Parent = function WMS_WGS84Parent(bbox, bboxParent) {
-    const dim = bbox.dimensions(UNIT.RADIAN);
-    const dimParent = bboxParent.dimensions(UNIT.RADIAN);
-    var scale = dim.x / dimParent.x;
-
-    var x =
-        Math.abs(bbox.west(UNIT.RADIAN) - bboxParent.west(UNIT.RADIAN)) /
-        dimParent.x;
-    var y =
-        Math.abs(
-            bbox.south(UNIT.RADIAN) + dim.y -
-            (bboxParent.south(UNIT.RADIAN) + dimParent.y)) /
-        dimParent.y;
-
-    return new THREE.Vector3(x, y, scale);
 };
 
 Projection.prototype.WGS84toWMTS = function WGS84toWMTS(bbox) {

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -17,6 +17,10 @@ Projection.prototype.WGS84ToY = function WGS84ToY(latitude) {
     return 0.5 - Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
 };
 
+Projection.prototype.YToWGS84 = function YToWGS84(y) {
+    return 2 * (Math.atan(Math.exp(-(y - 0.5) / MathExt.INV_TWO_PI)) - MathExt.PI_OV_FOUR);
+};
+
 Projection.prototype.WGS84ToOneSubY = function WGS84ToOneSubY(latitude) {
     return 0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
 };
@@ -92,7 +96,7 @@ Projection.prototype.WMTS_WGS84ToWMTS_PM = function WMTS_WGS84ToWMTS_PM(cWMTS, b
     const minRow = Math.floor(min);
     maxRow = Math.floor(max);
 
-    if (max - maxRow === 0.0 || maxRow === nbRow)
+    if (Number.isInteger(max))
         { maxRow--; }
 
     var minCol = cWMTS.col;

--- a/src/Globe/TileGeometry.js
+++ b/src/Globe/TileGeometry.js
@@ -81,6 +81,9 @@ TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder)
     var scratchBuffers = new Buffers();
 
     var nSeg = params.segment || 32;
+    // segments count :
+    // Tile : (nSeg + 1) * (nSeg + 1)
+    // Skirt : 8 * (nSeg - 1)
     var nVertex = (nSeg + 1) * (nSeg + 1) + 8 * (nSeg - 1); // correct pour uniquement les vertex
     var triangles = (nSeg) * (nSeg) + 16 * (nSeg - 1); // correct pour uniquement les vertex
 

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -159,19 +159,34 @@ TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
     }
 };
 
-TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layer) {
+TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layerId) {
     if (this.material === null) {
         return;
     }
     if (textures) {
-        this.material.setTexturesLayer(textures, layerType, layer);
+        this.material.setTexturesLayer(textures, layerType, layerId);
     }
     this.loadingCheck();
 };
 
-TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layer) {
+TileMesh.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
     var mat = this.materials[RendererConstant.FINAL];
-    return mat.isColorLayerDownscaled(layer, this.level);
+    return mat.getLayerTextures(layerType, layerId);
+};
+
+TileMesh.prototype.isColorLayerLoaded = function isColorLayerLoaded(layerId) {
+    var mat = this.materials[RendererConstant.FINAL];
+    return mat.getColorLayerLevelById(layerId) > -1;
+};
+
+TileMesh.prototype.isElevationLayerLoaded = function isElevationLayerLoaded() {
+    var mat = this.materials[RendererConstant.FINAL];
+    return mat.getElevationLayerLevel() > -1;
+};
+
+TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layerId) {
+    var mat = this.materials[RendererConstant.FINAL];
+    return mat.isColorLayerDownscaled(layerId, this.level);
 };
 
 TileMesh.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType) {

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -89,14 +89,14 @@ TileMesh.prototype.disposeChildren = function disposeChildren() {
     this.pendingSubdivision = false;
 
     while (this.children.length > 0) {
-        var child = this.children[0];
+        const child = this.children[0];
         this.remove(child);
         child.dispose();
     }
 };
 
 TileMesh.prototype.setDisplayed = function setDisplayed(show) {
-    for (var material of this.materials) {
+    for (const material of this.materials) {
         material.visible = show;
     }
 };
@@ -119,7 +119,7 @@ TileMesh.prototype.setFog = function setFog(fog) {
 };
 
 TileMesh.prototype.setMatrixRTC = function setMatrixRTC(rtc) {
-    for (var material of this.materials) {
+    for (const material of this.materials) {
         material.setMatrixRTC(rtc);
     }
 };
@@ -150,9 +150,8 @@ TileMesh.prototype.setTextureElevation = function setTextureElevation(elevation)
 TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
     if (Math.floor(min) !== Math.floor(this.bbox.bottom()) || Math.floor(max) !== Math.floor(this.bbox.top())) {
         this.bbox.setBBoxZ(min, max);
-        var delta = this.geometry.OBB.addHeight(this.bbox);
-
-        var trans = this.normal.clone().setLength(delta.y);
+        const delta = this.geometry.OBB.addHeight(this.bbox);
+        const trans = this.normal.clone().setLength(delta.y);
 
         this.geometry.boundingSphere.radius = Math.sqrt(delta.x * delta.x + this.oSphere.radius * this.oSphere.radius);
         this.centerSphere = new THREE.Vector3().addVectors(this.oSphere.center, trans);
@@ -170,27 +169,27 @@ TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerT
 };
 
 TileMesh.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
-    var mat = this.materials[RendererConstant.FINAL];
+    const mat = this.materials[RendererConstant.FINAL];
     return mat.getLayerTextures(layerType, layerId);
 };
 
 TileMesh.prototype.isColorLayerLoaded = function isColorLayerLoaded(layerId) {
-    var mat = this.materials[RendererConstant.FINAL];
+    const mat = this.materials[RendererConstant.FINAL];
     return mat.getColorLayerLevelById(layerId) > -1;
 };
 
 TileMesh.prototype.isElevationLayerLoaded = function isElevationLayerLoaded() {
-    var mat = this.materials[RendererConstant.FINAL];
+    const mat = this.materials[RendererConstant.FINAL];
     return mat.getElevationLayerLevel() > -1;
 };
 
 TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layerId) {
-    var mat = this.materials[RendererConstant.FINAL];
+    const mat = this.materials[RendererConstant.FINAL];
     return mat.isColorLayerDownscaled(layerId, this.level);
 };
 
 TileMesh.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType) {
-    var mat = this.materials[RendererConstant.FINAL];
+    const mat = this.materials[RendererConstant.FINAL];
     return mat.isLayerTypeDownscaled(layerType, this.level);
 };
 
@@ -238,7 +237,7 @@ TileMesh.prototype.removeColorLayer = function removeColorLayer(idLayer) {
 };
 
 TileMesh.prototype.changeSequenceLayers = function changeSequenceLayers(sequence) {
-    var layerCount = this.materials[RendererConstant.FINAL].getColorLayersCount();
+    const layerCount = this.materials[RendererConstant.FINAL].getColorLayersCount();
 
     // Quit if there is only one layer
     if (layerCount < 2) {

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -10,6 +10,7 @@ import LayeredMaterial, { l_ELEVATION } from '../Renderer/LayeredMaterial';
 import GlobeDepthMaterial from '../Renderer/GlobeDepthMaterial';
 import MatteIdsMaterial from '../Renderer/MatteIdsMaterial';
 import RendererConstant from '../Renderer/RendererConstant';
+import OGCWebServiceHelper from '../Core/Commander/Providers/OGCWebServiceHelper';
 
 function TileMesh(geometry, params) {
     // Constructor
@@ -32,13 +33,22 @@ function TileMesh(geometry, params) {
     this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, params.center);
 
     this.oSphere = new THREE.Sphere(this.centerSphere.clone(), this.geometry.boundingSphere.radius);
-    this.texturesNeeded = 0;
 
     this.materials = [];
 
+    if (params.parentMaterial instanceof LayeredMaterial) {
+        if (params.parentMaterial.getElevationLayerLevel() > -1) {
+            OGCWebServiceHelper.computeTileMatrixSetCoordinates(this);
+        }
+        for (let i = params.parentMaterial.colorLayersId.length - 1; i >= 0; i--) {
+            const projection = params.parentMaterial.getLayerUV(i);
+            OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, projection ? 'PM' : 'WGS84G');
+        }
+    }
     // instantiations all state materials : final, depth, id
     // Final rendering : return layered color + fog
-    this.materials[RendererConstant.FINAL] = new LayeredMaterial();
+    this.materials[RendererConstant.FINAL] = new LayeredMaterial(params.parentMaterial, this.wmtsCoords, params.parentWmtsCoords);
+
     // Depth : return the distance between projection point and the node
     this.materials[RendererConstant.DEPTH] = new GlobeDepthMaterial(this.materials[RendererConstant.FINAL]);
     // ID : return id color in RGBA (float Pack in RGBA)
@@ -74,13 +84,10 @@ TileMesh.prototype.getUuid = function getUuid(uuid) {
     return this.materials[RendererConstant.ID].getUuid(uuid);
 };
 
-TileMesh.prototype.setColorLayerParameters = function setColorLayerParameters(paramsTextureColor, lighting) {
-    if (!this.loaded) {
-        const material = this.materials[RendererConstant.FINAL];
-        material.setLightingOn(lighting.enable);
-        material.uniforms.lightPosition.value = lighting.position;
-        material.setColorLayerParameters(paramsTextureColor);
-    }
+TileMesh.prototype.setLightingParameters = function setLightingParameters(lighting) {
+    const material = this.materials[RendererConstant.FINAL];
+    material.setLightingOn(lighting.enable);
+    material.uniforms.lightPosition.value = lighting.position;
 };
 /**
  *
@@ -143,8 +150,6 @@ TileMesh.prototype.setTextureElevation = function setTextureElevation(elevation)
     this.materials[RendererConstant.FINAL].setTexture(elevation.texture, l_ELEVATION, 0, offsetScale);
     this.materials[RendererConstant.DEPTH].uniforms.texturesCount.value = this.materials[RendererConstant.FINAL].loadedTexturesCount[0];
     this.materials[RendererConstant.ID].uniforms.texturesCount.value = this.materials[RendererConstant.FINAL].loadedTexturesCount[0];
-
-    this.loadingCheck();
 };
 
 TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
@@ -165,7 +170,6 @@ TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerT
     if (textures) {
         this.material.setTexturesLayer(textures, layerType, layerId);
     }
-    this.loadingCheck();
 };
 
 TileMesh.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
@@ -185,12 +189,12 @@ TileMesh.prototype.isElevationLayerLoaded = function isElevationLayerLoaded() {
 
 TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layerId) {
     const mat = this.materials[RendererConstant.FINAL];
-    return mat.isColorLayerDownscaled(layerId, this.level);
+    return mat.isColorLayerDownscaled(layerId, this.wmtsCoords);
 };
 
 TileMesh.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType) {
     const mat = this.materials[RendererConstant.FINAL];
-    return mat.isLayerTypeDownscaled(layerType, this.level);
+    return mat.isLayerTypeDownscaled(layerType, this.wmtsCoords);
 };
 
 TileMesh.prototype.normals = function normals() {
@@ -213,27 +217,12 @@ TileMesh.prototype.OBB = function OBB() {
     return this.geometry.OBB;
 };
 
-TileMesh.prototype.allTexturesAreLoaded = function allTexturesAreLoaded() {
-    return this.texturesNeeded === this.materials[RendererConstant.FINAL].getLoadedTexturesCount();
-};
-
-TileMesh.prototype.loadingCheck = function loadingCheck() {
-    if (this.allTexturesAreLoaded()) {
-        this.loaded = true;
-        this.parent.childrenLoaded();
-    }
-};
-
 TileMesh.prototype.getIndexLayerColor = function getIndexLayerColor(idLayer) {
     return this.materials[RendererConstant.FINAL].indexOfColorLayer(idLayer);
 };
 
 TileMesh.prototype.removeColorLayer = function removeColorLayer(idLayer) {
-    const index = this.materials[RendererConstant.FINAL].indexOfColorLayer(idLayer);
-    const texturesCount = this.materials[RendererConstant.FINAL].getTextureCountByLayerIndex(index);
     this.materials[RendererConstant.FINAL].removeColorLayer(idLayer);
-    this.texturesNeeded -= texturesCount;
-    this.loadingCheck();
 };
 
 TileMesh.prototype.changeSequenceLayers = function changeSequenceLayers(sequence) {

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -12,10 +12,10 @@ import GlobeVS from './Shader/GlobeVS.glsl';
 import GlobeFS from './Shader/GlobeFS.glsl';
 import pitUV from './Shader/Chunk/pitUV.glsl';
 
-const EMPTY_TEXTURE_LEVEL = -1;
+const EMPTY_TEXTURE_ZOOM = -1;
 
 var emptyTexture = new THREE.Texture();
-emptyTexture.level = EMPTY_TEXTURE_LEVEL;
+emptyTexture.coordWMTS = { zoom: EMPTY_TEXTURE_ZOOM };
 
 const layerTypesCount = 2;
 var vector = new THREE.Vector3(0.0, 0.0, 0.0);
@@ -239,7 +239,7 @@ LayeredMaterial.prototype.removeColorLayer = function removeColorLayer(layer) {
     const removedTexturesLayer = this.textures[l_COLOR].splice(offset, texturesCount);
     this.offsetScale[l_COLOR].splice(offset, texturesCount);
 
-    const loadedTexturesLayerCount = removedTexturesLayer.reduce((sum, texture) => sum + (texture.level > -1), 0);
+    const loadedTexturesLayerCount = removedTexturesLayer.reduce((sum, texture) => sum + (texture.coordWMTS.zoom > EMPTY_TEXTURE_ZOOM), 0);
 
     // refill remove textures
     for (let i = 0, max = texturesCount; i < max; i++) {
@@ -308,8 +308,8 @@ LayeredMaterial.prototype.pushLayer = function pushLayer(param) {
     this.uniforms.colorLayersCount.value = this.getColorLayersCount();
 };
 
-LayeredMaterial.prototype.indexOfColorLayer = function indexOfColorLayer(layer) {
-    return this.colorLayersId.indexOf(layer);
+LayeredMaterial.prototype.indexOfColorLayer = function indexOfColorLayer(layerId) {
+    return this.colorLayersId.indexOf(layerId);
 };
 
 LayeredMaterial.prototype.getColorLayersCount = function getColorLayersCount() {
@@ -324,8 +324,8 @@ LayeredMaterial.prototype.getTextureCountByLayerIndex = function getTextureCount
     return this.layerTexturesCount[index];
 };
 
-LayeredMaterial.prototype.getLayerTextureOffset = function getLayerTextureOffset(layer) {
-    const index = this.indexOfColorLayer(layer);
+LayeredMaterial.prototype.getLayerTextureOffset = function getLayerTextureOffset(layerId) {
+    const index = this.indexOfColorLayer(layerId);
     return index > -1 ? this.getTextureOffsetByLayerIndex(index) : -1;
 };
 
@@ -362,29 +362,29 @@ LayeredMaterial.prototype.getLoadedTexturesCount = function getLoadedTexturesCou
     return this.loadedTexturesCount[l_ELEVATION] + this.loadedTexturesCount[l_COLOR];
 };
 
-LayeredMaterial.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layer, level) {
-    return this.textures[l_COLOR][this.getLayerTextureOffset(layer)].level < level;
+LayeredMaterial.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layerId, level) {
+    if (this.textures[l_COLOR][this.getLayerTextureOffset(layerId)]) {
+        return this.textures[l_COLOR][this.getLayerTextureOffset(layerId)].coordWMTS.zoom < level;
+    } else {
+        return false;
+    }
 };
 
 LayeredMaterial.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType, level) {
     if (layerType === l_ELEVATION) {
         const tex = this.textures[l_ELEVATION][0];
-        // 3 possible cases
-        //   - initialization (no texture)
-        if (tex === undefined) {
-            return true;
-        }
         //   - blank texture (eg: empty xbil texture)
-        if (tex.level === EMPTY_TEXTURE_LEVEL) {
+        if (tex.coordWMTS.zoom === EMPTY_TEXTURE_ZOOM) {
             return false;
         }
         //   - regular texture
-        return tex.level < level;
+        return tex.coordWMTS.zoom < level;
     } else if (layerType === l_COLOR) {
         // browse each layer
         for (let index = 0, max = this.colorLayersId.length; index < max; index++) {
             const offset = this.getTextureOffsetByLayerIndex(index);
-            if (this.textures[l_COLOR][offset].level < level) {
+            const texture = this.textures[l_COLOR][offset];
+            if (texture.coordWMTS.zoom < level) {
                 return true;
             }
         }
@@ -394,26 +394,41 @@ LayeredMaterial.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled
 };
 
 LayeredMaterial.prototype.getColorLayerLevelById = function getColorLayerLevelById(colorLayerId) {
-    let index = this.indexOfColorLayer(colorLayerId);
-    // TODO: hiding the "colorLayerId is invalid", it's problem, needs new PR
+    const index = this.indexOfColorLayer(colorLayerId);
     if (index === -1) {
-        index = 0;
+        return EMPTY_TEXTURE_ZOOM;
     }
     const slot = this.getTextureOffsetByLayerIndex(index);
-    const tex = this.textures[l_COLOR][slot];
+    const texture = this.textures[l_COLOR][slot];
 
-    return tex ? tex.level : EMPTY_TEXTURE_LEVEL;
+    return texture ? texture.coordWMTS.zoom : EMPTY_TEXTURE_ZOOM;
 };
 
 LayeredMaterial.prototype.getElevationLayerLevel = function getElevationLayerLevel() {
-    return this.textures[l_ELEVATION][0].level;
+    return this.textures[l_ELEVATION][0].coordWMTS.zoom;
 };
 
-LayeredMaterial.prototype.getLayerLevel = function getLayerLevel(layerType, layer) {
+LayeredMaterial.prototype.getLayerLevel = function getLayerLevel(layerType, layerId) {
     if (layerType == l_ELEVATION) {
         return this.getElevationLayerLevel();
     } else {
-        return this.getColorLayerLevelById(layer);
+        return this.getColorLayerLevelById(layerId);
+    }
+};
+
+LayeredMaterial.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
+    if (layerType === l_ELEVATION) {
+        return this.textures[l_ELEVATION];
+    }
+
+    const index = this.indexOfColorLayer(layerId);
+
+    if (index !== -1) {
+        const count = this.getTextureCountByLayerIndex(index);
+        const textureIndex = this.getTextureOffsetByLayerIndex(index);
+        return this.textures[l_COLOR].slice(textureIndex, textureIndex + count);
+    } else {
+        throw new Error('No known layer :', layerId);
     }
 };
 

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -363,11 +363,8 @@ LayeredMaterial.prototype.getLoadedTexturesCount = function getLoadedTexturesCou
 };
 
 LayeredMaterial.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layerId, level) {
-    if (this.textures[l_COLOR][this.getLayerTextureOffset(layerId)]) {
-        return this.textures[l_COLOR][this.getLayerTextureOffset(layerId)].coordWMTS.zoom < level;
-    } else {
-        return false;
-    }
+    return this.textures[l_COLOR][this.getLayerTextureOffset(layerId)] &&
+        this.textures[l_COLOR][this.getLayerTextureOffset(layerId)].coordWMTS.zoom < level;
 };
 
 LayeredMaterial.prototype.isLayerTypeDownscaled = function isLayerTypeDownscaled(layerType, level) {
@@ -408,14 +405,6 @@ LayeredMaterial.prototype.getElevationLayerLevel = function getElevationLayerLev
     return this.textures[l_ELEVATION][0].coordWMTS.zoom;
 };
 
-LayeredMaterial.prototype.getLayerLevel = function getLayerLevel(layerType, layerId) {
-    if (layerType == l_ELEVATION) {
-        return this.getElevationLayerLevel();
-    } else {
-        return this.getColorLayerLevelById(layerId);
-    }
-};
-
 LayeredMaterial.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
     if (layerType === l_ELEVATION) {
         return this.textures[l_ELEVATION];
@@ -428,7 +417,7 @@ LayeredMaterial.prototype.getLayerTextures = function getLayerTextures(layerType
         const textureIndex = this.getTextureOffsetByLayerIndex(index);
         return this.textures[l_COLOR].slice(textureIndex, textureIndex + count);
     } else {
-        throw new Error('No known layer :', layerId);
+        throw new Error(`Invalid layer id "${layerId}"`);
     }
 };
 

--- a/src/Renderer/Shader/GlobeVS.glsl
+++ b/src/Renderer/Shader/GlobeVS.glsl
@@ -52,7 +52,7 @@ void main() {
 
                 float dv = max(decode32(rgba),0.0);
 
-                // In RGBA elevation texture LinearFilter give some errors with nodata value.
+                // TODO In RGBA elevation texture LinearFilter give some errors with nodata value.
                 // need to rewrite sample function in shader
                 // simple solution
                 if(dv>5000.0)

--- a/src/Scene/BoundingBox.js
+++ b/src/Scene/BoundingBox.js
@@ -138,10 +138,17 @@ BoundingBox.prototype.offsetScale = function offsetScale(bbox) {
     if (bbox.crs() != this.crs()) {
         throw new Error('unsupported offscale between 2 diff crs');
     }
-    var pitX = Math.abs(bbox.west() - this.west()) / this._dimension.x;
-    var pitY = Math.abs(bbox.north() - this.north()) / this._dimension.y;
-    var scale = bbox._dimension.x / this._dimension.x;
-    return new THREE.Vector3(pitX, pitY, scale);
+
+    const dimension = {
+        x: Math.abs(this.east() - this.west()),
+        y: Math.abs(this.north() - this.south()),
+    };
+
+    var originX = (bbox.west() - this.west()) / dimension.x;
+    var originY = (bbox.north() - this.north()) / dimension.y;
+
+    var scale = Math.abs(bbox.east() - bbox.west()) / dimension.x;
+    return new THREE.Vector3(originX, originY, scale);
 };
 
 /**

--- a/src/Scene/BrowseTree.js
+++ b/src/Scene/BrowseTree.js
@@ -113,14 +113,6 @@ BrowseTree.prototype._browseNonDisplayableNode = function _browseNonDisplayableN
     node.setDisplayed(false);
 
     const sse = process.checkNodeSSE(node);
-    if (!node.loaded) {
-        // Make sure this node is not stuck in a !loaded state
-        // TODO: we could be smarter and do this only for visible tiles for instance
-        // but we need to be careful due to the number of possible states for a tile (pendingSubdivision,
-        // loaded, disposed etc). Also: once this is fixed we should be able to simplify the commandC
-        // cancellation function to something like: `return !node.isVisible()`
-        process.refineNodeLayers(node, camera, params);
-    }
 
     // recursively clean children
     if (node.children.length > 0) {

--- a/src/Scene/LayersConfiguration.js
+++ b/src/Scene/LayersConfiguration.js
@@ -4,7 +4,6 @@
  * Description: Le layer est une couche de données. Cette couche peut etre des images ou de l'information 3D. Les requètes de cette couche sont acheminées par une interfaceCommander.
  *
  */
-import { l_COLOR, l_ELEVATION } from '../Renderer/LayeredMaterial';
 
 /**
  *
@@ -48,13 +47,11 @@ function defaultState(seq) {
 }
 
 LayersConfiguration.prototype.addElevationLayer = function addElevationLayer(layer) {
-    layer.type = l_ELEVATION;
     this.elevationLayers.push(layer);
     this.layersState[layer.id] = defaultState();
 };
 
 LayersConfiguration.prototype.addColorLayer = function addColorLayer(layer) {
-    layer.type = l_COLOR;
     this.colorLayers.push(layer);
     this.layersState[layer.id] = defaultState(this.colorLayers.length - 1);
 };

--- a/src/Scene/LayersConfiguration.js
+++ b/src/Scene/LayersConfiguration.js
@@ -4,6 +4,7 @@
  * Description: Le layer est une couche de données. Cette couche peut etre des images ou de l'information 3D. Les requètes de cette couche sont acheminées par une interfaceCommander.
  *
  */
+import { l_COLOR, l_ELEVATION } from '../Renderer/LayeredMaterial';
 
 /**
  *
@@ -47,11 +48,13 @@ function defaultState(seq) {
 }
 
 LayersConfiguration.prototype.addElevationLayer = function addElevationLayer(layer) {
+    layer.type = l_ELEVATION;
     this.elevationLayers.push(layer);
     this.layersState[layer.id] = defaultState();
 };
 
 LayersConfiguration.prototype.addColorLayer = function addColorLayer(layer) {
+    layer.type = l_COLOR;
     this.colorLayers.push(layer);
     this.layersState[layer.id] = defaultState(this.colorLayers.length - 1);
 };

--- a/src/Scene/Node.js
+++ b/src/Scene/Node.js
@@ -16,7 +16,6 @@ function Node() {
     this.id = null;
     this.level = 0;
     this.screenSpaceError = 0.0;
-    this.loaded = false;
     // TODO: remove pendingSubdivision and use layerUpdateState instead
     this.pendingSubdivision = false;
     this.layerUpdateState = {};

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -235,13 +235,14 @@ function updateNodeImagery(scene, quadtree, node, layersConfig, force) {
         }
 
         node.layerUpdateState[layer.id].newTry();
-
+        const searchInParent = !node.isColorLayerLoaded(layer.id) && node.parent.isColorLayerLoaded(layer.id);
         const command = {
             /* mandatory */
             layer,
             requester: node,
             priority: nodeCommandQueuePriorityFunction(node),
             earlyDropFunction: refinementCommandCancellationFn,
+            parentTextures: searchInParent ? node.parent.getLayerTextures(l_COLOR, layer.id) : undefined,
         };
 
         promises.push(quadtree.scheduler.execute(command).then(
@@ -336,12 +337,15 @@ function updateNodeElevation(scene, quadtree, node, layersConfig, force) {
     if (bestLayer !== null) {
         node.layerUpdateState[bestLayer.id].newTry();
 
+        const searchInParent = (!node.isElevationLayerLoaded() && node.parent.isElevationLayerLoaded()) || (node.level > bestLayer.zoom.max);
+
         const command = {
             /* mandatory */
             layer: bestLayer,
             requester: node,
             priority: nodeCommandQueuePriorityFunction(node),
             earlyDropFunction: refinementCommandCancellationFn,
+            parentTextures: searchInParent ? node.parent.getLayerTextures(l_ELEVATION) : undefined,
         };
 
         quadtree.scheduler.execute(command).then(


### PR DESCRIPTION
### Refactor
**Remove node's ancestor**
The ancestor gave the textures downscaled WMTS and WMS. Now, ancestor is replaced by direct parent. This replacement is effective for color and elevation.
