### PR TITLE
feature: add command.targetLevel support to WMS_Provider

### DIFF
--- a/examples/planar.js
+++ b/examples/planar.js
@@ -36,6 +36,10 @@ view.addLayer({
     options: {
         mimetype: 'image/jpeg',
     },
+    updateStrategy: {
+        type: itowns.STRATEGY_DICHOTOMY,
+        options: {},
+    },
 });
 
 // Add an WMS elevation layer (see WMS_Provider* for valid options)


### PR DESCRIPTION
If targetLevel is defined and < to node.level we request the texture for the parent that has level == targetLevel and then use this texture for node.

It's already supported for WMTS provider but it was missing for WMS.

This PR also modifies the `planar` example to use this feature.
