### PR TITLE
fix: fix transparent layer rendering in FF

### DIFF
--- a/src/Renderer/Shader/GlobeFS.glsl
+++ b/src/Renderer/Shader/GlobeFS.glsl
@@ -139,6 +139,7 @@ void main() {
 
         // Fog
         gl_FragColor = mix(CFog, diffuseColor, fogIntensity);
+        gl_FragColor.a = 1.0;
 
         if(lightingEnabled) {   // Add lighting
             float light = min(2. * dot(vNormal, lightPosition),1.);


### PR DESCRIPTION
One-liner patch that fixes rendering for Firefox.
Before:
![capture d ecran de 2017-05-03 09-57-59](https://cloud.githubusercontent.com/assets/2198295/25652212/65acc3b6-2fe7-11e7-9bd9-56e83eea8e74.png)

After:
![capture d ecran de 2017-05-03 09-58-25](https://cloud.githubusercontent.com/assets/2198295/25652215/6bd8c42e-2fe7-11e7-89c9-965f7fcbf6d1.png)

