### PR TITLE
Package lib

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["transform-runtime"]
+    "presets": ["es2015"],
+    "plugins": [
+        "transform-runtime",
+        [ "babel-plugin-webpack-loaders", { "config": "./webpack-babel.config.js", "verbose": false }]
+    ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
+// please consider modifying babel-loader configuration in webpack.config.js
 {
     "presets": ["es2015"],
     "plugins": [

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 /node_modules/
 /dist/
+/lib/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run lint && npm run build && npm run doclint",
     "build": "webpack -p",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
-    "prepublish": "npm run build && babel src --out-dir lib"
+    "prepublish": "npm run build && BABEL_DISABLE_CACHE=1 babel src --out-dir lib"
   },
   "files": [
     "*.md",
@@ -42,6 +42,7 @@
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-runtime": "^6.22.0",
+    "babel-plugin-webpack-loaders": "^0.8.0",
     "babel-preset-es2015": "^6.22.0",
     "cross-env": "^3.1.4",
     "eslint": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "itowns",
   "version": "0.0.0-alpha",
   "description": "A JS/WebGL framework for 3D geospatial data visualization",
-  "main": "dist/itowns.js",
+  "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
     "doc": "jsdoc src/Core/Commander/Interfaces/ApiInterface/*",
@@ -10,11 +10,12 @@
     "test": "npm run lint && npm run build && npm run doclint",
     "build": "webpack -p",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build && babel src --out-dir lib"
   },
   "files": [
     "*.md",
     "dist",
+    "lib",
     "doc",
     "examples"
   ],
@@ -27,16 +28,22 @@
     "url": "https://github.com/iTowns/itowns2/issues"
   },
   "homepage": "https://itowns.github.io/",
+  "dependencies": {
+    "babel-runtime": "^6.20.0",
+    "custom-event": "^1.0.1",
+    "es6-promise": "^4.0.5",
+    "js-priority-queue": "^0.1.5",
+    "jszip": "^3.1.3",
+    "three": "^0.84.0",
+    "whatwg-fetch": "^2.0.2"
+  },
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
-    "babel-runtime": "^6.20.0",
     "cross-env": "^3.1.4",
-    "custom-event": "^1.0.1",
-    "es6-promise": "^4.0.5",
     "eslint": "^3.14.0",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-import-resolver-webpack": "^0.8.1",
@@ -45,16 +52,9 @@
     "eslint-loader": "^1.6.1",
     "eslint-plugin-import": "^2.2.0",
     "imports-loader": "^0.7.0",
-    "js-priority-queue": "^0.1.5",
     "jsdoc": "^3.4.3",
-    "jszip": "^3.1.3",
-    "paralleljs": "^0.2.1",
     "raw-loader": "^0.5.1",
-    "simd": "^2.0.0",
-    "string_format": "^0.0.6",
-    "three": "^0.84.0",
     "webpack": "^1.14.0",
-    "webpack-dev-server": "^1.16.2",
-    "whatwg-fetch": "^2.0.2"
+    "webpack-dev-server": "^1.16.2"
   }
 }

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -4,18 +4,18 @@
  * Description: Classe façade pour attaquer les fonctionnalités du code.
  */
 
-import Scene from 'Scene/Scene';
-import Globe from 'Globe/Globe';
-import WMTS_Provider from 'Core/Commander/Providers/WMTS_Provider';
-import WMS_Provider from 'Core/Commander/Providers/WMS_Provider';
-import TileProvider from 'Core/Commander/Providers/TileProvider';
-import loadGpx from 'Core/Commander/Providers/GpxUtils';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
-import Ellipsoid from 'Core/Math/Ellipsoid';
-import Projection from 'Core/Geographic/Projection';
 import CustomEvent from 'custom-event';
-import Fetcher from 'Core/Commander/Providers/Fetcher';
-import { STRATEGY_MIN_NETWORK_TRAFFIC } from 'Scene/LayerUpdateStrategy';
+import Scene from '../../../../Scene/Scene';
+import Globe from '../../../../Globe/Globe';
+import WMTS_Provider from '../../Providers/WMTS_Provider';
+import WMS_Provider from '../../Providers/WMS_Provider';
+import TileProvider from '../../Providers/TileProvider';
+import loadGpx from '../../Providers/GpxUtils';
+import GeoCoordinate, { UNIT } from '../../../Geographic/GeoCoordinate';
+import Ellipsoid from '../../../Math/Ellipsoid';
+import Projection from '../../../Geographic/Projection';
+import Fetcher from '../../Providers/Fetcher';
+import { STRATEGY_MIN_NETWORK_TRAFFIC } from '../../../../Scene/LayerUpdateStrategy';
 
 var sceneIsLoaded = false;
 var eventLoaded = new CustomEvent('globe-loaded');

