### PR TITLE
feature (Coordinate) store normal vector already computed

### DIFF
--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -136,8 +136,11 @@ function _convert(coordsIn, newCrs, target) {
         }
     } else {
         if (coordsIn.crs === 'EPSG:4326' && newCrs === 'EPSG:4978') {
-            const cartesian = ellipsoid.cartographicToCartesian(coordsIn);
-            return target.set(newCrs, cartesian);
+            const normal = ellipsoid.geodeticSurfaceNormalCartographic(coordsIn);
+            const cartesian = ellipsoid.cartographicToCartesian(coordsIn, normal);
+            target.set(newCrs, cartesian);
+            target._normal = normal;
+            return target;
         }
 
         if (coordsIn.crs === 'EPSG:4978' && newCrs === 'EPSG:4326') {

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -224,7 +224,31 @@ export function convertValueToUnit(unitIn, unitOut, value) {
 function Coordinates(crs, ...coordinates) {
     this._values = new Float64Array(3);
     this.set(crs, ...coordinates);
+
+    Object.defineProperty(this, 'surfaceNormal',
+        {
+            configurable: true,
+            get: () => {
+                const result = this._normal || this.computeSurfaceNormal();
+                return result;
+            },
+        });
 }
+
+Coordinates.prototype.computeSurfaceNormal = function computeSurfaceNormal() {
+    // compute a normal only for cartesian coordinate.
+    if (this._internalStorageUnit != UNIT.METER) {
+        throw (new Error('You can only compute cartesian normal when unit is METER'));
+    }
+    // In globe mode (EPSG:4978), we compute the normal.
+    if (this.crs == 'EPSG:4978') {
+        this._normal = ellipsoid.geodeticSurfaceNormal(this);
+        return this._normal;
+    }
+    // In planar mode, normal is the up vector.
+    this._normal = THREE.Object3D.DefaultUp;
+    return this._normal;
+};
 
 Coordinates.prototype.set = function set(crs, ...coordinates) {
     _crsToUnitWithError(crs);

--- a/src/Core/Math/Ellipsoid.js
+++ b/src/Core/Math/Ellipsoid.js
@@ -19,7 +19,19 @@ function Ellipsoid(size) {
     this.size = new THREE.Vector3(size.x, size.y, size.z);
 
     this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
+
+    this._oneOverRadiiSquared = new THREE.Vector3(size.x === 0.0 ? 0.0 : 1.0 / (size.x * size.x),
+        size.y === 0.0 ? 0.0 : 1.0 / (size.y * size.y),
+        size.z === 0.0 ? 0.0 : 1.0 / (size.z * size.z));
 }
+
+Ellipsoid.prototype.geodeticSurfaceNormal = function geodeticSurfaceNormal(cartesian) {
+    var result = new THREE.Vector3(
+        cartesian.x() * this._oneOverRadiiSquared.x,
+        cartesian.y() * this._oneOverRadiiSquared.y,
+        cartesian.z() * this._oneOverRadiiSquared.z);
+    return result.normalize();
+};
 
 Ellipsoid.prototype.geodeticSurfaceNormalCartographic = function geodeticSurfaceNormalCartographic(coordCarto) {
     var longitude = coordCarto.longitude(UNIT.RADIAN);

--- a/src/Core/Math/Ellipsoid.js
+++ b/src/Core/Math/Ellipsoid.js
@@ -56,10 +56,10 @@ Ellipsoid.prototype.setSize = function setSize(size) {
 };
 
 
-Ellipsoid.prototype.cartographicToCartesian = function cartographicToCartesian(coordCarto) {
+Ellipsoid.prototype.cartographicToCartesian = function cartographicToCartesian(coordCarto, normal) {
     // var n;
     var k = new THREE.Vector3();
-    var n = this.geodeticSurfaceNormalCartographic(coordCarto);
+    var n = normal.clone() || this.geodeticSurfaceNormalCartographic(coordCarto);
 
     k.multiplyVectors(this._radiiSquared, n);
 

--- a/test/coordinate_unit_test.js
+++ b/test/coordinate_unit_test.js
@@ -1,4 +1,5 @@
 /* global describe, it */
+import * as THREE from 'three';
 import proj4 from 'proj4';
 import assert from 'assert';
 import Coordinates, { UNIT } from '../src/Core/Geographic/Coordinates';
@@ -41,7 +42,7 @@ describe('Coordinate conversions', function () {
         assertCoordEqual(coord1, coord3);
     });
     // This case happend in iTowns when we convert the tile extent (4326 radian) to a target WFS server (EPSG:3946 for example) to request Lyon bus line in WFS.
-    it('Coordinate conversion from EPSG:4326 Radian (tiles extent) to EPSG:3946 (Lyon WFS) and back to EPSG:4326 (degrees)', function () {
+    it('should correctly convert from EPSG:4326 Radian (tiles extent) to EPSG:3946 (Lyon WFS) and back to EPSG:4326 (degrees)', function () {
         // geographic example for EPSG 4326 in degrees
         var longIn = 4.82212;
         var latIn = 45.723722;
@@ -58,5 +59,31 @@ describe('Coordinate conversions', function () {
         // verify coordinates
         assertFloatEqual(longIn, coord3.longitude());
         assertFloatEqual(latIn, coord3.latitude());
+    });
+});
+
+describe('Coordinate surface normale property', function () {
+    it('should correctly compute a surface normal ', function () {
+        const coord0 = new Coordinates('EPSG:4326', 15.0, 12.0).as('EPSG:4978');
+        const normal0 = coord0.surfaceNormal;
+
+        assertFloatEqual(normal0.x, 0.944818029);
+        assertFloatEqual(normal0.y, 0.253163227);
+        assertFloatEqual(normal0.z, 0.207911690);
+
+        const coord1 = new Coordinates('EPSG:4978', 6027050.95, 1614943.43, 1317402.53);
+        const normal1 = coord1.surfaceNormal;
+
+        assertFloatEqual(normal0.x, normal1.x);
+        assertFloatEqual(normal0.y, normal1.y);
+        assertFloatEqual(normal0.z, normal1.z);
+    });
+    it('should correctly return the default up vector for planar mode ', function () {
+        const coord0 = new Coordinates('EPSG:4326', 15.0, 12.0);
+        coord0._internalStorageUnit = UNIT.METER;
+
+        const normal0 = coord0.surfaceNormal;
+
+        assert.equal(normal0, THREE.Object3D.DefaultUp);
     });
 });


### PR DESCRIPTION
## Description
Store normal vector in the coordinate object when we already have computed it.

## Motivation and Context
It's a preparation work for a feature : Extrude feature polygon, to have a box instead of a flat polygon.
To extrude a polygon, I need the Normal vector.

In planar mode, it's ok, it's always the Vecor(0, 0, 1).
In globe mode, we always have to convert cartographic coordinate to cartesian position, and during this conversion, we compute the normal vertor.

I suggest that we store the normal vector in the coordinate object, during the conversion. So I will use the normal vector later in the extrusing process, without computing it a second times.
