### PR TITLE
feature: add support for transparent geometries (tiles or pointcloud)

### DIFF
--- a/src/Core/Scheduler/Providers/PointCloudProvider.js
+++ b/src/Core/Scheduler/Providers/PointCloudProvider.js
@@ -223,6 +223,8 @@ export default {
             points.tightbbox.max.y *= layer.metadata.scale;
             points.tightbbox.max.z *= layer.metadata.scale;
             points.tightbbox.translate(node.bbox.min);
+            points.material.transparent = layer.opacity < 1.0;
+            points.material.uniforms.opacity.value = layer.opacity;
             points.updateMatrix();
             points.updateMatrixWorld(true);
             points.layers.set(layer.threejsLayer);

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -81,6 +81,8 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
     }
 
     tile.position.copy(params.center);
+    tile.material.transparent = command.layer.opacity < 1.0;
+    tile.material.uniforms.opacity.value = command.layer.opacity;
     tile.setVisibility(false);
     tile.updateMatrix();
     if (parent) {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -145,6 +145,14 @@ function _preprocessLayer(view, layer, provider) {
         layer.threejsLayer = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
         defineLayerProperty(layer, 'visible', true, () => _syncThreejsLayer(layer, view));
         _syncThreejsLayer(layer, view);
+        defineLayerProperty(layer, 'opacity', 1.0, () => {
+            layer.object3d.traverse((o) => {
+                if (o.material && o.material.uniforms.opacity) {
+                    o.material.transparent = layer.opacity < 1.0;
+                    o.material.uniforms.opacity.value = layer.opacity;
+                }
+            });
+        });
     }
     return layer;
 }

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -172,6 +172,8 @@ const LayeredMaterial = function LayeredMaterial(options) {
 
     this.uniforms.noTextureColor = new THREE.Uniform(new THREE.Color(0.04, 0.23, 0.35));
 
+    this.uniforms.opacity = new THREE.Uniform(1.0);
+
     this.colorLayersId = [];
     this.elevationLayersId = [];
 

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -13,6 +13,7 @@ class PointsMaterial extends RawShaderMaterial {
         this.uniforms.resolution = new Uniform(new Vector2(window.innerWidth, window.innerHeight));
         this.uniforms.pickingMode = new Uniform(false);
         this.uniforms.density = new Uniform(0.01);
+        this.uniforms.opacity = new Uniform(1.0);
 
         if (__DEBUG__) {
             this.uniforms.useDebugColor = new Uniform(false);

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -5,6 +5,7 @@ precision highp int;
 
 varying vec4 vColor;
 uniform bool pickingMode;
+uniform float opacity;
 
 #ifdef DEBUG
 uniform bool useDebugColor;
@@ -21,6 +22,8 @@ void main() {
     }
 
     gl_FragColor = vColor;
+    gl_FragColor.a = opacity;
+
 #ifdef DEBUG
     if (useDebugColor && !pickingMode) {
         gl_FragColor = mix(vColor, vec4(debugColor, 1.0), 0.5);

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -34,6 +34,8 @@ varying vec2        vUv_WGS84;
 varying float       vUv_PM;
 varying vec3        vNormal;
 
+uniform float opacity;
+
 #if defined(DEBUG)
     uniform bool showOutline;
     const float sLine = 0.008;
@@ -147,5 +149,6 @@ void main() {
             gl_FragColor.rgb *= light;
         }
     }
+    gl_FragColor.a = opacity;
     #endif
 }


### PR DESCRIPTION
## Description
Add a 'opacity' uniform to LayeredMaterial/PointsMaterial that controls the
opacity of the geometry.

The value of this opacity uniform is controlled using layer.opacity (exactly
like for color layers).

## Screenshots
Here's an example:
![capture d ecran de 2017-09-25 11-32-41](https://user-images.githubusercontent.com/2198295/30802208-06db3b12-a1e6-11e7-970c-036937f97a7f.png)

