### PR TITLE
fix: missing 4th component value of unpack1K factors

### DIFF
--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -32,7 +32,7 @@ export function unpack1K(color, factor) {
         UnpackDownscale / (256.0 * 256.0 * 256.0),
         UnpackDownscale / (256.0 * 256.0),
         UnpackDownscale / 256.0,
-        1.0);
+        UnpackDownscale);
     return bitSh.dot(color) * factor;
 }
 


### PR DESCRIPTION
The original formula in three.js shader is:
  const vec4 UnpackFactors = UnpackDownscale / vec4( PackFactors, 1. );
so the 4th component should be 'UnpackFactors' which is:
  255 / 256

Partial fix for #411 