### PR TITLE
Fixes bad camera positions and change options WMTS

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -69,9 +69,9 @@ and open the template in the editor.
             menuGlobe.addGUI('RealisticLighting', false,
                 (newValue) => { itowns.viewer.setRealisticLightingOn(newValue); });
 
-            itowns.viewer.addEventListener('globe-loaded', () => {
+            itowns.viewer.addEventListener(itowns.viewer.INITIALIZED_EVENT, () => {
                 // eslint-disable-next-line no-console
-                console.info('Globe Loaded');
+                console.info('Globe initialized');
             });
 
 </script>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ and open the template in the editor.
 
             /* global itowns,document,GuiTools*/
 
-            const positionOnGlobe = { longitude: 2.3465, latitude: 48.88, altitude: 25000000 };
+            const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
             // iTowns namespace defined here
             const viewerDiv = document.getElementById('viewerDiv');

--- a/index.html
+++ b/index.html
@@ -74,9 +74,9 @@ and open the template in the editor.
             menuGlobe.addGUI('RealisticLighting', false,
                 (newValue) => { itowns.viewer.setRealisticLightingOn(newValue); });
 
-            itowns.viewer.addEventListener('globe-loaded', () => {
+            itowns.viewer.addEventListener(itowns.INITIALIZED_EVENT, () => {
                 // eslint-disable-next-line no-console
-                console.info('Globe Loaded');
+                console.info('Globe initialized');
             });
 
 </script>

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -97,10 +97,54 @@ ApiGlobe.prototype.addGeometryLayer = function addGeometryLayer(layer) {
 };
 
 /**
- * This function adds an imagery layer to the scene. The layer id must be unique. The protocol rules wich parameters are then needed for the function.
- * @constructor
- * @param {Layer} layer.
+ * The intellectual property rights
+ * @typedef {Object} Attribution
+ * @property {string} name
+ * @property {string} url
  */
+
+/**
+ * Options to wms protocol
+ * @typedef {Object} OptionsWms
+ * @property {Attribution} attribution The intellectual property rights for the layer
+ * @property {string} name
+ * @property {string} mimetype
+ */
+
+/**
+ * Options to wtms protocol
+ * @typedef {Object} OptionsWmts
+ * @property {Attribution} attribution The intellectual property rights for the layer
+ * @property {string} name
+ * @property {string} mimetype
+ * @property {string} tileMatrixSet
+ * @property {Array.<Object>} tileMatrixSetLimits The limits for the tile matrix set
+ * @property {number} tileMatrixSetLimits.minTileRow Minimum row for tiles at the level
+ * @property {number} tileMatrixSetLimits.maxTileRow Maximum row for tiles at the level
+ * @property {number} tileMatrixSetLimits.minTileCol Minimum col for tiles at the level
+ * @property {number} tileMatrixSetLimits.maxTileCol Maximum col for tiles at the level
+ * @property {Object} [zoom]
+ * @property {Object} [zoom.min] layer's zoom minimum
+ * @property {Object} [zoom.max] layer's zoom maximum
+ */
+
+/**
+ * Layer
+ * @typedef {Object} Layer
+ * @property {string} id Unique layer's id
+ * @property {string} layer.protocol wmts and wms (wmtsc for custom deprecated)
+ * @property {string} layer.url Base URL of the repository or of the file(s) to load
+ * @property {Object} layer.updateStrategy strategy to load imagery files
+ * @property {OptionsWmts|OptionsWms} layer.options WMTS or WMS options
+ */
+
+/**
+ * This function adds an imagery layer to the scene. The layer id must be unique.
+ * The protocol rules wich parameters are then needed for the function.
+ * @constructor
+ * @param {Layer} Layer
+ */
+
 ApiGlobe.prototype.addImageryLayer = function addImageryLayer(layer) {
     preprocessLayer(layer, this.scene.scheduler.getProtocolProvider(layer.protocol));
     const map = this.scene.getMap();
@@ -195,7 +239,7 @@ ApiGlobe.prototype.removeImageryLayer = function removeImageryLayer(id) {
  * The layer id must be unique amongst all layers already inserted.
  * The protocol rules which parameters are then needed for the function.
  * @constructor
- * @param {Layer} layer.
+ * @param {Layer} layer
  */
 
 ApiGlobe.prototype.addElevationLayer = function addElevationLayer(layer) {
@@ -456,7 +500,7 @@ ApiGlobe.prototype.setCameraOrientation = function setCameraOrientation(orientat
 /**
  * Pick a position on the globe at the given position.
  * @constructor
- * @param {Number | MouseEvent} x|event - The x-position inside the Globe element or a mouse event.
+ * @param {number | MouseEvent} x|event - The x-position inside the Globe element or a mouse event.
  * @param {number | undefined} y - The y-position inside the Globe element.
  * @return {Position} position
  */
@@ -505,7 +549,7 @@ ApiGlobe.prototype.getHeading = function getHeading() {
  * Returns the "range": the distance in meters between the camera and the current central point on the screen.
  * <iframe width="100%" height="400" src="//jsfiddle.net/iTownsIGN/Lbt1vfek/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
  * @constructor
- * @return {Number} number
+ * @return {number} number
  */
 
 ApiGlobe.prototype.getRange = function getRange() {
@@ -642,13 +686,13 @@ ApiGlobe.prototype.setCameraTargetGeoPosition = function setCameraTargetGeoPosit
  * The zoom level and the scale can't be set at the same time.
  * <iframe width="100%" height="400" src="//jsfiddle.net/iTownsIGN/7yk0mpn0/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
  * @param {Position} position
- * @param {Number}  position.longitude  Coordinate longitude WGS84 in degree
- * @param {Number}  position.latitude  Coordinate latitude WGS84 in degree
- * @param {Number}  [position.tilt]  Camera tilt in degree
- * @param {Number}  [position.heading]  Camera heading in degree
- * @param {Number}  [position.range]  The camera distance to the target center
- * @param {Number}  [position.level]  level,  ignored if range is set
- * @param {Number}  [position.scale]  scale,  ignored if the zoom level or range is set. For a scale of 1/500 it is necessary to write 0,002.
+ * @param {number}  position.longitude  Coordinate longitude WGS84 in degree
+ * @param {number}  position.latitude  Coordinate latitude WGS84 in degree
+ * @param {number}  [position.tilt]  Camera tilt in degree
+ * @param {number}  [position.heading]  Camera heading in degree
+ * @param {number}  [position.range]  The camera distance to the target center
+ * @param {number}  [position.level]  level,  ignored if range is set
+ * @param {number}  [position.scale]  scale,  ignored if the zoom level or range is set. For a scale of 1/500 it is necessary to write 0,002.
  * @param {boolean}  isAnimated  Indicates if animated
  * @return {Promise}
  */

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -259,14 +259,14 @@ ApiGlobe.prototype.addElevationLayersFromJSONArray = function addElevationLayers
  */
 ApiGlobe.prototype.getMinZoomLevel = function getMinZoomLevel(index) {
     var layer = this.getImageryLayers()[index];
-    if (layer && layer.zoom) {
-        return layer.zoom.min;
+    if (layer && layer.options.zoom) {
+        return layer.options.zoom.min;
     } else {
         var layers = this.getImageryLayers();
         let min = Infinity;
         for (var i = layers.length - 1; i >= 0; i--) {
-            if (layers[i].zoom) {
-                min = Math.min(min, layers[i].zoom.min);
+            if (layers[i].options.zoom) {
+                min = Math.min(min, layers[i].options.zoom.min);
             }
         }
         return min;
@@ -282,14 +282,14 @@ ApiGlobe.prototype.getMinZoomLevel = function getMinZoomLevel(index) {
  */
 ApiGlobe.prototype.getMaxZoomLevel = function getMaxZoomLevel(index) {
     var layer = this.getImageryLayers()[index];
-    if (layer && layer.zoom) {
-        return layer.zoom.max;
+    if (layer && layer.options.zoom) {
+        return layer.options.zoom.max;
     } else {
         var layers = this.getImageryLayers();
         let max = 0;
         for (var i = layers.length - 1; i >= 0; i--) {
-            if (layers[i].zoom) {
-                max = Math.max(max, layers[i].zoom.max);
+            if (layers[i].options.zoom) {
+                max = Math.max(max, layers[i].options.zoom.max);
             }
         }
         return max;

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -688,7 +688,7 @@ ApiGlobe.prototype.setRange = function setRange(pRange, isAnimated) {
 
     return this.scene.currentControls().setRange(pRange, isAnimated).then(() => {
         this.scene.notifyChange(1);
-        this.setSceneLoaded().then(() => {
+        return this.setSceneLoaded().then(() => {
             this.scene.currentControls().updateCameraTransformation();
             this.viewerDiv.dispatchEvent(eventRange);
         });

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -179,6 +179,11 @@ Coordinates.prototype.altitude = function altitude() {
     return this._values[2];
 };
 
+Coordinates.prototype.setAltitude = function setAltitude(altitude) {
+    _assertIsGeographic(this.crs);
+    this._values[2] = altitude;
+};
+
 Coordinates.prototype.x = function x() {
     _assertIsGeocentric(this.crs);
     return this._values[0];

--- a/src/Main.js
+++ b/src/Main.js
@@ -11,7 +11,9 @@ const itowns = scope.itowns || {
     viewer: new ApiGlobe(),
 };
 scope.itowns = itowns;
+
 export const viewer = itowns.viewer;
+export { INITIALIZED_EVENT } from './Core/Commander/Interfaces/ApiInterface/ApiGlobe';
 export { C } from './Core/Geographic/Coordinates';
 export { Coordinates } from './Core/Geographic/Coordinates';
 export default scope.itowns;

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1269,6 +1269,16 @@ GlobeControls.prototype.getCameraTargetPosition = function getCameraTargetPositi
 GlobeControls.prototype.setCameraTargetPosition = function setCameraTargetPosition(position, isAnimated) {
     const center = this.getCameraTargetPosition();
 
+    if (position.range) {
+        // Compensation of the altitude from the approximation of the ellipsoid by a sphere
+        // This approximation comes from the movements around the ellipsoid, are rotations with constant radius
+        const currentTargetPosition = C.fromXYZ('EPSG:4978', center).as('EPSG:4326');
+        const targetOnEllipsoid = new C.EPSG_4326(currentTargetPosition.longitude(), currentTargetPosition.latitude(), 0)
+            .as('EPSG:4978').xyz();
+        const compensation = position.length() - targetOnEllipsoid.length();
+        position.range += compensation;
+    }
+
     snapShotCamera.shot(this.camera);
 
     ptScreenClick.x = this.domElement.width / 2;

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -277,7 +277,7 @@ var snapShotCamera = null;
 
 /* globals document,window */
 
-function GlobeControls(camera, domElement, engine) {
+function GlobeControls(camera, target, domElement, engine) {
     player = new AnimationPlayer(domElement);
     const scene = engine.scene;
     this.camera = camera;
@@ -1179,11 +1179,10 @@ function GlobeControls(camera, domElement, engine) {
     window.addEventListener('keydown', onKeyDown.bind(this), false);
     window.addEventListener('keyup', onKeyUp.bind(this), false);
 
-    // Initialisation camera target on globe and movingCameraTargetOnGlobe
-    var positionTarget = new THREE.Vector3().copy(camera.position).setLength(tSphere.radius);
-    setCameraTargetObjectPosition(positionTarget);
-    movingCameraTargetOnGlobe.copy(positionTarget);
-    this.camera.up.copy(positionTarget.normalize());
+    // Initialisation Globe Target and movingGlobeTarget
+    setCameraTargetObjectPosition(target);
+    movingCameraTargetOnGlobe.copy(target);
+    this.camera.up.copy(target.clone().normalize());
     engine.scene3D.add(cameraTargetOnGlobe);
     spherical.radius = camera.position.length();
 

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1131,13 +1131,15 @@ function GlobeControls(camera, target, domElement, engine) {
     };
 
     // update object camera position
-    this.updateCameraTransformation = function updateCameraTransformation(controlState)
+    this.updateCameraTransformation = function updateCameraTransformation(controlState, updateCameraTarget = true)
     {
         const bkDamping = this.enableDamping;
         this.enableDamping = false;
         state = controlState || CONTROL_STATE.ORBIT;
         update();
-        updateCameraTargetOnGlobe.bind(this)();
+        if (updateCameraTarget) {
+            updateCameraTargetOnGlobe.bind(this)();
+        }
         this.enableDamping = bkDamping;
     };
 
@@ -1233,7 +1235,7 @@ GlobeControls.prototype.setOrbitalPosition = function setOrbitalPosition(range, 
 
 const destSpherical = new THREE.Spherical();
 
-GlobeControls.prototype.moveOrbitalPosition = function moveOrbitalPositionfunction(deltaRange, deltaTheta, deltaPhi, isAnimated) {
+GlobeControls.prototype.moveOrbitalPosition = function moveOrbitalPosition(deltaRange, deltaTheta, deltaPhi, isAnimated) {
     const range = deltaRange + this.getRange();
     if (isAnimated) {
         destSpherical.theta = deltaTheta + spherical.theta;
@@ -1254,8 +1256,8 @@ GlobeControls.prototype.moveOrbitalPosition = function moveOrbitalPositionfuncti
         sphericalDelta.theta = deltaTheta;
         sphericalDelta.phi = deltaPhi;
         orbit.scale = range / this.getRange();
-        this.updateCameraTransformation();
-        return new Promise((r) => { r(); });
+        this.updateCameraTransformation(CONTROL_STATE.ORBIT, false);
+        return Promise.resolve();
     }
 };
 

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -15,7 +15,7 @@ import RendererConstant from './RendererConstant';
 
 var instance3DEngine = null;
 
-function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
+function c3DEngine(scene, controlOptions, viewerDiv, debugMode, gLDebug) {
     // Constructor
 
     if (instance3DEngine !== null) {
@@ -108,7 +108,7 @@ function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
     //
     // init camera
     //
-    this.camera.setPosition(positionCamera);
+    this.camera.setPosition(controlOptions.position);
     this.camera.camera3D.near = this.size * 2.333; // if near is too small --> bug no camera helper
     this.camera.camera3D.far = this.size * 10;
     this.camera.camera3D.updateProjectionMatrix();
@@ -157,7 +157,7 @@ function c3DEngine(scene, positionCamera, viewerDiv, debugMode, gLDebug) {
     //
     // Create Control
     //
-    this.controls = new GlobeControls(this.camera.camera3D, this.renderer.domElement, this);
+    this.controls = new GlobeControls(this.camera.camera3D, controlOptions.target, this.renderer.domElement, this);
     this.controls.rotateSpeed = 0.25;
     this.controls.zoomSpeed = 2.0;
     this.controls.minDistance = 30;

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -45,6 +45,14 @@ function Scene(crs, positionCamera, viewerDiv, debugMode, gLDebug) {
     }
     this.referenceCrs = crs;
 
+    const positionTargetCamera = positionCamera.clone();
+    positionTargetCamera.setAltitude(0);
+
+    const controlOptions = {
+        position: positionCamera.as(crs).xyz(),
+        target: positionTargetCamera.as(crs).xyz(),
+    };
+
     this.layers = [];
     this.map = null;
 
@@ -56,7 +64,7 @@ function Scene(crs, positionCamera, viewerDiv, debugMode, gLDebug) {
     this.stylesManager = new StyleManager();
 
     this.gLDebug = gLDebug;
-    this.gfxEngine = c3DEngine(this, positionCamera.as(crs).xyz(), viewerDiv, debugMode, gLDebug);
+    this.gfxEngine = c3DEngine(this, controlOptions, viewerDiv, debugMode, gLDebug);
     this.browserScene = new BrowseTree(this.gfxEngine);
 
     this.needsRedraw = false;


### PR DESCRIPTION
Fixes camera bad positions when you use :

* setCameraTargetGeoPosition() #255
* setRange()
* pan() see #260
* createSceneGlobe()


Move WMTS's options in layer.options 

Add little doc addImageryLayer and addElevationLayer

**Warning, this PR doesn't fix incorrect position with setZoomLevel and setZoomScale** 
