### PR TITLE
Debug improvement

### DIFF
--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -167,8 +167,10 @@ function Debug(scene) {
             nbDisplayedDataset.data.shift();
         }
 
-        nbObjectsChart.update();
-        nbVisibleChart.update();
+        if (chartDiv.style.display != 'none') {
+            nbObjectsChart.update();
+            nbVisibleChart.update();
+        }
     }
 
     // hook that to scene.update

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -149,6 +149,25 @@ function Debug(scene) {
             }
         }
 
+
+        // update line graph
+        const newCount = countElem(scene.gfxEngine.scene3D);
+
+        // test if we values didn't change
+        if (nbObjectsDataset.data.length > 1) {
+            const last = nbObjectsDataset.data.length - 1;
+            if (nbObjectsDataset.data[last].y === newCount &&
+                nbVisibleDataset.data[last].y === totalVisible &&
+                nbDisplayedDataset.data[last].y === totalDisplayed) {
+                // nothing change: drop the last point, to keep more interesting (changing)
+                // data displayed
+                nbObjectsDataset.data.pop();
+                nbVisibleDataset.data.pop();
+                nbDisplayedDataset.data.pop();
+                nbObjectsChartLabel.pop();
+            }
+        }
+
         // update time
         const limit = 25;
         const timeInS = Math.floor((Date.now() - timestamp) / 1000);
@@ -157,8 +176,7 @@ function Debug(scene) {
             nbObjectsChartLabel.shift();
         }
 
-        // update line graph
-        nbObjectsDataset.data.push({ x: timeInS, y: countElem(scene.gfxEngine.scene3D) });
+        nbObjectsDataset.data.push({ x: timeInS, y: newCount });
         nbVisibleDataset.data.push({ x: timeInS, y: totalVisible });
         nbDisplayedDataset.data.push({ x: timeInS, y: totalDisplayed });
         if (nbObjectsDataset.data.length > limit) {


### PR DESCRIPTION
Another small PR, this time improving debug code.

1st commit: reduce CPU usage of debug graph when they're hidden
2nd commit: improve graph drawing, by removing duplicate values

Here's an example (notice the jumps in x-axis):
![Example](https://cloud.githubusercontent.com/assets/2198295/25650606/66054b20-2fde-11e7-9fdc-cb671a313b7e.png)
