### PR TITLE
fix (test) : process.env.PWD is undefined in Windows

### DIFF
--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -102,6 +102,10 @@ global.requestAnimationFrame = (cb) => {
     }
 };
 
+// Fix: process.env.PWD is undefined for Windows
+if (!process.env.PWD) {
+    process.env.PWD = process.cwd();
+}
 // eslint-disable-next-line import/no-dynamic-require
 const itowns = require(`${process.env.PWD}/lib/Main.js`);
 


### PR DESCRIPTION
`npm run test` fails on Windows because` process.env.PWD` is undefined