### PR TITLE
fix (globe): workaround texture issues at North Pole

### DIFF
--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -373,7 +373,7 @@ LayeredMaterial.prototype.pushLayer = function pushLayer(param) {
     this.uniforms.paramLayers.value[newIndex] = new THREE.Vector4();
 
     this.setTextureOffsetByLayerIndex(newIndex, offset);
-    this.setLayerUV(newIndex, param.tileMT === 'PM' ? 1 : 0);
+    this.setLayerUV(newIndex, param.tileMT === 'PM' ? param.texturesCount : 0);
     this.setLayerFx(newIndex, param.fx);
     this.setLayerOpacity(newIndex, param.opacity);
     this.setLayerVisibility(newIndex, param.visible);

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -93,7 +93,19 @@ void main() {
 
                 if(paramsA.w > 0.0) {
                     bool projWGS84 = paramsA.y == 0.0;
+                    int pmTextureCount = int(paramsA.y);
                     int textureIndex = int(paramsA.x) + (projWGS84 ? 0 : pmSubTextureIndex);
+
+                    if (!projWGS84 && pmTextureCount <= textureIndex) {
+                        continue;
+                    }
+
+                    #if defined(DEBUG)
+                    if (showOutline && !projWGS84 && (uvPM.x < sLine || uvPM.x > 1.0 - sLine || uvPM.y < sLine || uvPM.y > 1.0 - sLine)) {
+                        gl_FragColor = COrange;
+                        return;
+                    }
+                    #endif
 
                     /* if (0 <= textureIndex && textureIndex < loadedTexturesCount[1]) */ {
 


### PR DESCRIPTION
## Description

This commit is a workaround (rather than a proper fix) to avoid
visual glitches at the North Pole.

We simply transmit the number of PM textures to the shader and test
the texture index against this value before using it.

## Screenshots
Without this PR:
![capture d ecran de 2017-09-25 14-31-58](https://user-images.githubusercontent.com/2198295/30808428-5b325c28-a1fe-11e7-97e5-e5d0d1b45c38.png)

With this PR:
![capture d ecran de 2017-09-25 14-31-38](https://user-images.githubusercontent.com/2198295/30808427-5b2cb17e-a1fe-11e7-8503-3dc12ae73b48.png)

Hopefully I'll be able to resume my work on PR #309 soon and cleanup the textures/layers management...