### PR TITLE
feature (3dtiles): add support for batch table

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -14,14 +14,42 @@
                 height:100%;
             }
 
-            div {
+
+            #batchInformationDiv {
+                position: absolute;
+                z-index: 0;
+                top: 0;
+                right: 0;
+                color: white;
+                color: #eee;
+                font: 11px 'Lucida Grande',sans-serif;
+                line-height: normal;
+                text-shadow: 0 -1px 0 #111;
+                padding: 0 1rem;
+                background: #1a1a1a;
+                border: 1px solid #2c2c2c;
+                opacity: 0.8;
+            }
+
+            #batchInformationDiv > p {
+                margin: 0.5rem 0;
+            }
+
+            #batchInformationDiv > ul {
+                padding: 0 1rem;
+            }
+
+            @media (max-width: 600px) {
+                #batchInformationDiv {
+                    display: none;
+                }
+            }
+            #menuDiv {
                 margin : auto auto;
                 width: 100%;
                 padding: 0;
                 height: 100%;
-            }
 
-            #menuDiv {
                 position: absolute;
                 top:0px;
                 margin-left: 0px;
@@ -32,6 +60,12 @@
                 }
             }
 
+            #viewerDiv {
+                margin : auto auto;
+                width: 100%;
+                padding: 0;
+                height: 100%;
+            }
             #viewerDiv > canvas {
                 display: block;
             }
@@ -80,7 +114,9 @@
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
-            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', globe.scene);
+
+            var container = new itowns.THREE.Group();
+            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', container);
 
             $3dTilesLayerRequestVolume.preUpdate = preUpdateGeo;
             $3dTilesLayerRequestVolume.update = itowns.process3dTilesNode(
@@ -94,15 +130,68 @@
             $3dTilesLayerRequestVolume.overrideMaterials = true;  // custom cesium shaders are not functional
             $3dTilesLayerRequestVolume.type = 'geometry';
             $3dTilesLayerRequestVolume.visible = true;
+            // add an event for have information when you move your mouse on a building
+            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
 
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume);
+            globe.scene.add(container);
 
             // Add the UI Debug
-            const d = new debug.Debug(globe, menuGlobe.gui);
+            var d = new debug.Debug(globe, menuGlobe.gui);
             debug.createTileDebugUI(menuGlobe.gui, globe, globe.wgs84TileLayer, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerDiscreteLOD, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerRequestVolume, d);
 
+
+
+// Picking example - - - - - - - - - - -- - - - -- - - - -- - - - -- - - - -- - - - -- - - - -
+            function findBatchTableParent(object) {
+                if (object.batchTable) {
+                    return object.batchTable;
+                }
+                else if (object.parent) {
+                    return findBatchTableParent(object.parent);
+                } else {
+                    return undefined;
+                }
+            }
+            function picking(event) {
+                // Pick an object with batch id
+                var mouse = new itowns.THREE.Vector2((event.clientX / window.innerWidth) * 2 - 1, -(event.clientY / window.innerHeight) * 2 + 1);
+                var raycaster = new itowns.THREE.Raycaster();
+                var htmlInfo = document.getElementById('info');
+                htmlInfo.innerHTML = ' ';
+
+                raycaster.setFromCamera(mouse, globe.camera.camera3D);
+                // calculate objects intersecting the picking ray
+                var intersects = raycaster.intersectObjects(container.children, true);
+                for (var i = 0; i < intersects.length; i++) {
+                    var interAttributes = intersects[i].object.geometry.attributes;
+                    if (interAttributes) {
+                        if (interAttributes._BATCHID) {
+                            var face = intersects[i].face.a;
+                            var batchID = interAttributes._BATCHID.array[face];
+                            var batchTable = findBatchTableParent(intersects[i].object);
+
+                            htmlInfo.innerHTML +='<li><b> Batch id: </b>'+ batchID +'</li>';
+                            Object.keys(batchTable).map(function(objectKey) {
+                                var value = batchTable[objectKey][batchID];
+                                // if the value is a integer or not
+                                var info = Number.isInteger(value) ? value.toString() : value.toFixed(3).toString();
+                                htmlInfo.innerHTML +='<li><b>' + objectKey.toString() + ': </b>'+ info +'</li>';
+                                return true;
+                            });
+
+                            return;
+                        }
+                    }
+                }
+            }
+
         </script>
+        <div id="batchInformationDiv">
+            <p><b>Information Batch Table: </b></p>
+            <ul id="info">
+            </ul>
+        </div>
     </body>
 </html>

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -332,6 +332,7 @@ GlobeView.prototype.removeLayer = function removeImageryLayer(layerId) {
 };
 
 GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
+    // update the picking ray with the camera and mouse position
     const selectedId = this.screenCoordsToNodeId(mouse);
 
     for (const n of this.wgs84TileLayer.level0Nodes) {

--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -142,14 +142,14 @@ $3dTiles_Provider.prototype.b3dmToMesh = function b3dmToMesh(data, layer) {
                 }
             }
         };
