### PR TITLE
Fix tile's geometric error 

### DIFF
--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -473,7 +473,7 @@ ApiGlobe.prototype.createSceneGlobe = function createSceneGlobe(globeLayerId, co
         }
     };
 
-    const SSE_SUBDIVISION_THRESHOLD = 6.0;
+    const SSE_SUBDIVISION_THRESHOLD = 1.0;
 
 
     // init globe layer with default parameter

--- a/src/Core/Commander/Providers/TileProvider.js
+++ b/src/Core/Commander/Providers/TileProvider.js
@@ -48,7 +48,6 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
     tile.layer = command.layer.id;
     tile.layers.set(command.threejsLayer);
     tile.setUuid();
-    tile.geometricError = Math.pow(2, (18 - params.level));
 
     if (parent) {
         parent.worldToLocal(params.center);

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -9,7 +9,7 @@ import LayeredMaterial, { l_ELEVATION } from '../Renderer/LayeredMaterial';
 import GlobeDepthMaterial from '../Renderer/GlobeDepthMaterial';
 import MatteIdsMaterial from '../Renderer/MatteIdsMaterial';
 import RendererConstant from '../Renderer/RendererConstant';
-import OGCWebServiceHelper from '../Core/Commander/Providers/OGCWebServiceHelper';
+import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from '../Core/Commander/Providers/OGCWebServiceHelper';
 
 function TileMesh(geometry, params) {
     // Constructor
@@ -56,6 +56,8 @@ function TileMesh(geometry, params) {
     this.material = this.materials[RendererConstant.FINAL];
 
     this.frustumCulled = false;
+
+    this.updateGeometricError();
 
     // Layer
     this.setDisplayed(false);
@@ -153,8 +155,15 @@ TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
         const trans = this.normal.clone().setLength(delta.y);
 
         this.geometry.boundingSphere.radius = Math.sqrt(delta.x * delta.x + this.oSphere.radius * this.oSphere.radius);
+        this.updateGeometricError();
         this.centerSphere = new THREE.Vector3().addVectors(this.oSphere.center, trans);
     }
+};
+
+TileMesh.prototype.updateGeometricError = function updateGeometricError() {
+    // The geometric error is calculated to have a correct texture display.
+    // For the projection of a texture's texel to be less than or equal to one pixel
+    this.geometricError = this.geometry.boundingSphere.radius / SIZE_TEXTURE_TILE;
 };
 
 TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layerId) {

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -394,11 +394,15 @@ var unpack1K = function unpack1K(color, factor) {
  * @returns {int} uuid's node
  * */
 c3DEngine.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {
+    if (mouse === undefined)
+        { mouse = new THREE.Vector2(Math.floor(this.width / 2), Math.floor(this.height / 2)); }
+
     var camera = this.scene.camera.camera3D;
 
     camera.updateMatrixWorld();
 
     var buffer = this.renderTobuffer(mouse.x, this.height - mouse.y, 1, 1, RendererConstant.ID);
+    this.renderScene();
 
     var depthRGBA = new THREE.Vector4().fromArray(buffer).divideScalar(255.0);
 


### PR DESCRIPTION
The geometric error is calculated to have a correct texture display.
For the projection of a texture's texel to be less than or equal to one pixel
To be completely correct one would have to take into account the number of segments of the tile but there will be losses of performance

This PR also fixes the getZoomLevel