### PR TITLE
feature: use parent's extent for attached layer if undefined

### DIFF
--- a/examples/cubic_planar.js
+++ b/examples/cubic_planar.js
@@ -104,13 +104,7 @@ for (index = 0; index < wmsLayers.length; index++) {
         id: 'wms_imagery' + wms + index,
         name: wms,
         projection: 'EPSG:3946',
-        transparent: false,
-        extent: extent,
         bbox_url: 'wsen',
-        updateStrategy: {
-            type: 0,
-            options: {},
-        },
         options: {
             mimetype: 'image/jpeg',
         },
@@ -125,10 +119,7 @@ for (index = 0; index < wmsLayers.length; index++) {
         version: '1.3.0',
         id: 'wms_elevation' + wms + index,
         name: 'MNT2012_Altitude_10m_CC46',
-        style: '',
         projection: 'EPSG:3946',
-        transparent: false,
-        extent: extent,
         bbox_url: 'wsen',
         heightMapWidth: 256,
         options: {

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -38,13 +38,7 @@ view.addLayer({
     id: 'wms_imagery',
     name: 'Ortho2009_vue_ensemble_16cm_CC46',
     projection: 'EPSG:3946',
-    transparent: false,
-    extent: extent,
     bbox_url: 'wsen',
-    updateStrategy: {
-        type: 0,
-        options: {},
-    },
     options: {
         mimetype: 'image/jpeg',
     },
@@ -59,10 +53,7 @@ view.addLayer({
     version: '1.3.0',
     id: 'wms_elevation',
     name: 'MNT2012_Altitude_10m_CC46',
-    style: '',
     projection: 'EPSG:3946',
-    transparent: false,
-    extent: extent,
     bbox_url: 'wsen',
     heightMapWidth: 256,
     options: {

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -80,7 +80,7 @@ Extent.prototype.clone = function clone() {
     if (_isTiledCRS(this._crs)) {
         return new Extent(this._crs, this.zoom, this.row, this.col);
     } else {
-        const result = Extent(this._crs, ...this._values);
+        const result = new Extent(this._crs, ...this._values);
         result._internalStorageUnit = this._internalStorageUnit;
         return result;
     }

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -109,6 +109,10 @@ export function createGlobeLayer(id, options) {
 
     const wgs84TileLayer = new GeometryLayer(id, options.object3d);
     wgs84TileLayer.schemeTile = globeSchemeTileWMTS(globeSchemeTile1);
+    wgs84TileLayer.extent = wgs84TileLayer.schemeTile[0].clone();
+    for (let i = 1; i < wgs84TileLayer.schemeTile.length; i++) {
+        wgs84TileLayer.extent.merge(wgs84TileLayer.schemeTile[i]);
+    }
     wgs84TileLayer.preUpdate = (context, layer, changeSources) => {
         SubdivisionControl.preUpdate(context, layer);
 

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -14,6 +14,7 @@ import SubdivisionControl from '../../Process/SubdivisionControl';
 
 export function createPlanarLayer(id, extent, options) {
     const tileLayer = new GeometryLayer(id, options.object3d);
+    tileLayer.extent = extent;
     tileLayer.schemeTile = [extent];
 
     // Configure tiles

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -256,6 +256,10 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         throw new Error(`Invalid id '${layer.id}': id already used`);
     }
 
+    if (parentLayer && !layer.extent) {
+        layer.extent = parentLayer.extent;
+    }
+
     layer = _preprocessLayer(this, layer, this.mainLoop.scheduler.getProtocolProvider(layer.protocol));
     if (parentLayer) {
         parentLayer.attach(layer);


### PR DESCRIPTION
No need to ask the user to copy-paste the extent if she wants to use
the same as the layer's parent.

@gchoqueux r?