### PR TITLE
fix (3tiles): handle 'refine' parameter inheritance properly 

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -130,7 +130,7 @@
             $3dTilesLayerRequestVolume.overrideMaterials = true;  // custom cesium shaders are not functional
             $3dTilesLayerRequestVolume.type = 'geometry';
             $3dTilesLayerRequestVolume.visible = true;
-            $3dTilesLayerRequestVolume.sseThreshold = 1;            
+            $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
             itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
 

--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -166,7 +166,11 @@ function configureTile(tile, layer, metadata, parent) {
     tile.applyMatrix(tile.transform);
     tile.geometricError = metadata.geometricError;
     tile.tileId = metadata.tileId;
-    tile.additiveRefinement = (metadata.refine === 'add');
+    if (metadata.refine) {
+        tile.additiveRefinement = (metadata.refine.toUpperCase() === 'ADD');
+    } else {
+        tile.additiveRefinement = parent ? (parent.additiveRefinement) : false;
+    }
     tile.parentFromLocalTransform = tile.transform;
     tile.worldFromLocalTransform = new THREE.Matrix4().multiplyMatrices(parent ? parent.worldFromLocalTransform : new THREE.Matrix4(), tile.parentFromLocalTransform);
     const m = new THREE.Matrix4();


### PR DESCRIPTION
fix (3tiles): handle 'refine' parameter inheritance properly 
A node must be inherited of the parent's value unless explicitly specified 
See issue #185