### PR TITLE
feature: add new functions to prevent subdivisions when textures are missing

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -173,8 +173,7 @@ TileMesh.prototype.isColorLayerLoaded = function isColorLayerLoaded(layerId) {
 };
 
 TileMesh.prototype.isElevationLayerLoaded = function isElevationLayerLoaded() {
-    const mat = this.material;
-    return mat.getElevationLayerLevel() > -1;
+    return this.material.loadedTexturesCount[l_ELEVATION] > 0;
 };
 
 TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layer) {

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -165,11 +165,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
         initNodeImageryTexturesFromParent(node, node.parent, layer);
     }
 
-    if (!node.isDisplayed()) {
-        return;
-    }
-
-    if (!layer.tileInsideLimit(node, layer)) {
+    if (!node.isDisplayed() || !layer.tileInsideLimit(node, layer)) {
         return Promise.resolve();
     }
 
@@ -198,7 +194,6 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
     }
 
     const currentLevel = node.material.getColorLayerLevelById(layer.id);
-
     const zoom = node.getCoordsForLayer(layer)[0].zoom || node.level;
     const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, zoom, currentLevel, layer);
     if (targetLevel <= currentLevel) {
@@ -276,7 +271,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, force) 
         currentElevation = material.getElevationLayerLevel();
     }
     if (!node.isDisplayed()) {
-        return;
+        return Promise.resolve();
     }
 
     if (!node.layerUpdateState[layer.id].canTryUpdate(ts)) {

--- a/src/Process/SubdivisionControl.js
+++ b/src/Process/SubdivisionControl.js
@@ -1,0 +1,27 @@
+export default {
+    preUpdate: (context, layer) => {
+        context.colorLayers = context.view.getLayers(
+            (l, a) => a && a.id == layer.id && l.type == 'color');
+        context.elevationLayers = context.view.getLayers(
+            (l, a) => a && a.id == layer.id && l.type == 'elevation');
+    },
+
+    hasEnoughTexturesToSubdivide: (context, layer, node) => {
+        // Prevent subdivision if node is covered by at least one elevation layer
+        // and if node doesn't have a elevation texture yet.
+        for (const e of context.elevationLayers) {
+            if (e.tileInsideLimit(node, e) && !node.isElevationLayerLoaded()) {
+                return false;
+            }
+        }
+
+        // Prevent subdivision if missing color texture
+        for (const c of context.colorLayers) {
+            if (c.tileInsideLimit(node, c) && !node.isColorLayerLoaded(c.id)) {
+                return false;
+            }
+        }
+
+        return true;
+    },
+};


### PR DESCRIPTION
Avoid the following issues:
- in planar.html: subdivision happens before texture fetches. The visual experience is that each small tile gets its elevation/color texture one after another, instead of refining. Example on planar.html:
![b](https://user-images.githubusercontent.com/2198295/28370394-7b7eb31c-6c9a-11e7-829a-03dd76cac4c5.jpg)

- if you start with the camera at a zoom level higher than allowed by the WMTS server, the visible tiles will never gets a texture since:
  * tile level is > to WMTS max level -> no texture for tile.
  * tile's parent are hidden (because subdisvision) -> no texture fetched for parent. Even if parent level is <= WMTS max level and then this parent's texture could be used by its displayed children  
Example on 3dtiles.html (when lowering initial altitude to 5000):

  ![a](https://user-images.githubusercontent.com/2198295/28370357-62de3238-6c9a-11e7-8b89-08a793e8328f.jpg)