### PR TITLE
  feature: add new FirstPersonControls

### DIFF
--- a/examples/planar.html
+++ b/examples/planar.html
@@ -61,20 +61,15 @@
             <ul>
               <li>↑ ↓ : forward / backward</li>
               <li>← → : strafe left / right</li>
-              <li>⇞ (PageUp), ⇟ (PageDown) : roll right / left</li>
+              <li>⇞ (PageUp), ⇟ (PageDown) : move up / down</li>
               <li>mouse Clic + drag : camera rotation</li>
             </ul>
         </div>
         <div id="viewerDiv"></div>
         <script src="../dist/itowns.js"></script>
-        <script src="GUI/dat.gui/dat.gui.min.js"></script>
         <script type="text/javascript">
             var renderer; var exports = {};
         </script>
         <script src="planar.js"></script>
-        <script>
-            var gui = new dat.GUI({ autoplace: false });
-            gui.add(flyControls, 'moveSpeed', 10, 1000).name('Move speed');
-        </script>
     </body>
 </html>

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -4,8 +4,6 @@
 var extent;
 var viewerDiv;
 var view;
-var c;
-var flyControls;
 
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 itowns.proj4.defs('EPSG:3946',
@@ -23,10 +21,6 @@ viewerDiv = document.getElementById('viewerDiv');
 // Instanciate PlanarView*
 view = new itowns.PlanarView(viewerDiv, extent, { renderer: renderer });
 view.tileLayer.disableSkirt = true;
-
-// instanciate controls
-flyControls = new itowns.FlyControls(view, { focusOnClick: true });
-flyControls.moveSpeed = 1000;
 
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
 view.addLayer({
@@ -67,12 +61,13 @@ view.tileLayer.materialOptions = {
     colorTextureElevationMaxZ: 240,
 };
 
-// Since PlanarView doesn't create default controls, we manipulate directly three.js camera
-// Position the camera at south-west corner
-c = new itowns.Coordinates('EPSG:3946', extent.west(), extent.south(), 2000);
-view.camera.camera3D.position.copy(c.xyz());
+view.camera.setPosition(new itowns.Coordinates('EPSG:3946', extent.west(), extent.south(), 2000));
 // Then look at extent's center
 view.camera.camera3D.lookAt(extent.center().xyz());
+
+// instanciate controls
+// eslint-disable-next-line no-new
+new itowns.FirstPersonControls(view, { focusOnClick: true, moveSpeed: 1000 });
 
 // Request redraw
 view.notifyChange(true);

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -7,7 +7,7 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     var viewerDiv;
     var debugGui;
     var view;
-    var flyControls;
+    var controls;
 
     viewerDiv = document.getElementById('viewerDiv');
     viewerDiv.style.display = 'block';
@@ -47,14 +47,14 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     }
     view.mainLoop.gfxEngine.renderer.domElement.addEventListener('dblclick', dblClickHandler);
 
-    // create fly controls
-    flyControls = new itowns.FlyControls(view, { focusOnClick: true });
-    debugGui.add(flyControls, 'moveSpeed', 1, 100).name('Movement speed');
-
 
     function placeCamera(position, lookAt) {
         view.camera.camera3D.position.set(position.x, position.y, position.z);
         view.camera.camera3D.lookAt(lookAt);
+        // create controls
+        controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
+        debugGui.add(controls, 'moveSpeed', 1, 100).name('Movement speed');
+
         view.notifyChange(true);
     }
 
@@ -74,7 +74,7 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
         lookAt = pointcloud.root.bbox.getCenter();
         lookAt.z = pointcloud.root.bbox.min.z;
         placeCamera(position, lookAt);
-        flyControls.moveSpeed = pointcloud.root.bbox.getSize().length() / 3;
+        controls.moveSpeed = pointcloud.root.bbox.getSize().length() / 3;
 
         // update stats window
         oldPostUpdate = pointcloud.postUpdate;

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Itowns - Planar example</title>
+        <title>Itowns - WFS (geojson) example</title>
 
         <style type="text/css">
             html {
@@ -61,20 +61,15 @@
             <ul>
               <li>↑ ↓ : forward / backward</li>
               <li>← → : strafe left / right</li>
-              <li>⇞ (PageUp), ⇟ (PageDown) : roll right / left</li>
+              <li>⇞ (PageUp), ⇟ (PageDown) : move up / down</li>
               <li>mouse Clic + drag : camera rotation</li>
             </ul>
         </div>
         <div id="viewerDiv"></div>
         <script src="../dist/itowns.js"></script>
-        <script src="GUI/dat.gui/dat.gui.min.js"></script>
         <script type="text/javascript">
             var renderer; var exports = {};
         </script>
         <script src="wfs.js"></script>
-        <script>
-            var gui = new dat.GUI({ autoplace: false });
-            gui.add(flyControls, 'moveSpeed', 10, 1000).name('Move speed');
-        </script>
     </body>
 </html>

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -4,7 +4,6 @@
 var extent;
 var viewerDiv;
 var view;
-var flyControls;
 
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 itowns.proj4.defs('EPSG:3946',
@@ -22,10 +21,6 @@ viewerDiv = document.getElementById('viewerDiv');
 // Instanciate PlanarView*
 view = new itowns.PlanarView(viewerDiv, extent, { renderer: renderer });
 view.tileLayer.disableSkirt = true;
-
-// instanciate controls
-flyControls = new itowns.FlyControls(view, { focusOnClick: true });
-flyControls.moveSpeed = 1000;
 
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
 view.addLayer({
@@ -47,6 +42,9 @@ view.addLayer({
 
 view.camera.camera3D.position.set(1839739, 5171618, 910);
 view.camera.camera3D.lookAt(new itowns.THREE.Vector3(1840839, 5172718, 0));
+
+// eslint-disable-next-line no-new
+new itowns.FirstPersonControls(view, { focusOnClick: true, moveSpeed: 1000 });
 
 // Request redraw
 view.notifyChange(true);

--- a/src/Main.js
+++ b/src/Main.js
@@ -22,5 +22,6 @@ export { ColorLayersOrdering } from './Renderer/ColorLayersOrdering';
 export { default as PointsMaterial } from './Renderer/PointsMaterial';
 export { default as PointCloudProcessing } from './Process/PointCloudProcessing';
 export { default as FlyControls } from './Renderer/ThreeExtended/FlyControls';
+export { default as FirstPersonControls } from './Renderer/ThreeExtended/FirstPersonControls';
 export { default as GeoJSON2Three } from './Renderer/ThreeExtended/GeoJSON2Three';
 export { CONTROL_EVENTS } from './Renderer/ThreeExtended/GlobeControls';

--- a/src/Renderer/ThreeExtended/FirstPersonControls.js
+++ b/src/Renderer/ThreeExtended/FirstPersonControls.js
@@ -1,0 +1,131 @@
+import * as THREE from 'three';
+
+const MAX_FOV = 90;
+
+// Note: we could use existing three.js controls (like https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/FirstPersonControls.js)
+// but including these controls in itowns allows use to integrate them tightly with itowns.
+// Especially the existing controls are expecting a continuous update loop while we have a pausable one (so our controls use .notifyChange when needed)
+
+function onDocumentMouseDown(event) {
+    event.preventDefault();
+    this._isUserInteracting = true;
+
+    this._onMouseDownMouseX = event.clientX;
+    this._onMouseDownMouseY = event.clientY;
+    this._onMouseDownPhi = this._phi;
+    this._onMouseDownTheta = this._theta;
+}
+
+function onDocumentMouseMove(event) {
+    if (this._isUserInteracting === true) {
+        const fovCorrection = this.camera.fov / MAX_FOV; // 1 at MAX_FOV
+        this._phi = (this._onMouseDownMouseX - event.clientX) * 0.13 * fovCorrection + this._onMouseDownPhi;
+        this._theta = (event.clientY - this._onMouseDownMouseY) * 0.13 * fovCorrection + this._onMouseDownTheta;
+        this.view.notifyChange(false);
+    }
+}
+
+function onDocumentMouseUp() {
+    this._isUserInteracting = false;
+}
+
+function onKeyUp(e) {
+    const move = MOVEMENTS[e.keyCode];
+    if (move) {
+        this.moves.delete(move);
+        this.view.notifyChange(true);
+        e.preventDefault();
+    }
+}
+
+function onKeyDown(e) {
+    const move = MOVEMENTS[e.keyCode];
+    if (move) {
+        this.moves.add(move);
+        this.view.notifyChange(false);
+        e.preventDefault();
+    }
+}
+
+const MOVEMENTS = {
+    38: { method: 'translateZ', sign: -1 }, // FORWARD: up key
+    40: { method: 'translateZ', sign: 1 }, // BACKWARD: down key
+    37: { method: 'translateX', sign: -1 }, // STRAFE_LEFT: left key
+    39: { method: 'translateX', sign: 1 }, // STRAFE_RIGHT: right key
+    33: { method: 'translateY', sign: 1 }, // UP: PageUp key
+    34: { method: 'translateY', sign: -1 }, // DOWN: PageDown key
+};
+
+
+class FirstPersonControls extends THREE.EventDispatcher {
+    constructor(view, options = {}) {
+        super();
+        this.camera = view.camera.camera3D;
+        this.view = view;
+        this.moves = new Set();
+        this.moveSpeed = options.moveSpeed || 10; // backward or forward move speed in m/s
+        this._isUserInteracting = false;
+        this._onMouseDownMouseX = 0;
+        this._onMouseDownMouseY = 0;
+        this._onMouseDownPhi = 0;
+        this._onMouseDownTheta = 0;
+
+        // init from camera rotation
+        this.camera.rotation.reorder('ZYX');
+        this._theta = THREE.Math.radToDeg(this.camera.rotation.x);
+        this._phi = THREE.Math.radToDeg(this.camera.rotation.z);
+        this.updateAngles();
+
+        const domElement = view.mainLoop.gfxEngine.renderer.domElement;
+        domElement.addEventListener('mousedown', onDocumentMouseDown.bind(this), false);
+        domElement.addEventListener('mousemove', onDocumentMouseMove.bind(this), false);
+        domElement.addEventListener('mouseup', onDocumentMouseUp.bind(this), false);
+        domElement.addEventListener('keyup', onKeyUp.bind(this), true);
+        domElement.addEventListener('keydown', onKeyDown.bind(this), true);
+
+        this.view.addFrameRequester(this);
+
+        // focus policy
+        if (options.focusOnMouseOver) {
+            domElement.addEventListener('mouseover', () => domElement.focus());
+        }
+        if (options.focusOnClick) {
+            domElement.addEventListener('click', () => domElement.focus());
+        }
+    }
+
+    isUserInteracting() {
+        return this.moves.size !== 0;
+    }
+
+    updateAngles() {
+        this.camera.rotation.order = 'ZYX';
+        this.camera.rotation.x = THREE.Math.degToRad(this._theta);
+        this.camera.rotation.z = THREE.Math.degToRad(this._phi);
+
+        this.view.notifyChange(true);
+    }
+
+    update(dt, updateLoopRestarted) {
+        // if we are in a keypressed state, then update position
+
+        // dt will not be relevant when we just started rendering, we consider a 1-frame move in this case
+        if (updateLoopRestarted) {
+            dt = 16;
+        }
+
+        for (const move of this.moves) {
+            if (move.method === 'translateY') {
+                this.camera.position.z += move.sign * this.moveSpeed * dt / 1000;
+            } else {
+                this.camera[move.method](move.sign * this.moveSpeed * dt / 1000);
+            }
+        }
+
+        if (this.moves.size || this._isUserInteracting) {
+            this.updateAngles();
+        }
+    }
+}
+
+export default FirstPersonControls;


### PR DESCRIPTION
(depends on #444)

This control is very similar to FlyControls but the major difference is that
in this control the camera cannot roll.
This is handy in app using a planar mode where the roll movement is never wanted.

This control can also be used to create a PanoramaControls, just set moveSpeed to 0.

At some point we'll probably refactor all our controls under a single class exposing
the different behavior.

Edit:
Here are the advantages I see at including controls in iTowns (instead of using existing ones):

- integrates better with iTowns architecture. Especially the existing controls are expecting a continuous update loop while we have a pausable one (so our controls use .notifyChange when needed)
-   in a second step we'll be able to hide the different controls under a single configurable Control thingy - instead of asking our user to find existing controls and plug them in itowns
-  last but not least: merging our controls doesn't prevent the user to use some existing three.js controls anyway.

