### PR TITLE
fix (geojson): check for empty coordinates list before iterating

### DIFF
--- a/src/Renderer/ThreeExtended/GeoJSON2Feature.js
+++ b/src/Renderer/ThreeExtended/GeoJSON2Feature.js
@@ -132,6 +132,9 @@ const GeometryToCoordinates = {
 };
 
 function readGeometry(crsIn, crsOut, json, filteringExtent, options) {
+    if (json.coordinates.length == 0) {
+        return;
+    }
     switch (json.type.toLowerCase()) {
         case 'point':
             return GeometryToCoordinates.point(crsIn, crsOut, [json.coordinates], filteringExtent, options);


### PR DESCRIPTION
Avoid crash by early returning if the coordinates list is empty.