### PR TITLE
Miniglobe

### DIFF
--- a/examples/globe.html
+++ b/examples/globe.html
@@ -20,6 +20,18 @@
                 padding: 0;
             }
 
+            #miniDiv {
+                display: block;
+                margin-bottom: 20px;
+                margin-right: 20px;
+                position: absolute;
+                width:100px;
+                height:100px;
+                left: 20;
+                bottom: 0;
+                color: white;
+            }
+
             #menuDiv {
                 position: absolute;
                 top:0px;
@@ -59,6 +71,8 @@
     <body>
         <div id="viewerDiv">
             <span class="divScaleWidget"> Scale </span>
+        </div>
+        <div id="miniDiv">
         </div>
         <script src="GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>

--- a/examples/globe.html
+++ b/examples/globe.html
@@ -25,6 +25,25 @@
                 top:0px;
                 margin-left: 0px;
             }
+            .divScaleWidget {
+                border: 2px solid black;
+                border-top: none;
+                text-align: center;
+                display: block;
+                background-image: linear-gradient(rgba(200, 200, 200, 0.3), rgba(200, 200, 200, 0.3));
+                margin-bottom: 20px;
+                margin-right: 20px;
+                position: absolute;
+                width:200px;
+                height:18px;
+                color: black;
+                font-family: 'Open Sans',
+                sans-serif;
+                font-size: 16px;
+                right: 0;
+                bottom: 0;
+            }
+
 
             @media (max-width: 600px) {
                 #menuDiv {
@@ -38,7 +57,9 @@
         <script src="GUI/dat.gui/dat.gui.min.js"></script>
     </head>
     <body>
-        <div id="viewerDiv"></div>
+        <div id="viewerDiv">
+            <span class="divScaleWidget"> Scale </span>
+        </div>
         <script src="GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="../dist/debug.js"></script>
@@ -51,6 +72,23 @@
             /* global itowns, document, GuiTools, globeView, promises */
             var menuGlobe = new GuiTools('menuDiv');
             menuGlobe.view = globeView;
+            var divScaleWidget = document.querySelectorAll('.divScaleWidget')[0];
+
+            function updateScaleWidget() {
+                var value = globeView.controls.pixelsToMeters(200);
+                value = Math.floor(value);
+                var digit = Math.pow(10, value.toString().length - 1);
+                value = Math.round(value / digit) * digit;
+                var pix = globeView.controls.metersToPixels(value);
+                var unit = 'm';
+                if (value >= 1000) {
+                    value /= 1000;
+                    unit = 'km';
+                }
+                divScaleWidget.innerHTML = `${value} ${unit}`;
+                divScaleWidget.style.width = `${pix}px`;
+            }
+
             // Listen for globe full initialisation event
             globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
@@ -59,6 +97,10 @@
                     menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
                     menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
                 });
+                updateScaleWidget();
+            });
+            globeView.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
+                updateScaleWidget();
             });
         </script>
     </body>

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -3,18 +3,54 @@
 
 // Define initial camera position
 var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+var promises = [];
+var miniView;
+var minDistance = 10000000;
+var maxDistance = 30000000;
 
 // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
 var viewerDiv = document.getElementById('viewerDiv');
+var miniDiv = document.getElementById('miniDiv');
 
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
-
-var promises = [];
-
 function addLayerCb(layer) {
     return globeView.addLayer(layer);
 }
+
+// Dont' instance mini viewer if it's Test env
+if (!renderer) {
+    miniView = new itowns.GlobeView(miniDiv, positionOnGlobe, {
+        // `limit globe' subdivision level:
+        // we're don't need a precise globe model
+        // since the mini globe will always be seen from a far point of view (see minDistance above)
+        maxSubdivisionLevel: 2,
+        // Don't instance default controls since miniview's camera will be synced
+        // on the main view's one (see globeView.onAfterRender)
+        noControls: true,
+    });
+
+    // Set a 0 alpha clear value (instead of the default '1')
+    // because we want a transparent background for the miniglobe view to be able
+    // to see the main view "behind"
+    miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
+
+    // update miniview's camera with the globeView's camera position
+    globeView.onAfterRender = function onAfterRender() {
+        // clamp distance camera from globe
+        var distanceCamera = globeView.camera.camera3D.position.length();
+        var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);
+        var camera = miniView.camera.camera3D;
+        // Update target miniview's camera
+        camera.position.copy(globeView.controls.moveTarget()).setLength(distance);
+        camera.lookAt(globeView.controls.moveTarget());
+        miniView.notifyChange(true);
+    };
+
+    // Add one imagery layer to the miniview
+    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) { miniView.addLayer(layer); });
+}
+
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -239,7 +239,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     }
 
     this._renderState = RendererConstant.FINAL;
