### PR TITLE
fix (subdivision) : no stop subdivision in case error loading

### DIFF
--- a/src/Core/Layer/LayerUpdateState.js
+++ b/src/Core/Layer/LayerUpdateState.js
@@ -60,4 +60,8 @@ LayerUpdateState.prototype.failure = function failure(timestamp, definitive) {
     this.errorCount++;
 };
 
+LayerUpdateState.prototype.inError = function inError() {
+    return this.state == UPDATE_STATE.DEFINITIVE_ERROR || this.state == UPDATE_STATE.ERROR;
+};
+
 export default LayerUpdateState;

--- a/src/Process/SubdivisionControl.js
+++ b/src/Process/SubdivisionControl.js
@@ -11,6 +11,10 @@ export default {
         // and if node doesn't have a elevation texture yet.
         for (const e of context.elevationLayers) {
             if (!e.frozen && e.tileInsideLimit(node, e) && !node.isElevationLayerLoaded()) {
+                // no stop subdivision in the case of a loading error
+                if (node.layerUpdateState[e.id] && node.layerUpdateState[e.id].inError()) {
+                    continue;
+                }
                 return false;
             }
         }
@@ -20,11 +24,14 @@ export default {
             if (c.frozen || !c.visible) {
                 continue;
             }
+            // no stop subdivision in the case of a loading error
+            if (node.layerUpdateState[c.id] && node.layerUpdateState[c.id].inError()) {
+                continue;
+            }
             if (c.tileInsideLimit(node, c) && !node.isColorLayerLoaded(c.id)) {
                 return false;
             }
         }
-
         return true;
     },
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Don't stop subdivision tile in case error loading
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
If some wmts, wms datas don't load, the tiles are no longer subdivided and block the display of the other downloaded data.

