### PR TITLE
refacto: rework Camera's API

### DIFF
--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -55,7 +55,7 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     function placeCamera(position, lookAt) {
         view.camera.camera3D.position.set(position.x, position.y, position.z);
         view.camera.camera3D.lookAt(lookAt);
-        view.camera.update();
+        view.notifyChange(true);
     }
 
     // add pointcloud to scene
@@ -86,9 +86,7 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
                 Math.floor(100 * pointcloud.counters.displayedCount / pointcloud.counters.pointCount) + '%) (' +
                 view.mainLoop.gfxEngine.renderer.info.memory.geometries + ')';
         };
-
-
-        view.notifyChange(true);
     }
+
     view.addLayer(pointcloud).then(onLayerReady);
 }

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -92,8 +92,8 @@ MainLoop.prototype._step = function _step(view, timestamp) {
 
     // update camera
     const dim = this.gfxEngine.getWindowSize();
-    view.camera.resize(dim.x, dim.y);
-    view.camera.update();
+
+    view.camera.update(dim.x, dim.y);
 
     // update data-structure
     this._update(view, updateSources, dt);

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -202,7 +202,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         coordCarto.latitude,
         coordCarto.altitude);
 
-    this.camera.setPosition(positionCamera.as('EPSG:4978').xyz());
+    this.camera.setPosition(positionCamera);
     this.camera.camera3D.lookAt({ x: 0, y: 0, z: 0 });
     this.camera.camera3D.near = Math.max(15.0, 0.000002352 * size);
     this.camera.camera3D.far = size * 10;
@@ -246,7 +246,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     this.preRender = () => {
         const v = new THREE.Vector3();
         v.setFromMatrixPosition(wgs84TileLayer.object3d.matrixWorld);
-        var len = v.distanceTo(this.camera.position());
+        var len = v.distanceTo(this.camera.camera3D.position);
         v.setFromMatrixScale(wgs84TileLayer.object3d.matrixWorld);
         var lim = v.x * size * 1.1;
 
@@ -359,8 +359,6 @@ GlobeView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) 
 
     mouse = mouse || new THREE.Vector2(Math.floor(dim.x / 2), Math.floor(dim.y / 2));
 
-    this.camera.update();
-
     const previousRenderState = this._renderState;
     this.changeRenderState(RendererConstant.ID);
 
@@ -395,9 +393,7 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
     const dim = this.mainLoop.gfxEngine.getWindowSize();
     mouse = mouse || dim.clone().multiplyScalar(0.5);
 
-
     var camera = this.camera.camera3D;
-    this.camera.update();
 
     // Prepare state
     const prev = this.camera.camera3D.layers.mask;
@@ -415,8 +411,6 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
 
     screen.x = (mouse.x / dim.x) * 2 - 1;
     screen.y = -(mouse.y / dim.y) * 2 + 1;
-
-    camera.matrixWorld.setPosition(camera.position);
 
     // Origin
     ray.origin.copy(camera.position);
@@ -443,7 +437,6 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
     // Restore initial state
     this.changeRenderState(previousRenderState);
     camera.layers.mask = prev;
-    camera.updateMatrixWorld(true);
 
     if (pickWorldPosition.length() > 10000000)
         { return undefined; }

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -127,7 +127,7 @@ function PlanarView(viewerDiv, extent, options = {}) {
     const lookat = positionCamera.xyz();
     lookat.z = 0;
 
-    this.camera.setPosition(positionCamera.xyz());
+    this.camera.setPosition(positionCamera);
     this.camera.camera3D.lookAt(lookat);
     this.camera.camera3D.near = 0.1;
     this.camera.camera3D.far = 2 * Math.max(dim.x, dim.y);
@@ -178,8 +178,6 @@ PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
 PlanarView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {
     const dim = this.mainLoop.gfxEngine.getWindowSize();
 
-    this.camera.update();
-
     const previousRenderState = this._renderState;
     this.changeRenderState(RendererConstant.ID);
 
@@ -210,10 +208,7 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
     const dim = this.mainLoop.gfxEngine.getWindowSize();
     mouse = mouse || dim.clone().multiplyScalar(0.5);
 
-
     var camera = this.camera.camera3D;
-    this.camera.update();
-    // camera.updateMatrixWorld();
 
     // Prepare state
     const prev = this.camera.camera3D.layers.mask;
@@ -231,8 +226,6 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
 
     screen.x = (mouse.x / dim.x) * 2 - 1;
     screen.y = -(mouse.y / dim.y) * 2 + 1;
-
-    camera.matrixWorld.setPosition(camera.position);
 
     // Origin
     ray.origin.copy(camera.position);
@@ -259,7 +252,6 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
     // Restore initial state
     this.changeRenderState(previousRenderState);
     camera.layers.mask = prev;
-    camera.updateMatrixWorld(true);
 
     if (pickWorldPosition.length() > 10000000)
         { return undefined; }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -64,6 +64,7 @@ function View(crs, viewerDiv, options = {}) {
     }
 
     this.camera = new Camera(
+        this.referenceCrs,
         this.mainLoop.gfxEngine.getWindowSize().x,
         this.mainLoop.gfxEngine.getWindowSize().y,
         options);
@@ -76,8 +77,6 @@ function View(crs, viewerDiv, options = {}) {
         // the container's size. Otherwise we use window' size.
         const newSize = new Vector2(viewerDiv.clientWidth, viewerDiv.clientHeight);
         this.mainLoop.gfxEngine.onWindowResize(newSize.x, newSize.y);
-        this.camera.resize(newSize.x, newSize.y);
-        this.camera.update();
         this.notifyChange(true);
     }, false);
 

--- a/src/Renderer/ThreeExtended/FlyControls.js
+++ b/src/Renderer/ThreeExtended/FlyControls.js
@@ -152,7 +152,6 @@ class FlyControls extends THREE.EventDispatcher {
         }
 
         if (this.moves.size > 0 || this._isMouseDown) {
-            this.view.camera.update();
             this.view.notifyChange(true, this._camera3D);
 
             for (const move of this.moves) {

--- a/test/globe_test.js
+++ b/test/globe_test.js
@@ -38,7 +38,6 @@ describe('Globe example', function () {
                         example.initialPosition.longitude,
                         example.initialPosition.latitude,
                         10000).as('EPSG:4978').xyz());
-                example.view.camera.update();
                 example.view.notifyChange(true);
             } else {
                 afterSetRange();


### PR DESCRIPTION
This commit changes the API of Camera as follow:
  - remove duplicate three.js-proxy function (like setRotation)
  - make this class GIS-aware: expose a function to retrieve the position in a
given crs
  - hide resize function and call it from update (since all the callers of resize
effectively call them in pair)