### PR TITLE
fix (Depth) : correct calculation of depth

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -389,7 +389,6 @@ const screen = new THREE.Vector2();
 const pickWorldPosition = new THREE.Vector3();
 const ray = new THREE.Ray();
 const direction = new THREE.Vector3();
-const depthRGBA = new THREE.Vector4();
 GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse) {
     const dim = this.mainLoop.gfxEngine.getWindowSize();
     mouse = mouse || dim.clone().multiplyScalar(0.5);
@@ -427,13 +426,11 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
     direction.applyMatrix4(matrix);
     direction.sub(ray.origin);
 
-    var angle = direction.angleTo(ray.direction);
+    const angle = direction.angleTo(ray.direction);
+    const orthoZ = this.mainLoop.gfxEngine.depthBufferRGBAValueToOrthoZ(buffer, camera);
+    const length = orthoZ / Math.cos(angle);
 
-    depthRGBA.fromArray(buffer).divideScalar(255.0);
-
-    var depth = unpack1K(depthRGBA, 100000000.0) / Math.cos(angle);
-
-    pickWorldPosition.addVectors(camera.position, ray.direction.setLength(depth));
+    pickWorldPosition.addVectors(camera.position, ray.direction.setLength(length));
 
     // Restore initial state
     this.changeRenderState(previousRenderState);

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -210,7 +210,6 @@ const screen = new THREE.Vector2();
 const pickWorldPosition = new THREE.Vector3();
 const ray = new THREE.Ray();
 const direction = new THREE.Vector3();
-const depthRGBA = new THREE.Vector4();
 PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse) {
     const dim = this.mainLoop.gfxEngine.getWindowSize();
     mouse = mouse || dim.clone().multiplyScalar(0.5);
@@ -248,13 +247,11 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
     direction.applyMatrix4(matrix);
     direction.sub(ray.origin);
 
-    var angle = direction.angleTo(ray.direction);
+    const angle = direction.angleTo(ray.direction);
+    const orthoZ = this.mainLoop.gfxEngine.depthBufferRGBAValueToOrthoZ(buffer, camera);
+    const length = orthoZ / Math.cos(angle);
 
-    depthRGBA.fromArray(buffer).divideScalar(255.0);
-
-    var depth = unpack1K(depthRGBA, 100000000.0) / Math.cos(angle);
-
-    pickWorldPosition.addVectors(camera.position, ray.direction.setLength(depth));
+    pickWorldPosition.addVectors(camera.position, ray.direction.setLength(length));
 
     // Restore initial state
     this.changeRenderState(previousRenderState);

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -33,7 +33,7 @@ export function unpack1K(color, factor) {
         UnpackDownscale / (256.0 * 256.0),
         UnpackDownscale / 256.0,
         UnpackDownscale);
-    return bitSh.dot(color) * factor;
+    return factor ? bitSh.dot(color) * factor : bitSh.dot(color);
 }
 
 var getColorAtIdUv = function getColorAtIdUv(nbTex) {

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -51,11 +51,11 @@ void main() {
         gl_FragColor = packDepthToRGBA(float(uuid) / (256.0 * 256.0 * 256.0));
     #elif defined(DEPTH_MODE)
         #if defined(USE_LOGDEPTHBUF) && defined(USE_LOGDEPTHBUF_EXT)
-            float z = 1.0/ gl_FragCoord.w ;
+            float z = gl_FragDepthEXT ;
         #else
-            float z = gl_FragCoord.z / gl_FragCoord.w;
+            float z = gl_FragCoord.z;
         #endif
-        gl_FragColor = packDepthToRGBA(z / 100000000.0);
+        gl_FragColor = packDepthToRGBA(z);
     #else
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Use of depth buffers instead of calculating Z in the shader TileFS.glsl
this PR doesn't resolve #411 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Before `DEPTH_MODE` returns Z value between 0 and camera.far, as `packDepthToRGBA` packs values between 0.0 and 1.0, Z was divided by a big constant.
It is therefore more logical to use the depth (between 0.0 and 1.0) and convert it out of the shader

