### PR TITLE
fix (View) : missing camera.update after resize

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -71,6 +71,7 @@ function View(crs, viewerDiv, options = {}) {
         // the container's size. Otherwise we use window' size.
         const newSize = new Vector2(viewerDiv.clientWidth, viewerDiv.clientHeight);
         this.mainLoop.gfxEngine.onWindowResize(newSize.x, newSize.y);
+        this.camera.update(newSize.x, newSize.y);
         this.notifyChange(true);
     }, false);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Just added the following line : 
`this.camera.update(newSize.x, newSize.y);`
It was missing since PR #435 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
After resizing the screen, the globe wasn't exactly following the mouse.

## Screenshots (if appropriate)
