### PR TITLE
fix (scheduler): improve layers with relative url support

### DIFF
--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -122,8 +122,7 @@ Scheduler.prototype.execute = function execute(command) {
 
     // parse host
     const layer = command.layer;
-
-    const host = layer.url ? new URL(layer.url).host : undefined;
+    const host = layer.url ? new URL(layer.url, document.location).host : undefined;
 
     command.promise = new Promise((resolve, reject) => {
         command.resolve = resolve;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added an exception when `Url` was instantiated
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Prior to this commit using a relative url (like ./foo.gpx) would produce 
an error.
This is fixed by this commit by using the optional 'base' parameter of URL
 constructor that specifies the base address if the first parameter is a 
relative URL.
(see https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)

