### PR TITLE
fix: make sure tile's children inherit correct layer settings

### DIFF
--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -189,7 +189,8 @@ const LayeredMaterial = function LayeredMaterial(material, coordsDestination, co
                 const index = this.colorLayersId.length - 1;
 
                 // 2) UPDATE Params layer
-                this.setLayerVisibility(material.uniforms.visibility.value[i]);
+                this.setLayerVisibility(index, material.uniforms.visibility.value[i]);
+
                 // Copy param layer
                 paramLayers[index] = new THREE.Vector4().copy(material.uniforms.paramLayers.value[i]);
                 const params = paramLayers[index];

--- a/src/Scene/NodeProcess.js
+++ b/src/Scene/NodeProcess.js
@@ -205,6 +205,7 @@ function updateNodeImagery(scene, quadtree, node, layersConfig, force) {
             };
 
             material.pushLayer(paramMaterial);
+            material.setSequence(layersConfig.getColorLayersIdOrderedBySequence());
         }
 
         if (!force) {


### PR DESCRIPTION
Fix a regression introduced in #244 : layers visibilty and material sequence weren't correctly set.