### PR TITLE
Remove ES6 syntax from examples

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,8 +57,11 @@ module.exports = {
 
     // TODO reactivate all the following rules
 
+    // maybe 'no-mixed-operators': ['error', { allowSamePrecedence: true }],
     'no-mixed-operators': 'off',
     'no-use-before-define': 'off',
+    // should probably be
+    // 'no-underscore-dangle': ['error', { allowAfterThis: true, allowAfterSuper: true }],
     'no-underscore-dangle': 'off',
     'eqeqeq': 'off',
     // what len ? Airbnb does 100. github wraps line above 80

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -1,0 +1,61 @@
+module.exports = {
+    'extends': [
+        'eslint-config-airbnb-base',
+        'eslint-config-airbnb-base/rules/strict',
+    ],
+    parserOptions: {
+        ecmaVersion: 5,
+        sourceType: 'script',
+        ecmaFeatures: {
+            impliedStrict: true
+        }
+    },
+    env: {
+        browser: true,
+        es6: false,
+        amd: true,
+        commonjs: true
+    },
+    rules: {
+        'no-plusplus': 'off',
+        // this option sets a specific tab width for your code
+        // http://eslint.org/docs/rules/indent
+        indent: ['error', 4, {
+            SwitchCase: 1,
+            VariableDeclarator: 1,
+            outerIIFEBody: 1,
+            // MemberExpression: null,
+            // CallExpression: {
+            // parameters: null,
+            // },
+            FunctionDeclaration: {
+                parameters: 1,
+                body: 1
+            },
+            FunctionExpression: {
+                parameters: 1,
+                body: 1
+            }
+        }],
+        'one-var': ['error', 'never'],
+        'valid-jsdoc': ['error', {
+            requireReturn: false,
+            requireParamDescription: false,
+            requireReturnDescription: false,
+        }],
+
+        // deactivated rules for es5
+        'no-var': 'off',
+        'prefer-arrow-callback': 'off',
+        'object-shorthand': 'off',
+        'no-param-reassign': ['error', { 'props': false }],
+        'no-mixed-operators': ['error', { allowSamePrecedence: true }],
+
+        // deactivated rules for `examples/`
+        'no-console': 'off',
+
+        // TODO reactivate all the following rules
+        'no-underscore-dangle': 'off',
+
+    }
+}

--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -42,18 +42,18 @@
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
-            const positionOnGlobe = { longitude: -75.61, latitude: 40.04, altitude: 50000 }
+            var positionOnGlobe = { longitude: -75.61, latitude: 40.04, altitude: 50000 }
             // iTowns namespace defined here
-            const viewerDiv = document.getElementById('viewerDiv');
+            var viewerDiv = document.getElementById('viewerDiv');
 
-            const globe = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            const menuGlobe = new GuiTools('menuDiv', globe, 300);
+            var globe = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv', globe, 300);
 
-            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(result => globe.addLayer(result));
+            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return globe.addLayer(result) });
 
             // function use :
             // For preupdate Layer geomtry :
