### PR TITLE
Generate texture atlases at runtime

### DIFF
--- a/examples/panorama.html
+++ b/examples/panorama.html
@@ -73,7 +73,7 @@
                         networkOptions: { crossOrigin: 'anonymous' },
                         type: 'color',
                         protocol: 'static',
-                        id: _id,
+                        id: 'pano' + index,
                         projection: 'EPSG:4326',
                     }).then(() => {
                         view.notifyChange(false);

--- a/examples/split.js
+++ b/examples/split.js
@@ -62,8 +62,12 @@ function changeLayerVisibility(ortho, osm) {
             orthoIndex = material.indexOfColorLayer(orthoLayer.id);
             opensmIndex = material.indexOfColorLayer(osmLayer.id);
 
-            material.setLayerVisibility(orthoIndex, ortho);
-            material.setLayerVisibility(opensmIndex, osm);
+            if (orthoIndex >= 0) {
+                material.setLayerVisibility(orthoIndex, ortho);
+            }
+            if (opensmIndex >= 0) {
+                material.setLayerVisibility(opensmIndex, osm);
+            }
         }
     });
 }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,18 @@ and open the template in the editor.
             }
             #menuDiv {position: absolute; top:0px; margin-left: 0px;}
 
+            #foobar {
+                position: absolute;
+                right: 0;
+                top: 0;
+                display: flex;
+                flex-direction: row;
+                background-color: beige;
+                transform: scale(0.5) translate(50%, -50%);
+            }
+            /*#foobar > canvas > p {
+
+            }*/
 
         </style>
         <meta charset="UTF-8">
@@ -29,6 +41,7 @@ and open the template in the editor.
     </head>
     <body>
         <div id="viewerDiv"></div>
+        <div id="foobar"></div>
         <script src="examples/GUI/GuiTools.js"></script>
         <script src="dist/itowns.js"></script>
         <script src="dist/debug.js"></script>
@@ -75,6 +88,28 @@ and open the template in the editor.
             globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
+            });
+
+            viewerDiv.addEventListener('mousemove', (evt) => {
+                const n = globeView.selectNodeAt(globeView.eventToViewCoords(evt));
+                const f = document.getElementById('foobar');
+                if (n) {
+                    while (f.firstChild) {
+                        f.removeChild(f.firstChild);
+                    }
+
+                    for (const a of n.material.uniforms.atlasTextures.value) {
+                        if (a.image) {
+                            f.appendChild(a.image);
+                        }
+                    }
+
+                    f.style.display = 'flex';
+                    // f.style.left = `${evt.clientX + 30}px`;
+                    // f.style.top = `${evt.clientY + 30}px`;
+                } else {
+                    f.style.display = 'none';
+                }
             });
 
             const d = new debug.Debug(globeView, menuGlobe.gui);

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -366,21 +366,23 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
     // update the picking ray with the camera and mouse position
     const selectedId = this.screenCoordsToNodeId(mouse);
 
+    let selected;
     for (const n of this.wgs84TileLayer.level0Nodes) {
         n.traverse((node) => {
             // only take of selectable nodes
             if (node.setSelected) {
-                node.setSelected(node.id === selectedId);
+                // node.setSelected(node.id === selectedId);
 
                 if (node.id === selectedId) {
                     // eslint-disable-next-line no-console
                     console.info(node);
+                    selected = node;
                 }
             }
         });
     }
 
-    this.notifyChange(true);
+    return selected;
 };
 
 GlobeView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -375,27 +375,6 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
                 if (node.id === selectedId) {
                     // eslint-disable-next-line no-console
                     console.info(node);
-
-                    if (__DEBUG__) {
-                        const container = document.getElementById('canvasDebug');
-                        if (container) {
-                            while (container.firstChild) {
-                                container.removeChild(container.firstChild);
-                            }
-
-                            for (const layer of node.material.colorLayersId) {
-                                const index = node.material.indexOfColorLayer(layer);
-                                const texture = node.material.uniforms.atlasTextures.value[index];
-                                const canvas = texture.image;
-                                for (const txt of [`${layer}`, `${texture.uv.length} images`, `${canvas.width}x${canvas.height}`]) {
-                                    const s = document.createElement('div');
-                                    s.textContent = txt;
-                                    container.appendChild(s);
-                                }
-                                container.appendChild(canvas);
-                            }
-                        }
-                    }
                 }
             }
         });

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -375,6 +375,27 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
                 if (node.id === selectedId) {
                     // eslint-disable-next-line no-console
                     console.info(node);
+
+                    if (__DEBUG__) {
+                        const container = document.getElementById('canvasDebug');
+                        if (container) {
+                            while (container.firstChild) {
+                                container.removeChild(container.firstChild);
+                            }
+
+                            for (const layer of node.material.colorLayersId) {
+                                const index = node.material.indexOfColorLayer(layer);
+                                const texture = node.material.uniforms.atlasTextures.value[index];
+                                const canvas = texture.image;
+                                for (const txt of [`${layer}`, `${texture.uv.length} images`, `${canvas.width}x${canvas.height}`]) {
+                                    const s = document.createElement('div');
+                                    s.textContent = txt;
+                                    container.appendChild(s);
+                                }
+                                container.appendChild(canvas);
+                            }
+                        }
+                    }
                 }
             }
         });

--- a/src/Core/Scheduler/Providers/Fetcher.js
+++ b/src/Core/Scheduler/Providers/Fetcher.js
@@ -86,4 +86,17 @@ export default {
             return response.arrayBuffer();
         });
     },
+
+    img(url, options = {}) {
+        return new Promise((resolve, reject) => {
+            var image = new Image();
+
+            image.onload = () => resolve(image);
+
+            image.onerror = () => reject(new Error(`Error loading ${url}`));
+
+            image.crossOrigin = options.crossOrigin;
+            image.src = url;
+        });
+    },
 };

