### PR TITLE
Turn on ESLint valid-jsdoc rule (as warning for now)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,11 @@ module.exports = {
       }
     }],
     'one-var': ['error', 'never'],
+    'valid-jsdoc': ['error', {
+      requireReturn: false,
+      requireParamDescription: false,
+      requireReturnDescription: false,
+    }],
     // TODO reactivate this rule once a proper npm package is made
     // a good configuration might be:
     /*'import/no-extraneous-dependencies': ['error', {

--- a/src/Core/AnimationPlayer.js
+++ b/src/Core/AnimationPlayer.js
@@ -80,7 +80,6 @@ const setPlayerState = function setPlayerState(player, state) {
 };
 
 /**
- * AnimationPlayer
  * It can play, pause or stop Animation or AnimationExpression (See below).
  * AnimationPlayer is needed to use Animation or AnimationExpression
  * AnimationPlayer emits events :
@@ -115,11 +114,11 @@ class AnimationPlayer extends THREE.EventDispatcher {
     // Public functions
 
     /**
-     * { Start animation }
-     * this function play one animation.
-     * If another animation is playing, it's stopped and the new animation is played
-     * @param      {Animation} The animation to play
-     * @return     {Promise}  Promise is resolved when animation is stopped or finished
+     * Play one animation.
+     * If another animation is playing, it's stopped and the new animation is played.
+     *
+     * @param {Animation} animation - The animation to play
+     * @return {Promise<void>} - Promise is resolved when animation is stopped or finished
      */
     play(animation) {
         this.animation = animation;
@@ -134,10 +133,11 @@ class AnimationPlayer extends THREE.EventDispatcher {
     }
 
     /**
-     * { The animation is played after a number of frames }
+     * Play an animation after a number of frames.
      *
      * @param      {Animation}  animation    The animation to play
-     * @param      {Number}  waitingTime  The waiting time before start animation (time in frame)
+     * @param      {number}  waitingFrame    The waiting time before start animation (time in frame)
+     * @return     {Promise<void>} Promise is resolved when animation is stopped or finished
      */
     playLater(animation, waitingFrame) {
         this.resolveWait = null;
@@ -149,9 +149,9 @@ class AnimationPlayer extends THREE.EventDispatcher {
     }
 
     /**
-     * { Stop current animation }
+     * Stop the current animation.
      *
-     * @return  {Promise}  Promise is resolved when animation is stopped or finished
+     * @return  {Promise<void>}  Promise is resolved when animation is stopped or finished
      */
     stop() {
         setPlayerState(this, PLAYER_STATE.STOP);
@@ -161,7 +161,9 @@ class AnimationPlayer extends THREE.EventDispatcher {
     }
 
     /**
-     * { this function is executed with each frame }
+     * Executed for each frame.
+     *
+     * @private
      */
     frame() {
         if (this.keyframe < this.animation.duration) {
@@ -181,15 +183,16 @@ class AnimationPlayer extends THREE.EventDispatcher {
 }
 
 /**
- * { Animation }
- * Animation is play by the AnimationPlayer during the time of duration
- * During playback, the AnimationPlayer emits event for each frame
+ * Animation is played by the AnimationPlayer during the time of duration
+ * During playback, the AnimationPlayer emits events for each frame
  * Animation is used to execute a callback to each frame
- * @class      Animation
- * @param      {Number}  duration  The animation's duration in number of frames. FRAMERATE is number of frames in one seconde.
- * @param      {String}  name      The animation's name. It's used for debug message.
  */
 class Animation {
+    /**
+     * @param {Object}  params
+     * @param {?number} params.duration - The animation's duration in number of frames. {@link FRAMERATE} is number of frames in one seconde.
+     * @param {string}  params.name     - The animation's name. It's used for debug message.
+     */
     constructor(params) {
         this.duration = params.duration || FRAMERATE;
         this.name = params.name;
@@ -197,19 +200,19 @@ class Animation {
 }
 
 /**
- * { function_description }
- * AnimatedExpression is play by the AnimationPlayer during the time of duration
+ * AnimatedExpression is played by the AnimationPlayer during the time of duration
  * During playback, the AnimationPlayer emits event for each frame and
  * it applies expression on root.
  * AnimatedExpression is used to change object's values for each frame
- * @class      AnimatedExpression (name)
- * @param      {Number}   duration    The animation's duration in number of frames. FRAMERATE is number of frames in one seconde.
- * @param      {Object}   root        The root is the object in scene to animate
- * @param      {Function} expression  The expression is function applied to root with each frame
- * @param      {String}   name        The animation's name. It's used for debug message
-  */
-
+ */
 class AnimatedExpression extends Animation {
+    /**
+     * @param {Object}   params
+     * @param {?number}  params.duration   - Duration in number of frames. {@link FRAMERATE} is number of frames in one seconde.
+     * @param {Object}   params.root       - Object in scene to animate
+     * @param {function(Object,number):void} params.expression - Function applied to root for each frame, arguments are the root object and the ratio of completion.
+     * @param {string}   params.name       - The animation's name. It's used for debug message
+     */
     constructor(params) {
         super(params);
         this.root = params.root;

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -436,6 +436,7 @@ export const C = {
      * @param {number} position.x - the x component of the position
      * @param {number} position.y - the y component of the position
      * @param {number} position.z - the z component of the position
+     * @return {Coordinates}
      */
     EPSG_4326: function EPSG_4326(...args) {
         return new Coordinates('EPSG:4326', ...args);

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -184,9 +184,10 @@ Extent.prototype.dimensions = function dimensions(unit) {
 };
 
 /**
- * @documentation: Retourne True if point is inside the bounding box
+ * Return true if coord is inside the bounding box.
  *
- * @param point {[object Object]}
+ * @param {Coordinates} coord
+ * @return {boolean}
  */
 Extent.prototype.isInside = function isInside(coord) {
     const c = (this.crs() == coord.crs) ? coord : coord.as(this.crs());

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -49,7 +49,6 @@ GeometryLayer.prototype.detach = function detach(layer) {
 };
 
 /**
- * @class      Layer (name)
  * Don't use directly constructor to instance a new Layer
  * use addLayer in {@link View}
  * @example
@@ -70,12 +69,13 @@ GeometryLayer.prototype.detach = function detach(layer) {
  * const layerToListen = view.getLayers(layer => layer.id == 'idLayerToListen')[0];
  * layerToListen.addEventListener('visible-property-changed', (event) => console.log(event));
  * layerToListen.addEventListener('opacity-property-changed', (event) => console.log(event));
+ * @constructor
  * @protected
  * @param      {String}  id
  */
-function Layer(i) {
+function Layer(id) {
     Object.defineProperty(this, 'id', {
-        value: i,
+        value: id,
         writable: false,
     });
 }

--- a/src/Core/Layer/LayerUpdateState.js
+++ b/src/Core/Layer/LayerUpdateState.js
@@ -10,6 +10,7 @@ const PAUSE_BETWEEN_ERRORS = [1.0, 3.0, 7.0, 60.0];
  * LayerUpdateState is the update state of a layer, for a given object (e.g tile).
  * It stores information to allow smart update decisions, and especially network
  * error handling.
+ * @constructor
  */
 function LayerUpdateState() {
     this.state = UPDATE_STATE.IDLE;

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -88,8 +88,6 @@ MainLoop.prototype._step = function _step(view) {
     }
 };
 
-/**
- */
 MainLoop.prototype._renderView = function _renderView(view) {
     const dim = this.gfxEngine.getWindowSize();
     view.camera.resize(dim.x, dim.y);

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -78,8 +78,9 @@ export const GLOBE_VIEW_EVENTS = {
  * @example view = new GlobeView(viewer, positionOnGlobe);
  * // positionOnGlobe in latitude, longitude and altitude
  * @augments View
- * @params {Div} string.
- * @param {Coords} coords.
+ * @param {HTMLDivElement} viewerDiv - Where to instanciate the Three.js scene in the DOM
+ * @param {object} coordCarto
+ * @param {object=} options - see {@link View}
  */
 function GlobeView(viewerDiv, coordCarto, options) {
     THREE.Object3D.DefaultUp.set(0, 0, 1);

--- a/src/Core/Scheduler/Providers/BuildingBox_Provider.js
+++ b/src/Core/Scheduler/Providers/BuildingBox_Provider.js
@@ -38,8 +38,10 @@ BuildingBox_Provider.prototype.constructor = BuildingBox_Provider;
 
 /**
  * Return url wmts MNT
- * @param {type} coWMTS : coord WMTS
- * @returns {Object@call;create.url.url|String}
+ * @param {number} longitude
+ * @param {number} latitude
+ * @param {number} radius
+ * @returns {string}
  */
 BuildingBox_Provider.prototype.url = function url(longitude, latitude, radius) {
     // var key    = "wmybzw30d6zg563hjlq8eeqb";

--- a/src/Core/Scheduler/Providers/CacheRessource.js
+++ b/src/Core/Scheduler/Providers/CacheRessource.js
@@ -13,9 +13,6 @@ function CacheRessource() {
     this._maximumSize = null;
 }
 
-/**
- * @param url
- */
 CacheRessource.prototype.getRessource = function getRessource(url) {
     return this.cacheObjects[url];
 };
@@ -25,9 +22,6 @@ CacheRessource.prototype.addRessource = function addRessource(url, ressource) {
 };
 
 
-/**
- * @param id
- */
 CacheRessource.prototype.getRessourceByID = function getRessourceByID(/* id*/) {
     // TODO: Implement Me
 

--- a/src/Core/Scheduler/Providers/IoDriver.js
+++ b/src/Core/Scheduler/Providers/IoDriver.js
@@ -14,37 +14,24 @@ function IoDriver() {
 IoDriver.prototype.constructor = IoDriver;
 
 
-/**
- * @param url
- */
 IoDriver.prototype.load = function load(/* url*/) {
     // TODO: Implement Me
 
 };
 
 
-/**
- * @param url
- * @param inputObject {Object}
- */
 IoDriver.prototype.write = function write(/* url, inputObject*/) {
     // TODO: Implement Me
 
 };
 
 
-/**
- * @param url
- */
 IoDriver.prototype.readAsync = function readAsync(/* url*/) {
     // TODO: Implement Me
 
 };
 
 
-/**
- * @param url
- */
 IoDriver.prototype.writeAsync = function writeAsync(/* url*/) {
     // TODO: Implement Me
 

--- a/src/Core/Scheduler/Providers/Provider.js
+++ b/src/Core/Scheduler/Providers/Provider.js
@@ -13,9 +13,6 @@ function Provider(iodriver) {
 
 Provider.prototype.constructor = Provider;
 
-/**
- * @param url
- */
 Provider.prototype.get = function get(/* url*/) {
     // TODO: Implement Me
 
@@ -29,9 +26,6 @@ Provider.prototype.preprocessLayer = function preprocessLayer(/* layer*/) {
 
 };
 
-/**
- * @param url
- */
 Provider.prototype.getInCache = function getInCache(/* url*/) {
     // TODO: Implement Me
 

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -11,10 +11,11 @@ import CacheRessource from './CacheRessource';
 
 /**
  * Return url wmts MNT
- * @param {String} options.url: service base url
- * @param {String} options.layer: requested data layer
- * @param {String} options.format: image format (default: format/jpeg)
- * @returns {Object@call;create.url.url|String}
+ * @param {Object} options
+ * @param {?string} options.url - service base url
+ * @param {?string} options.layer - requested data layer
+ * @param {?string} options.format - image format (default: format/jpeg)
+ * @constructor
  */
 function WFS_Provider(options) {
     this.cache = CacheRessource();

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -14,7 +14,6 @@ import OGCWebServiceHelper from './OGCWebServiceHelper';
  * @param {String} options.url: service base url
  * @param {String} options.layer: requested data layer
  * @param {String} options.format: image format (default: format/jpeg)
- * @returns {Object@call;create.url.url|String}
  */
 function WMS_Provider() {
 }

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -58,8 +58,9 @@ WMTS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer
 
 /**
  * Return url wmts orthophoto
- * @param {type} coWMTS
- * @returns {Object@call;create.urlOrtho.url|String}
+ * @param {{zoom:number,row:number,col:number}} coWMTS
+ * @param {Layer} layer
+ * @returns {string}
  */
 WMTS_Provider.prototype.url = function url(coWMTS, layer) {
     return this.customUrl(layer, layer.customUrl, coWMTS.zoom, coWMTS.row, coWMTS.col);
@@ -67,8 +68,10 @@ WMTS_Provider.prototype.url = function url(coWMTS, layer) {
 
 /**
  * return texture float alpha THREE.js of MNT
- * @param {type} coWMTS : coord WMTS
- * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;_IoDriver@call;read@call;then}
+ * @param {TileMesh} tile
+ * @param {Layer} layer
+ * @param {number} targetZoom
+ * @returns {Promise<portableXBIL>}
  */
 WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, targetZoom) {
     const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
@@ -96,9 +99,9 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, ta
 /**
  * Return texture RGBA THREE.js of orthophoto
  * TODO : RGBA --> RGB remove alpha canal
- * @param {type} coordWMTS
- * @param {type} id
- * @returns {WMTS_Provider_L15.WMTS_Provider.prototype@pro;ioDriverImage@call;read@call;then}
+ * @param {{zoom:number,row:number,col:number}} coordWMTS
+ * @param {Layer} layer
+ * @returns {Promise<Texture>}
  */
 WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, layer) {
     const url = this.url(coordWMTS, layer);

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -192,6 +192,8 @@ Scheduler.prototype.getProviders = function getProviders() {
 
 /**
  * Custom error thrown when cancelling commands. Allows the caller to act differently if needed.
+ * @constructor
+ * @param {Command} command
  */
 function CancelledCommandException(command) {
     this.command = command;
@@ -201,8 +203,6 @@ CancelledCommandException.prototype.toString = function toString() {
     return `Cancelled command ${this.command.requester.id}/${this.command.layer.id}`;
 };
 
-/**
- */
 Scheduler.prototype.deQueue = function deQueue(queue) {
     var st = queue.storage;
     while (st.length > 0) {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -17,13 +17,12 @@ import Scheduler from './Scheduler/Scheduler';
  * Constructs an Itowns Scene instance
  *
  * @param {string} crs - The default CRS of Three.js coordinates. Should be a cartesian CRS.
- * @param {DOMElement} viewerDiv - Where to instanciate the Three.js scene in the DOM
- * @param {boolean} options - Optional properties. May contain:
- *    - mainLoop: {MainLoop} instance to use, otherwise a default one will be constructed
- *    - renderer: {WebGLRenderer} instance to use, otherwise a default one will be constructed. If
+ * @param {HTMLElement} viewerDiv - Where to instanciate the Three.js scene in the DOM
+ * @param {Object=} options - Optional properties.
+ * @param {?MainLoop} options.mainLoop - {@link MainLoop} instance to use, otherwise a default one will be constructed
+ * @param {?WebGLRenderer} options.renderer - {@link WebGLRenderer} instance to use, otherwise a default one will be constructed. If
  *    not present, a new <canvas> will be created and added to viewerDiv (mutually exclusive with mainLoop)
- *    - scene3D: {Scene} instance to use, otherwise a default one will be constructed
- * @param {boolean} glDebug - debug gl code
+ * @param {?Scene} options.scene3D - {@link Scene} instance to use, otherwise a default one will be constructed
  * @constructor
  * @example
  * // How add gpx object
@@ -150,14 +149,13 @@ function _preprocessLayer(view, layer, provider) {
  */
 
 /**
- * LayerOptions
  * @typedef {Object} LayerOptions
  * @property {string} id Unique layer's id
  * @property {string} type the layer's type : 'color', 'elevation', 'geometry'
- * @property {string} layer.protocol wmts and wms (wmtsc for custom deprecated)
- * @property {string} layer.url Base URL of the repository or of the file(s) to load
- * @property {Object} layer.updateStrategy strategy to load imagery files
- * @property {OptionsWmts|OptionsWms} layer.options WMTS or WMS options
+ * @property {string} protocol wmts and wms (wmtsc for custom deprecated)
+ * @property {string} url Base URL of the repository or of the file(s) to load
+ * @property {Object} updateStrategy strategy to load imagery files
+ * @property {OptionsWmts|OptionsWms} options WMTS or WMS options
  */
 
 /**
@@ -193,7 +191,10 @@ function _preprocessLayer(view, layer, provider) {
  *      type: 'elevation',
  *      id: 'iElevation',
  * });
- * @param {LayerOptions} layer option
+ *
+ * @param {LayerOptions|Layer|GeometryLayer} layer
+ * @param {Layer=} parentLayer
+ * @return {Layer|GeometryLayer}
  */
 View.prototype.addLayer = function addLayer(layer, parentLayer) {
     layer = _preprocessLayer(this, layer, this.mainLoop.scheduler.getProtocolProvider(layer.protocol));
@@ -217,7 +218,8 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
  * Notifies the scene it needs to be updated due to changes exterior to the
  * scene itself (e.g. camera movement).
  * non-interactive events (e.g: texture loaded)
- * @param {Boolean} needsRedraw indicates if notified change requires a full scene redraw.
+ * @param {boolean} needsRedraw - indicates if notified change requires a full scene redraw.
+ * @param {*} changeSource
  */
 View.prototype.notifyChange = function notifyChange(needsRedraw, changeSource) {
     this._changeSources.add(changeSource);
@@ -240,8 +242,8 @@ View.prototype.notifyChange = function notifyChange(needsRedraw, changeSource) {
  * view.getLayers(layer => layer.type === 'geometry');
  * // get one layer with id
  * view.getLayers(layer => layer.id === 'itt');
- * @param {function} filter
- * @returns {Array}  array of Layer
+ * @param {function(Layer):boolean} filter
+ * @returns {Array<Layer>}
  */
 View.prototype.getLayers = function getLayers(filter) {
     const result = [];

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -26,8 +26,6 @@ function Camera(width, height) {
     this.height = height;
 }
 
-/**
- */
 Camera.prototype.position = function position() {
     return this.camera3D.position;
 };

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -357,7 +357,15 @@ function defer() {
 
 /* globals document,window */
 
-/** @class GlobeControls */
+/**
+ * @class
+ * @param {View} view
+ * @param {*} target
+ * @param {HTMLElement} domElement
+ * @param {HTMLElement} viewerDiv
+ * @param {number} radius
+ * @param {function(THREE.Vector2):THREE.Vector2} getPickingPosition
+ */
 function GlobeControls(view, target, domElement, viewerDiv, radius, getPickingPosition) {
     player = new AnimationPlayer();
     this._view = view;
@@ -1358,9 +1366,9 @@ function getRangeFromScale(scale, pitch) {
 /**
  * Changes the tilt of the current camera, in degrees.
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/p6t76zox/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @param {Angle} Number - The angle.
- * @param      {boolean}  isAnimated  Indicates if animated
- * @return     {Promise}
+ * @param {number}  tilt
+ * @param {boolean} isAnimated
+ * @return {Promise<void>}
  */
 GlobeControls.prototype.setTilt = function setTilt(tilt, isAnimated) {
     return this.setOrbitalPosition({ tilt }, isAnimated);
@@ -1369,9 +1377,9 @@ GlobeControls.prototype.setTilt = function setTilt(tilt, isAnimated) {
 /**
  * Changes the heading of the current camera, in degrees.
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/rxe4xgxj/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @param {Angle} Number - The angle.
- * @param      {boolean}  isAnimated  Indicates if animated
- * @return     {Promise}
+ * @param {number} heading
+ * @param {boolean} isAnimated
+ * @return {Promise<void>}
  */
 GlobeControls.prototype.setHeading = function setHeading(heading, isAnimated) {
     return this.setOrbitalPosition({ heading }, isAnimated);
@@ -1380,9 +1388,9 @@ GlobeControls.prototype.setHeading = function setHeading(heading, isAnimated) {
 /**
  * Sets the "range": the distance in meters between the camera and the current central point on the screen.
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/Lt3jL5pd/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @param {Number} pRange - The camera altitude.
- * @param      {boolean}  isAnimated  Indicates if animated
- * @return     {Promise}
+ * @param {number} range
+ * @param {boolean} isAnimated
+ * @return {Promise<void>}
  */
 GlobeControls.prototype.setRange = function setRange(range, isAnimated) {
     return this.setOrbitalPosition({ range }, isAnimated);
@@ -1391,9 +1399,9 @@ GlobeControls.prototype.setRange = function setRange(range, isAnimated) {
 /**
  * Sets orientation angles of the current camera, in degrees.
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/9qr2mogh/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @param      {object}   orientation  The angle of the rotation in degrees
- * @param      {boolean}  isAnimated   Indicates if animated
- * @return     {Promise}   { description_of_the_return_value }
+ * @param {{tilt:number,heading:number,range:number}} position
+ * @param {boolean}  isAnimated
+ * @return {Promise<void>}
  */
 GlobeControls.prototype.setOrbitalPosition = function setOrbitalPosition(position, isAnimated) {
     isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
@@ -1452,6 +1460,7 @@ GlobeControls.prototype.getCameraTargetPosition = function getCameraTargetPositi
  *
  * @param {THREE.Vector3} position - the position on the globe to aim, in EPSG:4978 projection
  * @param {boolean} isAnimated - if we should animate the move
+ * @return {Promise<void>}
  */
 GlobeControls.prototype.setCameraTargetPosition = function setCameraTargetPosition(position, isAnimated) {
     isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
@@ -1560,6 +1569,7 @@ GlobeControls.prototype.moveTarget = function moveTarget() {
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/1z7q3c4z/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
  * The view flies to the desired coordinate, i.e.is not teleported instantly. Note : The results can be strange in some cases, if ever possible, when e.g.the camera looks horizontally or if the displaced center would not pick the ground once displaced.
  * @param      {vector}  pVector  The vector
+ * @return {Promise<void>}
  */
 GlobeControls.prototype.pan = function pan(pVector) {
     this.mouseToPan(pVector.x, pVector.y);
@@ -1573,6 +1583,7 @@ GlobeControls.prototype.pan = function pan(pVector) {
 /**
  * Returns the orientation angles of the current camera, in degrees.
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/okfj460p/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+ * @return {Array<number>}
  */
 GlobeControls.prototype.getCameraOrientation = function getCameraOrientation() {
     var tiltCam = this.getTilt();
@@ -1583,7 +1594,7 @@ GlobeControls.prototype.getCameraOrientation = function getCameraOrientation() {
 /**
  * Returns the camera location projected on the ground in lat,lon. See {@linkcode Coordinates} for conversion.
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/mjv7ha02/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
- * @return {Position} position
+ * @return {Coordinates} position
  */
 
 GlobeControls.prototype.getCameraLocation = function getCameraLocation() {
@@ -1726,9 +1737,9 @@ GlobeControls.prototype.setCameraTargetGeoPositionAdvanced = function setCameraT
 
 /**
  * Pick a position on the globe at the given position in lat,lon. See {@linkcode Coordinates} for conversion.
- * @param {number | MouseEvent} x|event - The x-position inside the Globe element or a mouse event.
- * @param {number | undefined} y - The y-position inside the Globe element.
- * @return {Position} position
+ * @param {number | MouseEvent} mouse - The x-position inside the Globe element or a mouse event.
+ * @param {number=} y - The y-position inside the Globe element.
+ * @return {Coordinates} position
  */
 GlobeControls.prototype.pickGeoPosition = function pickGeoPosition(mouse, y) {
     var screenCoords = {


### PR DESCRIPTION
Don't require descriptions for parameter and return tags:
type matters most, and description can sometimes be redundant
and useless, making it annoying and noisy.

#314 