### PR TITLE
feature: add removeLayer function to View

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -282,6 +282,27 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
 };
 
 /**
+ * Removes a layer from the view
+ * @param {string} layerId - the id of the layer to remove
+ */
+View.prototype.removeLayer = function removeLayer(layerId) {
+    const layers = this.getLayers((l => l.id == layerId));
+    if (layers.length === 0) {
+        throw new Error(`No layer with id '${layerId}' to remove`);
+    }
+    const toRemove = this.scene.children.filter((c => c.layer == layerId));
+    for (const obj of toRemove) {
+        const idx = this.scene.children.indexOf(obj);
+        this.scene.children.splice(idx, 1);
+    }
+
+    const idx = this._layers.indexOf(layers[0]);
+    this._layers.splice(idx, 1);
+
+    this.notifyChange(true);
+};
+
+/**
  * Notifies the scene it needs to be updated due to changes exterior to the
  * scene itself (e.g. camera movement).
  * non-interactive events (e.g: texture loaded)


### PR DESCRIPTION
Added a function to remove a layer from a view.

How to test:
- Open examples/planar.html
- Run the command `itowns.View.prototype.removeLayer.call(view, 'planar')`