--- a/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
+++ b/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
@@ -42,7 +42,6 @@ export default {
         texture.minFilter = THREE.LinearFilter;
         texture.anisotropy = 16;
 
-
         cachePending.set(url, { texture, promise });
 
         return promise.then(() => {
@@ -51,6 +50,29 @@ export default {
             }
             cachePending.delete(url);
             return texture;
+        });
+    },
+    getColorImgByUrl(url, networkOptions) {
+        const key = `img-${url}`;
+        const cachedTexture = cache.getRessource(key);
+
+        if (cachedTexture) {
+            return Promise.resolve(cachedTexture);
+        }
+        if (cachePending.has(key)) {
+            return cachePending.get(key);
+        }
+
+        const promise = Fetcher.img(url, networkOptions);
+
+        cachePending.set(key, promise);
+
+        return promise.then((img) => {
+            if (!cache.getRessource(key)) {
+                cache.addRessource(key, img);
+            }
+            cachePending.delete(key);
+            return img;
         });
     },
     getXBilTextureByUrl(url, networkOptions) {

--- a/src/Core/Scheduler/Providers/TMS_Provider.js
+++ b/src/Core/Scheduler/Providers/TMS_Provider.js
@@ -47,9 +47,6 @@ TMS_Provider.prototype.executeCommand = function executeCommand(command) {
         result.pitch = coordTMSParent ?
             coordTMS.offsetToParent(coordTMSParent) :
             new THREE.Vector4(0, 0, 1, 1);
-        if (layer.transparent) {
-            texture.premultiplyAlpha = true;
-        }
         return result;
     });
 };