-            const preUpdateGeo = (context, layer) => {
+            var preUpdateGeo = function (context, layer) {
                 if(layer.root === undefined) {
                     itowns.init3dTilesLayer(context, layer);
                     return [];
@@ -64,7 +64,7 @@
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
-            const $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod');
+            var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod');
 
             $3dTilesLayerDiscreteLOD.preUpdate = preUpdateGeo;
             $3dTilesLayerDiscreteLOD.update = itowns.process3dTilesNode(
@@ -82,7 +82,7 @@
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
-            const $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume');
+            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume');
 
             $3dTilesLayerRequestVolume.preUpdate = preUpdateGeo;
             $3dTilesLayerRequestVolume.update = itowns.process3dTilesNode(

--- a/examples/GUI/GuiTools.js
+++ b/examples/GUI/GuiTools.js
@@ -25,58 +25,64 @@ dat.GUI.prototype.hideFolder = function hideFolder(name, value) {
     folder.__ul.hidden = value;
 };
 
-function GuiTools(domId, view, width = 245) {
-    this.gui = new dat.GUI({ autoPlace: false, width });
+function GuiTools(domId, view, w) {
+    var width = w || 245;
+    this.gui = new dat.GUI({ autoPlace: false, width: width });
     this.gui.domElement.id = domId;
     viewerDiv.appendChild(this.gui.domElement);
     this.colorGui = this.gui.addFolder('Color Layers');
     this.elevationGui = this.gui.addFolder('Elevation Layers');
 
     if (view) {
-        view.addEventListener('layers-order-changed', () => {
-            for (const layer of view.getLayers(l => l.type === 'color')) {
-                this.removeLayersGUI(layer.id);
+        view.addEventListener('layers-order-changed', (function refreshColorGui() {
+            var i;
+            var colorLayers = view.getLayers(function filter(l) { return l.type === 'color'; });
+            for (i = 0; i < colorLayers.length; i++) {
+                this.removeLayersGUI(colorLayers[i].id);
             }
 
-            const colorLayers = view.getLayers(l => l.type === 'color');
             this.addImageryLayersGUI(colorLayers);
-        });
+        }).bind(this));
     }
 }
 
 GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {
     var folder = this.colorGui.addFolder(layer.id);
-    folder.add({ visible: true }, 'visible').onChange((value) => {
+    folder.add({ visible: true }, 'visible').onChange((function updateVisibility(value) {
         layer.visible = value;
         this.view.notifyChange(true);
-    });
-    folder.add({ opacity: 1.0 }, 'opacity').min(0.0).max(1.0).onChange((value) => {
+    }).bind(this));
+    folder.add({ opacity: 1.0 }, 'opacity').min(0.0).max(1.0).onChange((function updateOpacity(value) {
         layer.opacity = value;
         this.view.notifyChange(true);
-    });
-    folder.add({ frozen: false }, 'frozen').onChange((value) => {
+    }).bind(this));
+    folder.add({ frozen: false }, 'frozen').onChange((function updateFrozen(value) {
         layer.frozen = value;
         this.view.notifyChange(true);
-    });
+    }).bind(this));
 };
 
 GuiTools.prototype.addElevationLayerGUI = function addElevationLayerGUI(layer) {
     var folder = this.elevationGui.addFolder(layer.id);
-    folder.add({ frozen: false }, 'frozen').onChange((value) => {
+    folder.add({ frozen: false }, 'frozen').onChange(function refreshFrozenGui(value) {
         layer.frozen = value;
     });
 };
 
 GuiTools.prototype.addImageryLayersGUI = function addImageryLayersGUI(layers) {
-    const seq = itowns.ImageryLayers.getColorLayersIdOrderedBySequence(layers);
-
-    for (const layer of layers.sort((a, b) => seq.indexOf(a.id) < seq.indexOf(b.id))) {
-        this.addImageryLayerGUI(layer);
+    var i;
+    var seq = itowns.ImageryLayers.getColorLayersIdOrderedBySequence(layers);
+    var sortedLayers = layers.sort(function comp(a, b) {
+        return seq.indexOf(a.id) < seq.indexOf(b.id);
+    });
+    for (i = 0; i < sortedLayers.length; i++) {
+        this.addImageryLayerGUI(sortedLayers[i]);
     }
 };
 
 GuiTools.prototype.addElevationLayersGUI = function addElevationLayersGUI(layers) {
-    for (var i = 0; i < layers.length; i++) {
+    var i;
+    for (i = 0; i < layers.length; i++) {
         this.addElevationLayerGUI(layers[i]);
     }
 };

--- a/examples/externalscene.html
+++ b/examples/externalscene.html
@@ -32,8 +32,8 @@
         </div>
         <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
-            let renderer;
-            let exports = {};
+            var renderer;
+            var exports = {};
         </script>
         <script src="externalscene.js"></script>
     </body>

--- a/examples/externalscene.js
+++ b/examples/externalscene.js
@@ -1,16 +1,21 @@
 /* global itowns, document, renderer */
-const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
-const scene = new itowns.THREE.Scene();
+var scene = new itowns.THREE.Scene();
 
 // iTowns namespace defined here
-const viewerDiv = document.getElementById('viewerDiv');
-const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { scene3D: scene, renderer });
+var viewerDiv = document.getElementById('viewerDiv');
+var globeView = new itowns.GlobeView(
+        viewerDiv, positionOnGlobe, { scene3D: scene, renderer: renderer });
 
 globeView.mainLoop.name = 'external-ML';
 
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
+function addLayerCb(layer) {
+    return globeView.addLayer(layer);
+}
+
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
 
 exports.globeView = globeView;
 exports.scene = scene;

--- a/examples/globe.html
+++ b/examples/globe.html
@@ -38,21 +38,21 @@
         <script src="../dist/itowns.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
-            let renderer;
-            let exports = {};
+            var renderer;
+            var exports = {};
         </script>
         <script src="globe.js"></script>
         <script type="text/javascript">
             /* global itowns, document, GuiTools, globeView, promises */
-            const menuGlobe = new GuiTools('menuDiv');
+            var menuGlobe = new GuiTools('menuDiv');
             menuGlobe.view = globeView;
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
+            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                Promise.all(promises).then(() => {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(l => l.type === 'color'));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(l => l.type === 'elevation'));
+                Promise.all(promises).then(function () {
+                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
                 });
             });
         </script>

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -2,23 +2,27 @@
 // # Simple Globe viewer
 
 // Define initial camera position
-const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
 // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
-const viewerDiv = document.getElementById('viewerDiv');
+var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
-const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer });
+var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
-const promises = [];
+var promises = [];
 
+function addLayerCb(layer) {
+    return globeView.addLayer(layer);
+}
 // Add one imagery layer to the scene
-// This layer is defined in a json file but it could be defined as a plain js object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
+// This layer is defined in a json file but it could be defined as a plain js
+// object. See Layer* for more info.
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(result => globeView.addLayer(result)));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result)));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -26,18 +26,34 @@
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
 
-            const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+            var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
             // iTowns namespace defined here
-            const viewerDiv = document.getElementById('viewerDiv');
-            const menuGlobe = new GuiTools('menuDiv');
-            const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var viewerDiv = document.getElementById('viewerDiv');
+            var menuGlobe = new GuiTools('menuDiv');
+            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             menuGlobe.view = globeView;
 
-            const promises = [];
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result)));
+            function addLayerCb(layer) {
+                return globeView.addLayer(layer);
+            }
+
+            var promises = [];
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb));
+
+            function removeDups(a) {
+                var temp = {};
+                for (var i = 0; i < a.length; i++) {
+                    temp[a[i]] = true;
+                }
+                var result = [];
+                for (var val in temp) {
+                    result.push(val);
+                }
+                return result;
+            }
 
             function getLayersColorVisible(node, layers) {
                 if (!node || !node.visible) {
@@ -48,35 +64,37 @@
                     // if node.material.colorLayersId is defined then the node have color layers
                     if (node.material.visible && node.material.colorLayersId) {
                         // get all node's color layers
-                        const tileColorLayers = node.material.colorLayersId;
-                        layers.id = [...new Set(layers.id.concat(tileColorLayers))];
+                        var tileColorLayers = node.material.colorLayersId;
+                        layers.id = removeDups(layers.id.concat(tileColorLayers));
                     }
                 }
                 if (node.children) {
-                    for (const child of node.children) {
+                    for (var child of node.children) {
                         getLayersColorVisible(child, layers);
                     }
                 }
             }
 
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
+            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                Promise.all(promises).then(() => {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(l => l.type === 'color'));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(l => l.type === 'elevation'));
+                Promise.all(promises).then(function () {
+                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function(l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
                 });
             });
 
             // Use preRender to update menu before rendering
