### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/autodeploy.sh
+++ b/autodeploy.sh
@@ -56,7 +56,7 @@ git config user.name "$COMMIT_AUTHOR_NAME"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 # Commit the "changes", i.e. the new version.
-git add dist index.html API_Doc examples
+git add dist index.html API_Doc examples dat.gui.min.js
 git commit -m "Deploy to GitHub Pages: ${SHA}"
 
 chmod 600 deploy_key

--- a/examples/index.html
+++ b/examples/index.html
@@ -32,7 +32,7 @@ and open the template in the editor.
     <body>
         <div id="viewerDiv"></div>
         <script src="examples/GUI/GuiTools.js"></script>
-        <script src="dist/itowns2.js"></script>
+        <script src="dist/itowns.js"></script>
         <script type="text/javascript">
 
             /* global itowns,document,GuiTools*/


### PR DESCRIPTION
Woops forgot to rename stuff :-)

That being said, we might want to change the `git add dist index.html API_Doc examples dat.gui.min.js` for something more resilient in the future (would `git add .` works here?)

@iTowns/reviewers r?