### PR TITLE
feature: add a postUpdate method to GeometryLayer

### DIFF
--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -71,6 +71,8 @@ function GeometryLayer(id, object3d) {
         value: id,
         writable: false,
     });
+
+    this.postUpdate = () => {};
 }
 
 GeometryLayer.prototype = Object.create(EventDispatcher.prototype);

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -67,8 +67,12 @@ MainLoop.prototype._update = function _update(view, updateSources, dt) {
 
     for (const geometryLayer of view.getLayers((x, y) => !y)) {
         context.geometryLayer = geometryLayer;
+        // `preUpdate` returns an array of elements to update
         const elementsToUpdate = geometryLayer.preUpdate(context, geometryLayer, updateSources);
+        // `update` is called in `updateElements`.
         updateElements(context, geometryLayer, elementsToUpdate);
+        // `postUpdate` is called when this geom layer update process is finished
+        geometryLayer.postUpdate(context, geometryLayer, updateSources);
     }
 };
 


### PR DESCRIPTION
Allows the user to perform an action when a GeometryLayer update is finished.
(this is different from preRender since an update may not request a render)