### PR TITLE
fix: Check elevation values before replacing parent : LayeredMaterialNodeProcessing

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -43,7 +43,7 @@ and open the template in the editor.
             menuGlobe.view = globeView;
 
             itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
-            itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
+            itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(result => globeView.addLayer(result));
             itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result));
 
             menuGlobe.addGUI('RealisticLighting', false,

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -7,7 +7,7 @@
 	"updateStrategy": {
 		"type": 1,
 		"options": {
-			"groups": [3, 7, 11, 14]
+			"groups": [11, 14]
 		}
 	},
 	"options": {
@@ -19,36 +19,6 @@
 		"mimetype": "image/x-bil;bits=32",
 		"tileMatrixSet": "WGS84G",
 		"tileMatrixSetLimits": {
-			"6": {
-				"minTileRow": 13,
-				"maxTileRow": 36,
-				"minTileCol": 62,
-				"maxTileCol": 80
-			},
-			"7": {
-				"minTileRow": 27,
-				"maxTileRow": 79,
-				"minTileCol": 84,
-				"maxTileCol": 167
-			},
-			"8": {
-				"minTileRow": 55,
-				"maxTileRow": 146,
-				"minTileCol": 248,
-				"maxTileCol": 320
-			},
-			"9": {
-				"minTileRow": 110,
-				"maxTileRow": 292,
-				"minTileCol": 497,
-				"maxTileCol": 640
-			},
-			"10": {
-				"minTileRow": 221,
-				"maxTileRow": 585,
-				"minTileCol": 994,
-				"maxTileCol": 1281
-			},
 			"11": {
 				"minTileRow": 442,
 				"maxTileRow": 1267,

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -1,0 +1,69 @@
+
+{
+    "type":       "elevation",
+    "protocol":   "wmts",
+    "id":         "MNT_WORLD_SRTM3",
+    "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
+    "noDataValue": -99999,
+    "updateStrategy": {
+        "type": 1,
+        "options": {
+            "groups": [3, 7, 9]
+        }
+    },
+    "options": {
+        "name": "ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3",
+        "mimetype": "image/x-bil;bits=32",
+        "tileMatrixSet": "WGS84G",
+        "tileMatrixSetLimits": {
+            "3": {
+                "minTileRow": 1,
+                "maxTileRow": 6,
+                "minTileCol": 0,
+                "maxTileCol": 16
+            },
+            "4": {
+                "minTileRow": 2,
+                "maxTileRow": 12,
+                "minTileCol": 0,
+                "maxTileCol": 32
+            },
+            "5": {
+                "minTileRow": 5,
+                "maxTileRow": 25,
+                "minTileCol": 0,
+                "maxTileCol": 64
+            },
+            "6": {
+                "minTileRow": 10,
+                "maxTileRow": 51,
+                "minTileCol": 0,
+                "maxTileCol": 128
+            },
+            "7": {
+                "minTileRow": 20,
+                "maxTileRow": 103,
+                "minTileCol": 0,
+                "maxTileCol": 256
+            },
+            "8": {
+                "minTileRow": 41,
+                "maxTileRow": 207,
+                "minTileCol": 0,
+                "maxTileCol": 512
+            },
+            "9": {
+                "minTileRow": 82,
+                "maxTileRow": 415,
+                "minTileCol": 0,
+                "maxTileCol": 1024
+            },
+            "10": {
+                "minTileRow": 164,
+                "maxTileRow": 830,
+                "minTileCol": 0,
+                "maxTileCol": 2048
+            }
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ and open the template in the editor.
             itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(result => globeView.addLayer(result));
             itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(result => globeView.addLayer(result));
 
-            itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
+            itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(result => globeView.addLayer(result));
             itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result));
 
             menuGlobe.addGUI('RealisticLighting', false,


### PR DESCRIPTION
This small fix allows for better handling of multiple DTM, it answers #192.

- WMTS can send some tiles with no real value in it through a code like -99999. We check this before replacing the elevation parent tile so we don't create holes and can keep other less precise DTM tile, typically around their borders
- This PR also modifies the index to handle a world DTM and a more precise for France.

It is not elegant at all, it should be handled with LayerState for example with a state specifying when an elevation tile is its max level.

The same should be done for Imagery as sometimes WMTS send white images, not errors.


