### PR TITLE
`camera-target-updated` (was `center-changed`) event 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "custom-event": "^1.0.1",
+    "earcut": "^2.1.1",
     "es6-promise": "^4.0.5",
     "js-priority-queue": "^0.1.5",
     "jszip": "^3.1.3",
+    "proj4": "^2.4.3",
     "three": "^0.84.0",
-    "earcut":"^2.1.1",
     "whatwg-fetch": "^2.0.2"
   },
   "devDependencies": {
@@ -55,7 +56,6 @@
     "eslint-plugin-import": "^2.2.0",
     "imports-loader": "^0.7.0",
     "jsdoc": "^3.4.3",
-    "proj4": "^2.3.17",
     "raw-loader": "^0.5.1",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -339,7 +339,9 @@ ApiGlobe.prototype.createSceneGlobe = function createSceneGlobe(coordCarto, view
 
     var coordinate = new C.EPSG_4326(coordCarto.longitude, coordCarto.latitude, coordCarto.altitude);
 
-    this.scene = Scene(coordinate, viewerDiv, debugMode, gLDebug);
+    // FIXME: the scene is not really in EPSG:4978 atm, some axis are inverted, see
+    // https://github.com/iTowns/itowns2/pull/246
+    this.scene = Scene('EPSG:4978', coordinate, viewerDiv, debugMode, gLDebug);
 
     var map = new Globe(gLDebug);
 

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -19,7 +19,6 @@ import { STRATEGY_MIN_NETWORK_TRAFFIC } from '../../../../Scene/LayerUpdateStrat
 var sceneIsLoaded = false;
 var eventLoaded = new CustomEvent('globe-loaded');
 var eventRange = new CustomEvent('rangeChanged');
-var eventCenter = new CustomEvent('centerchanged');
 var eventOrientation = new CustomEvent('orientationchanged');
 var eventPan = new CustomEvent('panchanged');
 var eventLayerAdded = new CustomEvent('layeradded');
@@ -439,9 +438,9 @@ ApiGlobe.prototype.getCameraLocation = function getCameraLocation() {
  * @return {Position} position
  */
 
-ApiGlobe.prototype.getCenter = function getCenter() {
+ApiGlobe.prototype.getCameraTargetGeoPosition = function getCameraTargetGeoPosition() {
     var controlCam = this.scene.currentControls();
-    return this.projection.cartesianToGeo(controlCam.getTargetCameraPosition());
+    return this.projection.cartesianToGeo(controlCam.getCameraTargetPosition());
 };
 
 /**
@@ -620,22 +619,22 @@ ApiGlobe.prototype.setSceneLoaded = function setSceneLoaded() {
 /**
  * Changes the center of the scene on screen to the specified coordinates.
  * <iframe width="100%" height="400" src="//jsfiddle.net/iTownsIGN/x06yhbq6/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @constructor
- * @param {coordinates} coordinates - Properties : longitude and latitude
- * @param      {boolean}  isAnimated  Indicates if animated
- * @return     {Promise}
+ * @param {Object} coordinates - The globe coordinates in EPSG_4326 projection to aim to
+ * @param {number} coordinates.latitude
+ * @param {number} coordinates.longitude
+ * @param {number} coordinates.range
+ * @param {boolean}  isAnimated - if the movement should be animated
+ * @return {Promise} A promise that resolves when the next 'globe-loaded' event fires.
  */
-ApiGlobe.prototype.setCenter = function setCenter(coordinates, isAnimated) {
+ApiGlobe.prototype.setCameraTargetGeoPosition = function setCameraTargetGeoPosition(coordinates, isAnimated) {
     isAnimated = isAnimated || this.isAnimationEnabled();
-    eventCenter.oldCenter = this.getCenter();
     const position3D = new C.EPSG_4326(coordinates.longitude, coordinates.latitude, 0)
         .as('EPSG:4978').xyz();
     position3D.range = coordinates.range;
-    return this.scene.currentControls().setCenter(position3D, isAnimated).then(() => {
+    return this.scene.currentControls().setCameraTargetPosition(position3D, isAnimated).then(() => {
         this.scene.notifyChange(1);
         return this.setSceneLoaded().then(() => {
             this.scene.currentControls().updateCameraTransformation();
-            this.viewerDiv.dispatchEvent(eventCenter);
         });
     });
 };
@@ -646,14 +645,13 @@ ApiGlobe.prototype.setCenter = function setCenter(coordinates, isAnimated) {
  * The level has to be between the [getMinZoomLevel(), getMaxZoomLevel()].
  * The zoom level and the scale can't be set at the same time.
  * <iframe width="100%" height="400" src="//jsfiddle.net/iTownsIGN/7yk0mpn0/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @constructor
  * @param {Position} pPosition - The detailed position in the scene.
  * @param      {boolean}  isAnimated  Indicates if animated
  * @return     {Promise}
  */
-ApiGlobe.prototype.setCenterAdvanced = function setCenterAdvanced(pPosition, isAnimated) {
+ApiGlobe.prototype.setCameraTargetGeoPositionAdvanced = function setCameraTargetGeoPositionAdvanced(pPosition, isAnimated) {
     isAnimated = isAnimated || this.isAnimationEnabled();
-    return this.setCenter(pPosition, isAnimated).then(() => {
+    return this.setCameraTargetGeoPosition(pPosition, isAnimated).then(() => {
         const p = this.scene.currentControls().setOrbitalPosition(undefined, pPosition.heading, pPosition.tilt, isAnimated);
         return p;
     });
@@ -738,7 +736,7 @@ ApiGlobe.prototype.getZoomScale = function getZoomScale(pitch) {
     //     * Globe is inside the frustrum camera
     //     * Globe intersects with the frustrum camera
     const camera = this.scene.currentCamera();
-    const center = this.scene.currentControls().getTargetCameraPosition();
+    const center = this.scene.currentControls().getCameraTargetPosition();
     const rayon = center.length();
     const range = center.distanceTo(camera.camera3D.position);
     // compute distance camera/globe's center
@@ -797,7 +795,7 @@ ApiGlobe.prototype.setZoomScale = function setZoomScale(zoomScale, pitch, isAnim
 
     const camera = this.scene.currentCamera();
     const projection = camera.height * pitch / zoomScale;
-    const rayon = this.scene.currentControls().getTargetCameraPosition().length();
+    const rayon = this.scene.currentControls().getCameraTargetPosition().length();
     const alpha = camera.FOV / 180 * Math.PI * 0.5;
     // distance camera/globe's center
     let distance;

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -12,7 +12,6 @@ import WMS_Provider from '../../Providers/WMS_Provider';
 import TileProvider from '../../Providers/TileProvider';
 import loadGpx from '../../Providers/GpxUtils';
 import { C } from '../../../Geographic/Coordinates';
-import Projection from '../../../Geographic/Projection';
 import Fetcher from '../../Providers/Fetcher';
 import { STRATEGY_MIN_NETWORK_TRAFFIC } from '../../../../Scene/LayerUpdateStrategy';
 
@@ -44,7 +43,6 @@ function ApiGlobe() {
     // Constructor
     this.scene = null;
     this.commandsTree = null;
-    this.projection = new Projection();
     this.viewerDiv = null;
     this.callback = null;
 }
@@ -429,8 +427,7 @@ ApiGlobe.prototype.getCameraOrientation = function getCameraOrientation() {
  */
 
 ApiGlobe.prototype.getCameraLocation = function getCameraLocation() {
-    var cam = this.scene.currentCamera().camera3D;
-    return this.projection.cartesianToGeo(cam.position);
+    return C.fromXYZ('EPSG:4978', this.scene.currentCamera().camera3D.position).as('EPSG:4326');
 };
 
 /**
@@ -441,8 +438,7 @@ ApiGlobe.prototype.getCameraLocation = function getCameraLocation() {
  */
 
 ApiGlobe.prototype.getCameraTargetGeoPosition = function getCameraTargetGeoPosition() {
-    var controlCam = this.scene.currentControls();
-    return this.projection.cartesianToGeo(controlCam.getCameraTargetPosition());
+    return C.fromXYZ('EPSG:4978', this.scene.currentControls().getCameraTargetPosition()).as('EPSG:4326');
 };
 
 /**
@@ -480,7 +476,7 @@ ApiGlobe.prototype.pickPosition = function pickPosition(mouse, y) {
         return;
     }
 
-    return this.projection.cartesianToGeo(pickedPosition);
+    return C.fromXYZ('EPSG:4978', pickedPosition).as('EPSG:4326');
 };
 
 /**

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -106,6 +106,15 @@ function _convert(coordsIn, newCrs) {
                                    cartesian.x, cartesian.y, cartesian.z);
         }
 
+        if (coordsIn.crs === 'EPSG:4978' && newCrs === 'EPSG:4326') {
+            const geo = ellipsoid.cartesianToCartographic({
+                x: coordsIn._values[0],
+                y: coordsIn._values[1],
+                z: coordsIn._values[2],
+            });
+            return new Coordinates(newCrs, geo.longitude, geo.latitude, geo.h);
+        }
+
         if (coordsIn.crs in proj4.defs && newCrs in proj4.defs) {
             const p = proj4(coordsIn.crs, newCrs, [coordsIn._values[0], coordsIn._values[1]]);
             return new Coordinates(newCrs,
@@ -148,8 +157,6 @@ function Coordinates(crs, ...coordinates) {
     }
     this._internalStorageUnit = crsToUnit(crs);
 }
-
-Coordinates.prototype.constructor = Coordinates;
 
 Coordinates.prototype.clone = function clone() {
     const r = new Coordinates(this.crs, ...this._values);

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -209,6 +209,20 @@ Coordinates.prototype.as = function as(crs) {
 };
 
 export const C = {
+
+    /**
+     * Return a Coordinates object from a position object. The object just
+     * needs to have x, y, z properties.
+     *
+     * @param {string} crs - The crs of the original position
+     * @param {Object} position - the position to transform
+     * @param {number} position.x - the x component of the position
+     * @param {number} position.y - the y component of the position
+     * @param {number} position.z - the z component of the position
+     */
+    fromXYZ: function fromXYZ(crs, position) {
+        return new Coordinates(crs, position.x, position.y, position.z);
+    },
     EPSG_4326: function EPSG_4326(...args) {
         return new Coordinates('EPSG:4326', ...args);
     },

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -6,7 +6,7 @@
 import * as THREE from 'three';
 import CoordWMTS from './CoordWMTS';
 import MathExt from '../Math/MathExtended';
-import Coordinates, { UNIT } from './Coordinates';
+import { UNIT } from './Coordinates';
 
 
 function Projection() {
@@ -164,28 +164,6 @@ Projection.prototype.UnitaryToLongitudeWGS84 = function UnitaryToLongitudeWGS84(
 Projection.prototype.UnitaryToLatitudeWGS84 = function UnitaryToLatitudeWGS84(v, bbox) {
     const dim = bbox.dimensions(UNIT.RADIAN);
     return bbox.south(UNIT.RADIAN) + v * dim.y;
-};
-
-Projection.prototype.cartesianToGeo = function cartesianToGeo(position) {
-    // FIXME: warning switch coord
-    const R = position.length();
-    const a = 6378137;
-    const b = 6356752.3142451793;
-    const e = Math.sqrt((a * a - b * b) / (a * a));
-    const f = 1 - Math.sqrt(1 - e * e);
-    const rsqXY = Math.sqrt(position.x * position.x + position.z * position.z);
-
-    const theta = Math.atan2(position.z, position.x);
-    const nu = Math.atan(position.y / rsqXY * ((1 - f) + e * e * a / R));
-
-    const sinu = Math.sin(nu);
-    const cosu = Math.cos(nu);
-
-    const phi = Math.atan((position.y * (1 - f) + e * e * a * sinu * sinu * sinu) / ((1 - f) * (rsqXY - e * e * a * cosu * cosu * cosu)));
-
-    const h = (rsqXY * Math.cos(phi)) + position.y * Math.sin(phi) - a * Math.sqrt(1 - e * e * Math.sin(phi) * Math.sin(phi));
-
-    return new Coordinates('EPSG:4326', -theta, phi, h);
 };
 
 Projection.prototype.wgs84_to_lambert93 = function wgs84_to_lambert93(latitude, longitude) // , x93, y93)

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -167,28 +167,23 @@ Projection.prototype.UnitaryToLatitudeWGS84 = function UnitaryToLatitudeWGS84(v,
 };
 
 Projection.prototype.cartesianToGeo = function cartesianToGeo(position) {
-    // TODO: warning switch coord
-    var p = position.clone();
-    p.x = position.x;
-    p.y = position.z;
-    p.z = position.y;
+    // FIXME: warning switch coord
+    const R = position.length();
+    const a = 6378137;
+    const b = 6356752.3142451793;
+    const e = Math.sqrt((a * a - b * b) / (a * a));
+    const f = 1 - Math.sqrt(1 - e * e);
+    const rsqXY = Math.sqrt(position.x * position.x + position.z * position.z);
 
-    var R = p.length();
-    var a = 6378137;
-    var b = 6356752.3142451793;
-    var e = Math.sqrt((a * a - b * b) / (a * a));
-    var f = 1 - Math.sqrt(1 - e * e);
-    var rsqXY = Math.sqrt(p.x * p.x + p.y * p.y);
+    const theta = Math.atan2(position.z, position.x);
+    const nu = Math.atan(position.y / rsqXY * ((1 - f) + e * e * a / R));
 
-    var theta = Math.atan2(p.y, p.x);
-    var nu = Math.atan(p.z / rsqXY * ((1 - f) + e * e * a / R));
+    const sinu = Math.sin(nu);
+    const cosu = Math.cos(nu);
 
-    var sinu = Math.sin(nu);
-    var cosu = Math.cos(nu);
+    const phi = Math.atan((position.y * (1 - f) + e * e * a * sinu * sinu * sinu) / ((1 - f) * (rsqXY - e * e * a * cosu * cosu * cosu)));
 
-    var phi = Math.atan((p.z * (1 - f) + e * e * a * sinu * sinu * sinu) / ((1 - f) * (rsqXY - e * e * a * cosu * cosu * cosu)));
-
-    var h = (rsqXY * Math.cos(phi)) + p.z * Math.sin(phi) - a * Math.sqrt(1 - e * e * Math.sin(phi) * Math.sin(phi));
+    const h = (rsqXY * Math.cos(phi)) + position.y * Math.sin(phi) - a * Math.sqrt(1 - e * e * Math.sin(phi) * Math.sin(phi));
 
     return new Coordinates('EPSG:4326', -theta, phi, h);
 };

--- a/src/Main.js
+++ b/src/Main.js
@@ -12,4 +12,5 @@ const itowns = scope.itowns || {
 };
 scope.itowns = itowns;
 export const viewer = itowns.viewer;
+export const projection = itowns.viewer.projection;
 export default scope.itowns;

--- a/src/Main.js
+++ b/src/Main.js
@@ -12,5 +12,6 @@ const itowns = scope.itowns || {
 };
 scope.itowns = itowns;
 export const viewer = itowns.viewer;
-export const projection = itowns.viewer.projection;
+export { C } from './Core/Geographic/Coordinates';
+export { Coordinates } from './Core/Geographic/Coordinates';
 export default scope.itowns;

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -133,8 +133,8 @@ const dollyDelta = new THREE.Vector2();
 
 // Globe move
 const quatGlobe = new THREE.Quaternion();
-const globeTarget = new THREE.Object3D();
-const movingGlobeTarget = new THREE.Vector3();
+const cameraTargetOnGlobe = new THREE.Object3D();
+const movingCameraTargetOnGlobe = new THREE.Vector3();
 var animatedScale = 0.0;
 
 const ctrl = {
@@ -182,9 +182,9 @@ const animationOrbit = new AnimatedExpression({ duration: 30, root: orbit, expre
 const dampingOrbitalMvt = new Animation({ duration: 60, name: 'orbit damping' });
 
 // Replace matrix float by matrix double
-globeTarget.matrixWorld.elements = new Float64Array(16);
-globeTarget.matrixWorldInverse = new THREE.Matrix4();
-globeTarget.matrixWorldInverse.elements = new Float64Array(16);
+cameraTargetOnGlobe.matrixWorld.elements = new Float64Array(16);
+cameraTargetOnGlobe.matrixWorldInverse = new THREE.Matrix4();
+cameraTargetOnGlobe.matrixWorldInverse.elements = new Float64Array(16);
 
 // Pan Move
 const panVector = new THREE.Vector3();
@@ -205,7 +205,7 @@ var initialZoom;
 const ptScreenClick = new THREE.Vector2();
 const sizeRendering = new THREE.Vector2();
 
-// Tangent sphere to ellispoid
+// Tangent sphere to ellipsoid
 const tSphere = new Sphere();
 tSphere.picking = { position: new THREE.Vector3(), normal: new THREE.Vector3() };
 
@@ -419,7 +419,7 @@ function GlobeControls(camera, domElement, engine) {
             var position = this.camera.position;
 
             // var offset = position.clone().sub(this.target);
-            var offset = position.clone().sub(this.getTargetCameraPosition());
+            var offset = position.clone().sub(this.getCameraTargetPosition());
 
             var targetDistance = offset.length();
 
@@ -517,28 +517,28 @@ function GlobeControls(camera, domElement, engine) {
         // MOVE_GLOBE
         // Rotate globe with mouse
         if (state === CONTROL_STATE.MOVE_GLOBE) {
-            movingGlobeTarget.copy(this.getTargetCameraPosition()).applyQuaternion(quatGlobe);
+            movingCameraTargetOnGlobe.copy(this.getCameraTargetPosition()).applyQuaternion(quatGlobe);
             this.camera.position.copy(snapShotCamera.position).applyQuaternion(quatGlobe);
             // combine zoom with move globe
             if (ctrl.progress > 0) {
-                this.camera.position.lerp(movingGlobeTarget, ctrl.progress * animatedScale);
+                this.camera.position.lerp(movingCameraTargetOnGlobe, ctrl.progress * animatedScale);
             }
-            this.camera.up.copy(movingGlobeTarget.clone().normalize());
+            this.camera.up.copy(movingCameraTargetOnGlobe.clone().normalize());
         // PAN
         // Move camera in projection plan
         } else if (state === CONTROL_STATE.PAN) {
             this.camera.position.add(panVector);
-            movingGlobeTarget.add(panVector);
+            movingCameraTargetOnGlobe.add(panVector);
         // PANORAMIC
         // Move target camera
         } else if (state === CONTROL_STATE.PANORAMIC) {
             // TODO: this part must be reworked
-            this.camera.worldToLocal(movingGlobeTarget);
+            this.camera.worldToLocal(movingCameraTargetOnGlobe);
             var normal = this.camera.position.clone().normalize().applyQuaternion(this.camera.quaternion.clone().inverse());
             quaterPano.setFromAxisAngle(normal, sphericalDelta.theta).multiply(quaterAxis.setFromAxisAngle(axisX, sphericalDelta.phi));
-            movingGlobeTarget.applyQuaternion(quaterPano);
-            this.camera.localToWorld(movingGlobeTarget);
-            this.camera.up.copy(movingGlobeTarget.clone().normalize());
+            movingCameraTargetOnGlobe.applyQuaternion(quaterPano);
+            this.camera.localToWorld(movingCameraTargetOnGlobe);
+            this.camera.up.copy(movingCameraTargetOnGlobe.clone().normalize());
         } else {
             // ZOOM/ORBIT
             // Move Camera around the target camera
@@ -547,7 +547,7 @@ function GlobeControls(camera, domElement, engine) {
             // offset.applyQuaternion( quat );
 
             // get camera position in local space of target
-            offset.copy(this.camera.position).applyMatrix4(globeTarget.matrixWorldInverse);
+            offset.copy(this.camera.position).applyMatrix4(cameraTargetOnGlobe.matrixWorldInverse);
 
             // angle from z-axis around y-axis
             if (sphericalDelta.theta || sphericalDelta.phi) {
@@ -580,10 +580,10 @@ function GlobeControls(camera, domElement, engine) {
             // rotate point back to "camera-up-vector-is-up" space
             // offset.applyQuaternion( quatInverse );
 
-            this.camera.position.copy(globeTarget.localToWorld(offset));
+            this.camera.position.copy(cameraTargetOnGlobe.localToWorld(offset));
         }
 
-        this.camera.lookAt(movingGlobeTarget);
+        this.camera.lookAt(movingCameraTargetOnGlobe);
 
         if (!this.enableDamping) {
             sphericalDelta.theta = 0;
@@ -633,17 +633,19 @@ function GlobeControls(camera, domElement, engine) {
         };
     }());
 
-    // set new globe target
-    var setGlobleTarget = function setGlobleTarget(newPosition) {
-        // Compute the new target center position
-        positionObject(newPosition, globeTarget);
+    // set new camera target on globe
+    const setCameraTargetObjectPosition = function setCameraTargetObjectPosition(newPosition) {
+        // Compute the new target position
+        positionObject(newPosition, cameraTargetOnGlobe);
 
-        globeTarget.matrixWorldInverse.getInverse(globeTarget.matrixWorld);
+        cameraTargetOnGlobe.matrixWorldInverse.getInverse(cameraTargetOnGlobe.matrixWorld);
     };
 
     const cT = new THREE.Vector3();
-    // update globe target
-    var updateGlobeTarget = function updateGlobeTarget() {
+
+    const updateCameraTargetOnGlobe = function updateCameraTargetOnGlobe() {
+        const oldCameraTargetPosition = cameraTargetOnGlobe.position.clone();
+
         // Get distance camera DME
         const pickingPosition = getPickingPosition();
 
@@ -653,20 +655,25 @@ function GlobeControls(camera, domElement, engine) {
 
         const distanceTarget = pickingPosition.distanceTo(this.camera.position);
 
-        // Position movingGlobeTarget on DME
-        cT.subVectors(movingGlobeTarget, this.camera.position);
+        // Position movingCameraTargetOnGlobe on DME
+        cT.subVectors(movingCameraTargetOnGlobe, this.camera.position);
         cT.setLength(distanceTarget);
-        movingGlobeTarget.addVectors(this.camera.position, cT);
+        movingCameraTargetOnGlobe.addVectors(this.camera.position, cT);
 
-        // set new globe target
-        setGlobleTarget(movingGlobeTarget);
+        setCameraTargetObjectPosition(movingCameraTargetOnGlobe);
 
         // update spherical from target
         offset.copy(this.camera.position);
-        offset.applyMatrix4(globeTarget.matrixWorldInverse);
+        offset.applyMatrix4(cameraTargetOnGlobe.matrixWorldInverse);
         spherical.setFromVector3(offset);
         state = CONTROL_STATE.NONE;
         lastRotation = [];
+
+        this.dispatchEvent({
+            type: 'camera-target-updated',
+            oldCameraTargetPosition,
+            newCameraTargetPosition: cameraTargetOnGlobe.position.clone(),
+        });
     };
 
     // Update helper
@@ -853,7 +860,7 @@ function GlobeControls(camera, domElement, engine) {
 
             if (point) {
                 animatedScale = 0.6;
-                this.setCenter(point, true);
+                this.setCameraTargetPosition(point, true);
             }
         }
     };
@@ -878,10 +885,10 @@ function GlobeControls(camera, domElement, engine) {
                 ctrl.qDelta.setFromUnitVectors(lastRotation[1], lastRotation[0]);
                 player.play(animationDampingMove).then(() => this.resetControls());
             } else {
-                updateGlobeTarget.bind(this)();
+                updateCameraTargetOnGlobe.bind(this)();
             }
         } else {
-            updateGlobeTarget.bind(this)();
+            updateCameraTargetOnGlobe.bind(this)();
         }
     };
 
@@ -921,7 +928,7 @@ function GlobeControls(camera, domElement, engine) {
 
         if (state === CONTROL_STATE.PAN)
         {
-            updateGlobeTarget.bind(this)();
+            updateCameraTargetOnGlobe.bind(this)();
         }
 
         keyCtrl = false;
@@ -1110,7 +1117,7 @@ function GlobeControls(camera, domElement, engine) {
     this.resetControls = function resetControls() {
         lastRotation.splice(0);
         ctrl.progress = 0;
-        updateGlobeTarget.bind(this)();
+        updateCameraTargetOnGlobe.bind(this)();
     };
 
     // update object camera position
@@ -1120,7 +1127,7 @@ function GlobeControls(camera, domElement, engine) {
         this.enableDamping = false;
         state = controlState || CONTROL_STATE.ORBIT;
         update();
-        updateGlobeTarget.bind(this)();
+        updateCameraTargetOnGlobe.bind(this)();
         this.enableDamping = bkDamping;
     };
 
@@ -1162,23 +1169,23 @@ function GlobeControls(camera, domElement, engine) {
     window.addEventListener('keydown', onKeyDown.bind(this), false);
     window.addEventListener('keyup', onKeyUp.bind(this), false);
 
-    // Initialisation Globe Target and movingGlobeTarget
+    // Initialisation camera target on globe and movingCameraTargetOnGlobe
     var positionTarget = new THREE.Vector3().copy(camera.position).setLength(tSphere.radius);
-    setGlobleTarget(positionTarget);
-    movingGlobeTarget.copy(positionTarget);
+    setCameraTargetObjectPosition(positionTarget);
+    movingCameraTargetOnGlobe.copy(positionTarget);
     this.camera.up.copy(positionTarget.normalize());
-    engine.scene3D.add(globeTarget);
+    engine.scene3D.add(cameraTargetOnGlobe);
     spherical.radius = camera.position.length();
 
     update();
 
     if (enableTargetHelper) {
-        globeTarget.add(new THREE.AxisHelper(500000));
+        cameraTargetOnGlobe.add(new THREE.AxisHelper(500000));
         engine.scene3D.add(this.pickingHelper);
     }
 
     // Start position
-    initialTarget = globeTarget.clone();
+    initialTarget = cameraTargetOnGlobe.clone();
     initialPosition = this.camera.position.clone();
     initialZoom = this.camera.zoom;
 
@@ -1244,16 +1251,22 @@ GlobeControls.prototype.moveOrbitalPosition = function moveOrbitalPositionfuncti
 };
 
 /**
- * Gets camera's target position
- *
- * @return     {Vecto3}
+ * Returns the coordinates of the globe point targeted by the camera.
+ * <iframe width="100%" height="400" src="//jsfiddle.net/iTownsIGN/4tjgnv7z/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+ * @return {THREE.Vector3} position
  */
-GlobeControls.prototype.getTargetCameraPosition = function getTargetCameraPosition() {
-    return globeTarget.position;
+GlobeControls.prototype.getCameraTargetPosition = function getCameraTargetPosition() {
+    return cameraTargetOnGlobe.position;
 };
 
-GlobeControls.prototype.setCenter = function setCenter(position, isAnimated) {
-    const center = this.getTargetCameraPosition();
+/**
+ * Make the camera aim a point in the globe
+ *
+ * @param {THREE.Vector3} position - the position on the globe to aim, in EPSG:4978 projection
+ * @param {boolean} isAnimated - if we should animate the move
+ */
+GlobeControls.prototype.setCameraTargetPosition = function setCameraTargetPosition(position, isAnimated) {
+    const center = this.getCameraTargetPosition();
 
     snapShotCamera.shot(this.camera);
 
@@ -1277,12 +1290,12 @@ GlobeControls.prototype.setCenter = function setCenter(position, isAnimated) {
     else {
         quatGlobe.setFromUnitVectors(vFrom, vTo);
         this.updateCameraTransformation(CONTROL_STATE.MOVE_GLOBE);
-        return new Promise((r) => { r(); });
+        return Promise.resolve();
     }
 };
 
 GlobeControls.prototype.getRange = function getRange() {
-    return this.getTargetCameraPosition().distanceTo(this.camera.position);
+    return this.getCameraTargetPosition().distanceTo(this.camera.position);
 };
 
 // TODO idea : remove this? used in API
@@ -1324,7 +1337,7 @@ GlobeControls.prototype.getAzimuthalAngle = function getAzimuthalAngle() {
 };
 
 GlobeControls.prototype.moveTarget = function moveTarget() {
-    return movingGlobeTarget;
+    return movingCameraTargetOnGlobe;
 };
 
 GlobeControls.prototype.pan = function pan(deltaX, deltaY) {

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -10,6 +10,7 @@ import * as THREE from 'three';
 import CustomEvent from 'custom-event';
 import Sphere from '../../Core/Math/Sphere';
 import AnimationPlayer, { Animation, AnimatedExpression } from '../../Scene/AnimationPlayer';
+import { C } from '../../Core/Geographic/Coordinates';
 
 var selectClick = new CustomEvent('selectClick');
 
@@ -644,7 +645,7 @@ function GlobeControls(camera, domElement, engine) {
     const cT = new THREE.Vector3();
 
     const updateCameraTargetOnGlobe = function updateCameraTargetOnGlobe() {
-        const oldCameraTargetPosition = cameraTargetOnGlobe.position.clone();
+        const oldCoord = C.fromXYZ(scene.referenceCrs, cameraTargetOnGlobe.position);
 
         // Get distance camera DME
         const pickingPosition = getPickingPosition();
@@ -671,8 +672,8 @@ function GlobeControls(camera, domElement, engine) {
 
         this.dispatchEvent({
             type: 'camera-target-updated',
-            oldCameraTargetPosition,
-            newCameraTargetPosition: cameraTargetOnGlobe.position.clone(),
+            oldCameraTargetPosition: oldCoord,
+            newCameraTargetPosition: C.fromXYZ(scene.referenceCrs, cameraTargetOnGlobe.position),
         });
     };
 

--- a/src/Scene/Scene.js
+++ b/src/Scene/Scene.js
@@ -25,12 +25,25 @@ var instanceScene = null;
 const RENDERING_PAUSED = 0;
 const RENDERING_ACTIVE = 1;
 
-function Scene(coordinate, viewerDiv, debugMode, gLDebug) {
+/**
+ * Constructs an Itowns Scene instance
+ *
+ * @param {string} crs - The default CRS of Three.js coordinates. Should be a cartesian CRS.
+ * @param {Coordinates} positionCamera - The initial position of the camera
+ * @param {DOMElement} viewerDiv - Where to instanciate the Three.js scene in the DOM
+ * @param {boolean} debugMode - activate debug mode
+ * @param {boolean} glDebug - debug gl code
+ * @constructor
+ */
+ /* TODO:
+ * - remove debug boolean, replace by if __DEBUG__ and checkboxes in debug UI
+ * - Scene (and subobjects) should be instanciable several times.
+ */
+function Scene(crs, positionCamera, viewerDiv, debugMode, gLDebug) {
     if (instanceScene !== null) {
         throw new Error('Cannot instantiate more than one Scene');
     }
-
-    var positionCamera = coordinate.as('EPSG:4978');
+    this.referenceCrs = crs;
 
     this.layers = [];
     this.map = null;
@@ -43,7 +56,7 @@ function Scene(coordinate, viewerDiv, debugMode, gLDebug) {
     this.stylesManager = new StyleManager();
 
     this.gLDebug = gLDebug;
-    this.gfxEngine = c3DEngine(this, positionCamera.xyz(), viewerDiv, debugMode, gLDebug);
+    this.gfxEngine = c3DEngine(this, positionCamera.as(crs).xyz(), viewerDiv, debugMode, gLDebug);
     this.browserScene = new BrowseTree(this.gfxEngine);
 
     this.needsRedraw = false;
@@ -307,7 +320,7 @@ Scene.prototype.orbit = function orbit(value) {
     this.orbitOn = value;
 };
 
-export default function (coordinate, viewerDiv, debugMode, gLDebug) {
-    instanceScene = instanceScene || new Scene(coordinate, viewerDiv, debugMode, gLDebug);
+export default function (crs, positionCamera, viewerDiv, debugMode, gLDebug) {
+    instanceScene = instanceScene || new Scene(crs, positionCamera, viewerDiv, debugMode, gLDebug);
     return instanceScene;
 }

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -1,5 +1,6 @@
 /* global menuGlobe */
 import Chart from 'chart.js';
+import { C } from '../../src/Core/Geographic/Coordinates';
 
 /**
  * Create a debug instance attached to an itowns instance
@@ -10,7 +11,6 @@ import Chart from 'chart.js';
  */
 // disabling eslint errors as it is the exported constructor
 function Debug(scene) {
-    const projection = window.itowns.projection;
     // CHARTS
     // create charts div
     const chartDiv = document.createElement('div');
@@ -231,25 +231,25 @@ function Debug(scene) {
                 eventFolder = gui.addFolder('Events');
 
                 // camera-target-updated event
-                const initialPosition = projection.cartesianToGeo(controls.getCameraTargetPosition());
+                const initialPosition = C.fromXYZ(scene.referenceCrs, controls.getCameraTargetPosition()).as('EPSG:4326');
                 const roundedLat = Math.round(initialPosition.latitude() * 10000) / 10000;
                 const roundedLon = Math.round(initialPosition.longitude() * 10000) / 10000;
                 state.cameraTargetUpdated = `lat: ${roundedLat} lon: ${roundedLon}`;
                 const cameraTargetUpdatedController = eventFolder.add(state, 'cameraTargetUpdated').name('camera-target-updated');
                 const cameraTargetListener = (ev) => {
-                    const positionGeo = projection.cartesianToGeo(ev.newCameraTargetPosition);
+                    const positionGeo = ev.newCameraTargetPosition.as('EPSG:4326');
                     const roundedLat = Math.round(positionGeo.latitude() * 10000) / 10000;
                     const roundedLon = Math.round(positionGeo.longitude() * 10000) / 10000;
                     state.cameraTargetUpdated = `lat: ${roundedLat} lon: ${roundedLon}`;
                     cameraTargetUpdatedController.updateDisplay();
                 };
                 controls.addEventListener('camera-target-updated', cameraTargetListener);
-                listeners.push({ type: 'camera-target-updated', fn: cameraTargetListener });
+                listeners.push({ type: 'camera-target-updated', stateName: 'cameraTargetUpdated', fn: cameraTargetListener });
             } else {
                 for (const listener of listeners) {
                     controls.removeEventListener(listener.type, listener.fn);
+                    delete state[listener.stateName];
                 }
-                delete state.cameraTargetUpdated;
                 gui.removeFolder('Events');
             }
         };


### PR DESCRIPTION
This PR correctly set and fire a `camera-target-updated` when the target of the camera on the Globe changes. This event was called `center-changed`, but arguably the new name is clearer.

This is WIP because it's based on peep's work in #239. As #239 is a core work, let's try to merge it quickly please!

Notifying @pjjmunier @elias75015 and @gcebelieu this is the first PR fixing the events you need, according to [this list](https://github.com/iTowns/itowns2/issues/272#issuecomment-287779100). Don't hesitate to test!

Notifying also @vcoindet : I believe this PR overlaps a bit was you did in #269, but it is only about one event, and pushed things a bit farther up (notably: it does not only fire when explicitly calling the API, but also when user interacts with the mouse, which is the intended behaviour I believe).
