### PR TITLE
Fix: correct network options for all examples and for TMS_Provider

### DIFF
--- a/examples/layers/JSONLayers/IGN_MNT.json
+++ b/examples/layers/JSONLayers/IGN_MNT.json
@@ -3,9 +3,6 @@
     "protocol":   "wmts",
     "id":         "IGN_MNT",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
-    "networkOptions": {
-        "credentials": "omit"
-    },
     "noDataValue" : -99999,
     "updateStrategy": {
         "type": 1,

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -3,9 +3,6 @@
 	"protocol":   "wmts",
 	"id":         "IGN_MNT_HIGHRES",
 	"url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
-    "networkOptions": {
-        "crossOrigin": "omit"
-    },
 	"noDataValue" : -99999,
 	"updateStrategy": {
 		"type": 1,

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -4,7 +4,7 @@
     "id":         "Ortho",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
     "networkOptions": {
-        "crossOrigin": "omit"
+        "crossOrigin": "anonymous"
     },
     "updateStrategy": {
         "type": "0",

--- a/examples/layers/JSONLayers/OrthosCRS.json
+++ b/examples/layers/JSONLayers/OrthosCRS.json
@@ -4,7 +4,7 @@
     "id":         "OrthoCRS",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
     "networkOptions": {
-        "crossOrigin": "omit"
+        "crossOrigin": "anonymous"
     },
     "fx" :        1.0,
     "updateStrategy": {

--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -2,7 +2,7 @@
     "type": "color",
     "url"       : "https://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/v/wms",
     "networkOptions": {
-        "crossOrigin": "omit"
+        "crossOrigin": "anonymous"
     },
     "protocol"  : "wms",
     "version"   : "1.3.0",

--- a/examples/layers/JSONLayers/ScanEX.json
+++ b/examples/layers/JSONLayers/ScanEX.json
@@ -4,7 +4,7 @@
     "id":         "ScanEX",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
     "networkOptions": {
-        "crossOrigin": "omit"
+        "crossOrigin": "anonymous"
     },
     "fx" :        2.5,
     "updateStrategy": {

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -4,9 +4,6 @@
     "protocol":   "wmts",
     "id":         "MNT_WORLD_SRTM3",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
-    "networkOptions": {
-        "crossOrigin": "omit"
-    },
     "noDataValue": -99999,
     "updateStrategy": {
         "type": 1,

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -87,6 +87,7 @@ and open the template in the editor.
                     "id": "DARK",
                     "opacity": 0.5,
                     "customUrl": "http://a.basemaps.cartocdn.com/dark_all/%TILEMATRIX/%COL/%ROW.png",
+                    "networkOptions": { crossOrigin: 'anonymous' },
                     "options": {
                         "attribution": {
                             "name":"CARTO",

--- a/examples/orthographic.js
+++ b/examples/orthographic.js
@@ -31,6 +31,7 @@ view.addLayer({
     id: 'OPENSM',
     // eslint-disable-next-line no-template-curly-in-string
     url: 'http://c.tile.stamen.com/watercolor/${z}/${x}/${y}.jpg',
+    networkOptions: { crossOrigin: 'anonymous' },
     extent: [extent.west(), extent.east(), extent.south(), extent.north()],
     projection: 'EPSG:3857',
     options: {

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -21,6 +21,7 @@ view.tileLayer.disableSkirt = true;
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
 view.addLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
+    networkOptions: { crossOrigin: 'anonymous' },
     type: 'color',
     protocol: 'wms',
     version: '1.3.0',
@@ -44,6 +45,7 @@ view.addLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     type: 'elevation',
     protocol: 'wms',
+    networkOptions: { crossOrigin: 'anonymous' },
     version: '1.3.0',
     id: 'wms_elevation',
     name: 'MNT2012_Altitude_10m_CC46',

--- a/src/Core/Scheduler/Providers/Fetcher.js
+++ b/src/Core/Scheduler/Providers/Fetcher.js
@@ -3,7 +3,7 @@ import { TextureLoader } from 'three';
 const textureLoader = new TextureLoader();
 
 function checkResponse(response) {
-    if (response.status < 200 || response.status >= 300) {
+    if (!response.ok) {
         var error = new Error(`Error loading ${response.url}: status ${response.status}`);
         error.status = response.status;
         throw error;

--- a/src/Core/Scheduler/Providers/IoDriver_XBIL.js
+++ b/src/Core/Scheduler/Providers/IoDriver_XBIL.js
@@ -5,6 +5,7 @@
 /* global Float32Array*/
 
 import IoDriver from './IoDriver';
+import Fetcher from './Fetcher';
 
 
 var portableXBIL = function portableXBIL(buffer) {
@@ -74,13 +75,8 @@ IoDriver_XBIL.prototype.parseXBil = function parseXBil(buffer, url) {
 };
 
 
-IoDriver_XBIL.prototype.read = function read(url) {
-    return fetch(url).then((response) => {
-        if (response.status < 200 || response.status >= 300) {
-            throw new Error(`Error loading ${url}: status ${response.status}`);
-        }
-        return response.arrayBuffer();
-    }).then(buffer => this.parseXBil(buffer, url));
+IoDriver_XBIL.prototype.read = function read(url, networkOptions) {
+    return Fetcher.arrayBuffer(url, networkOptions).then(buffer => this.parseXBil(buffer, url));
 };
 
 

--- a/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
+++ b/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
@@ -51,14 +51,14 @@ export default {
             return texture;
         });
     },
-    getXBilTextureByUrl(url) {
+    getXBilTextureByUrl(url, networkOptions) {
         const textureCache = cache.getRessource(url);
 
         if (textureCache !== undefined) {
             return Promise.resolve({ texture: textureCache });
         }
 
-        const promiseXBil = (cachePending.get(url) || ioDXBIL.read(url)).then((result) => {
+        const promiseXBil = (cachePending.get(url) || ioDXBIL.read(url, networkOptions)).then((result) => {
             // TODO  RGBA is needed for navigator with no support in texture float
             // In RGBA elevation texture LinearFilter give some errors with nodata value.
             // need to rewrite sample function in shader

--- a/src/Core/Scheduler/Providers/TMS_Provider.js
+++ b/src/Core/Scheduler/Providers/TMS_Provider.js
@@ -39,7 +39,7 @@ TMS_Provider.prototype.executeCommand = function executeCommand(command) {
 
     const url = this.url(coordTMSParent || coordTMS, layer);
 
-    return OGCWebServiceHelper.getColorTextureByUrl(url).then((texture) => {
+    return OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions).then((texture) => {
         const result = {};
         result.texture = texture;
         result.texture.coords = coordTMSParent || coordTMS;

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -21,7 +21,7 @@ import CacheRessource from './CacheRessource';
 function WFS_Provider(options) {
     this.cache = CacheRessource();
     this.baseUrl = options.url || '';
-    this.networkOptions = options.fetchOptions;
+    this.networkOptions = options.networkOptions;
     this.layer = options.layer || '';
     this.typename = options.typename || '';
     this.format = options.format === undefined ? 'json' : options.format;

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -101,7 +101,7 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer) {
 
 WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
     const url = this.url(tile.extent.as(layer.projection), layer);
-    return this.getXBilTextureByUrl(url, new THREE.Vector3(0, 0, 1));
+    return OGCWebServiceHelper.getXBilTextureByUrl(url, layer.networkOptions);
 };
 
 WMS_Provider.prototype.executeCommand = function executeCommand(command) {

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -83,7 +83,7 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, ta
 
     const url = this.url(coordWMTS, layer);
 
-    return OGCWebServiceHelper.getXBilTextureByUrl(url).then((result) => {
+    return OGCWebServiceHelper.getXBilTextureByUrl(url, layer.networkOptions).then((result) => {
         const { min, max } = OGCWebServiceHelper.ioDXBIL.computeMinMaxElevation(
         result.texture.image.data,
         SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,

--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -28,9 +28,10 @@ global.fetch = function _fetch(url) {
             counters.fetch.push(url);
         }
         res({
-            buffer: () => content || {},
-            json: () => JSON.parse(content),
-            arrayBuffer: () => content || {},
+            buffer: () => Promise.resolve(content || {}),
+            json: () => Promise.resolve(JSON.parse(content)),
+            arrayBuffer: () => Promise.resolve(content || {}),
+            ok: true,
         });
     });
     return pr;


### PR DESCRIPTION
This is a followup from #348 where I forgot a lot of things... Sorry for that!

Apparently, we don't need any cors options for ArrayBuffer fetching.

I didn't change the default of the web (so by default, fetches have mode and credentials not set, and img have crossOrigin not set), because apparently it helps to prevent CRSF attacks. 