### PR TITLE
Refacto: replace TextDecoder polyfill with a lighter one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5377,10 +5377,10 @@
       "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0=",
       "dev": true
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+    "text-encoding-utf-8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.1.tgz",
+      "integrity": "sha1-Uepsen6y+09nRnt2NzVmH1YDSS0="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jszip": "^3.1.3",
     "monotone-convex-hull-2d": "^1.0.1",
     "proj4": "^2.4.3",
-    "text-encoding": "^0.6.4",
+    "text-encoding-utf-8": "^1.0.1",
     "three": "^0.86.0",
     "whatwg-fetch": "^2.0.2"
   },

--- a/src/utils/polyfill.js
+++ b/src/utils/polyfill.js
@@ -1,0 +1,7 @@
+import {
+  TextDecoder as TextDecoderPolyfill,
+  TextEncoder as TextEncoderPolyfill,
+} from 'text-encoding-utf-8';
+
+export const TextDecoder = typeof global.TextDecoder === 'function' ? global.TextDecoder : TextDecoderPolyfill;
+export const TextEncoder = typeof global.TextEncoder === 'function' ? global.TextEncoder : TextEncoderPolyfill;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,8 @@ var definePlugin = new webpack.DefinePlugin({
 });
 
 var providePlugin = new webpack.ProvidePlugin({
-    TextDecoder: ['text-encoding', 'TextDecoder'],
-    TextEncoder: ['text-encoding', 'TextEncoder'],
+    TextDecoder: [path.resolve(__dirname, 'src/utils/polyfill'), 'TextDecoder'],
+    TextEncoder: [path.resolve(__dirname, 'src/utils/polyfill'), 'TextEncoder'],
 });
 
 module.exports = {
@@ -26,7 +26,8 @@ module.exports = {
     plugins: [
         definePlugin,
         providePlugin,
-        new webpack.optimize.CommonsChunkPlugin({ name: 'itowns' })],
+        new webpack.optimize.CommonsChunkPlugin({ name: 'itowns' }),
+    ],
     module: {
         rules: [
             {


### PR DESCRIPTION
EDIT: now this PR only change the dependencie to one that only supports utf-8, but is much lighter.

text-encoding dependency is very big. Not very worthy for how we use it. Inspiration: https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/GLTFLoader.js#L665 (thanks @Jeremy-Gaillard)

This brings back our bundle size from 1.4Mo to ~800ko.

@iTowns/reviewers please r?