### PR TITLE
fix: make sure camera's matrix is only updated by iTowns

### DIFF
--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -95,6 +95,16 @@ MainLoop.prototype._step = function _step(view, timestamp) {
 
     view.camera.update(dim.x, dim.y);
 
+    // Disable camera's matrix auto update to make sure the camera's
+    // world matrix is never updated mid-update.
+    // Otherwise inconsistencies can appear because object visibility
+    // testing and object drawing could be performed using different
+    // camera matrixWorld.
+    // Note: this is required at least because WEBGLRenderer calls
+    // camera.updateMatrixWorld()
+    const oldAutoUpdate = view.camera.camera3D.matrixAutoUpdate;
+    view.camera.camera3D.matrixAutoUpdate = false;
+
     // update data-structure
     this._update(view, updateSources, dt);
 
@@ -117,6 +127,8 @@ MainLoop.prototype._step = function _step(view, timestamp) {
     if (__DEBUG__) {
         document.title = document.title.substr(0, document.title.length - 2);
     }
+
+    view.camera.camera3D.matrixAutoUpdate = oldAutoUpdate;
 };
 
 MainLoop.prototype._renderView = function _renderView(view) {


### PR DESCRIPTION
## Description
We must make sure that camera.matrixWorld is not modified in between mainloop.update
and mainloop.render otherwise we'll have visual inconsistencies.

## Screenshots (if appropriate)
e.g: there were holes in the planar view when rotating quickly the camera because of
this issue (three.js calls camera.updateWorldMatrix at the beginning of its rendering
code).
![camera](https://user-images.githubusercontent.com/2198295/30366248-c698ce54-986a-11e7-8013-21494e18d930.jpg)
