### PR TITLE
fix (api): getZoom debug

### DIFF
--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -12,6 +12,18 @@ let SSE_SUBDIVISION_THRESHOLD;
 
 const worldToScaledEllipsoid = new THREE.Matrix4();
 
+function _preSSE(view) {
+    const canvasSize = view.mainLoop.gfxEngine.getWindowSize();
+    const hypotenuse = canvasSize.length();
+    const radAngle = view.camera.camera3D.fov * Math.PI / 180;
+
+     // TODO: not correct -> see new preSSE
+    // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
+    const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / canvasSize.x);
+
+    preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
+}
+
 export function preGlobeUpdate(context, layer) {
     // We're going to use the method described here:
     //    https://cesiumjs.org/2013/04/25/Horizon-culling/
@@ -30,15 +42,7 @@ export function preGlobeUpdate(context, layer) {
     vhMagnitudeSquared = cV.lengthSq() - 1.0;
 
     // pre-sse
-    const canvasSize = context.engine.getWindowSize();
-    const hypotenuse = canvasSize.length();
-    const radAngle = context.camera.camera3D.fov * Math.PI / 180;
-
-     // TODO: not correct -> see new preSSE
-    // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
-    const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / canvasSize.x);
-
-    preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
+    _preSSE(context.view);
 }
 
 function pointHorizonCulling(pt) {
@@ -139,7 +143,8 @@ export function globeSchemeTileWMTS(type) {
     return schemeT;
 }
 
-export function computeTileZoomFromDistanceCamera(distance) {
+export function computeTileZoomFromDistanceCamera(distance, view) {
+    _preSSE(view);
     const sizeEllipsoid = ellipsoidSizes().x;
     const preSinus = SIZE_TEXTURE_TILE * (SSE_SUBDIVISION_THRESHOLD * 0.5) / preSSE / sizeEllipsoid;
 

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1615,7 +1615,7 @@ GlobeControls.prototype.isAnimationEnabled = function isAnimationEnabled() {
  * @return     {number}  The zoom .
  */
 GlobeControls.prototype.getZoom = function getZoom() {
-    return computeTileZoomFromDistanceCamera(this.getRange());
+    return computeTileZoomFromDistanceCamera(this.getRange(), this._view);
 };
 
 /**


### PR DESCRIPTION
With the miniGlobe, getZoom used to always return 0.

getZoom() needs the preSSE wich is calculated with the size of the canvas. But with the miniGlobe, preSSE was calculated with the size of the miniGlobe's canvas, so it was wrong.

To solve this I added IDs to the canvas elements, so now preSSE is calculated with the good size.