-        result.scene.traverse(init);
-        return result.scene;
+        result.gltf.scene.traverse(init);
+        return result.gltf.scene;
     });
 };
 
 $3dTiles_Provider.prototype.pntsParse = function pntsParse(data) {
     return new Promise((resolve) => {
-        resolve(PntsLoader.parse(data));
+        resolve(PntsLoader.parse(data).point);
     });
 };
 

--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -143,13 +143,15 @@ $3dTiles_Provider.prototype.b3dmToMesh = function b3dmToMesh(data, layer) {
             }
         };
         result.gltf.scene.traverse(init);
-        return result.gltf.scene;
+        const batchTable = result.batchTable;
+        const object3d = result.gltf.scene;
+        return { batchTable, object3d };
     });
 };
 
 $3dTiles_Provider.prototype.pntsParse = function pntsParse(data) {
     return new Promise((resolve) => {
-        resolve(PntsLoader.parse(data).point);
+        resolve({ object3d: PntsLoader.parse(data).point });
     });
 };
 
@@ -211,8 +213,11 @@ $3dTiles_Provider.prototype.executeCommand = function executeCommand(command) {
                 if (func) {
                     // TODO: request should be delayed if there is a viewerRequestVolume
                     return func(result, layer).then((content) => {
-                        tile.content = content;
-                        tile.add(content);
+                        tile.content = content.object3d;
+                        if (content.batchTable) {
+                            tile.batchTable = content.batchTable;
+                        }
+                        tile.add(content.object3d);
                         tile.traverse(setLayer);
                         return tile;
                     });

--- a/src/Renderer/ThreeExtended/BatchTable.js
+++ b/src/Renderer/ThreeExtended/BatchTable.js
@@ -1,0 +1,9 @@
+const textDecoder = new TextDecoder('utf-8');
+
+export default {
+    parse(buffer) {
+        const content = textDecoder.decode(new Uint8Array(buffer));
+        const json = JSON.parse(content);
+        return json;
+    },
+};

--- a/src/Renderer/ThreeExtended/GLTFLoader.js
+++ b/src/Renderer/ThreeExtended/GLTFLoader.js
@@ -1,5 +1,6 @@
 // This file is copy pasted from THREE
 /* CUSTOM ITOWNS */
+/* Add the extention _BATCHID */
 /* eslint-disable */
 import * as THREE from 'three';
 /* END CUSTOM ITOWNS */
@@ -1661,6 +1662,9 @@ THREE.GLTFLoader = ( function () {
 									geometry.addAttribute( 'skinIndex', bufferAttribute );
 									break;
 
+								case '_BATCHID':
+									geometry.addAttribute( '_BATCHID', bufferAttribute );
+									break;
 							}
 
 						}

--- a/src/Renderer/ThreeExtended/PntsLoader.js
+++ b/src/Renderer/ThreeExtended/PntsLoader.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import BT from './BatchTable';
 
 const textDecoder = new TextDecoder('utf-8');
 export default {
@@ -10,6 +11,8 @@ export default {
 
         let byteOffset = 0;
         const pntsHeader = {};
+        let batchTable = {};
+        let point = {};
 
         // Magic type is unsigned char [4]
         pntsHeader.magic = textDecoder.decode(new Uint8Array(buffer, byteOffset, 4));
@@ -37,13 +40,17 @@ export default {
 
             // binary table
             if (pntsHeader.FTBinaryLength > 0) {
-                return parseFeatureBinary(buffer, byteOffset, pntsHeader.FTJSONLength);
+                point = parseFeatureBinary(buffer, byteOffset, pntsHeader.FTJSONLength);
             }
 
             // batch table
-            if (pntsHeader.BTBinaryLength > 0) {
-                throw new Error('For pnts loader, BTBinaryLength: not yet managed');
+            if (pntsHeader.BTJSONLength > 0) {
+                const sizeBegin = 28 + pntsHeader.FTJSONLength + pntsHeader.FTBinaryLength;
+                batchTable = BT.parseBatchTableJSON(buffer.slice(sizeBegin, pntsHeader.BTJSONLength + sizeBegin));
             }
+
+            const pnts = { point, batchTable };
+            return pnts;
         } else {
             throw new Error('Invalid pnts file.');
         }


### PR DESCRIPTION
This PR contribute to the 3D tiles support. issue #185
 - This PR parse the optional batch table for each supported format (.pnts, .b3dm) and make the relationship between an object and its Batch Table. The table is stored in the object for later usage (e.g: use batch ID to colorize mesh for example). 
 - See [Batch Table](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/TileFormats/BatchTable/README.md) for more information

Example: 
![](http://zupimages.net/up/17/34/ctsm.png)
I move my mouse on 1 building and I have the information about him on your top left.