### PR TITLE
Avoid collision for preSSE

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -79,7 +79,6 @@ export function $3dTilesCulling(node, camera) {
     return false;
 }
 
-let preSSE;
 export function pre3dTilesUpdate(context, layer) {
     // pre-sse
     const hypotenuse = Math.sqrt(context.camera.width * context.camera.width + context.camera.height * context.camera.height);
@@ -88,7 +87,7 @@ export function pre3dTilesUpdate(context, layer) {
      // TODO: not correct -> see new preSSE
     // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
     const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / context.camera.width);
-    preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
+    context.camera.preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
     return [layer.root];
 }
 
@@ -100,7 +99,7 @@ function computeNodeSSE(camera, node) {
         cameraLocalPosition.y -= node.boundingVolume.region.matrixWorld.elements[13];
         cameraLocalPosition.z -= node.boundingVolume.region.matrixWorld.elements[14];
         const distance = node.boundingVolume.region.box3D.distanceToPoint(cameraLocalPosition);
-        return preSSE * (node.geometricError / distance);
+        return camera.preSSE * (node.geometricError / distance);
     }
     if (node.boundingVolume.box) {
         const cameraLocalPosition = camera.camera3D.position.clone();
@@ -108,7 +107,7 @@ function computeNodeSSE(camera, node) {
         cameraLocalPosition.y -= node.matrixWorld.elements[13];
         cameraLocalPosition.z -= node.matrixWorld.elements[14];
         const distance = node.boundingVolume.box.distanceToPoint(cameraLocalPosition);
-        return preSSE * (node.geometricError / distance);
+        return camera.preSSE * (node.geometricError / distance);
     }
     if (node.boundingVolume.sphere) {
         const cameraLocalPosition = camera.camera3D.position.clone();
@@ -116,7 +115,7 @@ function computeNodeSSE(camera, node) {
         cameraLocalPosition.y -= node.matrixWorld.elements[13];
         cameraLocalPosition.z -= node.matrixWorld.elements[14];
         const distance = node.boundingVolume.sphere.distanceToPoint(cameraLocalPosition);
-        return preSSE * (node.geometricError / distance);
+        return camera.preSSE * (node.geometricError / distance);
     }
     return Infinity;
 }

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1629,7 +1629,7 @@ GlobeControls.prototype.getZoom = function getZoom() {
  */
 GlobeControls.prototype.setZoom = function setZoom(zoom, isAnimated) {
     isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
-    const range = computeDistanceCameraFromTileZoom(zoom);
+    const range = computeDistanceCameraFromTileZoom(zoom, this._view);
     return this.setRange(range, isAnimated);
 };
 
@@ -1731,7 +1731,7 @@ GlobeControls.prototype.setCameraTargetGeoPosition = function setCameraTargetGeo
 GlobeControls.prototype.setCameraTargetGeoPositionAdvanced = function setCameraTargetGeoPositionAdvanced(position, isAnimated) {
     isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
     if (position.zoom) {
-        position.range = computeDistanceCameraFromTileZoom(position.zoom);
+        position.range = computeDistanceCameraFromTileZoom(position.zoom, this._view);
     } else if (position.scale) {
         position.range = getRangeFromScale(position.scale);
     }


### PR DESCRIPTION
This is a followup of #458:
- it fixes preSSE for 3dTiles
- it fixes GlobeTileProcessing.computeDistanceCameraFromTileZoom

Now preSSE is a field of layer to avoid all risks of collision if we don't call `_preSSE` before using the value.

@iTowns/reviewers please r?