### PR TITLE
fix: correct network options for OSM examples

### DIFF
--- a/examples/layers/JSONLayers/DARK.json
+++ b/examples/layers/JSONLayers/DARK.json
@@ -1,6 +1,7 @@
 {
     "type": "color",
     "protocol": "wmtsc",
+	"networkOptions": { "crossOrigin" : "anonymous" },
     "id": "DARK",
     "customUrl": "http://a.basemaps.cartocdn.com/dark_all/%TILEMATRIX/%COL/%ROW.png",
     "options": {

--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -1,6 +1,7 @@
 {
     "type": "color",
     "protocol":   "wmtsc",
+    "networkOptions": { "crossOrigin" : "anonymous" },
     "id":         "OPENSM",
     "fx" :2.5,
     "customUrl":  "http://b.tile.openstreetmap.fr/osmfr/%TILEMATRIX/%COL/%ROW.png",


### PR DESCRIPTION
added crossOrigin network options for osm services: OPENSM.json and DARK.json