### PR TITLE
feature: allow layer custom 'can this tile get a better texture' mechanism

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -192,9 +192,16 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
     }
 
     // does this tile needs a new texture?
-    if (!node.isColorLayerDownscaled(layer)) {
+    if (layer.canTileTextureBeImproved) {
+        // if the layer has a custom method -> use it
+        if (!layer.canTileTextureBeImproved(layer, node)) {
+            return Promise.resolve();
+        }
+    } else if (!node.isColorLayerDownscaled(layer)) {
+        // default decision method
         return Promise.resolve();
     }
+
     // is fetching data from this layer disabled?
     if (!layer.visible || layer.frozen) {
         return Promise.resolve();


### PR DESCRIPTION
The default mechanism is based on a simple approach: if texture.level and
node.level don't match -> try to fetch a new texture.

This works well for providers that can compute meaningful level attributes,
but breaks if it's not possible.

This commit allows layer to have their own function.

(PR coming later with a Provider using this feature)
