### PR TITLE
Support parent object that isn't a THREE.Scene

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -69,7 +69,7 @@
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
-            var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod');
+            var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod', globe.scene);
 
             $3dTilesLayerDiscreteLOD.preUpdate = preUpdateGeo;
             $3dTilesLayerDiscreteLOD.update = itowns.process3dTilesNode(
@@ -87,7 +87,7 @@
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
-            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume');
+            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', globe.scene););
 
             $3dTilesLayerRequestVolume.preUpdate = preUpdateGeo;
             $3dTilesLayerRequestVolume.update = itowns.process3dTilesNode(

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -53,11 +53,22 @@ export const defineLayerProperty = function defineLayerProperty(layer, propertyN
     }
 };
 
-function GeometryLayer(i) {
+function GeometryLayer(id, object3d) {
+    if (!id) {
+        throw new Error('Missing id parameter (GeometryLayer must have a unique id defined)');
+    }
+    if (!object3d || !object3d.isObject3D) {
+        throw new Error('Missing/Invalid object3d parameter (must be a three.js Object3D instance)');
+    }
     this._attachedLayers = [];
 
+    Object.defineProperty(this, 'object3d', {
+        value: object3d,
+        writable: false,
+    });
+
     Object.defineProperty(this, 'id', {
-        value: i,
+        value: id,
         writable: false,
     });
 }

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -12,7 +12,7 @@ import { planarCulling, planarSubdivisionControl, planarSchemeTile } from '../..
 import PlanarTileBuilder from './Planar/PlanarTileBuilder';
 import SubdivisionControl from '../../Process/SubdivisionControl';
 
-function PlanarView(viewerDiv, boundingbox, options) {
+function PlanarView(viewerDiv, boundingbox, options = {}) {
     THREE.Object3D.DefaultUp.set(0, 0, 1);
 
     // Setup View
@@ -44,7 +44,7 @@ function PlanarView(viewerDiv, boundingbox, options) {
         }
     };
 
-    const tileLayer = new GeometryLayer('planar');
+    const tileLayer = new GeometryLayer('planar', options.object3d || this.scene);
     const initLayer = initTiledGeometryLayer(planarSchemeTile(boundingbox));
 
     function _commonAncestorLookup(a, b) {

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -54,7 +54,7 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
     tile.layers.set(command.threejsLayer);
 
     if (parent) {
-        parent.worldToLocal(params.center);
+        params.center.sub(parent.geometry.center);
     }
 
     tile.position.copy(params.center);

--- a/src/Core/TileGeometry.js
+++ b/src/Core/TileGeometry.js
@@ -43,7 +43,7 @@ function TileGeometry(params, builder) {
     // Constructor
     THREE.BufferGeometry.call(this);
 
-    this.center = builder.Center(params);
+    this.center = builder.Center(params).clone();
     this.OBB = builder.OBB(params);
 
     // TODO : free array

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -26,10 +26,9 @@ function TileMesh(geometry, params) {
     this.geometry = geometry;
     this.normal = params.center.clone().normalize();
 
-    // TODO Why move sphere center
-    this.centerSphere = new THREE.Vector3().addVectors(this.geometry.boundingSphere.center, params.center);
+    this.boundingSphereOffset = new THREE.Vector3();
 
-    this.oSphere = new THREE.Sphere(this.centerSphere.clone(), this.geometry.boundingSphere.radius);
+    this.oSphere = new THREE.Sphere(this.geometry.boundingSphere.center.clone(), this.geometry.boundingSphere.radius);
 
     this.material = new LayeredMaterial(params.materialOptions);
 
@@ -79,6 +78,11 @@ TileMesh.prototype.dispose = function dispose() {
     this.geometry.dispose();
     this.geometry = null;
     this.material = null;
+};
+
+TileMesh.prototype.updateMatrixWorld = function updateMatrixWorld(force) {
+    THREE.Mesh.prototype.updateMatrixWorld.call(this, force);
+    this.geometry.OBB.update();
 };
 
 TileMesh.prototype.isVisible = function isVisible() {
@@ -143,7 +147,7 @@ TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
 
         this.geometry.boundingSphere.radius = Math.sqrt(delta.x * delta.x + this.oSphere.radius * this.oSphere.radius);
         this.updateGeometricError();
-        this.centerSphere = new THREE.Vector3().addVectors(this.oSphere.center, trans);
+        this.boundingSphereOffset = trans;
     }
 };
 

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -131,7 +131,7 @@ export function init3dTilesLayer(context, layer) {
         layer.asset = tileset.asset;
         requestNewTile(context.view, context.scheduler, layer, tileset.root, undefined).then(
             (tile) => {
-                context.view.scene.add(tile);
+                layer.object3d.add(tile);
                 tile.updateMatrixWorld();
                 layer.root = tile;
             });

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -111,10 +111,7 @@ export function initTiledGeometryLayer(schemeTile) {
         Promise.all(_promises).then((level0s) => {
             layer.level0Nodes = level0s;
             for (const level0 of level0s) {
-                // TODO: support a layer.root attribute, to be able
-                // to add a layer to a three.js node, e.g:
-                // layer.root.add(level0);
-                context.view.scene.add(level0);
+                layer.object3d.add(level0);
                 level0.updateMatrixWorld();
             }
         });

--- a/test/globe_test.js
+++ b/test/globe_test.js
@@ -38,6 +38,7 @@ describe('Globe example', function () {
                         example.initialPosition.longitude,
                         example.initialPosition.latitude,
                         10000).as('EPSG:4978').xyz());
+                example.view.camera.update();
                 example.view.notifyChange(true);
             } else {
                 afterSetRange();


### PR DESCRIPTION
Allows the user to specify an object onto which the created Object3D from a Layer will be added (instead of being added to the root of the scene).

I started fixing all the places that assumed that the matrixWorld of their top most parent is an identity matrix.
There's still work to be done in Atmosphere shaders (it's using `cameraPosition`), GlobeControls (because it's moving the camera as if the globe is centered in (0, 0, 0) and if the globe size is constant) and probably many others.

@iTowns/reviewers r?
