### PR TITLE
fix (geoportal key) : changed the geoportal key for Region.json (WMS)

### DIFF
--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -1,6 +1,6 @@
 {
     "type": "color",
-    "url"       : "https://wxs.ign.fr/gratuit/geoportail/v/wms",
+    "url"       : "https://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/v/wms",
     "protocol"  : "wms",
     "version"   : "1.3.0",
     "id"        : "Region",


### PR DESCRIPTION
changed the geoportal key in Region.js file. The old one (named 'gratuit') wasn't in conformity with their policy.