### PR TITLE
fix (camera): use scale component when using matrixWorld

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -70,10 +70,10 @@ export function $3dTilesCulling(node, camera) {
     if (node.boundingVolume) {
         const boundingVolume = node.boundingVolume;
         if (boundingVolume.region) {
-            return !camera.isBox3DVisible(boundingVolume.region.box3D, boundingVolume.region.matrixWorld);
+            return !camera.isBox3Visible(boundingVolume.region.box3D, boundingVolume.region.matrixWorld);
         }
         if (boundingVolume.box) {
-            return !camera.isBox3DVisible(boundingVolume.box, node.matrixWorld);
+            return !camera.isBox3Visible(boundingVolume.box, node.matrixWorld);
         }
         if (boundingVolume.sphere) {
             return !camera.isSphereVisible(boundingVolume.sphere, node.matrixWorld);

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -60,7 +60,7 @@ function horizonCulling(node) {
 }
 
 function frustumCullingOBB(node, camera) {
-    return camera.isBox3DVisible(node.OBB().box3D, node.OBB().matrixWorld);
+    return camera.isBox3Visible(node.OBB().box3D, node.OBB().matrixWorld);
 }
 
 export function globeCulling(minLevelForHorizonCulling) {

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -1,7 +1,7 @@
 import SchemeTile from '../Core/Geographic/SchemeTile';
 
 function frustumCullingOBB(node, camera) {
-    return camera.isBox3DVisible(node.OBB().box3D, node.OBB().matrixWorld);
+    return camera.isBox3Visible(node.OBB().box3D, node.OBB().matrixWorld);
 }
 
 export function planarCulling(node, camera) {
@@ -9,7 +9,7 @@ export function planarCulling(node, camera) {
 }
 
 function _isTileBigOnScreen(camera, node) {
-    const onScreen = camera.box3DSizeOnScreen(node.geometry.OBB.box3D, node.matrixWorld);
+    const onScreen = camera.box3SizeOnScreen(node.geometry.OBB.box3D, node.matrixWorld);
 
     // onScreen.x/y/z are [-1, 1] so divide by 2
     // (so x = 0.4 means the object width on screen is 40% of the total screen width)


### PR DESCRIPTION
- 1st commit fixes Camera's method that were incorrectly ignoring scale
- ~2nd commit : add a 2d camera to allow the user to draw in pixel coords. This is something that could easily be done by a user, but we can save them the boilerplate code to do this so I think it belongs to itowns.~
- ~3rd commit : add new methods to camera, to compute contour and area of a Box3. As stated in the commit message we ideally would like to support any kind of geometry so this is only the first step.~

~As a quick demo of commits 2 and 3, here's a quick screenshot showing the contour (red) of OBB on top of its OBBHelper (green):~

![export](https://user-images.githubusercontent.com/2198295/28019539-97f75b9a-6581-11e7-9cfe-54f0b29efdd3.jpg)

~(I have other unmerged branches that really using these features)~

Edit: went back to my first PR that simply fix the scale issue.

@iTowns/reviewers r?