-            globeView.preRender = () => {
-                const layers = { id: [] };
+            globeView.preRender = function () {
+                var layers = { id: [] };
                 // globeView.scene is THREE.js scene
                 getLayersColorVisible(globeView.scene, layers);
-                const colorLayers = globeView.getLayers(l => l.type == 'color');
+                console.log('layers', layers);
+                var colorLayers = globeView.getLayers(function (l) { return l.type == 'color'; });
 
-                colorLayers.forEach(layer =>
-                    menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1));
+                colorLayers.forEach(function (layer) {
+                    menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1)
+                });
             };
         </script>
     </body>

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -46,50 +46,54 @@ and open the template in the editor.
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
 
-            const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+            var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
             // iTowns namespace defined here
-            const viewerDiv = document.getElementById('viewerDiv');
+            var viewerDiv = document.getElementById('viewerDiv');
 
 
-            let menuGlobe = new GuiTools('menuDiv');
-            const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv');
+            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             menuGlobe.view = globeView;
 
-            const promises = [];
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/OrthosCRS.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/ScanEX.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(result => globeView.addLayer(result)));
+            function addLayerCb(layer) {
+                return globeView.addLayer(layer);
+            }
 
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result)));
+            var promises = [];
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/OrthosCRS.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/ScanEX.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(addLayerCb));
+
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
             menuGlobe.addGUI('RealisticLighting', false,
-                (newValue) => { globeView.setRealisticLightingOn(newValue); });
+                function (newValue) { globeView.setRealisticLightingOn(newValue); });
 
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
+            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                Promise.all(promises).then(() => {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(l => l.type === 'color'));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(l => l.type === 'elevation'));
+                Promise.all(promises).then(function () {
+                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function(l) { return l.type === 'elevation'; }));
                 });
             });
 
 
             // hack: not searched why yet
