### PR TITLE
Small fixes

### DIFF
--- a/src/Core/Layer/LayerUpdateStrategy.js
+++ b/src/Core/Layer/LayerUpdateStrategy.js
@@ -1,3 +1,4 @@
+import { EMPTY_TEXTURE_ZOOM } from '../../Renderer/LayeredMaterial';
 /**
  * This modules implements various layer update strategies.
  *
@@ -36,23 +37,26 @@ function _progressive(nodeLevel, currentLevel, options) {
 // Load textures at mid-point between current level and node's level.
 // This produces smoother transitions and a single fetch updates multiple
 // tiles thanks to caching.
-function _dichotomy(nodeLevel, currentLevel /* , options */) {
+function _dichotomy(nodeLevel, currentLevel, options) {
+    if (currentLevel == EMPTY_TEXTURE_ZOOM) {
+        return options.zoom.min;
+    }
     return Math.min(
         nodeLevel,
         Math.ceil((currentLevel + nodeLevel) / 2));
 }
 
-export function chooseNextLevelToFetch(strategy, node, nodeLevel, currentLevel, options) {
+export function chooseNextLevelToFetch(strategy, node, nodeLevel, currentLevel, layer) {
     switch (strategy) {
         case STRATEGY_GROUP:
-            return _group(nodeLevel, currentLevel, options);
+            return _group(nodeLevel, currentLevel, layer.updateStrategy.options);
         case STRATEGY_PROGRESSIVE:
-            return _progressive(nodeLevel, currentLevel, options);
+            return _progressive(nodeLevel, currentLevel, layer.updateStrategy.options);
         case STRATEGY_DICHOTOMY:
-            return _dichotomy(nodeLevel, currentLevel, options);
+            return _dichotomy(nodeLevel, currentLevel, layer.options);
         // default strategy
         case STRATEGY_MIN_NETWORK_TRAFFIC:
         default:
-            return _minimizeNetworkTraffic(node, nodeLevel, currentLevel, options);
+            return _minimizeNetworkTraffic(node, nodeLevel, currentLevel);
     }
 }

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -103,7 +103,6 @@ MainLoop.prototype._renderView = function _renderView(view) {
         // use default rendering method
         this.gfxEngine.renderView(view);
     }
-    this.needsRedraw = false;
 
     // Mimic three Object3D.onAfterRender (which sadly doesn't work on Scene)
     view.onAfterRender();

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -163,14 +163,11 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
 
     const currentLevel = node.materials[RendererConstant.FINAL].getColorLayerLevelById(layer.id);
 
-    if (currentLevel > EMPTY_TEXTURE_ZOOM) {
-        const zoom = node.getCoordsForLayer(layer)[0].zoom || node.level;
-        var targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, zoom, currentLevel, layer.updateStrategy.options);
-        if (targetLevel <= currentLevel) {
-            return Promise.resolve();
-        }
+    const zoom = node.getCoordsForLayer(layer)[0].zoom || node.level;
+    const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, zoom, currentLevel, layer);
+    if (targetLevel <= currentLevel) {
+        return Promise.resolve();
     }
-    // TODO: targetLevel shouldn't be ignored
 
     node.layerUpdateState[layer.id].newTry();
     const command = {
@@ -180,6 +177,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
         requester: node,
         priority: nodeCommandQueuePriorityFunction(node),
         earlyDropFunction: refinementCommandCancellationFn,
+        targetLevel,
     };
 
     return context.scheduler.execute(command).then(
@@ -251,7 +249,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, force) 
 
     const c = node.getCoordsForLayer(layer)[0];
     const zoom = c.zoom || node.level;
-    const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, zoom, currentElevation, layer.updateStrategy.options);
+    const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, zoom, currentElevation, layer);
 
     if (targetLevel <= currentElevation || !layer.tileInsideLimit(node, layer, targetLevel)) {
         return Promise.resolve();


### PR DESCRIPTION
2 small fixes:
- 1st commit ensure that mainLoop.needsRedraw is reset only once
- 2nd commit restore a feature lost in PR https://github.com/iTowns/itowns2/pull/244/ to allow downloading textures from a different level than the tile's level. Note that this need support in each provider to work properly.

r?