### PR TITLE
Initialization imagery and elevation layer

### DIFF
--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -210,7 +210,11 @@ ApiGlobe.prototype.addElevationLayer = function addElevationLayer(layer) {
         console.error(`Error : id "${layer.id}" already exist, WARNING your layer isn't added`);
     } else {
         map.layersConfiguration.addElevationLayer(layer);
-        this.viewerDiv.dispatchEvent(eventLayerAdded);
+        this.scene.getMap().update();
+        this.scene.notifyChange(1, true);
+        this.setSceneLoaded().then(() => {
+            this.viewerDiv.dispatchEvent(eventLayerAdded);
+        });
     }
 };
 

--- a/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
+++ b/src/Core/Commander/Interfaces/ApiInterface/ApiGlobe.js
@@ -103,13 +103,17 @@ ApiGlobe.prototype.addGeometryLayer = function addGeometryLayer(layer) {
  */
 ApiGlobe.prototype.addImageryLayer = function addImageryLayer(layer) {
     preprocessLayer(layer, this.scene.scheduler.getProtocolProvider(layer.protocol));
-    const map = this.scene.getMap();
     if (this.getLayerById(layer.id)) {
       // eslint-disable-next-line no-console
         console.error(`Error : id "${layer.id}" already exist, WARNING your layer isn't added`);
     } else {
+        const map = this.scene.getMap();
         map.layersConfiguration.addColorLayer(layer);
-        this.viewerDiv.dispatchEvent(eventLayerAdded);
+        this.scene.getMap().update();
+        this.scene.notifyChange(1, true);
+        this.setSceneLoaded().then(() => {
+            this.viewerDiv.dispatchEvent(eventLayerAdded);
+        });
     }
 };
 

--- a/src/Globe/Globe.js
+++ b/src/Globe/Globe.js
@@ -202,6 +202,16 @@ Globe.prototype.removeColorLayer = function removeColorLayer(layer) {
     this.tiles.children[0].traverse(cO);
 };
 
+Globe.prototype.update = function update() {
+    var cO = function cO(object) {
+        if (object.loaded !== undefined) {
+            object.loaded = false;
+        }
+    };
+
+    this.tiles.children[0].traverse(cO);
+};
+
 Globe.prototype.getZoomLevel = function getZoomLevel() {
     var cO = (function getCOFn() {
         var zoom = 0;

--- a/src/Globe/TileMesh.js
+++ b/src/Globe/TileMesh.js
@@ -74,12 +74,11 @@ TileMesh.prototype.getUuid = function getUuid(uuid) {
     return this.materials[RendererConstant.ID].getUuid(uuid);
 };
 
-TileMesh.prototype.setColorLayerParameters = function setColorLayerParameters(paramsTextureColor, lighting) {
+TileMesh.prototype.setLightingParameters = function setLightingParameters(lighting) {
     if (!this.loaded) {
         const material = this.materials[RendererConstant.FINAL];
         material.setLightingOn(lighting.enable);
         material.uniforms.lightPosition.value = lighting.position;
-        material.setColorLayerParameters(paramsTextureColor);
     }
 };
 /**

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -151,6 +151,7 @@ const LayeredMaterial = function LayeredMaterial(id) {
     // this.wireframe = true;
 
     this.colorLayersId = [];
+    this.elevationLayersId = [];
 };
 
 LayeredMaterial.prototype = Object.create(BasicMaterial.prototype);


### PR DESCRIPTION
Move all initializations of imagery and elevation, in dedicated functions.
Because the tiles wasn't initialized to add new layer after globe loaded.