### PR TITLE
Remove useless events and add a preprocessed promise

### DIFF
--- a/examples/GUI/GuiTools.js
+++ b/examples/GUI/GuiTools.js
@@ -31,17 +31,6 @@ function GuiTools(domId, view, width = 245) {
     viewerDiv.appendChild(this.gui.domElement);
     this.colorGui = this.gui.addFolder('Color Layers');
     this.elevationGui = this.gui.addFolder('Elevation Layers');
-
-    if (view) {
-        view.addEventListener('layers-order-changed', () => {
-            for (const layer of view.getLayers(l => l.type === 'color')) {
-                this.removeLayersGUI(layer.id);
-            }
-
-            const colorLayers = view.getLayers(l => l.type === 'color');
-            this.addImageryLayersGUI(colorLayers);
-        });
-    }
 }
 
 GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 
 import View from '../View';
-import { COLOR_LAYERS_ORDER_CHANGED } from '../../Renderer/ColorLayersOrdering';
 import RendererConstant from '../../Renderer/RendererConstant';
 import GlobeControls from '../../Renderer/ThreeExtended/GlobeControls';
 import { unpack1K } from '../../Renderer/LayeredMaterial';
@@ -24,51 +23,14 @@ import BuilderEllipsoidTile from './Globe/BuilderEllipsoidTile';
  * @property target {view} dispatched on view
  * @property type {string} initialized
  */