--- a/src/Core/Commander/Providers/BuildingBox_Provider.js
+++ b/src/Core/Commander/Providers/BuildingBox_Provider.js
@@ -13,13 +13,12 @@
 
 
 // TODO , will use WFS_Provider
-import Provider from 'Core/Commander/Providers/Provider';
-import WFS_Provider from 'Core/Commander/Providers/WFS_Provider';
 import * as THREE from 'three';
-import Ellipsoid from 'Core/Math/Ellipsoid';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
-import CVML from 'Core/Math/CVML';
-
+import Provider from './Provider';
+import WFS_Provider from './WFS_Provider';
+import Ellipsoid from '../../Math/Ellipsoid';
+import GeoCoordinate, { UNIT } from '../../Geographic/GeoCoordinate';
+import CVML from '../../Math/CVML';
 
 function BuildingBox_Provider(options) {
     // Constructor

--- a/src/Core/Commander/Providers/GpxUtils.js
+++ b/src/Core/Commander/Providers/GpxUtils.js
@@ -5,10 +5,10 @@
  */
 
 import * as THREE from 'three';
-import Fetcher from 'Core/Commander/Providers/Fetcher';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
-import ItownsLine from 'Core/Commander/Providers/ItownsLine';
-import ItownsPoint from 'Core/Commander/Providers/ItownsPoint';
+import Fetcher from './Fetcher';
+import GeoCoordinate, { UNIT } from '../../Geographic/GeoCoordinate';
+import ItownsLine from './ItownsLine';
+import ItownsPoint from './ItownsPoint';
 
 
 function _gpxToWayPointsArray(gpxXML) {

--- a/src/Core/Commander/Providers/IoDriver_XBIL.js
+++ b/src/Core/Commander/Providers/IoDriver_XBIL.js
@@ -4,7 +4,7 @@
  */
 /* global Float32Array*/
 
-import IoDriver from 'Core/Commander/Providers/IoDriver';
+import IoDriver from './IoDriver';
 
 
 var portableXBIL = function portableXBIL(buffer) {

--- a/src/Core/Commander/Providers/ItownsLine.js
+++ b/src/Core/Commander/Providers/ItownsLine.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import ItownsLineMaterial from 'Renderer/ItownsLineMaterial';
+import ItownsLineMaterial from '../../../Renderer/ItownsLineMaterial';
 
 const ItownsLine = function ItownsLine(options) {
     THREE.Mesh.call(this);

--- a/src/Core/Commander/Providers/ItownsPoint.js
+++ b/src/Core/Commander/Providers/ItownsPoint.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import ItownsPointMaterial from 'Renderer/ItownsPointMaterial';
+import ItownsPointMaterial from '../../../Renderer/ItownsPointMaterial';
 
 
 const ItownsPoint = function ItownsPoint(options) {

--- a/src/Core/Commander/Providers/KML_Provider.js
+++ b/src/Core/Commander/Providers/KML_Provider.js
@@ -5,11 +5,11 @@
  */
 /* global Promise*/
 
-import Provider from 'Core/Commander/Providers/Provider';
-import Fetcher from 'Core/Commander/Providers/Fetcher';
 import * as THREE from 'three';
-import KMZLoader from 'Renderer/ThreeExtended/KMZLoader';
-import BasicMaterial from 'Renderer/BasicMaterial';
+import Provider from './Provider';
+import Fetcher from './Fetcher';
+import KMZLoader from '../../../Renderer/ThreeExtended/KMZLoader';
+import BasicMaterial from '../../../Renderer/BasicMaterial';
 
 
 function KML_Provider(ellipsoid) {

--- a/src/Core/Commander/Providers/PanoramicProvider.js
+++ b/src/Core/Commander/Providers/PanoramicProvider.js
@@ -10,11 +10,11 @@
 /* global Promise*/
 
 import * as THREE from 'three';
-import Provider from 'Core/Commander/Providers/Provider';
-import BuildingBox_Provider from 'Core/Commander/Providers/BuildingBox_Provider';
-import ProjectiveTexturingMaterial from 'Renderer/ProjectiveTexturingMaterial';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import PanoramicMesh from 'Renderer/PanoramicMesh';
+import Provider from './Provider';
+import BuildingBox_Provider from './BuildingBox_Provider';
+import ProjectiveTexturingMaterial from '../../../Renderer/ProjectiveTexturingMaterial';
+import BasicMaterial from '../../../Renderer/BasicMaterial';
+import PanoramicMesh from '../../../Renderer/PanoramicMesh';
 
 
 let _options = null;

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -13,10 +13,10 @@
  *
  */
 
-import Provider from 'Core/Commander/Providers/Provider';
-import Projection from 'Core/Geographic/Projection';
-import BuilderEllipsoidTile from 'Globe/BuilderEllipsoidTile';
-import TileGeometry from 'Globe/TileGeometry';
+import Provider from './Provider';
+import Projection from '../../Geographic/Projection';
+import BuilderEllipsoidTile from '../../../Globe/BuilderEllipsoidTile';
+import TileGeometry from '../../../Globe/TileGeometry';
 
 function TileProvider(ellipsoid) {
     Provider.call(this, null);

--- a/src/Core/Commander/Providers/WFS_Provider.js
+++ b/src/Core/Commander/Providers/WFS_Provider.js
@@ -5,9 +5,9 @@
  */
 
 
-import Provider from 'Core/Commander/Providers/Provider';
-import Fetcher from 'Core/Commander/Providers/Fetcher';
-import CacheRessource from 'Core/Commander/Providers/CacheRessource';
+import Provider from './Provider';
+import Fetcher from './Fetcher';
+import CacheRessource from './CacheRessource';
 
 /**
  * Return url wmts MNT

--- a/src/Core/Commander/Providers/WMS_Provider.js
+++ b/src/Core/Commander/Providers/WMS_Provider.js
@@ -5,15 +5,15 @@
  */
 
 
-import Provider from 'Core/Commander/Providers/Provider';
-import IoDriver_XBIL from 'Core/Commander/Providers/IoDriver_XBIL';
-import Fetcher from 'Core/Commander/Providers/Fetcher';
 import * as THREE from 'three';
-import Projection from 'Core/Geographic/Projection';
-import CacheRessource from 'Core/Commander/Providers/CacheRessource';
-import mE from 'Core/Math/MathExtended';
-import BoundingBox from 'Scene/BoundingBox';
-import { UNIT } from 'Core/Geographic/GeoCoordinate';
+import Provider from './Provider';
+import IoDriver_XBIL from './IoDriver_XBIL';
+import Fetcher from './Fetcher';
+import Projection from '../../Geographic/Projection';
+import CacheRessource from './CacheRessource';
+import mE from '../../Math/MathExtended';
+import BoundingBox from '../../../Scene/BoundingBox';
+import { UNIT } from '../../Geographic/GeoCoordinate';
 
 /**
  * Return url wmts MNT

--- a/src/Core/Commander/Providers/WMTS_Provider.js
+++ b/src/Core/Commander/Providers/WMTS_Provider.js
@@ -5,13 +5,13 @@
  */
 
 
-import Provider from 'Core/Commander/Providers/Provider';
-import Projection from 'Core/Geographic/Projection';
-import CoordWMTS from 'Core/Geographic/CoordWMTS';
-import IoDriver_XBIL from 'Core/Commander/Providers/IoDriver_XBIL';
-import Fetcher from 'Core/Commander/Providers/Fetcher';
 import * as THREE from 'three';
-import CacheRessource from 'Core/Commander/Providers/CacheRessource';
+import Provider from './Provider';
+import Projection from '../../Geographic/Projection';
+import CoordWMTS from '../../Geographic/CoordWMTS';
+import IoDriver_XBIL from './IoDriver_XBIL';
+import Fetcher from './Fetcher';
+import CacheRessource from './CacheRessource';
 
 const SIZE_TEXTURE_TILE = 256;
 

--- a/src/Core/Commander/Scheduler.js
+++ b/src/Core/Commander/Scheduler.js
@@ -4,8 +4,8 @@
  * Description: Cette classe singleton gère les requetes/Commandes  de la scène. Ces commandes peuvent etre synchrone ou asynchrone. Elle permet d'executer, de prioriser  et d'annuler les commandes de la pile. Les commandes executées sont placées dans une autre file d'attente.
  */
 
-import EventsManager from 'Core/Commander/Interfaces/EventsManager';
 import PriorityQueue from 'js-priority-queue';
+import EventsManager from './Interfaces/EventsManager';
 
 var instanceScheduler = null;
 

--- a/src/Core/Geographic/CoordStars.js
+++ b/src/Core/Geographic/CoordStars.js
@@ -3,7 +3,7 @@
  * Class: CoordStars
  * Description: get coord of stars like earth...
  */
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
+import GeoCoordinate, { UNIT } from './GeoCoordinate';
 
 const CoordStars = {
 

--- a/src/Core/Geographic/GeoCoordinate.js
+++ b/src/Core/Geographic/GeoCoordinate.js
@@ -4,7 +4,7 @@
  * Description: Coordonnées cartographiques
  */
 
-import mE from 'Core/Math/MathExtended';
+import mE from '../Math/MathExtended';
 
 export const COORD = {
     LONG: 0,

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -4,10 +4,10 @@
  * Description: Outils de projections cartographiques et de convertion
  */
 
-import CoordWMTS from 'Core/Geographic/CoordWMTS';
-import MathExt from 'Core/Math/MathExtended';
-import GeoCoordinate from 'Core/Geographic/GeoCoordinate';
 import * as THREE from 'three';
+import CoordWMTS from './CoordWMTS';
+import MathExt from '../Math/MathExtended';
+import GeoCoordinate from './GeoCoordinate';
 
 
 function Projection() {

--- a/src/Globe/Atmosphere.js
+++ b/src/Globe/Atmosphere.js
@@ -5,15 +5,15 @@
  */
 
 
-import NodeMesh from 'Renderer/NodeMesh';
 import * as THREE from 'three';
-import Sky from 'Globe/SkyShader';
-import skyFS from 'Renderer/Shader/skyFS.glsl';
-import skyVS from 'Renderer/Shader/skyVS.glsl';
-import groundFS from 'Renderer/Shader/groundFS.glsl';
-import groundVS from 'Renderer/Shader/groundVS.glsl';
-import GlowFS from 'Renderer/Shader/GlowFS.glsl';
-import GlowVS from 'Renderer/Shader/GlowVS.glsl';
+import NodeMesh from '../Renderer/NodeMesh';
+import Sky from './SkyShader';
+import skyFS from '../Renderer/Shader/skyFS.glsl';
+import skyVS from '../Renderer/Shader/skyVS.glsl';
+import groundFS from '../Renderer/Shader/groundFS.glsl';
+import groundVS from '../Renderer/Shader/groundVS.glsl';
+import GlowFS from '../Renderer/Shader/GlowFS.glsl';
+import GlowVS from '../Renderer/Shader/GlowVS.glsl';
 
 export const LIGHTING_POSITION = new THREE.Vector3(1, 0, 0);
 

--- a/src/Globe/BuilderEllipsoidTile.js
+++ b/src/Globe/BuilderEllipsoidTile.js
@@ -1,6 +1,6 @@
-import GeoCoordinate from 'Core/Geographic/GeoCoordinate';
 import * as THREE from 'three';
-import OBB from 'Renderer/ThreeExtended/OBB';
+import GeoCoordinate from '../Core/Geographic/GeoCoordinate';
+import OBB from '../Renderer/ThreeExtended/OBB';
 
 function BuilderEllipsoidTile(model, projector) {
     this.ellipsoid = model;

--- a/src/Globe/Clouds.js
+++ b/src/Globe/Clouds.js
@@ -5,12 +5,12 @@
  */
 
 
-import NodeMesh from 'Renderer/NodeMesh';
 import * as THREE from 'three';
-import WMS_Provider from 'Core/Commander/Providers/WMS_Provider';
-import CloudsFS from 'Renderer/Shader/CloudsFS.glsl';
-import CloudsVS from 'Renderer/Shader/CloudsVS.glsl';
-import { LIGHTING_POSITION } from 'Globe/Atmosphere';
+import NodeMesh from '../Renderer/NodeMesh';
+import WMS_Provider from '../Core/Commander/Providers/WMS_Provider';
+import CloudsFS from '../Renderer/Shader/CloudsFS.glsl';
+import CloudsVS from '../Renderer/Shader/CloudsVS.glsl';
+import { LIGHTING_POSITION } from './Atmosphere';
 
 function Clouds(/* size*/) {
     NodeMesh.call(this);

--- a/src/Globe/Globe.js
+++ b/src/Globe/Globe.js
@@ -4,19 +4,19 @@
  * Description: Le globe est le noeud du globe (node) principale.
  */
 
-import Layer from 'Scene/Layer';
-import Quadtree from 'Scene/Quadtree';
-import SchemeTile from 'Scene/SchemeTile';
-import MathExt from 'Core/Math/MathExtended';
-import TileMesh from 'Globe/TileMesh';
-import Atmosphere from 'Globe/Atmosphere';
-import Clouds from 'Globe/Clouds';
-import Capabilities from 'Core/System/Capabilities';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import LayersConfiguration from 'Scene/LayersConfiguration';
 import * as THREE from 'three';
-import { SSE_SUBDIVISION_THRESHOLD } from 'Scene/NodeProcess';
+import Layer from '../Scene/Layer';
+import Quadtree from '../Scene/Quadtree';
+import SchemeTile from '../Scene/SchemeTile';
+import MathExt from '../Core/Math/MathExtended';
+import TileMesh from './TileMesh';
+import Atmosphere from './Atmosphere';
+import Clouds from './Clouds';
+import Capabilities from '../Core/System/Capabilities';
+import GeoCoordinate, { UNIT } from '../Core/Geographic/GeoCoordinate';
+import BasicMaterial from '../Renderer/BasicMaterial';
+import LayersConfiguration from '../Scene/LayersConfiguration';
+import { SSE_SUBDIVISION_THRESHOLD } from '../Scene/NodeProcess';
 
 
 /* eslint-disable */

--- a/src/Globe/Star.js
+++ b/src/Globe/Star.js
@@ -5,9 +5,9 @@
  */
 
 
-import NodeMesh from 'Renderer/NodeMesh';
-import StarGeometry from 'Renderer/ThreeExtended/StarGeometry';
 import * as THREE from 'three';
+import NodeMesh from '../Renderer/NodeMesh';
+import StarGeometry from '../Renderer/ThreeExtended/StarGeometry';
 
 
 const Star = function Star() {

--- a/src/Globe/TileGeometry.js
+++ b/src/Globe/TileGeometry.js
@@ -7,7 +7,7 @@
  */
 /* global Float32Array*/
 import * as THREE from 'three';
-import CacheRessource from 'Core/Commander/Providers/CacheRessource';
+import CacheRessource from '../Core/Commander/Providers/CacheRessource';
 
 // TODO Why? it's not necessary
 

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -14,13 +14,13 @@
  * @param {type} GeoCoordinate
  * @returns {EllipsoidTileMesh_L20.TileMesh}
  */
-import NodeMesh from 'Renderer/NodeMesh';
-import BoundingBox from 'Scene/BoundingBox';
 import * as THREE from 'three';
-import LayeredMaterial, { l_ELEVATION } from 'Renderer/LayeredMaterial';
-import GlobeDepthMaterial from 'Renderer/GlobeDepthMaterial';
-import MatteIdsMaterial from 'Renderer/MatteIdsMaterial';
-import RendererConstant from 'Renderer/RendererConstant';
+import NodeMesh from '../Renderer/NodeMesh';
+import BoundingBox from '../Scene/BoundingBox';
+import LayeredMaterial, { l_ELEVATION } from '../Renderer/LayeredMaterial';
+import GlobeDepthMaterial from '../Renderer/GlobeDepthMaterial';
+import MatteIdsMaterial from '../Renderer/MatteIdsMaterial';
+import RendererConstant from '../Renderer/RendererConstant';
 
 function TileMesh(geometry, params) {
     // Constructor

--- a/src/Main.js
+++ b/src/Main.js
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-import ApiGlobe from 'Core/Commander/Interfaces/ApiInterface/ApiGlobe';
+import ApiGlobe from './Core/Commander/Interfaces/ApiInterface/ApiGlobe';
 // browser execution or not ?
 const scope = typeof window !== 'undefined' ? window : {};
 const itowns = scope.itowns || {

--- a/src/MobileMapping/MobileMappingLayer.js
+++ b/src/MobileMapping/MobileMappingLayer.js
@@ -4,13 +4,13 @@
  * Description: Layer for mobileMappingData
  */
 
-import Layer from 'Scene/Layer';
 import * as THREE from 'three';
-import gfxEngine from 'Renderer/c3DEngine';
-import Projection from 'Core/Geographic/Projection';
-import PanoramicProvider from 'Core/Commander/Providers/PanoramicProvider';
-import Ellipsoid from 'Core/Math/Ellipsoid';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
+import Layer from '../Scene/Layer';
+import gfxEngine from '../Renderer/c3DEngine';
+import Projection from '../Core/Geographic/Projection';
+import PanoramicProvider from '../Core/Commander/Providers/PanoramicProvider';
+import Ellipsoid from '../Core/Math/Ellipsoid';
+import GeoCoordinate, { UNIT } from '../Core/Geographic/GeoCoordinate';
 
 /**
  * Layer for MobileMapping data. Up to now it is used for panoramic imagery

--- a/src/MobileMapping/Ori.js
+++ b/src/MobileMapping/Ori.js
@@ -7,7 +7,7 @@
  */
 
 import * as THREE from 'three';
-import Sensor from 'MobileMapping/Sensor';
+import Sensor from './Sensor';
 
 const Ori = {
 

--- a/src/Renderer/BasicMaterial.js
+++ b/src/Renderer/BasicMaterial.js
@@ -6,10 +6,10 @@
 
 
 import * as THREE from 'three';
-import c3DEngine from 'Renderer/c3DEngine';
-import SimpleVS from 'Renderer/Shader/SimpleVS.glsl';
-import SimpleFS from 'Renderer/Shader/SimpleFS.glsl';
-import LogDepthBuffer from 'Renderer/Shader/Chunk/LogDepthBuffer.glsl';
+import c3DEngine from './c3DEngine';
+import SimpleVS from './Shader/SimpleVS.glsl';
+import SimpleFS from './Shader/SimpleFS.glsl';
+import LogDepthBuffer from './Shader/Chunk/LogDepthBuffer.glsl';
 
 function BasicMaterial(color) {
     // Constructor

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -6,8 +6,8 @@
 
 /* global Float64Array*/
 
-import Node from 'Scene/Node';
 import * as THREE from 'three';
+import Node from '../Scene/Node';
 
 function Camera(width, height, debug) {
     // Constructor

--- a/src/Renderer/GlobeDepthMaterial.js
+++ b/src/Renderer/GlobeDepthMaterial.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import GlobeDepthFS from 'Renderer/Shader/GlobeDepthFS.glsl';
-import GlobeDepthVS from 'Renderer/Shader/GlobeDepthVS.glsl';
+import BasicMaterial from './BasicMaterial';
+import GlobeDepthFS from './Shader/GlobeDepthFS.glsl';
+import GlobeDepthVS from './Shader/GlobeDepthVS.glsl';
 
 const GlobeDepthMaterial = function GlobeDepthMaterial(otherMaterial) {
     BasicMaterial.call(this);

--- a/src/Renderer/ItownsLineMaterial.js
+++ b/src/Renderer/ItownsLineMaterial.js
@@ -5,9 +5,9 @@
  */
 
 import * as THREE from 'three';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import LineVS from 'Renderer/Shader/LineVS.glsl';
-import LineFS from 'Renderer/Shader/LineFS.glsl';
+import BasicMaterial from './BasicMaterial';
+import LineVS from './Shader/LineVS.glsl';
+import LineFS from './Shader/LineFS.glsl';
 
 const ItownsLineMaterial = function ItownsLineMaterial(options) {
     BasicMaterial.call(this);

--- a/src/Renderer/ItownsPointMaterial.js
+++ b/src/Renderer/ItownsPointMaterial.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import PointVS from 'Renderer/Shader/PointVS.glsl';
-import PointFS from 'Renderer/Shader/PointFS.glsl';
+import BasicMaterial from './BasicMaterial';
+import PointVS from './Shader/PointVS.glsl';
+import PointFS from './Shader/PointFS.glsl';
 
 const ItownsPointMaterial = function ItownsPointMaterial(options) {
     BasicMaterial.call(this);

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -6,11 +6,11 @@
 
 
 import * as THREE from 'three';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import gfxEngine from 'Renderer/c3DEngine';
-import GlobeVS from 'Renderer/Shader/GlobeVS.glsl';
-import GlobeFS from 'Renderer/Shader/GlobeFS.glsl';
-import pitUV from 'Renderer/Shader/Chunk/pitUV.glsl';
+import BasicMaterial from './BasicMaterial';
+import gfxEngine from './c3DEngine';
+import GlobeVS from './Shader/GlobeVS.glsl';
+import GlobeFS from './Shader/GlobeFS.glsl';
+import pitUV from './Shader/Chunk/pitUV.glsl';
 
 const EMPTY_TEXTURE_LEVEL = -1;
 

--- a/src/Renderer/MatteIdsMaterial.js
+++ b/src/Renderer/MatteIdsMaterial.js
@@ -6,9 +6,9 @@
 
 
 import * as THREE from 'three';
-import BasicMaterial from 'Renderer/BasicMaterial';
-import MatteIdsFS from 'Renderer/Shader/MatteIdsFS.glsl';
-import GlobeDepthVS from 'Renderer/Shader/GlobeDepthVS.glsl';
+import BasicMaterial from './BasicMaterial';
+import MatteIdsFS from './Shader/MatteIdsFS.glsl';
+import GlobeDepthVS from './Shader/GlobeDepthVS.glsl';
 
 // This material renders the id in RGBA Color
 // Warning the RGBA contains id in float pack in 4 unsigned char

--- a/src/Renderer/NodeMesh.js
+++ b/src/Renderer/NodeMesh.js
@@ -5,8 +5,8 @@
  */
 
 
-import Node from 'Scene/Node';
 import * as THREE from 'three';
+import Node from '../Scene/Node';
 
 
 const NodeMesh = function NodeMesh() {

--- a/src/Renderer/PanoramicMesh.js
+++ b/src/Renderer/PanoramicMesh.js
@@ -6,7 +6,7 @@
  */
 
 
-import NodeMesh from 'Renderer/NodeMesh';
+import NodeMesh from './NodeMesh';
 
 
 const PanoramicMesh = function PanoramicMesh(geom, mat, absC) {

--- a/src/Renderer/ProjectiveTexturingMaterial.js
+++ b/src/Renderer/ProjectiveTexturingMaterial.js
@@ -6,13 +6,13 @@
  * and its projective camera information.
  */
 
-import graphicEngine from 'Renderer/c3DEngine';
 import * as THREE from 'three';
-import Ori from 'MobileMapping/Ori';
-import Shader from 'MobileMapping/Shader';
 import url from 'url';
-import Ellipsoid from 'Core/Math/Ellipsoid';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
+import graphicEngine from './c3DEngine';
+import Ori from '../MobileMapping/Ori';
+import Shader from '../MobileMapping/Shader';
+import Ellipsoid from '../Core/Math/Ellipsoid';
+import GeoCoordinate, { UNIT } from '../Core/Geographic/GeoCoordinate';
 
 window.requestAnimSelectionAlpha = (function getRequestAnimSelectionAlphaFn() {
     return window.requestAnimationFrame ||

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -7,9 +7,9 @@
 //    Pan - right mouse, or arrow keys / touch: three finter swipe
 
 import * as THREE from 'three';
-import Sphere from 'Core/Math/Sphere';
 import CustomEvent from 'custom-event';
-import AnimationPlayer, { Animation, AnimatedExpression } from 'Scene/AnimationPlayer';
+import Sphere from '../../Core/Math/Sphere';
+import AnimationPlayer, { Animation, AnimatedExpression } from '../../Scene/AnimationPlayer';
 
 var selectClick = new CustomEvent('selectClick');
 

--- a/src/Renderer/ThreeExtended/KMZLoader.js
+++ b/src/Renderer/ThreeExtended/KMZLoader.js
@@ -4,7 +4,7 @@
 
 import JSZip from 'jszip';
 import * as THREE from 'three';
-import GeoCoordinate, { UNIT } from 'Core/Geographic/GeoCoordinate';
+import GeoCoordinate, { UNIT } from '../../Core/Geographic/GeoCoordinate';
 
 function KMZLoader() {
     this.colladaLoader = new THREE.ColladaLoader();

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -7,11 +7,11 @@
 /* global Uint8Array, Float64Array, document, window, Image */
 
 import * as THREE from 'three';
-import GlobeControls from 'Renderer/ThreeExtended/GlobeControls';
-import Camera from 'Renderer/Camera';
-import Atmosphere from 'Globe/Atmosphere';
-import Capabilities from 'Core/System/Capabilities';
-import RendererConstant from 'Renderer/RendererConstant';
+import GlobeControls from './ThreeExtended/GlobeControls';
+import Camera from './Camera';
+import Atmosphere from '../Globe/Atmosphere';
+import Capabilities from '../Core/System/Capabilities';
+import RendererConstant from './RendererConstant';
 
 var instance3DEngine = null;
 

--- a/src/Scene/BoundingBox.js
+++ b/src/Scene/BoundingBox.js
@@ -4,10 +4,10 @@
  * Description: BoundingBox délimite une zone de l'espace. Cette zone est défnie  par des coordonées cartographiques.
  */
 
-import mE from 'Core/Math/MathExtended';
-import Point2D from 'Core/Math/Point2D';
 import * as THREE from 'three';
-import GeoCoordinate from 'Core/Geographic/GeoCoordinate';
+import mE from '../Core/Math/MathExtended';
+import Point2D from '../Core/Math/Point2D';
+import GeoCoordinate from '../Core/Geographic/GeoCoordinate';
 
 /**
  *

--- a/src/Scene/Description/StyleManager.js
+++ b/src/Scene/Description/StyleManager.js
@@ -4,7 +4,7 @@
  * Description:
  */
 
-import { Style } from 'Scene/Description/Style';
+import { Style } from './Style';
 
 function StyleManager() {
     this.styles = [];

--- a/src/Scene/Layer.js
+++ b/src/Scene/Layer.js
@@ -14,9 +14,9 @@
  * @returns {Layer_L15.Layer}
  */
 import * as THREE from 'three';
-import Node from 'Scene/Node';
-import Projection from 'Core/Geographic/Projection';
-import NodeMesh from 'Renderer/NodeMesh';
+import Node from './Node';
+import Projection from '../Core/Geographic/Projection';
+import NodeMesh from '../Renderer/NodeMesh';
 
 function Layer() {
     // Constructor

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -5,11 +5,11 @@
  */
 
 import * as THREE from 'three';
-import RendererConstant from 'Renderer/RendererConstant';
-import { chooseNextLevelToFetch } from 'Scene/LayerUpdateStrategy';
-import { l_ELEVATION, l_COLOR } from 'Renderer/LayeredMaterial';
-import LayerUpdateState from 'Scene/LayerUpdateState';
-import { CancelledCommandException } from 'Core/Commander/Scheduler';
+import RendererConstant from '../Renderer/RendererConstant';
+import { chooseNextLevelToFetch } from './LayerUpdateStrategy';
+import { l_ELEVATION, l_COLOR } from '../Renderer/LayeredMaterial';
+import LayerUpdateState from './LayerUpdateState';
+import { CancelledCommandException } from '../Core/Commander/Scheduler';
 
 export const SSE_SUBDIVISION_THRESHOLD = 6.0;
 

--- a/src/Scene/Quadtree.js
+++ b/src/Scene/Quadtree.js
@@ -10,10 +10,10 @@
  * @param {type} Quad
  * @returns {Quadtree_L13.Quadtree}
  */
-import Layer from 'Scene/Layer';
-import Scheduler from 'Core/Commander/Scheduler';
-import NodeMesh from 'Renderer/NodeMesh';
-import BoundingBox from 'Scene/BoundingBox';
+import Layer from './Layer';
+import Scheduler from '../Core/Commander/Scheduler';
+import NodeMesh from '../Renderer/NodeMesh';
+import BoundingBox from './BoundingBox';
 
 function Quadtree(type, schemeTile, link) {
     Layer.call(this);

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -6,17 +6,17 @@
 
 /* global window, requestAnimationFrame */
 
-import c3DEngine from 'Renderer/c3DEngine';
-import Globe from 'Globe/Globe';
-import Scheduler from 'Core/Commander/Scheduler';
-import BrowseTree from 'Scene/BrowseTree';
-import NodeProcess from 'Scene/NodeProcess';
-import Quadtree from 'Scene/Quadtree';
-import CoordStars from 'Core/Geographic/CoordStars';
-import Layer from 'Scene/Layer';
-import MobileMappingLayer from 'MobileMapping/MobileMappingLayer';
 import CustomEvent from 'custom-event';
-import StyleManager from 'Scene/Description/StyleManager';
+import c3DEngine from '../Renderer/c3DEngine';
+import Globe from '../Globe/Globe';
+import Scheduler from '../Core/Commander/Scheduler';
+import BrowseTree from './BrowseTree';
+import NodeProcess from './NodeProcess';
+import Quadtree from './Quadtree';
+import CoordStars from '../Core/Geographic/CoordStars';
+import Layer from './Layer';
+import MobileMappingLayer from '../MobileMapping/MobileMappingLayer';
+import StyleManager from './Description/StyleManager';
 
 var instanceScene = null;
 

--- a/src/Scene/SchemeTile.js
+++ b/src/Scene/SchemeTile.js
@@ -5,7 +5,7 @@
  */
 
 
-import BoundingBox from 'Scene/BoundingBox';
+import BoundingBox from './BoundingBox';
 
 function SchemeTile() {
     // Constructor

--- a/webpack-babel.config.js
+++ b/webpack-babel.config.js
@@ -1,0 +1,19 @@
+var path = require('path');
+
+module.exports = {
+  output: {
+    libraryTarget: 'commonjs2',
+    umdNamedDefine: true
+  },
+  module: {
+    loaders: [
+       {
+        test: /\.glsl$/,
+        include: [
+          path.resolve(__dirname, 'src'),
+        ],
+        loader: 'raw'
+      },
+    ],
+  },
+};

--- a/webpack-babel.config.js
+++ b/webpack-babel.config.js
@@ -7,7 +7,8 @@ module.exports = {
   },
   module: {
     loaders: [
-       {
+      // please consider modifying corresponding loaders in webpack.config.js too
+      {
         test: /\.glsl$/,
         include: [
           path.resolve(__dirname, 'src'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,13 +43,17 @@ module.exports = {
           path.resolve(__dirname, 'utils')
         ],
         loader: 'babel',
+        // Please consider modifying .babelrc too
+        // .babelrc is used for transpiling src/ into lib/ in the prepublish
+        // phase, see package.json
         query: {
           presets: ['es2015'],
           plugins: ['transform-runtime'],
           babelrc: false
         },
       },
-       {
+      {
+        // please consider modifying corresponding loaders in webpack-babel.config.js too
         test: /\.glsl$/,
         include: [
           path.resolve(__dirname, 'src'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,6 @@ module.exports = {
     ]
   },
   resolve: {
-    root: path.resolve(__dirname, 'src'),
     extensions: ['', '.js']
   },
   devServer: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,12 @@ module.exports = {
           path.resolve(__dirname, 'test'),
           path.resolve(__dirname, 'utils')
         ],
-        loader: 'babel'
+        loader: 'babel',
+        query: {
+          presets: ['es2015'],
+          plugins: ['transform-runtime'],
+          babelrc: false
+        },
       },
        {
         test: /\.glsl$/,


### PR DESCRIPTION
Here is the PR that fixes #243 

I've put a lot of explanations on each commit messages. Please do read them!

What I like:
- now our npm package are bundle/compiler agnostics. Client code can use the bundle like an old webpage, or they can require each module separately without relying on our babel config, or even on webpack loaders for glsl (as they are inlined)
- No change from our previous dev workflow
- Minimal addition to our devDependencies, and the ability to put back our real dependencies in "dependencies" tag in `package.json`

What I like less:
- There is now a bit of magic involved (webpack and npm calls babel to process js files, which in turns uses a webpack loader in `webpack-babel.config.js` to inline glsl files)

What still needs to be done:
- Build an itowns-full.js containing our code + all the dependencies, and an itowns.js without dependencies + vendor.js. Then github releases would contain these 3 files, but npm packages might contain only itowns.js (as they would have dependencies through npm)

@tbroyer this is my attempt to realize [agnostic.md](https://gist.github.com/mattdesl/aaf759da84cc44c22305) goals.

@iTowns/reviewers please r?