### PR TITLE
fix (Scheduler) Error caught from the providers is logged in the console

### DIFF
--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -56,7 +56,7 @@ function _instanciateQueue() {
                 this.counters.executing--;
                 cmd.reject(err);
                 this.counters.failed++;
-                if (__DEBUG__) {
+                if (__DEBUG__ && this.counters.failed < 3) {
                     // eslint-disable-next-line no-console
                     console.error(err);
                 }

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -56,6 +56,10 @@ function _instanciateQueue() {
                 this.counters.executing--;
                 cmd.reject(err);
                 this.counters.failed++;
+                if (__DEBUG__) {
+                    // eslint-disable-next-line no-console
+                    console.error(err);
+                }
             });
         },
     };


### PR DESCRIPTION

## Description
Add log in the console, when error occurs in the Providers.

## Motivation and Context
When an error occurs in the Promise, we can't see it.
With this change, the error is logged in the console.

I didn't manage to reOpen #491
