### PR TITLE
fix (Camera): don't reset camera's position on resize

### DIFF
--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -25,8 +25,9 @@ function resize(camera, width, height) {
         camera.camera3D.aspect = ratio;
         if (camera.camera3D.isOrthographicCamera) {
             const halfH = (camera.camera3D.right - camera.camera3D.left) * 0.5 / ratio;
-            camera.camera3D.top = halfH;
-            camera.camera3D.bottom = -halfH;
+            const y = (camera.camera3D.top + camera.camera3D.bottom) * 0.5;
+            camera.camera3D.top = y + halfH;
+            camera.camera3D.bottom = y - halfH;
         }
     }
 


### PR DESCRIPTION
Camera's position y component was set to -h/h, which centered the view around 0.
This commit adjust camera's height to the new ratio but also remember the old
camera's y position.

Fixes issue https://github.com/iTowns/itowns/issues/399
