### PR TITLE
fix (api): pan correction

### DIFF
--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -518,7 +518,7 @@ function GlobeControls(view, target, radius, options = {}) {
             targetDistance *= Math.tan((this.camera.fov / 2) * Math.PI / 180.0);
 
             // we actually don't use screenWidth, since perspective camera is fixed to screen height
-            this.panLeft(2 * deltaX * targetDistance / element.clientHeight);
+            this.panLeft(2 * deltaX * targetDistance * this.camera.aspect / element.clientWidth);
             this.panUp(2 * deltaY * targetDistance / element.clientHeight);
         } else if (this.camera instanceof THREE.OrthographicCamera) {
             // orthographic


### PR DESCRIPTION
## Description
Small PR to correct the pan function in GlobeControls.
changed element.clientHeight to element.clientWidth for the left pan.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

## Screenshots (if appropriate)
