### PR TITLE
feature: remove delay param from notifyChange

### DIFF
--- a/examples/GUI/GuiTools.js
+++ b/examples/GUI/GuiTools.js
@@ -29,15 +29,15 @@ GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {
     var folder = this.colorGui.addFolder(layer.id);
     folder.add({ visible: true }, 'visible').onChange((value) => {
         layer.visible = value;
-        this.view.notifyChange(0, true);
+        this.view.notifyChange(true);
     });
     folder.add({ opacity: 1.0 }, 'opacity').min(0.0).max(1.0).onChange((value) => {
         layer.opacity = value;
-        this.view.notifyChange(0, true);
+        this.view.notifyChange(true);
     });
     folder.add({ frozen: false }, 'frozen').onChange((value) => {
         layer.frozen = value;
-        this.view.notifyChange(0, true);
+        this.view.notifyChange(true);
     });
 };
 

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -72,7 +72,7 @@ and open the template in the editor.
             itowns.proj4.defs('EPSG:3946',
                 '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
-            const menuGlobe = new GuiTools(itowns.viewer, 'menuDiv');
+            const menuGlobe = new GuiTools('menuDiv');
 
             const bbox = new itowns.Extent(
                 'EPSG:3946',
@@ -158,7 +158,7 @@ and open the template in the editor.
                 view.camera.camera3D.updateMatrix();
                 view.camera.camera3D.updateMatrixWorld(true);
 
-                view.notifyChange(20, true);
+                view.notifyChange(true);
             }
 
             view.onAfterRender = () => {
@@ -168,7 +168,7 @@ and open the template in the editor.
             };
             moveCamera();
 
-            view.notifyChange(0, true);
+            view.notifyChange(true);
 
             // play-pause button from https://codepen.io/mistkaes/pen/WvPrJL
             pause = "M11,10 L18,13.74 18,22.28 11,26 M18,13.74 L26,18 26,18 18,22.28",
@@ -181,7 +181,7 @@ and open the template in the editor.
                 animation.setAttribute("to", animationEnabled ? play : pause);
                 animation.beginElement();
                 if (animationEnabled) {
-                    view.notifyChange(0, true);
+                    view.notifyChange(true);
                     previous = Date.now();
                 }
             });

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -59,12 +59,12 @@ GeometryLayer.prototype.detach = function detach(layer) {
  * // Change layer's visibilty
  * const layerToChange = view.getLayers(layer => layer.id == 'idLayerToChange')[0];
  * layerToChange.visible = false;
- * view.notifyChange(0,true); // update viewer
+ * view.notifyChange(true); // update viewer
  *
  * // Change layer's opacity
  * const layerToChange = view.getLayers(layer => layer.id == 'idLayerToChange')[0];
  * layerToChange.opacity = 0.5;
- * view.notifyChange(0,true); // update viewer
+ * view.notifyChange(true); // update viewer
  *
  * // Listen properties
  * const layerToListen = view.getLayers(layer => layer.id == 'idLayerToListen')[0];

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -212,7 +212,7 @@ function GlobeView(viewerDiv, coordCarto, options) {
 
     this.controls.addEventListener('change', () => {
         this.camera.update();
-        this.notifyChange(0, true);
+        this.notifyChange(true);
     });
 
     this.controls.addEventListener('selectClick', (event) => {
@@ -247,7 +247,7 @@ function GlobeView(viewerDiv, coordCarto, options) {
         this.controls.updateCamera(this.camera, this.viewerDiv.clientWidth, this.viewerDiv.clientHeight);
     }, false);
 
-    this.notifyChange(0, true);
+    this.notifyChange(true);
 }
 
 GlobeView.prototype = Object.create(View.prototype);
@@ -297,7 +297,7 @@ GlobeView.prototype.removeLayer = function removeImageryLayer(layerId) {
             }
         }
 
-        this.notifyChange(0, true);
+        this.notifyChange(true);
         this.dispatchEvent({
             type: GLOBE_VIEW_EVENTS.LAYER_REMOVED,
             layerId,
@@ -326,7 +326,7 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
         });
     }
 