-
+    const renderer = this.mainLoop.gfxEngine.renderer;
     this.preRender = () => {
         const v = new THREE.Vector3();
         v.setFromMatrixPosition(wgs84TileLayer.object3d.matrixWorld);
@@ -250,9 +250,9 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         if (len < lim) {
             var t = Math.pow(Math.cos((lim - len) / (lim - v.x * size * 0.9981) * Math.PI * 0.5), 1.5);
             var color = new THREE.Color(0x93d5f8);
-            this.mainLoop.gfxEngine.renderer.setClearColor(color.multiplyScalar(1.0 - t));
+            renderer.setClearColor(color.multiplyScalar(1.0 - t), renderer.getClearAlpha());
         } else if (len >= lim) {
-            this.mainLoop.gfxEngine.renderer.setClearColor(0x030508);
+            renderer.setClearColor(0x030508, renderer.getClearAlpha());
         }
     };
 

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1651,6 +1651,30 @@ GlobeControls.prototype.getScale = function getScale(pitch) {
 };
 
 /**
+ * To convert the projection in meters on the globe of a number of pixels of screen
+ * @param      {number} pixels count pixels to project
+ * @param      {number} pixelPitch Screen pixel pitch, in millimeters (default = 0.28 mm / standard pixel size of 0.28 millimeters as defined by the OGC)
+ * @return     {number} projection in meters on globe
+ */
+GlobeControls.prototype.pixelsToMeters = function pixelsToMeters(pixels, pixelPitch = 0.28) {
+    const scaled = this.getScale(pixelPitch);
+    const size = pixels * pixelPitch;
+    return size / scaled / 1000;
+};
+
+/**
+ * Projection on screen in pixels of length in meter on globe
+ * @param      {number}  value Length in meter on globe
+ * @param      {number}  pixelPitch Screen pixel pitch, in millimeters (default = 0.28 mm / standard pixel size of 0.28 millimeters as defined by the OGC)
+ * @return     {number}  projection in pixels on screen
+ */
+GlobeControls.prototype.metersToPixels = function metersToPixels(value, pixelPitch = 0.28) {
+    const scaled = this.getScale(pixelPitch);
+    pixelPitch /= 1000;
+    return value * scaled / pixelPitch;
+};
+
+/**
  * Changes the zoom of the central point of screen so that screen acts as a map with a specified scale.
  *  The view flies to the desired zoom scale;
  * <iframe width="100%" height="400" src="http://jsfiddle.net/iTownsIGN/0w4mfdb6/embedded/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>

--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -123,6 +123,7 @@ global.renderer = {
         logarithmicDepthBuffer: true,
     },
     setClearColor: () => {},
+    getClearAlpha: () => {},
     setViewport: () => {},
     clear: () => {},
     clearTarget: () => {},


### PR DESCRIPTION
**Add feature to render : add alphaClearValue in viewer option**
alphaClearValue : set alpha value in renderer.setClearColor(color, alpha)

**example : add a mini globe prefab**
The mini-globe allows to have a farther away from the globe to quickly find position.

The mini-globe is handle of geometry Layer Globe, it displays only the level 2 tiles.
![capture du 2017-06-07 17-57-59](https://user-images.githubusercontent.com/11291849/26888398-33b8a7d2-4bab-11e7-9e67-1acf650d384a.png)


**Add example scale widget in index.html**
This example shows how to display and refresh a widget scale on the screen