### PR TITLE
feature: add Camera.box3DSizeOnScreen method

### DIFF
--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -96,4 +96,15 @@ Camera.prototype.isBox3DVisible = function isBox3DVisible(box3d, matrixWorld) {
     return frustum.intersectsBox(box3d);
 };
 
+Camera.prototype.box3DSizeOnScreen = function box3DSizeOnScreen(box3d, matrixWorld) {
+    const c = box3d.clone();
+    const m = matrixWorld ? matrixWorld.clone() : new THREE.Matrix4();
+    m.elements[12] -= this._visibilityTestingOffset.x;
+    m.elements[13] -= this._visibilityTestingOffset.y;
+    m.elements[14] -= this._visibilityTestingOffset.z;
+    m.premultiply(this._viewMatrix);
+
+    return c.applyMatrix4(m);
+};
+
 export default Camera;


### PR DESCRIPTION
Helper method to project a box3D to screen.
Can be used in several places:
  * SSE like calculations
  * placing DOM overlay on the scene using something like:
```js
      const overlay = document.getElementById('overlay');
      const onScreen = camera.box3DSizeOnScreen(...);
      overlay.style.bottom = `${50 * (onScreen.min.y + 1)}%`;
      overlay.style.top = `${100 - 50 * (onScreen.max.y + 1)}%`
      overlay.style.left = `${50 * (onScreen.min.x + 1)}%`;
      overlay.style.right = `${100 - 50 * (onScreen.max.x + 1)}%`;
```