### PR TITLE
feature: add collision handling for camera with terrain

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -236,6 +236,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         this.camera.camera3D.lookAt(positionTargetCamera.as('EPSG:4978').xyz());
     } else {
         this.controls = new GlobeControls(this, positionTargetCamera.as('EPSG:4978').xyz(), size);
+        this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
     }
 
     this._renderState = RendererConstant.FINAL;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -1,9 +1,3 @@
-/**
- * Generated On: 2015-10-5
- * Class: Scene
- * Description: La Scene est l'instance principale du client. Elle est le chef orchestre de l'application.
- */
-
 /* global window, requestAnimationFrame */
 import { Scene, EventDispatcher, Vector2 } from 'three';
 import Camera from '../Renderer/Camera';

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -16,7 +16,6 @@ import { computeTileZoomFromDistanceCamera, computeDistanceCameraFromTileZoom } 
 // Recast touch for globe
 // Fix target problem with pan and panoramic (when target isn't on globe)
 // Fix problem with space
-// Add real collision
 
 // FIXME:
 // when move globe in damping orbit, there isn't move!!
@@ -410,6 +409,10 @@ function GlobeControls(view, target, radius, options = {}) {
     this.minAzimuthAngle = -Infinity; // radians
     this.maxAzimuthAngle = Infinity; // radians
 
+    // Set collision options
+    this.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
+    this.minDistanceCollision = 100;
+
     // Set to true to disable use of the keys
     this.enableKeys = true;
 
@@ -573,6 +576,10 @@ function GlobeControls(view, target, radius, options = {}) {
     const axisX = new THREE.Vector3(1, 0, 0);
 
     var update = function update() {
+        // We test if camera collide to geometry layer or too close to ground and ajust it's altitude in case
+        if (this.handleCollision) { // We check distance to the ground/surface geometry. (Could be another geometry layer)
+            this._view.camera.adjustAltitudeToAvoidCollisionWithLayer(this._view, view.getLayers(layer => layer.type === 'geometry')[0], this.minDistanceCollision);
+        }
         // MOVE_GLOBE
         // Rotate globe with mouse
         if (state === CONTROL_STATE.MOVE_GLOBE) {

--- a/src/Renderer/ThreeExtended/PlanarControls.js
+++ b/src/Renderer/ThreeExtended/PlanarControls.js
@@ -88,6 +88,10 @@ function PlanarControls(view, options = {}) {
     this.focusOnMouseOver = options.focusOnMouseOver || true;
     this.focusOnMouseClick = options.focusOnMouseClick || true;
 
+    // Set collision options
+    this.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
+    this.minDistanceCollision = 30;
+
     // starting camera position and orientation target are setup before instanciating PlanarControls
     // using: view.camera.setPosition() and view.camera.lookAt()
     // startPosition and startQuaternion are stored to be able to return to the start view
@@ -148,6 +152,10 @@ function PlanarControls(view, options = {}) {
 
     // Updates the view and camera if needed, and handles the animated travel
     this.update = function update(dt, updateLoopRestarted) {
+        // We test if camera collide to geometry layer or too close to ground and ajust it's altitude in case
+        if (this.handleCollision) { // We check distance to the ground/surface geometry. (Could be another geometry layer)
+            this.view.camera.adjustAltitudeToAvoidCollisionWithLayer(this.view, view.getLayers(layer => layer.type === 'geometry')[0], this.minDistanceCollision);
+        }
         // dt will not be relevant when we just started rendering, we consider a 1-frame move in this case
         if (updateLoopRestarted) {
             dt = 16;


### PR DESCRIPTION
This PR adds a test for collision between the camera and the terrain (geometry layer) for all Views (Planar, Globe...) (issue #153).


