### PR TITLE
feature (3dtiles): sliders for sse Threshold

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -130,6 +130,7 @@
             $3dTilesLayerRequestVolume.overrideMaterials = true;  // custom cesium shaders are not functional
             $3dTilesLayerRequestVolume.type = 'geometry';
             $3dTilesLayerRequestVolume.visible = true;
+            $3dTilesLayerRequestVolume.sseThreshold = 1;            
             // add an event for have information when you move your mouse on a building
             itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
 

--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -47,6 +47,7 @@ $3dTiles_Provider.prototype.removeLayer = function removeLayer() {
 };
 
 $3dTiles_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer, view, scheduler) {
+    layer.sseThreshold = layer.sseThreshold || 16;
     return Fetcher.json(layer.url, layer.networkOptions).then((tileset) => {
         layer.tileset = tileset;
         const urlPrefix = layer.url.slice(0, layer.url.lastIndexOf('/') + 1);

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -179,5 +179,5 @@ export function process3dTilesNode(cullingTest, subdivisionTest) {
 
 export function $3dTilesSubdivisionControl(context, layer, node) {
     const sse = computeNodeSSE(context.camera, node);
-    return sse > 1.0;
+    return sse > layer.sseThreshold;
 }

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -96,6 +96,11 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
             });
         });
 
+    // The sse Threshold for each tile
+    gui.add(layer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
+        view.notifyChange(true);
+    });
+
     gui.add(layer, 'visible').name('Visible').onChange(() => {
         view.notifyChange(true);
     });


### PR DESCRIPTION
feature (3dtiles): sse subdivision threshold can be manually defined

- Default threshold is now 16 instead of 1
- This commit also adds a new slider to modify the threshold, for each tileset in the 3d-tiles example
![](http://www.zupimages.net/up/17/35/pg1f.png)
