### PR TITLE
chore: rework examples and stop commit builds/example to this repo

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -39,13 +39,13 @@
         </style>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="/node_modules/dat.gui/build/dat.gui.min.js"></script>
+        <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <script src="/examples/GUI/GuiTools.js"></script>
-        <script src="/dist/itowns.js"></script>
-        <script src="/dist/debug.js"></script>
+        <script src="GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
             const positionOnGlobe = { longitude: -75.61, latitude: 40.04, altitude: 50000 }

--- a/examples/externalscene.html
+++ b/examples/externalscene.html
@@ -30,11 +30,11 @@
     <body>
         <div id="viewerDiv">
         </div>
-        <script src="/dist/itowns.js"></script>
+        <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
             let renderer;
             let exports = {};
         </script>
-        <script src="/examples/externalscene.js"></script>
+        <script src="externalscene.js"></script>
     </body>
 </html>

--- a/examples/externalscene.js
+++ b/examples/externalscene.js
@@ -9,8 +9,8 @@ const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { scene3D: sc
 
 globeView.mainLoop.name = 'external-ML';
 
-itowns.Fetcher.json('/examples/layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
-itowns.Fetcher.json('/examples/layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
 
 exports.globeView = globeView;
 exports.scene = scene;

--- a/examples/globe.html
+++ b/examples/globe.html
@@ -30,14 +30,14 @@
         <meta charset="UTF-8">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="/node_modules/dat.gui/build/dat.gui.min.js"></script>
+        <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>
 
-        <script src="/examples/GUI/GuiTools.js"></script>
-        <script src="/dist/itowns.js"></script>
-        <script src="/dist/debug.js"></script>
+        <script src="GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
         <script type="text/javascript">
             let exports = {};
         </script>

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -12,7 +12,7 @@ const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer })
 
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js object. See Layer* for more info.
-itowns.Fetcher.json('/examples/layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
 // itowns.Fetcher.json('/examples/layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));

--- a/examples/index.html
+++ b/examples/index.html
@@ -27,12 +27,12 @@ and open the template in the editor.
         <meta charset="UTF-8">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="dat.gui.min.js"></script>
+        <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <script src="examples/GUI/GuiTools.js"></script>
-        <script src="dist/itowns.js"></script>
+        <script src="./GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
 
             /* global itowns,document,GuiTools*/
@@ -43,9 +43,9 @@ and open the template in the editor.
             menuGlobe.view = globeView;
 
             let promises = [];
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result)));
 
             menuGlobe.addGUI('RealisticLighting', false,
                 (newValue) => { globeView.setRealisticLightingOn(newValue); });

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -21,7 +21,7 @@
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <script src="GUI/GuiTools.js"></script>
+        <script src="./GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
@@ -35,9 +35,9 @@
             menuGlobe.view = globeView;
 
             const promises = [];
-            promises.push(itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('layers/JSONLayers/Region.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result)));
 
             function getLayersColorVisible(node, layers) {
                 if (!node || !node.visible) {

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -35,14 +35,14 @@ and open the template in the editor.
         <meta charset="UTF-8">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="/node_modules/dat.gui/build/dat.gui.min.js"></script>
+        <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>
         <div id="viewerDiv2"></div>
-        <script src="/examples/GUI/GuiTools.js"></script>
-        <script src="/dist/itowns.js"></script>
-        <script src="/dist/debug.js"></script>
+        <script src="GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
 

--- a/examples/orthographic.html
+++ b/examples/orthographic.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <script src="/dist/itowns.js"></script>
+        <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
             let renderer;
         </script>

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <script src="/dist/itowns.js"></script>
+        <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
             let renderer; let exports = {};
         </script>

--- a/examples/postprocessing.html
+++ b/examples/postprocessing.html
@@ -27,7 +27,7 @@
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <script src="/dist/itowns.js"></script>
+        <script src="../dist/itowns.js"></script>
         <!-- from https://github.com/mrdoob/three.js/blob/master/examples/js/shaders/DotScreenShader.js -->
         <script type="x-shader/x-vertex" id="vertexshader">
             varying vec2 vUv;

--- a/examples/postprocessing.js
+++ b/examples/postprocessing.js
@@ -46,8 +46,8 @@ globeView.render = () => {
         cam);
 };
 
-itowns.Fetcher.json('/examples/layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
-itowns.Fetcher.json('/examples/layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
 
 exports.globeView = globeView;
 exports.postprocessScene = postprocessScene;

--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -23,7 +23,7 @@ global.fetch = function _fetch(url) {
     });
 
     // try reading as a file
-    fs.readFile(process.env.PWD + url, 'utf-8', (err, content) => {
+    fs.readFile(`${process.env.PWD}/examples/${url}`, 'utf-8', (err, content) => {
         if (!content || err) {
             counters.fetch.push(url);
         }


### PR DESCRIPTION
gh-pages branch uses a lot of space, so moving this out to the organization
repository will help reduce the git repository size.

Use this PR to fix all examples path as well, so they work both after a git clone
and when used for the website.

@iTowns/reviewers r?

I'm not sure if the `deploy_key` can push to other repo in the `iTowns` org.
Maybe @tbroyer knows?