-/**
- * Fires when a layer is added
- * @event GlobeView#layer-added
- * @property layerId {string} the id of the layer
- * @property target {view} dispatched on view
- * @property type {string} layers-added
- */
-/**
- * Fires when a layer is removed
- * @event GlobeView#layer-removed
- * @property layerId {string} the id of the layer
- * @property target {view} dispatched on view
- * @property type {string} layers-added
- */
-/**
- * Fires when the layers oder has changed
- * @event GlobeView#layers-order-changed
- * @property new {object}
- * @property new.sequence {array}
- * @property new.sequence.0 {number} the new layer at position 0
- * @property new.sequence.1 {number} the new layer at position 1
- * @property new.sequence.2 {number} the new layer at position 2
- * @property previous {object}
- * @property previous.sequence {array}
- * @property previous.sequence.0 {number} the previous layer at position 0
- * @property previous.sequence.1 {number} the previous layer at position 1
- * @property previous.sequence.2 {number} the previous layer at position 2
- * @property target {view} dispatched on view
- * @property type {string} layers-order-changed
- */
-
 
 /**
  * Globe's EVENT
  * @property GLOBE_INITIALIZED {string} emit one time when globe is initialized
- * @property LAYER_ADDED {string} emit when layer id added in viewer
- * @property LAYER_REMOVED {string} emit when layer id removed in viewer
- * @property COLOR_LAYERS_ORDER_CHANGED {string} emit when  color layers order change
  */
 
 export const GLOBE_VIEW_EVENTS = {
     GLOBE_INITIALIZED: 'initialized',
-    LAYER_ADDED: 'layer-added',
-    LAYER_REMOVED: 'layer-removed',
-    COLOR_LAYERS_ORDER_CHANGED,
 };
 
 /**
@@ -271,15 +233,7 @@ GlobeView.prototype.addLayer = function addLayer(layer) {
         }
         layer.update = updateLayeredMaterialNodeElevation;
     }
-    const layerId = layer.id;
-    View.prototype.addLayer.call(this, layer, this.wgs84TileLayer);
-
-    this.dispatchEvent({
-        type: GLOBE_VIEW_EVENTS.LAYER_ADDED,
-        layerId,
-    });
-
-    return layer;
+    return View.prototype.addLayer.call(this, layer, this.wgs84TileLayer);
 };
 
 /**

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -102,7 +102,12 @@ function _preprocessLayer(view, layer, provider) {
         }
 
         if (provider.preprocessDataLayer) {
-            provider.preprocessDataLayer(layer);
+            const preprocessingResult = provider.preprocessDataLayer(layer);
+            if (preprocessingResult && preprocessingResult.then) {
+                layer.preprocessedPromise = preprocessingResult;
+            } else {
+                layer.preprocessedPromise = Promise.resolve();
+            }
         }
     }
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -17,6 +17,6 @@ export { default as View } from './Core/View';
 export { process3dTilesNode, init3dTilesLayer, $3dTilesCulling, $3dTilesSubdivisionControl, pre3dTilesUpdate } from './Process/3dTilesProcessing';
 export { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } from './Process/LayeredMaterialNodeProcessing';
 export { processTiledGeometryNode, initTiledGeometryLayer } from './Process/TiledNodeProcessing';
-export { ColorLayersOrdering } from './Renderer/ColorLayersOrdering';
+export { default as ColorLayersOrdering } from './Renderer/ColorLayersOrdering';
 export { CONTROL_EVENTS } from './Renderer/ThreeExtended/GlobeControls';
 

--- a/src/Renderer/ColorLayersOrdering.js
+++ b/src/Renderer/ColorLayersOrdering.js
@@ -13,9 +13,7 @@ function updateLayersOrdering(geometryLayer, imageryLayers) {
     }
 }
 
-export const COLOR_LAYERS_ORDER_CHANGED = 'layers-order-changed';
-
-export const ColorLayersOrdering = {
+const ColorLayersOrdering = {
     /**
      * Moves up in the layer list. This function has no effect if the layer is moved to its current index.
      * @function moveLayerUp
@@ -28,13 +26,8 @@ export const ColorLayersOrdering = {
         const imageryLayers = view.getLayers(l => l.type === 'color');
         const layer = view.getLayers(l => l.id === layerId)[0];
         if (layer) {
-            const previousSequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             ImageryLayers.moveLayerUp(layer, imageryLayers);
             updateLayersOrdering(view.wgs84TileLayer, imageryLayers);
-            view.dispatchEvent({ type: COLOR_LAYERS_ORDER_CHANGED,
-                previous: { sequence: previousSequence },
-                new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
-            });
             view.notifyChange(true);
         } else {
             throw new Error(`${layerId} isn't color layer`);
@@ -52,20 +45,17 @@ export const ColorLayersOrdering = {
         const imageryLayers = view.getLayers(l => l.type === 'color');
         const layer = view.getLayers(l => l.id === layerId)[0];
         if (layer) {
-            const previousSequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             ImageryLayers.moveLayerDown(layer, imageryLayers);
             updateLayersOrdering(view.wgs84TileLayer, imageryLayers);
-            view.dispatchEvent({ type: COLOR_LAYERS_ORDER_CHANGED,
-                previous: { sequence: previousSequence },
-                new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
-            });
             view.notifyChange(true);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }
     },
     /**
-     * Moves a specific layer to a specific index in the layer list. This function has no effect if the layer is moved to its current index.
+     * Moves a specific layer to a specific index in the layer list. This
+     * function has no effect if the layer is moved to its current index.
+     *
      * @function moveLayerToIndex
      * @param      {View}  view the viewer
      * @param      {string}  layerId   The layer's idendifiant
@@ -77,16 +67,12 @@ export const ColorLayersOrdering = {
         const imageryLayers = view.getLayers(l => l.type === 'color');
         const layer = view.getLayers(l => l.id === layerId)[0];
         if (layer) {
-            const previousSequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             ImageryLayers.moveLayerToIndex(layer, newIndex, imageryLayers);
             updateLayersOrdering(view.wgs84TileLayer, imageryLayers);
-            view.dispatchEvent({ type: COLOR_LAYERS_ORDER_CHANGED,
-                previous: { sequence: previousSequence },
-                new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
-            });
             view.notifyChange(true);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }
     },
 };
+export default ColorLayersOrdering;


### PR DESCRIPTION
We dont need to fire events for synchronous methods. It's useless, but
even more, it's confusing for users.

This commit adds a promise to deal with the only asynchronous case:
preprocessLayer. This *will* get asynchronous in the future when we'll
support GetCapabilities call and other metadata fetching methods.