### PR TITLE
Chore: deduplicate dependencies between itowns.js and debug.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ This version includes a globe visualization mode.
 
 ![iTowns screenshot](http://www.itowns.fr/videos/itowns2.jpg)
 
+## How to use Itowns in your project
+
+You can use it through npm (the preferred way) or download a bundle from our github release page.
+
+### With NPM
+
+In your project:
+
+```bash
+npm install --save itowns
+```
+This package contains the ES5-compatible sources of Itowns.
+
+If you're using a module bundler (like wepback), you can directly `require('itowns')` in your code.
+
+Alternatively, we provide a bundle you can directly include in your html files that exposes `itowns` in  `window`:
+```html
+<script src="node_modules/itowns/dist/itowns.js"></script>
+```
+
+**/!\ Please note that this bundle also contains the dependencies**.
+
+### From a release bundle
+
+See our [release page](https://github.com/iTowns/itowns2/releases) (coming soon).
+
+
 ## Supported data types
 
 - Aerial photography 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     libraryTarget: 'umd',
     umdNamedDefine: true
   },
+  plugins: [definePlugin, new webpack.optimize.CommonsChunkPlugin({ name: 'itowns' }) ],
   module: {
     preLoaders: [
       {
@@ -80,5 +81,4 @@ module.exports = {
   devServer: {
     publicPath: '/dist/'
   },
-  plugins: [definePlugin]
 };


### PR DESCRIPTION
If you import things somewhere in bundles itowns.js AND debug.js,
corresponding files (and all their deps) are getting bundled twice.
Apart from the extra size, this can cause bugs when some deps (eg.
three.js) expects you to include them only once (for id counting for
instance).

This commit removes deps that are already in itowns.js from debug.js.
One consequences is that we need to include debug.js after itowns.js.

In the future, it would be good to also extract a vendor.js bundle.

@iTowns/reviewers please r?