-    this.notifyChange(0, true);
+    this.notifyChange(true);
 };
 
 GlobeView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {
@@ -463,14 +463,14 @@ GlobeView.prototype.setRealisticLightingOn = function setRealisticLightingOn(val
 
     this.updateMaterialUniform('lightingEnabled', value);
     this.updateMaterialUniform('lightPosition', coSun);
-    this.notifyChange(0, true);
+    this.notifyChange(true);
 };
 
 GlobeView.prototype.setLightingPos = function setLightingPos(pos) {
     const lightingPos = pos || CoordStars.getSunPositionInScene(this.ellipsoid, new Date().getTime(), 48.85, 2.35);
 
     this.updateMaterialUniform('lightPosition', lightingPos.clone().normalize());
-    this.notifyChange(0, true);
+    this.notifyChange(true);
 };
 
 GlobeView.prototype.updateMaterialUniform = function updateMaterialUniform(uniformName, value) {

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -97,10 +97,7 @@ Scheduler.prototype.runCommand = function runCommand(command, queue, executingCo
 
     queue.execute(command, provider, executingCounterUpToDate).then(() => {
         // notify view that one command ended.
-        // We allow the view to delay the update/repaint up to 100ms
-        // to reduce CPU load (no need to perform an update on completion if we
-        // know there's another one ending soon)
-        command.view.notifyChange(100, 'redraw' in command ? command.redraw : true, command.requester);
+        command.view.notifyChange('redraw' in command ? command.redraw : true, command.requester);
 
         // try to execute next command
         if (queue.counters.executing < this.maxCommandsPerHost) {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -34,7 +34,7 @@ import Debug from '../../utils/debug/Debug';
  *      }
  * });
  *
- * viewer.notifyChange(0, true);
+ * viewer.notifyChange(true);
  */
  /* TODO:
  * - remove debug boolean, replace by if __DEBUG__ and checkboxes in debug UI
@@ -65,7 +65,7 @@ function View(crs, viewerDiv, options = {}) {
         this.mainLoop.gfxEngine.onWindowResize();
         this.camera.resize(this.viewerDiv.clientWidth, this.viewerDiv.clientHeight);
         this.camera.update();
-        this.notifyChange(0, true);
+        this.notifyChange(true);
     }, false);
 
     this.onAfterRender = () => {};
@@ -221,20 +221,12 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
 /**
  * Notifies the scene it needs to be updated due to changes exterior to the
  * scene itself (e.g. camera movement).
- * @param {Number} delay Using a non-0 delay allows to delay update - useful to reduce CPU load for
  * non-interactive events (e.g: texture loaded)
  * @param {Boolean} needsRedraw indicates if notified change requires a full scene redraw.
  */
-View.prototype.notifyChange = function notifyChange(delay, needsRedraw, changeSource) {
-    if (delay) {
-        window.setTimeout(() => {
-            this._changeSources.add(changeSource);
-            this.mainLoop.scheduleViewUpdate(this, needsRedraw);
-        }, delay);
-    } else {
-        this._changeSources.add(changeSource);
-        this.mainLoop.scheduleViewUpdate(this, needsRedraw);
-    }
+View.prototype.notifyChange = function notifyChange(needsRedraw, changeSource) {
+    this._changeSources.add(changeSource);
+    this.mainLoop.scheduleViewUpdate(this, needsRedraw);
 };
 
 /**

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -207,7 +207,9 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
                 node.layerUpdateState[layer.id].success();
             } else {
                 node.layerUpdateState[layer.id].failure(Date.now());
-                context.view.notifyChange(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000, false);
+                window.setTimeout(() => {
+                    context.view.notifyChange(false, node);
+                }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
             }
         });
 }
@@ -294,7 +296,9 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, force) 
                 node.layerUpdateState[layer.id].success();
             } else {
                 node.layerUpdateState[layer.id].failure(Date.now());
-                context.view.notifyChange(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000, false);
+                window.setTimeout(() => {
+                    context.view.notifyChange(false, node);
+                }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
             }
         });
 }

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -84,7 +84,7 @@ function subdivideNode(context, layer, node, initNewNode) {
             }
             */
             node.pendingSubdivision = false;
-            context.view.notifyChange(0, false);
+            context.view.notifyChange(false);
         }, (err) => {
             node.pendingSubdivision = false;
             if (!(err instanceof CancelledCommandException)) {

--- a/src/Renderer/ColorLayersOrdering.js
+++ b/src/Renderer/ColorLayersOrdering.js
@@ -35,7 +35,7 @@ export const ColorLayersOrdering = {
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
             });
-            view.notifyChange(0, true);
+            view.notifyChange(true);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }
@@ -59,7 +59,7 @@ export const ColorLayersOrdering = {
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
             });
-            view.notifyChange(0, true);
+            view.notifyChange(true);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }
@@ -84,7 +84,7 @@ export const ColorLayersOrdering = {
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
             });
-            view.notifyChange(0, true);
+            view.notifyChange(true);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -202,7 +202,7 @@ function Debug(view, viewerDiv) {
             material.uniforms.showOutline = { value: newValue };
             material.needsUpdate = true;
         });
-        view.notifyChange(0, true);
+        view.notifyChange(true);
     });
 
     // tiles wireframe
@@ -213,7 +213,7 @@ function Debug(view, viewerDiv) {
         applyToNodeFirstMaterial((material) => {
             material.wireframe = newValue;
         });
-        view.notifyChange(0, true);
+        view.notifyChange(true);
     });
 
     gui.add(state, 'eventsDebug').name('Debug event').onChange((() => {
@@ -326,13 +326,13 @@ function addGeometryLayerDebugFeatures(layer, view, gui, state) {
 
     folder.add(state, layer.id).name('Visible').onChange((newValue) => {
         layer.visible = newValue;
-        view.notifyChange(0, true);
+        view.notifyChange(true);
     });
 
     state[debugLayer.id] = false;
     folder.add(state, debugLayer.id).name('OBB visible').onChange((newValue) => {
         debugLayer.visible = newValue;
-        view.notifyChange(0, true);
+        view.notifyChange(true);
     });
 
     var consistencyCheck = { click: () => {


### PR DESCRIPTION
Removed because it's a rarely used feature, and with 2 different use case, and both
can be implemented in a better way.

- reduce CPU usage (see Scheduler usage): iTowns partial update support cover this use-case,
with the benefit of not adding any latency.

- rescheduling an update after an error (see Layered...Processing.js): the user can use setTimeout
directly