### PR TITLE
3dtiles micro fixes

### DIFF
--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -133,7 +133,13 @@ $3dTiles_Provider.prototype.b3dmToMesh = function b3dmToMesh(data, layer) {
             mesh.frustumCulled = false;
             if (mesh.material) {
                 if (layer.overrideMaterials) {
-                    mesh.material = new THREE.MeshLambertMaterial(0xffffff);
+                    mesh.material.dispose();
+                    if (typeof (layer.overrideMaterials) === 'object' &&
+                        layer.overrideMaterials.isMaterial) {
+                        mesh.material = layer.overrideMaterials.clone();
+                    } else {
+                        mesh.material = new THREE.MeshLambertMaterial({ color: 0xffffff });
+                    }
                 } else if (Capabilities.isLogDepthBufferSupported()
                             && mesh.material.isRawShaderMaterial
                             && !layer.doNotPatchMaterial) {

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -4,7 +4,7 @@ function requestNewTile(view, scheduler, geometryLayer, metadata, parent) {
         view,
         requester: parent,
         layer: geometryLayer,
-        priority: 10000,
+        priority: parent ? 1.0 / (parent.distance + 1) : 100,
         /* specific params */
         metadata,
         redraw: false,
@@ -99,6 +99,7 @@ function computeNodeSSE(camera, node) {
         cameraLocalPosition.y -= node.boundingVolume.region.matrixWorld.elements[13];
         cameraLocalPosition.z -= node.boundingVolume.region.matrixWorld.elements[14];
         const distance = node.boundingVolume.region.box3D.distanceToPoint(cameraLocalPosition);
+        node.distance = distance;
         return camera.preSSE * (node.geometricError / distance);
     }
     if (node.boundingVolume.box) {
@@ -107,6 +108,7 @@ function computeNodeSSE(camera, node) {
         cameraLocalPosition.y -= node.matrixWorld.elements[13];
         cameraLocalPosition.z -= node.matrixWorld.elements[14];
         const distance = node.boundingVolume.box.distanceToPoint(cameraLocalPosition);
+        node.distance = distance;
         return camera.preSSE * (node.geometricError / distance);
     }
     if (node.boundingVolume.sphere) {
@@ -115,6 +117,7 @@ function computeNodeSSE(camera, node) {
         cameraLocalPosition.y -= node.matrixWorld.elements[13];
         cameraLocalPosition.z -= node.matrixWorld.elements[14];
         const distance = node.boundingVolume.sphere.distanceToPoint(cameraLocalPosition);
+        node.distance = distance;
         return camera.preSSE * (node.geometricError / distance);
     }
     return Infinity;


### PR DESCRIPTION
2 small 3d-tiles commits:

    feat (3dtiles): allow layer.overrideMaterials to be a material
    
    If layer.overrideMaterials is a material, all meshes for this layer
    will get a clone() of it as their material.
    If it's 'true', all meshes will get a default MeshLambertMaterial mat.
    Else they'll get the GLTFLoader supplied mesh.
    
    This commit also adds the missing material.dispose() call.

Second one:

    fix (3dtiles): use distance to as commands priority value
    
    Distance may not be the best metric to determine priority but it's better
    than a constant value.