### PR TITLE
Refactor: fail fast if a protocol is given but unknown

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -259,7 +259,11 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         layer.extent = parentLayer.extent;
     }
 
-    layer = _preprocessLayer(this, layer, this.mainLoop.scheduler.getProtocolProvider(layer.protocol));
+    const provider = this.mainLoop.scheduler.getProtocolProvider(layer.protocol);
+    if (layer.protocol && !provider) {
+        throw new Error(`${layer.protocol} is not a recognized protocol name.`);
+    }
+    layer = _preprocessLayer(this, layer, provider);
     if (parentLayer) {
         parentLayer.attach(layer);
     } else {


### PR DESCRIPTION
Partially fixes #455 

Making a typo in layer.protocol yields unrelated error message and this could be painful to application devs. Let's be nice and warn them as soon as possible.