### PR TITLE
refactor: rework Tiles removal and cleanup

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -47,39 +47,6 @@ function TileMesh(geometry, params) {
 TileMesh.prototype = Object.create(THREE.Mesh.prototype);
 TileMesh.prototype.constructor = TileMesh;
 
-TileMesh.prototype.removeChildren = function removeChildren() {
-    // remove all children from a node from same layer
-    let i = this.children.length;
-    while (i--) {
-        const c = this.children[i];
-        if (c.layer !== this.layer) {
-            continue;
-        }
-        if (typeof c.removeChildren === 'function') {
-            c.removeChildren();
-        }
-
-        if (typeof c.dispose === 'function') {
-            c.dispose();
-        } else {
-            if (c.geometry) {
-                c.geometry.dispose();
-            }
-            if (c.material) {
-                c.material.dispose();
-            }
-        }
-        this.children.splice(i, 1);
-    }
-};
-
-TileMesh.prototype.dispose = function dispose() {
-    this.material.dispose();
-    this.geometry.dispose();
-    this.geometry = null;
-    this.material = null;
-};
-
 TileMesh.prototype.updateMatrixWorld = function updateMatrixWorld(force) {
     THREE.Mesh.prototype.updateMatrixWorld.call(this, force);
     this.geometry.OBB.update();

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -128,6 +128,9 @@ function checkNodeElevationTextureValidity(texture, noDataValue) {
 }
 
 export function updateLayeredMaterialNodeImagery(context, layer, node) {
+    if (!node.parent) {
+        return;
+    }
     if (!layer.tileInsideLimit(node, layer)) {
         // we also need to check that tile's parent doesn't have a texture for this layer,
         // because even if this tile is outside of the layer, it could inherit it's
@@ -248,6 +251,9 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
 }
 
 export function updateLayeredMaterialNodeElevation(context, layer, node, force) {
+    if (!node.parent) {
+        return;
+    }
     // TODO: we need either
     //  - compound or exclusive layers
     //  - support for multiple elevation layers

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -1,0 +1,70 @@
+export default {
+    /**
+     * Cleanup obj to release three.js allocated resources
+     * @param {Object3D} obj object to release
+     */
+    cleanup(obj) {
+        if (typeof obj.dispose === 'function') {
+            obj.dispose();
+        } else {
+            if (obj.geometry) {
+                obj.geometry.dispose();
+                obj.geometry = null;
+            }
+            if (obj.material) {
+                obj.material.dispose();
+                obj.material = null;
+            }
+        }
+    },
+
+    /**
+     * Remove obj's children belonging to layerId layer.
+     * Neither obj nor its children will be disposed!
+     * @param {String} layerId The id of the layer that objects must belong to. Other object are ignored
+     * @param {Object3D} obj The Object3D we want to clean
+     * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
+     */
+    removeChildren(layerId, obj) {
+        const toRemove = obj.children.filter(c => c.layer === layerId);
+        obj.remove(...toRemove);
+        return toRemove;
+    },
+
+    /**
+     * Remove obj's children belonging to layerId layer and cleanup objexts.
+     * obj will be disposed but its children **won't**!
+     * @param {String} layerId The id of the layer that objects must belong to. Other object are ignored
+     * @param {Object3D} obj The Object3D we want to clean
+     * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
+     */
+    removeChildrenAndCleanup(layerId, obj) {
+        const toRemove = obj.children.filter(c => c.layer === layerId);
+
+        if (obj.layer === layerId) {
+            this.cleanup(obj);
+        }
+
+        obj.remove(...toRemove);
+        return toRemove;
+    },
+
+    /**
+     * Recursively remove obj's children belonging to layerId layer.
+     * All removed obj will have their geometry/material disposed.
+     * @param {String} layerId The id of the layer that objects must belong to. Other object are ignored
+     * @param {Object3D} obj The Object3D we want to clean
+     * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
+     */
+    removeChildrenAndCleanupRecursively(layerId, obj) {
+        const toRemove = obj.children.filter(c => c.layer === layerId);
+        for (const c of toRemove) {
+            this.removeChildrenAndCleanupRecursively(layerId, c);
+        }
+        if (obj.layer === layerId) {
+            this.cleanup(obj);
+        }
+        obj.remove(...toRemove);
+        return toRemove;
+    },
+};

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -1,5 +1,6 @@
 import Extent from '../Core/Geographic/Extent';
 import { CancelledCommandException } from '../Core/Scheduler/Scheduler';
+import ObjectRemovalHelper from './ObjectRemovalHelper';
 
 function subdivisionExtents(bbox) {
     const center = bbox.center();
@@ -97,7 +98,10 @@ function subdivideNode(context, layer, node) {
 
 export function processTiledGeometryNode(cullingTest, subdivisionTest) {
     return function _processTiledGeometryNode(context, layer, node) {
-    // early exit if parent' subdivision is in progress
+        if (!node.parent) {
+            return ObjectRemovalHelper.removeChildrenAndCleanup(layer.id, node);
+        }
+        // early exit if parent' subdivision is in progress
         if (node.parent.pendingSubdivision) {
             node.visible = false;
             node.setDisplayed(false);
@@ -125,7 +129,7 @@ export function processTiledGeometryNode(cullingTest, subdivisionTest) {
                 node.setFog(1000000000);
 
                 if (!requestChildrenUpdate) {
-                    node.removeChildren();
+                    return ObjectRemovalHelper.removeChildren(layer.id, node);
                 }
             }
 
@@ -134,8 +138,6 @@ export function processTiledGeometryNode(cullingTest, subdivisionTest) {
         }
 
         node.setDisplayed(false);
-        node.removeChildren();
-
-        return undefined;
+        return ObjectRemovalHelper.removeChildren(layer.id, node);
     };
 }

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -2,6 +2,7 @@ import OBBHelper from './OBBHelper';
 import TileObjectChart from './charts/TileObjectChart';
 import TileVisibilityChart from './charts/TileVisibilityChart';
 import View from '../../src/Core/View';
+import ObjectRemovalHelper from '../../src/Process/ObjectRemovalHelper';
 
 function applyToNodeFirstMaterial(view, root, layerId, cb) {
     root.traverse((object) => {
@@ -78,6 +79,11 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
 
     const debugIdUpdate = function debugIdUpdate(context, layer, node) {
         const enabled = context.camera.camera3D.layers.test({ mask: 1 << layer.threejsLayer });
+
+        if (!node.parent || !enabled) {
+            ObjectRemovalHelper.removeChildrenAndCleanupRecursively(layer.id, node);
+            return;
+        }
 
         if (!enabled) {
             return;


### PR DESCRIPTION
This commit removes TileMesh specific cleanup code and instead
introduce ObjectRemovalHelper that can be used on any object.

Another change is that attached layers get called on just-removed
elements. This allows each layer to perform its own cleanup.

