### PR TITLE
fix (3dtiles): do not try to subdivide a tile without children

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -15,12 +15,12 @@ function requestNewTile(view, scheduler, geometryLayer, metadata, parent) {
 
 function subdivideNode(context, layer, node) {
     if (!node.pendingSubdivision && node.children.filter(n => n.layer == layer.id).length == 0) {
-        node.pendingSubdivision = true;
-
         const childrenTiles = layer.tileIndex.index[node.tileId].children;
-        if (childrenTiles === undefined) {
+        if (childrenTiles === undefined || childrenTiles.length === 0) {
             return;
         }
+
+        node.pendingSubdivision = true;
 
         const promises = [];
         for (let i = 0; i < childrenTiles.length; i++) {


### PR DESCRIPTION
This commits add a check to prevent an infinite loop when using 3dtiles.

Without it the 'process3dTilesNode' would try to subdivide tiles that
don't have children and on completion of the subdivision (ie: instantly) would
issue a 'view.notifyChange()' call.

