### PR TITLE
feature (GlobeView) : use cache depth buffer

### DIFF
--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -1,7 +1,7 @@
 import { EventDispatcher } from 'three';
 
-const RENDERING_PAUSED = 0;
-const RENDERING_SCHEDULED = 1;
+export const RENDERING_PAUSED = 0;
+export const RENDERING_SCHEDULED = 1;
 
 function MainLoop(scheduler, engine) {
     this.renderingState = RENDERING_PAUSED;

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 import View from '../View';
+import { RENDERING_PAUSED } from '../MainLoop';
 import { COLOR_LAYERS_ORDER_CHANGED } from '../../Renderer/ColorLayersOrdering';
 import RendererConstant from '../../Renderer/RendererConstant';
 import GlobeControls from '../../Renderer/ThreeExtended/GlobeControls';
@@ -239,8 +240,17 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     }
 
     this._renderState = RendererConstant.FINAL;
+    this._fullSizeDepthBuffer = null;
+
     const renderer = this.mainLoop.gfxEngine.renderer;
     this.preRender = () => {
+        // WARNING, if the prerender is re-defined by the user,
+        // These mechanisms no longer work
+        // TODO: need to fix it
+        if (this._fullSizeDepthBuffer != null) {
+            // clean depth buffer
+            this._fullSizeDepthBuffer = null;
+        }
         const v = new THREE.Vector3();
         v.setFromMatrixPosition(wgs84TileLayer.object3d.matrixWorld);
         var len = v.distanceTo(this.camera.camera3D.position);
@@ -384,30 +394,43 @@ GlobeView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) 
     return Math.round(unpack);
 };
 
+GlobeView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
+    const g = this.mainLoop.gfxEngine;
+    const previousRenderState = this._renderState;
+    this.changeRenderState(RendererConstant.DEPTH);
+    const buffer = g.renderViewTobuffer(this, g.fullSizeRenderTarget, x, y, width, height);
+    this.changeRenderState(previousRenderState);
+    return buffer;
+};
+
 const matrix = new THREE.Matrix4();
 const screen = new THREE.Vector2();
 const pickWorldPosition = new THREE.Vector3();
 const ray = new THREE.Ray();
 const direction = new THREE.Vector3();
 GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse) {
-    const dim = this.mainLoop.gfxEngine.getWindowSize();
+    const l = this.mainLoop;
+    const viewPaused = l.scheduler.commandsWaitingExecutionCount() == 0 && l.renderingState == RENDERING_PAUSED;
+    const g = l.gfxEngine;
+    const dim = g.getWindowSize();
+    const camera = this.camera.camera3D;
+
     mouse = mouse || dim.clone().multiplyScalar(0.5);
+    mouse.x = Math.floor(mouse.x);
+    mouse.y = Math.floor(mouse.y);
 
-    var camera = this.camera.camera3D;
+    const prev = camera.layers.mask;
+    camera.layers.mask = 1 << this.wgs84TileLayer.threejsLayer;
 
-    // Prepare state
-    const prev = this.camera.camera3D.layers.mask;
-    this.camera.camera3D.layers.mask = 1 << this.wgs84TileLayer.threejsLayer;
-
-    const previousRenderState = this._renderState;
-    this.changeRenderState(RendererConstant.DEPTH);
-
-    // Render to buffer
-    var buffer = this.mainLoop.gfxEngine.renderViewTobuffer(
-        this,
-        this.mainLoop.gfxEngine.fullSizeRenderTarget,
-        mouse.x, dim.y - mouse.y,
-        1, 1);
+    // Render/Read to buffer
+    let buffer;
+    if (viewPaused) {
+        this._fullSizeDepthBuffer = this._fullSizeDepthBuffer || this.readDepthBuffer(0, 0, dim.x, dim.y);
+        const id = ((dim.y - mouse.y - 1) * dim.x + mouse.x) * 4;
+        buffer = this._fullSizeDepthBuffer.slice(id, id + 4);
+    } else {
+        buffer = this.readDepthBuffer(mouse.x, dim.y - mouse.y - 1, 1, 1);
+    }
 
     screen.x = (mouse.x / dim.x) * 2 - 1;
     screen.y = -(mouse.y / dim.y) * 2 + 1;
@@ -427,13 +450,11 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
     direction.sub(ray.origin);
 
     const angle = direction.angleTo(ray.direction);
-    const orthoZ = this.mainLoop.gfxEngine.depthBufferRGBAValueToOrthoZ(buffer, camera);
+    const orthoZ = g.depthBufferRGBAValueToOrthoZ(buffer, camera);
     const length = orthoZ / Math.cos(angle);
 
     pickWorldPosition.addVectors(camera.position, ray.direction.setLength(length));
 
-    // Restore initial state
-    this.changeRenderState(previousRenderState);
     camera.layers.mask = prev;
 
     if (pickWorldPosition.length() > 10000000)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add cache depth buffer, this buffer is updated when all datas is loaded and no camera movement

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
This allows you to read depth information without rendering again when the viewer is paused.
and thus to read the geographical positions without new rendering (`GlobeControls.readGeoPosition` )
