### PR TITLE
feature: add StaticProvider

### DIFF
--- a/src/Core/Layer/LayerUpdateState.js
+++ b/src/Core/Layer/LayerUpdateState.js
@@ -3,6 +3,7 @@ const UPDATE_STATE = {
     PENDING: 1,
     ERROR: 2,
     DEFINITIVE_ERROR: 3,
+    FINISHED: 4,
 };
 const PAUSE_BETWEEN_ERRORS = [1.0, 3.0, 7.0, 60.0];
 
@@ -24,7 +25,8 @@ LayerUpdateState.prototype.canTryUpdate = function canTryUpdate(timestamp) {
             return true;
         }
         case UPDATE_STATE.DEFINITIVE_ERROR:
-        case UPDATE_STATE.PENDING: {
+        case UPDATE_STATE.PENDING:
+        case UPDATE_STATE.FINISHED: {
             return false;
         }
         case UPDATE_STATE.ERROR:
@@ -52,6 +54,10 @@ LayerUpdateState.prototype.newTry = function newTry() {
 LayerUpdateState.prototype.success = function success() {
     this.lastErrorTimestamp = 0;
     this.state = UPDATE_STATE.IDLE;
+};
+
+LayerUpdateState.prototype.noMoreUpdatePossible = function noMoreUpdatePossible() {
+    this.state = UPDATE_STATE.FINISHED;
 };
 
 LayerUpdateState.prototype.failure = function failure(timestamp, definitive) {

--- a/src/Core/Scheduler/Providers/StaticProvider.js
+++ b/src/Core/Scheduler/Providers/StaticProvider.js
@@ -1,0 +1,132 @@
+import { Vector3 } from 'three';
+import Extent from '../../Geographic/Extent';
+import OGCWebServiceHelper from './OGCWebServiceHelper';
+import Fetcher from './Fetcher';
+import { l_COLOR } from '../../../Renderer/LayeredMaterial';
+
+// select the smallest image entirely covering the tile
+function selectBestImageForExtent(images, extent) {
+    let selection;
+    for (const entry of images) {
+        if (extent.isInside(entry.extent)) {
+            if (!selection) {
+                selection = entry;
+            } else {
+                const d = selection.extent.dimensions();
+                const e = entry.extent.dimensions();
+                if (e.x <= d.x && e.y <= d.y) {
+                    selection = entry;
+                }
+            }
+        }
+    }
+    return selection;
+}
+
+function getColorTexture(tile, layer) {
+    if (!layer.tileInsideLimit(tile, layer)) {
+        return Promise.reject(`Tile '${tile}' is outside layer bbox ${layer.extent}`);
+    }
+    if (!tile.material) {
+        return Promise.resolve();
+    }
+
+    if (!layer.images) {
+        return Promise.reject();
+    }
+
+    const selection = selectBestImageForExtent(layer.images, tile.extent);
+
+    if (!selection) {
+        return Promise.reject(
+            new Error(`No available image for tile ${tile}`));
+    }
+
+    const url = layer.url.href.substr(0, layer.url.href.lastIndexOf('/') + 1) + selection.image;
+    return OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions).then((texture) => {
+        // adjust pitch
+        const result = {
+            texture,
+            pitch: new Vector3(0, 0, 1),
+        };
+
+        result.texture.extent = selection.extent;
+        result.texture.coords = selection.extent;
+        if (!result.texture.coords.zoom || result.texture.coords.zoom > tile.level) {
+            result.texture.coords.zoom = tile.level;
+            result.texture.file = selection.image;
+        }
+        // TODO: modify TileFS to handle tiles with ratio != image's ratio
+        result.pitch = tile.extent.offsetToParent(selection.extent);
+
+
+        return result;
+    });
+}
+
+
+/**
+ * This provider uses no protocol but instead download static images directly.
+ *
+ * It uses as input 'image_filename: extent' values and then tries to find the best image
+ * for a given tile using the extent property.
+ */
+export default {
+    preprocessDataLayer(layer) {
+        if (!layer.extent) {
+            throw new Error('layer.extent is required');
+        }
+
+        if (!(layer.extent instanceof Extent)) {
+            layer.extent = new Extent(layer.projection, ...layer.extent);
+        }
+
+        layer.options = {};
+        layer.canTileTextureBeImproved = this.canTileTextureBeImproved;
+        layer.url = new URL(layer.url, window.location);
+        return Fetcher.json(layer.url.href).then((metadata) => {
+            layer.images = [];
+            // eslint-disable-next-line guard-for-in
+            for (const image in metadata) {
+                const extent = new Extent(layer.projection, ...metadata[image]);
+                layer.images.push({
+                    image,
+                    extent,
+                });
+            }
+        });
+    },
+
+    tileInsideLimit(tile, layer) {
+        if (!layer.images) {
+            return false;
+        }
+        for (const entry of layer.images) {
+            if (tile.extent.isInside(entry.extent)) {
+                return true;
+            }
+        }
+
+        return false;
+    },
+
+    canTileTextureBeImproved(layer, tile) {
+        const s = selectBestImageForExtent(layer.images, tile.extent);
+        if (!s) {
+            return false;
+        }
+        const mat = tile.material;
+        const idx = mat.getLayerTextureOffset(layer.id);
+        const currentTexture = mat.textures[l_COLOR][idx];
+        if (!currentTexture.file) {
+            return true;
+        }
+        return currentTexture.file != s.image;
+    },
+
+    executeCommand(command) {
+        const tile = command.requester;
+        const layer = command.layer;
+        return getColorTexture(tile, layer);
+    },
+};

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -13,6 +13,7 @@ import TMS_Provider from './Providers/TMS_Provider';
 import PointCloudProvider from './Providers/PointCloudProvider';
 import WFS_Provider from './Providers/WFS_Provider';
 import Raster_Provider from './Providers/Raster_Provider';
+import StaticProvider from './Providers/StaticProvider';
 
 var instanceScheduler = null;
 
@@ -97,6 +98,7 @@ Scheduler.prototype.initDefaultProviders = function initDefaultProviders() {
     this.addProtocolProvider('potreeconverter', PointCloudProvider);
     this.addProtocolProvider('wfs', new WFS_Provider());
     this.addProtocolProvider('rasterizer', Raster_Provider);
+    this.addProtocolProvider('static', StaticProvider);
 };
 
 Scheduler.prototype.runCommand = function runCommand(command, queue, executingCounterUpToDate) {

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -195,10 +195,12 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
     if (layer.canTileTextureBeImproved) {
         // if the layer has a custom method -> use it
         if (!layer.canTileTextureBeImproved(layer, node)) {
+            node.layerUpdateState[layer.id].noMoreUpdatePossible();
             return Promise.resolve();
         }
     } else if (!node.isColorLayerDownscaled(layer)) {
         // default decision method
+        node.layerUpdateState[layer.id].noMoreUpdatePossible();
         return Promise.resolve();
     }
 


### PR DESCRIPTION
Sometimes it's handy to be able to use a single image as a layer (mainly want you
want to quick test without the hassle of setting up a wms server for instance).

This provider is really simple, and just compute the offset in the image to use
to match the tile extent.

Example usage:
```js
    view.addLayer({
        url: 'http://localhost:8080/foo.png',
        networkOptions: { crossOrigin: 'anonymous' },
        type: 'color',
        protocol: 'image',
        id: 'myimage',
    });
```