### PR TITLE
Fix: workaround for https://github.com/travis-ci/travis-ci/issues/8082

### DIFF
--- a/autodeploy.sh
+++ b/autodeploy.sh
@@ -76,5 +76,7 @@ git push $SITE_REPO
 
 # clean key
 cd ..
-ssh-add -d ./deploy_key
 rm ./deploy_key
+
+# See https://github.com/travis-ci/travis-ci/issues/8082#issuecomment-315151953
+ssh-agent -k


### PR DESCRIPTION
For reference, here is the conversation I had with travis support (stripped from irrelevant stuff):

On Thu, Jul 13, 2017 at 10:14:17 UTC, Augustin Trancart wrote:
> Hi Travis!
>
> I have a problem with one of my build:
> https://travis-ci.org/iTowns/itowns/builds/252859764
>
> On one of the job, the output says:
>
> >_Done. Your build exited with 0.
> >
> > No output has been received in the last 10m0s, this potentially indicates a
> > stalled build or something wrong with the build itself.
> >
> > Check the details on how to adjust your build configuration on:
> https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
> >
> > The build has been terminated
>
> Even though the other job works fine. Both were fine before, and I don't think
> the recent landed changeset could have caused that.
>
> Any ideas?
>
> Thanks!
>
> -- 
> Augustin Trancart - Oslandia


On 13/07/2017 19:52, Hiro Asari wrote:
> Hi, Augustin,
> 
> Thanks for the email. We are sorry to hear about the problem you are having. We
> are happy to look into it.
> 
> I believe this is the issue reported in
> https://github.com/travis-ci/travis-ci/issues/8082. There, I characterize the
> issue in a comment
> https://github.com/travis-ci/travis-ci/issues/8082#issuecomment-315147561. Do
> they fit your case? If so, could you try the workaround I suggested in the
> comment immediately following that?
> 
> Thanks, and we look forward to how the workaround works for you.
> 
> --
> Hiro Asari
> Travis Builder
> support@travis-ci.com

Let's see if @BanzaiMan was right!