-            setTimeout(() => {
+            setTimeout(function () {
                 // hack because Debug access directly menuGlobe global var...
                 menuGlobe = new GuiTools('menuDiv2');
-                const viewerDiv2 = document.getElementById('viewerDiv2');
-                const globeView2 = new itowns.GlobeView(viewerDiv2, positionOnGlobe);
+                var viewerDiv2 = document.getElementById('viewerDiv2');
+                var globeView2 = new itowns.GlobeView(viewerDiv2, positionOnGlobe);
 
-                for (const layer of globeView.getLayers(l => l.type == 'color' || l.type == 'elevation')) {
+                for (var layer of globeView.getLayers(function (l) { return l.type == 'color' || l.type == 'elevation'; })) {
                     globeView2.addLayer(layer);
                 }
 
-                const e = {
+                var e = {
                     "type": 'color',
                     "protocol": "wmtsc",
                     "id": "DARK",

--- a/examples/orthographic.html
+++ b/examples/orthographic.html
@@ -28,7 +28,7 @@
         <div id="viewerDiv"></div>
         <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
-            let renderer;
+            var renderer;
         </script>
         <script src="orthographic.js"></script>
     </body>

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -28,7 +28,7 @@
         <div id="viewerDiv"></div>
         <script src="../dist/itowns.js"></script>
         <script type="text/javascript">
-            let renderer; let exports = {};
+            var renderer; var exports = {};
         </script>
         <script src="planar.js"></script>
     </body>

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -1,21 +1,26 @@
 /* global itowns, document, renderer */
 // # Planar (EPSG:3946) viewer
 
+var extent;
+var viewerDiv;
+var view;
+var c;
+
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 itowns.proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 // Define geographic extent: CRS, min/max X, min/max Y
-const extent = new itowns.Extent(
+extent = new itowns.Extent(
     'EPSG:3946',
     1837816.94334, 1847692.32501,
     5170036.4587, 5178412.82698);
 
 // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
-const viewerDiv = document.getElementById('viewerDiv');
+viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate PlanarView*
-var view = new itowns.PlanarView(viewerDiv, extent, { renderer });
+view = new itowns.PlanarView(viewerDiv, extent, { renderer: renderer });
 view.tileLayer.disableSkirt = true;
 
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
@@ -29,7 +34,7 @@ view.addLayer({
     name: 'Ortho2009_vue_ensemble_16cm_CC46',
     projection: 'EPSG:3946',
     transparent: false,
-    extent,
+    extent: extent,
     bbox_url: 'wsen',
     updateStrategy: {
         type: 0,
@@ -52,7 +57,7 @@ view.addLayer({
     style: '',
     projection: 'EPSG:3946',
     transparent: false,
-    extent,
+    extent: extent,
     bbox_url: 'wsen',
     heightMapWidth: 256,
     options: {
@@ -68,7 +73,7 @@ view.tileLayer.materialOptions = {
 
 // Since PlanarView doesn't create default controls, we manipulate directly three.js camera
 // Position the camera at south-west corner
-const c = new itowns.Coordinates('EPSG:3946', extent.west(), extent.south(), 2000);
+c = new itowns.Coordinates('EPSG:3946', extent.west(), extent.south(), 2000);
 view.camera.camera3D.position.copy(c.xyz());
 // Then look at extent's center
 view.camera.camera3D.lookAt(extent.center().xyz());

--- a/examples/postprocessing.html
+++ b/examples/postprocessing.html
@@ -65,8 +65,8 @@
         </script>
 
         <script type="text/javascript">
-            let renderer;
-            let exports = {};
+            var renderer;
+            var exports = {};
         </script>
         <script src="postprocessing.js"></script>
     </body>

--- a/examples/postprocessing.js
+++ b/examples/postprocessing.js
@@ -1,14 +1,16 @@
 /* global itowns, document, renderer */
-const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
 // iTowns namespace defined here
-const viewerDiv = document.getElementById('viewerDiv');
-const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer });
+var viewerDiv = document.getElementById('viewerDiv');
+var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
 // Simple postprocessing setup
 //
-const postprocessScene = new itowns.THREE.Scene();
-const quad = new itowns.THREE.Mesh(new itowns.THREE.PlaneBufferGeometry(2, 2), null);
+var postprocessScene = new itowns.THREE.Scene();
+var quad = new itowns.THREE.Mesh(new itowns.THREE.PlaneBufferGeometry(2, 2), null);
+var cam = new itowns.THREE.OrthographicCamera(-1, 1, 1, -1, 0, 10);
+
 quad.frustumCulled = false;
 quad.material = new itowns.THREE.ShaderMaterial({
     uniforms: {
@@ -22,11 +24,10 @@ quad.material = new itowns.THREE.ShaderMaterial({
     fragmentShader: document.getElementById('fragmentshader').textContent,
 });
 postprocessScene.add(quad);
-const cam = new itowns.THREE.OrthographicCamera(-1, 1, 1, -1, 0, 10);
 
-globeView.render = () => {
-    const g = globeView.mainLoop.gfxEngine;
-    const r = g.renderer;
+globeView.render = function render() {
+    var g = globeView.mainLoop.gfxEngine;
+    var r = g.renderer;
     r.setRenderTarget(g.fullSizeRenderTarget);
     r.clear();
     r.setViewport(0, 0, g.getWindowSize().x, g.getWindowSize().y);
@@ -46,8 +47,12 @@ globeView.render = () => {
         cam);
 };
 
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result));
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(result => globeView.addLayer(result));
+function addLayerCb(layer) {
+    return globeView.addLayer(layer);
+}
+
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
 
 exports.globeView = globeView;
 exports.postprocessScene = postprocessScene;

--- a/index.html
+++ b/index.html
@@ -35,33 +35,33 @@ and open the template in the editor.
         <script type="text/javascript">
             /* global itowns,document,GuiTools*/
 
-            const positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
+            var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
             // iTowns namespace defined here
-            const viewerDiv = document.getElementById('viewerDiv');
-            const globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            const menuGlobe = new GuiTools('menuDiv', globeView);
+            var viewerDiv = document.getElementById('viewerDiv');
+            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv', globeView);
             menuGlobe.view = globeView;
 
-            let promises = []
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(result => globeView.addLayer(result)));
+            var promises = []
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(function(result) { return globeView.addLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(function(result) { return globeView.addLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(function(result) { return globeView.addLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(function(result) { return globeView.addLayer(result); }));
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(result => globeView.addLayer(result)));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(result => globeView.addLayer(result)));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(function(result) { return globeView.addLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(function(result) { return globeView.addLayer(result); }));
 
             menuGlobe.addGUI('RealisticLighting', false,
-                (newValue) => { globeView.setRealisticLightingOn(newValue); });
+                function(newValue) { globeView.setRealisticLightingOn(newValue); });
 
-            Promise.all(promises).then(() => {
-                menuGlobe.addImageryLayersGUI(globeView.getLayers(l => l.type === 'color'));
-                menuGlobe.addElevationLayersGUI(globeView.getLayers(l => l.type === 'elevation'));
+            Promise.all(promises).then(function () {
+                menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
+                menuGlobe.addElevationLayersGUI(globeView.getLayers(function(l) { return l.type === 'elevation'; }));
                 console.info('menuGlobe initialized');
-            }).catch( e => console.error(e));
+            }).catch( function (e) { console.error(e) });
 
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
+            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itowns",
-  "version": "0.0.0-alpha",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "dependencies": {
     "accepts": {
@@ -4302,6 +4302,11 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
       "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0=",
       "dev": true
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "js-priority-queue": "^0.1.5",
     "jszip": "^3.1.3",
     "proj4": "^2.4.3",
+    "text-encoding": "^0.6.4",
     "three": "^0.86.0",
     "whatwg-fetch": "^2.0.2"
   },

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -8,7 +8,7 @@ import View from '../../src/Core/View';
 
 function createChartContainer(chartDiv, width, left, chartId) {
     const div = document.createElement('div');
-    div.style = `position: absolute; bottom: 0; left: ${left}vw; width: ${width}vw; height: 20rem; background-color: white;`;
+    div.style.cssText = `position: absolute; bottom: 0; left: ${left}vw; width: ${width}vw; height: 20rem; background-color: white;`;
     chartDiv.appendChild(div);
 
     const chartCanvas = document.createElement('canvas');
@@ -227,7 +227,7 @@ function Debug(view, viewerDiv) {
     // create charts div
     const chartDiv = document.createElement('div');
     chartDiv.id = 'chart-div';
-    chartDiv.style = 'position: absolute; bottom: 0; left: 0; width: 100vw; height: 20rem; background-color: white; display: none';
+    chartDiv.style.cssText = 'position: absolute; bottom: 0; left: 0; width: 100vw; height: 20rem; background-color: white; display: none';
 
     viewerDiv.appendChild(chartDiv);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,11 @@ var definePlugin = new webpack.DefinePlugin({
     __DEBUG__: JSON.stringify(process.env.NODE_ENV === 'development'),
 });
 
+var providePlugin = new webpack.ProvidePlugin({
+    TextDecoder: ['text-encoding', 'TextDecoder'],
+    TextEncoder: ['text-encoding', 'TextEncoder'],
+});
+
 module.exports = {
     entry: {
         itowns: ['es6-promise', 'whatwg-fetch', path.resolve(__dirname, 'src/Main.js')],
@@ -18,7 +23,10 @@ module.exports = {
         libraryTarget: 'umd',
         umdNamedDefine: true,
     },
-    plugins: [definePlugin, new webpack.optimize.CommonsChunkPlugin({ name: 'itowns' })],
+    plugins: [
+        definePlugin,
+        providePlugin,
+        new webpack.optimize.CommonsChunkPlugin({ name: 'itowns' })],
     module: {
         rules: [
             {


### PR DESCRIPTION
`examples/` are not processed by babel. Therefore they should be written only with ES5 syntax until we drop support from those older browsers.