--- a/src/Core/Scheduler/Providers/TMS_Provider.js
+++ b/src/Core/Scheduler/Providers/TMS_Provider.js
@@ -40,7 +40,9 @@ TMS_Provider.prototype.executeCommand = function executeCommand(command) {
 
     const url = this.url(coordTMSParent || coordTMS, layer);
 
-    return OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions).then((texture) => {
+    return (command.rawImage ?
+        OGCWebServiceHelper.getColorImgByUrl(url, layer.networkOptions) :
+        OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions)).then((texture) => {
         const result = {};
         result.texture = texture;
         result.texture.coords = coordTMSParent || coordTMS;

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -94,7 +94,7 @@ WMS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) {
         layer.extent.intersectsExtent(tile.extent);
 };
 
-WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, targetLevel, tileCoords) {
+WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, targetLevel, tileCoords, rawImage) {
     if (!this.tileInsideLimit(tile, layer)) {
         return Promise.reject(`Tile '${tile}' is outside layer bbox ${layer.extent}`);
     }
@@ -123,7 +123,8 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, t
     const pitch = tileCoords ? new THREE.Vector4(0, 0, 1, 1) : tile.extent.offsetToParent(extent);
     const result = { pitch };
 
-    return OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions).then((texture) => {
+    return (rawImage ? OGCWebServiceHelper.getColorImgByUrl(url, layer.networkOptions) : OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions))
+    .then((texture) => {
         result.texture = texture;
         result.texture.extent = extent;
         if (layer.transparent) {
@@ -155,7 +156,7 @@ WMS_Provider.prototype.executeCommand = function executeCommand(command) {
     const func = supportedFormats[layer.format];
 
     if (func) {
-        return func(tile, layer, command.targetLevel);
+        return func(tile, layer, command.targetLevel, undefined, command.rawImage);
     } else {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.format}`));
     }

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -164,13 +164,13 @@ WMS_Provider.prototype.executeCommand = function executeCommand(command) {
 
 // In the case where the tilematrixset of the tile don't correspond to the projection of the layer
 // when the projection of the layer corresponds to a tilematrixset inside the tile, like the PM
-WMS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer, targetLevel) {
+WMS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer, targetLevel, dummy, rawImage) {
     if (tile.material === null) {
         return Promise.resolve();
     }
     const promises = [];
     for (const coord of tile.getCoordsForLayer(layer)) {
-        promises.push(this.getColorTexture(tile, layer, targetLevel, coord));
+        promises.push(this.getColorTexture(tile, layer, targetLevel, coord, rawImage));
     }
 
     return Promise.all(promises);

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -54,6 +54,7 @@ WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer)
         layer.options.zoom = { min: 0, max: 21 };
     }
 
+    layer.fx = layer.fx || 0.0;
     layer.format = layer.options.mimetype || 'image/png';
     layer.width = layer.heightMapWidth || 256;
     layer.version = layer.version || '1.3.0';
@@ -127,9 +128,6 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, t
     .then((texture) => {
         result.texture = texture;
         result.texture.extent = extent;
-        if (layer.transparent) {
-            texture.premultiplyAlpha = true;
-        }
         if (tileCoords) {
             result.texture.coords = tileCoords;
         } else {

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -101,11 +101,13 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, ta
  * TODO : RGBA --> RGB remove alpha canal
  * @param {{zoom:number,row:number,col:number}} coordWMTS
  * @param {Layer} layer
+ * @param {bool} rawImage If true returns an Image instead of a THREE.Texture object
  * @returns {Promise<Texture>}
  */
-WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, layer) {
+WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, layer, rawImage) {
     const url = this.url(coordWMTS, layer);
-    return OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions).then((texture) => {
+    return (rawImage ? OGCWebServiceHelper.getColorImgByUrl(url, layer.networkOptions) : OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions))
+    .then((texture) => {
         const result = {};
         result.texture = texture;
         result.texture.coords = coordWMTS;
@@ -131,7 +133,7 @@ WMTS_Provider.prototype.executeCommand = function executeCommand(command) {
 
     const func = supportedFormats[layer.options.mimetype];
     if (func) {
-        return func(tile, layer, command.targetLevel);
+        return func(tile, layer, command.targetLevel, command.rawImage);
     } else {
         return Promise.reject(new Error(`Unsupported mimetype ${layer.options.mimetype}`));
     }
@@ -171,7 +173,7 @@ WMTS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer, 
     return true;
 };
 
-WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer) {
+WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer, rawImage) {
     if (tile.material === null) {
         return Promise.resolve();
     }
@@ -179,7 +181,7 @@ WMTS_Provider.prototype.getColorTextures = function getColorTextures(tile, layer
     const bcoord = tile.getCoordsForLayer(layer);
 
     for (const coordWMTS of bcoord) {
-        promises.push(this.getColorTexture(coordWMTS, layer));
+        promises.push(this.getColorTexture(coordWMTS, layer, rawImage));
     }
 
     return Promise.all(promises);

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -112,9 +112,6 @@ WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, la
         result.texture = texture;
         result.texture.coords = coordWMTS;
         result.pitch = new THREE.Vector4(0, 0, 1, 1);
-        if (layer.transparent) {
-            texture.premultiplyAlpha = true;
-        }
 
         return result;
     });

--- a/src/Core/System/Capabilities.js
+++ b/src/Core/System/Capabilities.js
@@ -1,6 +1,7 @@
 // default values
 let logDepthBufferSupported = false;
 let maxTexturesUnits = 8;
+let maxTextureSize;
 
 export default {
     isLogDepthBufferSupported() {
@@ -13,9 +14,13 @@ export default {
     getMaxTextureUnitsCount() {
         return maxTexturesUnits;
     },
+    getMaxTextureSize() {
+        return maxTextureSize;
+    },
     updateCapabilities(renderer) {
         const gl = renderer.context;
         maxTexturesUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+        maxTextureSize = renderer.capabilities.maxTextureSize;
 
         const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
         if (debugInfo !== null) {

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -84,6 +84,17 @@ TileMesh.prototype.changeState = function changeState(state) {
     this.material.needsUpdate = true;
 };
 
+TileMesh.prototype.getElevationTexture = function getElevationTexture() {
+    const mat = this.material;
+    return mat.textures[l_ELEVATION][0];
+};
+
+TileMesh.prototype.getColorLayerTextures = function getColorLayerTextures(layerId) {
+    const mat = this.material;
+    const index = mat.indexOfColorLayer(layerId);
+    return mat.uniforms.atlasTextures.value[index];
+};
+
 TileMesh.prototype.setFog = function setFog(fog) {
     this.material.setFogDistance(fog);
 };

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -100,7 +100,7 @@ TileMesh.prototype.setTextureElevation = function setTextureElevation(elevation)
     const offsetScale = elevation.pitch || new THREE.Vector4(0, 0, 1, 1);
     this.setBBoxZ(elevation.min, elevation.max);
 
-    this.material.setTexture(elevation.texture, l_ELEVATION, 0, offsetScale);
+    this.material.setElevationTexture(elevation.texture, offsetScale);
 };
 
 
@@ -121,18 +121,13 @@ TileMesh.prototype.updateGeometricError = function updateGeometricError() {
     this.geometricError = this.boundingSphere.radius / SIZE_TEXTURE_TILE;
 };
 
-TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layerId) {
+TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layer) {
     if (this.material === null) {
         return;
     }
     if (textures) {
-        this.material.setTexturesLayer(textures, layerType, layerId);
+        this.material.setTexturesLayer(textures, layerType, layer);
     }
-};
-
-TileMesh.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
-    const mat = this.material;
-    return mat.getLayerTextures(layerType, layerId);
 };
 
 TileMesh.prototype.isColorLayerLoaded = function isColorLayerLoaded(layerId) {

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -26,15 +26,13 @@ function initNodeImageryTexturesFromParent(node, parent, layer) {
 
                 if (c.isInside(parentCoords)) {
                     const result = c.offsetToParent(parentCoords);
-
                     const p = atlas.uv[i];
-
                     const idx = coords.indexOf(c);
                     offsetScale[idx] = p.clone();
                     offsetScale[idx].x += result.x * p.z;
                     offsetScale[idx].y += result.y * p.w;
                     offsetScale[idx].z *= result.z;
-                    offsetScale[idx].w *= result.z;
+                    offsetScale[idx].w *= result.w;
 
                     found++;
                     break;
@@ -164,7 +162,6 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
     }
 
     const material = node.material;
-    let index = material.indexOfColorLayer(layer.id);
 
     // Initialisation
     if (node.layerUpdateState[layer.id] === undefined) {
@@ -200,11 +197,12 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
             };
 
             material.pushLayer(paramMaterial);
+
+            initNodeImageryTexturesFromParent(node, node.parent, layer);
+
             const imageryLayers = context.view.getLayers(l => l.type === 'color');
             const sequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             material.setSequence(sequence);
-
-            initNodeImageryTexturesFromParent(node, node.parent, layer);
         }
     }
 
@@ -217,6 +215,9 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
     // to avoid mixing layer's network updates and layer's params
     // Update material parameters
     const layerIndex = material.indexOfColorLayer(layer.id);
+    if (layerIndex < 0) {
+        return;
+    }
     material.setLayerVisibility(layerIndex, layer.visible);
     material.setLayerOpacity(layerIndex, layer.opacity);
 

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -1,4 +1,5 @@
 import { l_ELEVATION, l_COLOR, EMPTY_TEXTURE_ZOOM } from '../Renderer/LayeredMaterialConstants';
+import { acquireTexture, releaseTexture } from '../Renderer/LayeredMaterial';
 import { chooseNextLevelToFetch } from '../Core/Layer/LayerUpdateStrategy';
 import LayerUpdateState from '../Core/Layer/LayerUpdateState';
 import { ImageryLayers } from '../Core/Layer/Layer';
@@ -11,30 +12,46 @@ const MAX_RETRY = 4;
 function initNodeImageryTexturesFromParent(node, parent, layer) {
     if (parent.material && parent.material.getColorLayerLevelById(layer.id) > EMPTY_TEXTURE_ZOOM) {
         const coords = node.getCoordsForLayer(layer);
-        const offsetTextures = node.material.getLayerTextureOffset(layer.id);
 
-        let textureIndex = offsetTextures;
+        const indexInNode = node.material.indexOfColorLayer(layer.id);
+        const indexInParent = parent.material.indexOfColorLayer(layer.id);
+
+        const offsetScale = node.material.offsetScale[l_COLOR][layer.id];
+
+        let found = 0;
+        const atlas = parent.material.uniforms.atlasTextures.value[indexInParent];
         for (const c of coords) {
-            for (const texture of parent.material.getLayerTextures(l_COLOR, layer.id)) {
-                if (c.isInside(texture.coords)) {
-                    const result = c.offsetToParent(texture.coords);
-                    node.material.textures[l_COLOR][textureIndex] = texture;
-                    node.material.offsetScale[l_COLOR][textureIndex] = result;
-                    textureIndex++;
+            for (let i = 0; i < atlas.coords.length; i++) {
+                const parentCoords = atlas.coords[i];
+
+                if (c.isInside(parentCoords)) {
+                    const result = c.offsetToParent(parentCoords);
+
+                    const p = atlas.uv[i];
+
+                    const idx = coords.indexOf(c);
+                    offsetScale[idx] = p.clone();
+                    offsetScale[idx].x += result.x * p.z;
+                    offsetScale[idx].y += result.y * p.w;
+                    offsetScale[idx].z *= result.z;
+                    offsetScale[idx].w *= result.z;
+
+                    found++;
                     break;
                 }
             }
         }
 
         if (__DEBUG__) {
-            if ((textureIndex - offsetTextures) != coords.length) {
+            if (found != coords.length) {
                 /* eslint-disable */
-                console.error(`non-coherent result ${textureIndex} ${offsetTextures} vs ${coords.length}. ${coords}`);
+                console.error(`non-coherent result ${textureIndex} ${found} vs ${coords.length}. ${coords}`);
                 /* eslint-enable */
             }
         }
-        const index = node.material.indexOfColorLayer(layer.id);
-        node.material.layerTexturesCount[index] = coords.length;
+
+        releaseTexture(node.material.uniforms.atlasTextures.value[indexInNode]);
+        node.material.uniforms.atlasTextures.value[indexInNode] = acquireTexture(atlas);
         node.material.loadedTexturesCount[l_COLOR] += coords.length;
     }
 }
@@ -58,7 +75,7 @@ function initNodeElevationTextureFromParent(node, parent, layer) {
         // extract min-max from the texture (too few information), we instead chose
         // to use parent's min-max.
         const useMinMaxFromParent = node.level - texture.coords.zoom > 6;
-        if (!useMinMaxFromParent) {
+        if (!useMinMaxFromParent && layer.options.mimetype.indexOf('x-bil') > 0) {
             const { min, max } = OGCWebServiceHelper.ioDXBIL.computeMinMaxElevation(
                 texture.image.data,
                 SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
@@ -147,6 +164,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
     }
 
     const material = node.material;
+    let index = material.indexOfColorLayer(layer.id);
 
     // Initialisation
     if (node.layerUpdateState[layer.id] === undefined) {
@@ -243,6 +261,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
         priority: nodeCommandQueuePriorityFunction(node),
         earlyDropFunction: refinementCommandCancellationFn,
         targetLevel,
+        rawImage: true, // color textures use atlas so we request an img, not a texture
     };
 
     return context.scheduler.execute(command).then(
@@ -252,9 +271,9 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
             }
 
             if (Array.isArray(result)) {
-                node.setTexturesLayer(result, l_COLOR, layer.id);
+                node.setTexturesLayer(result, l_COLOR, layer);
             } else if (result.texture) {
-                node.setTexturesLayer([result], l_COLOR, layer.id);
+                node.setTexturesLayer([result], l_COLOR, layer);
             } else {
                 // TODO: null texture is probably an error
                 // Maybe add an error counter for the node/layer,

--- a/src/Renderer/AtlasBuilder.js
+++ b/src/Renderer/AtlasBuilder.js
@@ -2,6 +2,16 @@ import * as THREE from 'three';
 import Capabilities from '../Core/System/Capabilities';
 import fit from './Packer';
 
+const availableCanvas = [];
+
+function getCanvas() {
+    if (availableCanvas.length) {
+        return availableCanvas.pop();
+    }
+    const canvas = document.createElement('canvas');
+    return canvas;
+}
+
 /**
  * Build a texture atlas from N images.
  *
@@ -18,7 +28,8 @@ import fit from './Packer';
  */
 export default function pack(images, uvs, needsPixelSeparation) {
     // pick an available canvas, or build a new one
-    const atlasCanvas = document.createElement('canvas');
+    const atlasCanvas = getCanvas();
+
     // Use a 1 pixel border to avoid color bleed when sampling at the edges
     // of the texture
     const colorBleedHalfOffset = (!needsPixelSeparation || images.length == 1) ? 0 : 1;
@@ -129,6 +140,11 @@ export default function pack(images, uvs, needsPixelSeparation) {
     atlas.minFilter = THREE.LinearFilter;
     atlas.anisotropy = 1;
     atlas.uv = uv;
+
+    atlas.onUpdate = () => {
+        availableCanvas.push(atlasCanvas);
+        atlas.onUpdate = undefined;
+    };
 
     return atlas;
 }

--- a/src/Renderer/AtlasBuilder.js
+++ b/src/Renderer/AtlasBuilder.js
@@ -1,0 +1,134 @@
+import * as THREE from 'three';
+import Capabilities from '../Core/System/Capabilities';
+import fit from './Packer';
+
+/**
+ * Build a texture atlas from N images.
+ *
+ * We use a classic 2D Bin Packing algorithm to assign each individual image a
+ * location in the resulting texture.
+ * Then this texture is created using a <canvas>,  onto which we draw all images.
+ * In the end we return a THREE.CanvasTexture and an array 'uv' of Vector4, describing
+ * the position/size of each input images in the atlas.
+ * @param {array} images - an array of <img>
+ * @param {array} uvs - an array of coordinates indicating what part of the image we should keep
+ * @param {boolean} needsPixelSeparation - does this atlas need to use a anti color bleed pixel
+ * between images
+ * @return {THREE.CanvasTexture}
+ */
+export default function pack(images, uvs, needsPixelSeparation) {
+    // pick an available canvas, or build a new one
+    const atlasCanvas = document.createElement('canvas');
+    // Use a 1 pixel border to avoid color bleed when sampling at the edges
+    // of the texture
+    const colorBleedHalfOffset = (!needsPixelSeparation || images.length == 1) ? 0 : 1;
+    const maxSize = Capabilities.getMaxTextureSize();
+    const blocks = [];
+
+    for (let i = 0; i < images.length; i++) {
+        const img = images[i];
+        const replaceWithEmpty = !img;
+        const sWidth = replaceWithEmpty ? 1 : img.width * uvs[i].z;
+        const sHeight = replaceWithEmpty ? 1 : img.height * uvs[i].z;
+
+        blocks.push({
+            index: i,
+            w: sWidth,
+            h: sHeight + 2 * colorBleedHalfOffset,
+            empty: replaceWithEmpty,
+        });
+    }
+
+    // sort from big > small images (the packing alg works best if big images are treated first)
+    blocks.sort((a, b) => Math.max(a.w, a.h) < Math.max(b.w, b.h));
+
+    const { maxX, maxY } = fit(blocks, maxSize, maxSize);
+
+    // allocate canvas size
+    atlasCanvas.width = maxX;
+    atlasCanvas.height = maxY;
+
+    const uv = [];
+    const ctx = atlasCanvas.getContext('2d');
+
+    // Iterate on all blocks, and draw images on canvas
+    for (const block of blocks) {
+        const i = block.index;
+        const img = images[i];
+
+        // src describe where (x, y) to read in source image, and the size (width, height)
+        // (for now its values are normalized)
+        const src = {
+            x: uvs[i].x * uvs[i].z,
+            y: uvs[i].y * uvs[i].z,
+            width: uvs[i].z,
+            height: uvs[i].z,
+        };
+
+
+        const x = block.fit.x + colorBleedHalfOffset;
+        const y = block.fit.y;
+
+        if (!block.empty) {
+            src.x *= img.width;
+            src.y *= img.height;
+            src.width *= img.width;
+            src.height *= img.height;
+
+            // draw the whole image
+            ctx.drawImage(img,
+                src.x, // sx
+                src.y, // sy
+                src.width, // sWidth
+                src.height, // sHeight
+                x, // dx
+                y, // dy
+                src.width, // dWidth
+                src.height); // dHeight
+
+            if (colorBleedHalfOffset > 0) {
+                // draw left column copy
+                ctx.drawImage(img,
+                    src.x, // sx
+                    src.y, // sy
+                    src.width, // sWidth
+                    1, // sHeight
+                    x, // dx
+                    y - colorBleedHalfOffset, // dy
+                    src.width, // dWidth
+                    colorBleedHalfOffset);
+
+                // draw right column copy
+                ctx.drawImage(img,
+                    src.x, // sx
+                    src.y + src.height - colorBleedHalfOffset - 1, // sy
+                    src.width, // sWidth
+                    1, // sHeight
+                    x, // dx
+                    y + src.height, // dy
+                    src.width, // dWidth
+                    colorBleedHalfOffset);
+            }
+        }
+
+        // dst describe where src will be written (x, y) and the size of src
+        // (dst is normalized, so x/z (resp y/w) are divided by atlas width (resp height))
+        const dst = new THREE.Vector4(
+            x / atlasCanvas.width,
+            y / atlasCanvas.height,
+            src.width / atlasCanvas.width,
+            src.height / atlasCanvas.height);
+
+        uv.push(dst);
+    }
+
+    const atlas = new THREE.CanvasTexture(atlasCanvas);
+
+    atlas.generateMipmaps = false;
+    atlas.magFilter = THREE.LinearFilter;
+    atlas.minFilter = THREE.LinearFilter;
+    atlas.anisotropy = 1;
+    atlas.uv = uv;
+
+    return atlas;
+}

--- a/src/Renderer/AtlasBuilder.js
+++ b/src/Renderer/AtlasBuilder.js
@@ -40,7 +40,7 @@ export default function pack(images, uvs, needsPixelSeparation) {
         const img = images[i];
         const replaceWithEmpty = !img;
         const sWidth = replaceWithEmpty ? 1 : img.width * uvs[i].z;
-        const sHeight = replaceWithEmpty ? 1 : img.height * uvs[i].z;
+        const sHeight = replaceWithEmpty ? 1 : img.height * uvs[i].w;
 
         blocks.push({
             index: i,

--- a/src/Renderer/AtlasBuilder.js
+++ b/src/Renderer/AtlasBuilder.js
@@ -142,7 +142,7 @@ export default function pack(images, uvs, needsPixelSeparation) {
     atlas.uv = uv;
 
     atlas.onUpdate = () => {
-        availableCanvas.push(atlasCanvas);
+        // availableCanvas.push(atlasCanvas);
         atlas.onUpdate = undefined;
     };
 

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -290,7 +290,10 @@ function _transformTexturesToTHREE(textures, layer) {
         // So reverse PM textures
         textures.reverse();
 
-        const atlas = _updateAtlas(textures.map(t => t.texture), textures.map(t => t.pitch || new THREE.Vector4(0.0, 0.0, 1.0, 1.0)), layer.transparent);
+        const atlas = _updateAtlas(
+            textures.map(t => t.texture),
+            textures.map(t => t.pitch || new THREE.Vector4(0.0, 0.0, 1.0, 1.0)),
+            layer.transparent);
 
         // Now, all is nice and well, except UV coords for PM textures suppose a specific order
         // (see ColorLayerPM.glsl 'int textureIndex = pmSubTextureIndex;' for instance)
@@ -306,6 +309,7 @@ function _transformTexturesToTHREE(textures, layer) {
 
 LayeredMaterial.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layer) {
     const layerTexture = _transformTexturesToTHREE(textures, layer);
+    layerTexture.premultiplyAlpha = layer.transparent;
 
     const index = this.indexOfColorLayer(layer.id);
 

--- a/src/Renderer/Packer.js
+++ b/src/Renderer/Packer.js
@@ -1,0 +1,46 @@
+// original code from https://github.com/jakesgordon/bin-packing
+// MIT License
+
+import { Math as _Math } from 'three';
+
+// 2D Bin Packing algorithm (fit N random dimension blocks in a w * h rectangle) implementation
+function fit(blocks, w, h) {
+    const root = { x: 0, y: 0, w, h };
+    let maxX = 0;
+    let maxY = 0;
+    for (const block of blocks) {
+        const node = _findNode(root, block.w, block.h);
+        if (node) {
+            block.fit = _splitNode(node, block.w, block.h);
+            maxX = Math.max(node.x + block.w);
+            maxY = Math.max(node.y + block.h);
+        }
+    }
+    if (!_Math.isPowerOfTwo(maxX)) {
+        maxX = _Math.nextPowerOfTwo(maxX);
+    }
+    if (!_Math.isPowerOfTwo(maxY)) {
+        maxY = _Math.nextPowerOfTwo(maxY);
+    }
+    return { maxX, maxY };
+}
+
+
+function _findNode(root, w, h) {
+    if (root.used) {
+        return _findNode(root.down, w, h) || _findNode(root.right, w, h);
+    } else if ((w <= root.w) && (h <= root.h)) {
+        return root;
+    } else {
+        return null;
+    }
+}
+
+function _splitNode(node, w, h) {
+    node.used = true;
+    node.down = { x: node.x, y: node.y + h, w: node.w, h: node.h - h };
+    node.right = { x: node.x + w, y: node.y, w: node.w - w, h };
+    return node;
+}
+
+export default fit;

--- a/src/Renderer/Packer.js
+++ b/src/Renderer/Packer.js
@@ -17,10 +17,10 @@ function fit(blocks, w, h) {
         }
     }
     if (!_Math.isPowerOfTwo(maxX)) {
-        maxX = _Math.nextPowerOfTwo(maxX);
+        maxX = _Math.ceilPowerOfTwo(maxX);
     }
     if (!_Math.isPowerOfTwo(maxY)) {
-        maxY = _Math.nextPowerOfTwo(maxY);
+        maxY = _Math.ceilPowerOfTwo(maxY);
     }
     return { maxX, maxY };
 }

--- a/src/Renderer/Shader/Chunk/ColorLayer.glsl
+++ b/src/Renderer/Shader/Chunk/ColorLayer.glsl
@@ -1,0 +1,21 @@
+{
+    vec3 paramsA = paramLayers[REPLACE_LAYER_INDEX];
+    // if layer is visible & opacity > 0
+    if(paramsA.x > 0.0 && paramsA.y > 0.0) {
+
+        // empty textures are 0 width & height
+        vec4 offsetScale = offsetScale_REPLACE_LAYER_NAME[0];
+        if(offsetScale.z > 0.0 && offsetScale.w > 0.0) {
+            vec2 uvIn = vUv_WGS84;
+
+            vec2 uv = vec2(
+                uvIn.x * offsetScale.z + offsetScale.x,
+                1.0 - ((1.0 - uvIn.y) * offsetScale.w + offsetScale.y));
+            vec4 layerColor = texture2D(atlasTextures[REPLACE_LAYER_INDEX], uv);
+
+            if (layerColor.a > 0.0) {
+                diffuseColor = mixLayerColor(diffuseColor, layerColor, paramsA);
+            }
+        }
+    }
+}

--- a/src/Renderer/Shader/Chunk/ColorLayerPM.glsl
+++ b/src/Renderer/Shader/Chunk/ColorLayerPM.glsl
@@ -1,0 +1,22 @@
+{
+    vec3 paramsA = paramLayers[REPLACE_LAYER_INDEX];
+    // if layer is visible & opacity > 0
+    if(paramsA.x > 0.0 && paramsA.y > 0.0) {
+        int textureIndex = pmSubTextureIndex;
+
+        vec4 offsetScale = paramByIndex(offsetScale_REPLACE_LAYER_NAME, textureIndex);
+        // empty textures are 0 width & height
+        if(offsetScale.z > 0.0 && offsetScale.w > 0.0) {
+            vec2 uvIn = uvPM;
+
+            vec2 uv = vec2(
+                uvIn.x * offsetScale.z + offsetScale.x,
+                1.0 - ((1.0 - uvIn.y) * offsetScale.w + offsetScale.y));
+            vec4 layerColor = texture2D(atlasTextures[REPLACE_LAYER_INDEX], uv);
+
+            if (layerColor.a > 0.0) {
+                diffuseColor = mixLayerColor(diffuseColor, layerColor, paramsA);
+            }
+        }
+    }
+}

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -59,13 +59,11 @@ REPLACE_PARAM_BY_INDEX
 }
 
 vec4 mixLayerColor(vec4 diffuseColor, vec4 layerColor, vec3 layerParams) {
-    float lum = 1.0;
-
-    if(layerParams.z > 2.0) {
+    if (layerParams.z > 2.0) {
         layerColor.rgb /= layerColor.a;
         layerColor = applyLightColorToInvisibleEffect(layerColor, layerParams.z);
         layerColor.rgb *= layerColor.a;
-    } else if(layerParams.z > 0.0) {
+    } else if (layerParams.z > 0.0) {
         layerColor.rgb /= layerColor.a;
         layerColor = applyWhiteToInvisibleEffect(layerColor, layerParams.z);
         layerColor.rgb *= layerColor.a;

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -71,7 +71,7 @@ vec4 mixLayerColor(vec4 diffuseColor, vec4 layerColor, vec3 layerParams) {
         layerColor.rgb *= layerColor.a;
     }
 
-    return diffuseColor * (1.0 - layerColor.a * paramsA.w) + layerColor * layerParams.w
+    return diffuseColor * (1.0 - layerColor.a * layerParams.y) + layerColor * layerParams.y;
 }
 
 #if defined(MATTE_ID_MODE) || defined(DEPTH_MODE)
@@ -98,6 +98,12 @@ void main() {
         gl_FragColor = CRed;
         return;
     }
+    #endif
+
+    #if defined(USE_LOGDEPTHBUF) && defined(USE_LOGDEPTHBUF_EXT)
+        float depth = gl_FragDepthEXT / gl_FragCoord.w;
+    #else
+        float depth = gl_FragCoord.z / gl_FragCoord.w;
     #endif
 
     // Reconstruct PM uv and PM subtexture id (see TileGeometry)

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -11,14 +11,14 @@ const vec4 CWhite = vec4(1.0,1.0,1.0,1.0);
 const vec4 COrange = vec4( 1.0, 0.3, 0.0, 1.0);
 const vec4 CRed = vec4( 1.0, 0.0, 0.0, 1.0);
 
+#define MAX_TEXTURE_COUNT_PER_PM_LAYER 4
 
-uniform sampler2D   dTextures_01[TEX_UNITS];
-uniform vec4        offsetScale_L01[TEX_UNITS];
+// Per layer uniforms
+uniform vec3        paramLayers[ColorLayersCount];
+uniform bool        visibility[ColorLayersCount];
+uniform sampler2D   atlasTextures [ColorLayersCount];
 
-// offset texture | Projection | fx | Opacity
-uniform vec4        paramLayers[8];
-uniform int         loadedTexturesCount[8];
-uniform bool        visibility[8];
+INSERT_OFFSET_SCALE_UNIFORMS
 
 uniform float       distanceFog;
 uniform int         colorLayersCount;
@@ -54,6 +54,26 @@ vec4 applyLightColorToInvisibleEffect(vec4 color, float intensity) {
     const float sLine = 0.008;
 #endif
 
+vec4 paramByIndex(vec4 offsetScale[MAX_TEXTURE_COUNT_PER_PM_LAYER], int index) {
+REPLACE_PARAM_BY_INDEX
+}
+
+vec4 mixLayerColor(vec4 diffuseColor, vec4 layerColor, vec3 layerParams) {
+    float lum = 1.0;
+
+    if(layerParams.z > 2.0) {
+        layerColor.rgb /= layerColor.a;
+        layerColor = applyLightColorToInvisibleEffect(layerColor, layerParams.z);
+        layerColor.rgb *= layerColor.a;
+    } else if(layerParams.z > 0.0) {
+        layerColor.rgb /= layerColor.a;
+        layerColor = applyWhiteToInvisibleEffect(layerColor, layerParams.z);
+        layerColor.rgb *= layerColor.a;
+    }
+
+    return diffuseColor * (1.0 - layerColor.a * paramsA.w) + layerColor * layerParams.w
+}
+
 #if defined(MATTE_ID_MODE) || defined(DEPTH_MODE)
 #include <packing>
 uniform int  uuid;
@@ -73,110 +93,39 @@ void main() {
         gl_FragColor = packDepthToRGBA(z);
     #else
 
-
     #if defined(DEBUG)
-         if (showOutline && (vUv_WGS84.x < sLine || vUv_WGS84.x > 1.0 - sLine || vUv_WGS84.y < sLine || vUv_WGS84.y > 1.0 - sLine))
-             gl_FragColor = CRed;
-         else
+    if (showOutline && (vUv_WGS84.x < sLine || vUv_WGS84.x > 1.0 - sLine || vUv_WGS84.y < sLine || vUv_WGS84.y > 1.0 - sLine)) {
+        gl_FragColor = CRed;
+        return;
+    }
     #endif
-    {
-        // Reconstruct PM uv and PM subtexture id (see TileGeometry)
-        vec2 uvPM ;
-        uvPM.x             = vUv_WGS84.x;
-        float y            = vUv_PM;
-        int pmSubTextureIndex = int(floor(y));
-        uvPM.y             = y - float(pmSubTextureIndex);
 
-        #if defined(USE_LOGDEPTHBUF) && defined(USE_LOGDEPTHBUF_EXT)
-            float depth = gl_FragDepthEXT / gl_FragCoord.w;
-        #else
-            float depth = gl_FragCoord.z / gl_FragCoord.w;
-        #endif
+    // Reconstruct PM uv and PM subtexture id (see TileGeometry)
+    vec2 uvPM ;
+    uvPM.x             = vUv_WGS84.x;
+    float y            = vUv_PM;
+    int pmSubTextureIndex = int(floor(y));
+    uvPM.y             = y - float(pmSubTextureIndex);
 
-        float fogIntensity = 1.0/(exp(depth/distanceFog));
+    float fogIntensity = 1.0/(exp(depth/distanceFog));
+    vec4 diffuseColor = vec4(noTextureColor, 1.0);
 
-        vec4 diffuseColor = vec4(noTextureColor, 1.0);
-        bool validTexture = false;
+    // --------------8<----------------------
+    REPLACE_COLOR_LAYER
+    // --------------8<----------------------
 
-        // TODO Optimisation des uv1 peuvent copier pas lignes!!
-        for (int layer = 0; layer < 8; layer++) {
-            if(layer == colorLayersCount) {
-                break;
-            }
+    // Selected
+    if(selected) {
+        diffuseColor = mix(COrange, diffuseColor, 0.5 );
+    }
 
-            if(visibility[layer]) {
-                vec4 paramsA = paramLayers[layer];
+    // Fog
+    gl_FragColor = mix(CFog, diffuseColor, fogIntensity);
+    gl_FragColor.a = 1.0;
 
-                if(paramsA.w > 0.0) {
-                    bool projWGS84 = paramsA.y == 0.0;
-                    int pmTextureCount = int(paramsA.y);
-                    int textureIndex = int(paramsA.x) + (projWGS84 ? 0 : pmSubTextureIndex);
-
-                    if (!projWGS84 && pmTextureCount <= pmSubTextureIndex) {
-                        continue;
-                    }
-
-                    #if defined(DEBUG)
-                    if (showOutline && !projWGS84 && (uvPM.x < sLine || uvPM.x > 1.0 - sLine || uvPM.y < sLine || uvPM.y > 1.0 - sLine)) {
-                        gl_FragColor = COrange;
-                        return;
-                    }
-                    #endif
-
-                    /* if (0 <= textureIndex && textureIndex < loadedTexturesCount[1]) */ {
-
-                        // TODO: Try other OS before delete dead
-                        // get value in array, the index must be constant
-                        // Strangely it's work with function returning a global variable, doesn't work on Chrome Windows
-                        // vec4 layerColor = texture2D(dTextures_01[getTextureIndex()],  pitUV(projWGS84 ? vUv_WGS84 : uvPM,pitScale_L01[getTextureIndex()]));
-                        vec4 layerColor = colorAtIdUv(
-                            dTextures_01,
-                            offsetScale_L01,
-                            textureIndex,
-                            projWGS84 ? vUv_WGS84 : uvPM);
-
-                        if (layerColor.a > 0.0 && paramsA.w > 0.0) {
-                            validTexture = true;
-                            if(paramsA.z > 2.0) {
-                                layerColor.rgb /= layerColor.a;
-                                layerColor = applyLightColorToInvisibleEffect(layerColor, paramsA.z);
-                                layerColor.rgb *= layerColor.a;
-                            } else if(paramsA.z > 0.0) {
-                                layerColor.rgb /= layerColor.a;
-                                layerColor = applyWhiteToInvisibleEffect(layerColor, paramsA.z);
-                                layerColor.rgb *= layerColor.a;
-                            }
-
-                            // Use premultiplied-alpha blending formula because source textures are either:
-                            //     - fully opaque (layer.transparent = false)
-                            //     - or use premultiplied alpha (texture.premultiplyAlpha = true)
-                            // Note: using material.premultipliedAlpha doesn't make sense since we're manually blending
-                            // the multiple colors in the shader.
-                            diffuseColor = diffuseColor * (1.0 - layerColor.a * paramsA.w) + layerColor * paramsA.w;
-                        }
-                    }
-                }
-            }
-        }
-
-        // No texture color
-        if (!validTexture) {
-            diffuseColor.rgb = noTextureColor;
-        }
-
-        // Selected
-        if(selected) {
-            diffuseColor = mix(COrange, diffuseColor, 0.5 );
-        }
-
-        // Fog
-        gl_FragColor = mix(CFog, diffuseColor, fogIntensity);
-        gl_FragColor.a = 1.0;
-
-        if(lightingEnabled) {   // Add lighting
-            float light = min(2. * dot(vNormal, lightPosition),1.);
-            gl_FragColor.rgb *= light;
-        }
+    if(lightingEnabled) {   // Add lighting
+        float light = min(2. * dot(vNormal, lightPosition),1.);
+        gl_FragColor.rgb *= light;
     }
     gl_FragColor.a = opacity;
     #endif

--- a/src/utils/DEMUtils.js
+++ b/src/utils/DEMUtils.js
@@ -169,7 +169,7 @@ function tileAt(pt, tile) {
                 return t;
             }
         }
-        if (tile.getLayerTextures(l_ELEVATION)[0].coords.zoom > -1) {
+        if (tile.getElevationTexture().coords.zoom > -1) {
             return tile;
         }
         return undefined;
@@ -371,7 +371,7 @@ function _readZ(layer, method, coord, nodes, cache) {
     }
 
     const tile = tileWithValidElevationTexture;
-    const src = tileWithValidElevationTexture.getLayerTextures(l_ELEVATION)[0];
+    const src = tileWithValidElevationTexture.getElevationTexture();
 
     // check cache value if existing
     if (cache) {

--- a/test/externalscene_test.js
+++ b/test/externalscene_test.js
@@ -7,7 +7,6 @@ describe('External Scene', function () {
     it('should use the user constructed scene', function (done) {
         example.globeView.mainLoop.addEventListener('command-queue-empty', () => {
             assert.equal(example.globeView.scene, example.scene);
-
             if (itownsTesting.counters.fetch.length > 0) {
                 done();
                 // 'command-queue-empty' can fire multiple times, because GlobeView

--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -44,7 +44,17 @@ global.URL = function URL(str) {
     return url.parse(str);
 };
 global.document = new function _d() {
-    this.createElement = () => ({});
+    this.createElement = (type) => {
+        const r = {};
+        if (type == 'canvas') {
+            r.getContext = () => {
+                const c = {};
+                c.drawImage = () => {};
+                return c;
+            };
+        }
+        return r;
+    };
 
     this.createElementNS = (foo, type) => {
         var r = {};
@@ -53,9 +63,11 @@ global.document = new function _d() {
         if (type == 'img') {
             r.addEventListener = (evt, fn) => {
                 if (evt == 'load') {
-                    r.loadListener = fn;
+                    r.onload = fn;
                 }
             };
+            r.width = 256;
+            r.height = 256;
 
             var src;
             Object.defineProperty(
@@ -65,14 +77,13 @@ global.document = new function _d() {
                     set: (u) => {
                         src = u;
                         fetch(u).then(resp => resp.buffer()).then(() => {
-                            if (r.loadListener) {
-                                r.loadListener({ width: 256, height: 256 });
+                            if (r.onload) {
+                                r.onload();
                             }
                         });
                     },
                 });
         }
-
         return r;
     };
 
@@ -85,8 +96,13 @@ global.document = new function _d() {
         devicePixelRatio: 1.0,
     });
 }();
+
+global.Image = function Image() {
+    return document.createElementNS(0, 'img');
+};
+
 global.window = {
-    addEventListener() {},
+    addEventListener: () => {},
     setTimeout,
 };
 global.Event = Object;
@@ -124,6 +140,7 @@ global.renderer = {
     },
     capabilities: {
         logarithmicDepthBuffer: true,
+        maxTextureSize: 4096,
     },
     setClearColor: () => {},
     getClearAlpha: () => {},


### PR DESCRIPTION
1st commit:
    Texture atlas usually perform better than individual textures.
    It also allows to reduce the number of Sampler2D to the number of layer,
    instead of the number of textures.
    
    I didn't merged all the layers in a single atlas, because updating this
    huge texture is slow (at least using the naive way of building a THREE.Texture
    from an atlas. It may be feasible to access directly WebGL functions like
    glTexSubImage2D).
    
    Currently the texture packer is naive and probably only works for our test
    data, but it should be easy to implement a more robust solution.
    
    Last but not least, without this commit iTowns crashes on my phone :)

~The 2nd commit leverages on the 1st and implements color textures transition.~ Edit: animation moved to a later PR

~Note that this PR is not quite ready for merging (layer deletion not implemented etc...) but you can test it and give feedback.~ Edit: ready!

Thanks!
