### PR TITLE
refactor: add Extent.intersects method and use three.js wording

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -296,13 +296,30 @@ Extent.prototype.offsetScale = function offsetScale(bbox) {
  * @param {type} bbox
  * @returns {Boolean}
  */
-Extent.prototype.intersect = function intersect(bbox) {
+Extent.prototype.intersectsExtent = function intersectsExtent(bbox) {
     const other = bbox.as(this.crs());
     return !(this.west() >= other.east(this._internalStorageUnit) ||
              this.east() <= other.west(this._internalStorageUnit) ||
              this.south() >= other.north(this._internalStorageUnit) ||
              this.north() <= other.south(this._internalStorageUnit));
 };
+
+/**
+ * @documentation: Return the intersection of this extent with another one
+ * @param {type} other
+ * @returns {Boolean}
+ */
+Extent.prototype.intersect = function intersect(other) {
+    if (!this.intersectsExtent(other)) {
+        return new Extent(this.crs(), 0, 0, 0, 0);
+    }
+    return new Extent(this.crs(),
+        Math.max(this.west(), other.west(this._internalStorageUnit)),
+        Math.min(this.east(), other.east(this._internalStorageUnit)),
+        Math.max(this.south(), other.south(this._internalStorageUnit)),
+        Math.min(this.north(), other.north(this._internalStorageUnit)));
+};
+
 
 Extent.prototype.set = function set(west, east, south, north) {
     this._values[CARDINAL.WEST] = west;

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -137,7 +137,7 @@ export default {
         }
     },
     tileInsideLimit(tile, layer) {
-        return layer.ready && tile.level >= layer.options.zoom.min && tile.level <= layer.options.zoom.max && layer.extent.intersect(tile.extent);
+        return layer.ready && tile.level >= layer.options.zoom.min && tile.level <= layer.options.zoom.max && layer.extent.intersectsExtent(tile.extent);
     },
     executeCommand(command) {
         const layer = command.layer;

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -52,7 +52,7 @@ WFS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer)
 };
 
 WFS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) {
-    return (layer.level === undefined || tile.level === layer.level) && layer.extent.intersect(tile.extent);
+    return (layer.level === undefined || tile.level === layer.level) && layer.extent.intersectsExtent(tile.extent);
 };
 
 WFS_Provider.prototype.executeCommand = function executeCommand(command) {

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -71,7 +71,9 @@ WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer)
 };
 
 WMS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer) {
-    return tile.level >= layer.options.zoom.min && tile.level <= layer.options.zoom.max && layer.extent.intersect(tile.extent);
+    return tile.level >= layer.options.zoom.min &&
+        tile.level <= layer.options.zoom.max &&
+        layer.extent.intersectsExtent(tile.extent);
 };
 
 WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer) {

--- a/src/Renderer/ThreeExtended/Feature2Texture.js
+++ b/src/Renderer/ThreeExtended/Feature2Texture.js
@@ -63,7 +63,7 @@ function drawFeature(ctx, feature, origin, dimension, extent, style = {}) {
     const coordinates = feature.geometry.coordinates.slice();
     if (feature.geometry.type === 'point') {
         drawPoint(ctx, coordinates[0], origin, dimension, style);
-    } else if (feature.geometry.extent.intersect(extent)) {
+    } else if (feature.geometry.extent.intersectsExtent(extent)) {
         ctx.globalCompositeOperation = 'destination-over';
         drawPolygon(ctx, coordinates, origin, dimension, properties, style);
     }
@@ -72,14 +72,14 @@ function drawFeature(ctx, feature, origin, dimension, extent, style = {}) {
 function drawFeatureCollection(ctx, collection, origin, dimension, extent, style = {}) {
     for (const features of collection.geometries) {
         /* eslint-disable guard-for-in */
-        if (features.extent.intersect(extent)) {
+        if (features.extent.intersectsExtent(extent)) {
             for (const id in features.featureVertices) {
                 const polygon = features.featureVertices[id];
                 const properties = collection.features[id].properties.properties;
                 const coordinates = features.coordinates.slice(polygon.offset, polygon.offset + polygon.count);
                 if (features.type === 'point') {
                     drawPoint(ctx, coordinates[0], origin, dimension, style);
-                } else if (polygon.extent.intersect(extent)) {
+                } else if (polygon.extent.intersectsExtent(extent)) {
                     ctx.globalCompositeOperation = 'destination-over';
                     drawPolygon(ctx, coordinates, origin, dimension, properties, style);
                 }


### PR DESCRIPTION
The old 'intersect' method is renamed 'intersects' (to match three.js wording
for Box2 for instance: 'intersectsBox').

A new 'intersection' method is added and return the intersection between 2 extents.
