### PR TITLE
Fix: correctly prepare lib/ for running test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint && npm run build && npm run test-examples",
-    "test-examples": "mocha test/globe_test.js && mocha test/planar_test.js && mocha test/postprocessing_test.js && mocha test/externalscene_test.js",
+    "test-examples": "npm run transpile && mocha test/globe_test.js && mocha test/planar_test.js && mocha test/postprocessing_test.js && mocha test/externalscene_test.js",
     "build": "webpack -p",
+    "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
-    "prepublish": "npm run build && cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib"
+    "prepublish": "npm run build && npm run transpile"
   },
   "files": [
     "*.md",


### PR DESCRIPTION
We now run the test using directly `lib/Main.js`, so it doesn't make sens to run `npm run build` before testing.