### PR TITLE
fix (GeoJSON2Feature) : filteringExtent parameter was missing

### DIFF
--- a/src/Renderer/ThreeExtended/GeoJSON2Feature.js
+++ b/src/Renderer/ThreeExtended/GeoJSON2Feature.js
@@ -106,7 +106,7 @@ const GeometryToCoordinates = {
     multiLineString(crsIn, crsOut, coordsIn, filteringExtent, options) {
         let result;
         for (const line of coordsIn) {
-            const l = this.lineString(crsIn, crsOut, line, options);
+            const l = this.lineString(crsIn, crsOut, line, filteringExtent, options);
             if (!l) {
                 return;
             }


### PR DESCRIPTION
## Description
Fix (GeoJSON2Feature)  filteringExtent parameter was missing for multiLineString conversion method.

## Motivation and Context
Prior to this change, in the WFS Planar example, we could see a TypeError in the console.
