### PR TITLE
NODE_ENV for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint && npm run build && npm run doclint",
     "build": "webpack -p",
-    "start": "NODE_ENV=development webpack-dev-server -d --inline --hot",
+    "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
     "prepublish": "npm run build"
   },
   "files": [
@@ -34,6 +34,7 @@
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-runtime": "^6.20.0",
+    "cross-env": "^3.1.4",
     "custom-event": "^1.0.1",
     "es6-promise": "^4.0.5",
     "eslint": "^3.14.0",


### PR DESCRIPTION
Adding devDependecies 'cross-env'

To be tested on other environment than windows.

Warning : still have the 'linebreak-style' problem on windows...