### PR TITLE
fix: make getXBilTextureByUrl always return a Texture

### DIFF
--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -99,11 +99,6 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer) {
     });
 };
 
-WMS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer) {
-    const url = this.url(tile.extent.as(layer.projection), layer);
-    return OGCWebServiceHelper.getXBilTextureByUrl(url, layer.networkOptions);
-};
-
 WMS_Provider.prototype.executeCommand = function executeCommand(command) {
     const tile = command.requester;
 
@@ -112,7 +107,6 @@ WMS_Provider.prototype.executeCommand = function executeCommand(command) {
         'image/png': this.getColorTexture.bind(this),
         'image/jpg': this.getColorTexture.bind(this),
         'image/jpeg': this.getColorTexture.bind(this),
-        'image/x-bil;bits=32': this.getXbilTexture.bind(this),
     };
 
     const func = supportedFormats[layer.format];

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -83,16 +83,20 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, ta
 
     const url = this.url(coordWMTS, layer);
 
-    return OGCWebServiceHelper.getXBilTextureByUrl(url, layer.networkOptions).then((result) => {
+    return OGCWebServiceHelper.getXBilTextureByUrl(url, layer.networkOptions).then((texture) => {
         const { min, max } = OGCWebServiceHelper.ioDXBIL.computeMinMaxElevation(
-        result.texture.image.data,
-        SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-        pitch);
-        result.min = min === undefined ? 0 : min;
-        result.max = max === undefined ? 0 : max;
-        result.texture.coords = coordWMTS;
-        result.pitch = pitch;
-        return result;
+            texture.image.data,
+            SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+            pitch);
+
+        texture.coords = coordWMTS;
+
+        return {
+            texture,
+            pitch,
+            min: min === undefined ? 0 : min,
+            max: max === undefined ? 0 : max,
+        };
     });
 };
 

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -235,6 +235,10 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
             if (err instanceof CancelledCommandException) {
                 node.layerUpdateState[layer.id].success();
             } else {
+                if (__DEBUG__) {
+                    // eslint-disable-next-line no-console
+                    console.warn(`Imagery texture update error for ${node}: ${err}`);
+                }
                 node.layerUpdateState[layer.id].failure(Date.now());
                 window.setTimeout(() => {
                     context.view.notifyChange(false, node);
@@ -319,7 +323,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, force) 
                 terrain.texture.needsUpdate = true;
             }
 
-            if (terrain.texture.image.data && !checkNodeElevationTextureValidity(terrain.texture, layer.noDataValue)) {
+            if (terrain.texture && terrain.texture.image.data && !checkNodeElevationTextureValidity(terrain.texture, layer.noDataValue)) {
                 // Quick check to avoid using elevation texture with no data value
                 // If we have no data values, we use value from the parent tile
                 // We should later implement multi elevation layer to choose the one to use at each level
@@ -332,6 +336,10 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, force) 
             if (err instanceof CancelledCommandException) {
                 node.layerUpdateState[layer.id].success();
             } else {
+                if (__DEBUG__) {
+                    // eslint-disable-next-line no-console
+                    console.warn(`Elevation texture update error for ${node}: ${err}`);
+                }
                 node.layerUpdateState[layer.id].failure(Date.now());
                 window.setTimeout(() => {
                     context.view.notifyChange(false, node);


### PR DESCRIPTION
Previously the cache could contain either a Texture or a 'result'.

Also add warning log on texture update error (in DEBUG mode only).