### PR TITLE
Tile geometry projection support

### DIFF
--- a/examples/epsg_finder.html
+++ b/examples/epsg_finder.html
@@ -1,0 +1,113 @@
+<html>
+    <head>
+        <title>Itowns - Globe</title>
+
+        <style type="text/css">
+            html {
+                height: 100%;
+            }
+
+            body {
+                margin: 0;
+                overflow:hidden;
+                height:100%;
+            }
+
+            #viewerDiv {
+                margin : auto auto;
+                width: 100%;
+                height: 100%;
+                padding: 0;
+            }
+        </style>
+        <meta charset="UTF-8">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="GUI/dat.gui/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id='viewerDiv'></div>
+        <script src="../dist/itowns.js"></script>
+        <script type="text/javascript">
+        // Define initial camera position
+        var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 5000000 };
+        var promises = [];
+        var minDistance = 10000000;
+        var maxDistance = 30000000;
+
+        // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+        var viewerDiv = document.getElementById('viewerDiv');
+
+        // Instanciate iTowns GlobeView*
+        var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+        function addLayerCb(layer) {
+            return globeView.addLayer(layer);
+        }
+
+        globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function _() {
+            var gui = new dat.GUI();
+            var state = {
+                epsg: '3946',
+                view: viewFunction
+            };
+            gui.add(state, 'epsg').name('EPSG Code');
+            gui.add(state, 'view').name('View');
+
+            function viewFunction() {
+                itowns.Fetcher.json(`http://epsg.io/?q=${state.epsg}&format=json`).then(function (content) {
+                    const code = `EPSG:${state.epsg}`;
+                    if (!itowns.proj4.defs[code]) {
+                        itowns.proj4.defs(code, content.results[0].proj4);
+                    }
+
+                    console.log(content.results[0].bbox);
+
+                    const geoExtent = new itowns.Extent(
+                        'EPSG:4326',
+                            content.results[0].bbox[1],
+                            content.results[0].bbox[3],
+                            content.results[0].bbox[2],
+                            content.results[0].bbox[0]);
+                    const extent = geoExtent.as(code);
+                    console.log('New extent', extent);
+
+                    const epsgLayer = itowns.createPlanarLayer(extent.crs(), extent, {
+                        object3d: globeView.scene,
+                    });
+                    epsgLayer.noTextureColor = new itowns.THREE.Color(0xeedeae);
+                    epsgLayer.disableSkirt = true;
+
+                    const oldOnTileCreated = epsgLayer.onTileCreated;
+                    epsgLayer.onTileCreated = function _t(layer, parent, node) {
+                        node.material.depthTest = false;
+                    };
+
+                    epsgLayer.opacity = 0.75;
+
+                    itowns.View.prototype.addLayer.call(globeView, epsgLayer);
+                    itowns.View.prototype.addLayer.call(globeView, {
+                        update: itowns.updateLayeredMaterialNodeImagery,
+                        url: 'http://osm.oslandia.io/services/wms',
+                        type: 'color',
+                        protocol: 'wms',
+                        networkOptions: { crossOrigin: 'anonymous' },
+                        version: '1.1.1',
+                        id: 'osm' + extent.crs(),
+                        name: 'positron',
+                        projection: 'EPSG:3857',
+                        axisOrder: 'wsen',
+                        options: {
+                            mimetype: 'image/jpeg',
+                        }
+                    }, epsgLayer);
+
+                    globeView.controls.setCameraTargetGeoPosition(
+                        {longitude: geoExtent.center().longitude(), latitude: geoExtent.center().latitude()});
+                });
+            }
+        });
+
+        promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+        </script>
+    </body>
+</html>

--- a/examples/epsg_finder.html
+++ b/examples/epsg_finder.html
@@ -71,9 +71,7 @@
                     const extent = geoExtent.as(code);
                     console.log('New extent', extent);
 
-                    const epsgLayer = itowns.createPlanarLayer(extent.crs(), extent, {
-                        object3d: globeView.scene,
-                    });
+                    const epsgLayer = itowns.createPlanarLayer(extent.crs(), extent, { });
                     epsgLayer.noTextureColor = new itowns.THREE.Color(0xeedeae);
                     epsgLayer.disableSkirt = true;
 
@@ -95,7 +93,6 @@
                         id: 'osm' + extent.crs(),
                         name: 'positron',
                         projection: 'EPSG:3857',
-                        axisOrder: 'wsen',
                         options: {
                             mimetype: 'image/jpeg',
                         }

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -163,9 +163,10 @@ Extent.prototype.as = function as(crs) {
     });
 };
 
-Extent.prototype.offsetToParent = function offsetToParent(other) {
+Extent.prototype.offsetToParent = function offsetToParent(_other) {
+    let other = _other;
     if (this.crs() != other.crs()) {
-        throw new Error('unsupported mix');
+        other = _other.as(this.crs());
     }
     if (_isTiledCRS(this.crs())) {
         const diffLevel = this._zoom - other.zoom;

--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -40,7 +40,7 @@ BuilderEllipsoidTile.prototype.Prepare = function Prepare(params) {
 // get center tile in cartesian 3D
 BuilderEllipsoidTile.prototype.Center = function Center(params) {
     params.center = params.extent.center(this.tmp.coords[0])
-        .as('EPSG:4978', this.tmp.coords[1]).xyz();
+        .as(params.crs, this.tmp.coords[1]).xyz();
     return params.center;
 };
 
@@ -49,7 +49,7 @@ BuilderEllipsoidTile.prototype.VertexPosition = function VertexPosition(params) 
     this.tmp.coords[0]._values[0] = params.projected.longitudeRad;
     this.tmp.coords[0]._values[1] = params.projected.latitudeRad;
 
-    this.tmp.coords[0].as('EPSG:4978', this.tmp.coords[1]).xyz(this.tmp.position);
+    this.tmp.coords[0].as(params.crs, this.tmp.coords[1]).xyz(this.tmp.position);
     this.tmp.normal.copy(this.tmp.position).normalize();
     return this.tmp.position;
 };

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -158,7 +158,7 @@ export function createGlobeLayer(id, options) {
 
     function subdivision(context, layer, node) {
         if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
-            return globeSubdivisionControl(2, options.maxSubdivisionLevel || 17, options.sseSubdivisionThreshold || 1.0)(context, layer, node);
+            return globeSubdivisionControl(2, options.maxSubdivisionLevel === undefined ? 17 : options.maxSubdivisionLevel, options.sseSubdivisionThreshold || 1.0)(context, layer, node);
         }
         return false;
     }

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -98,7 +98,7 @@ export function createPlanarLayer(id, extent, options) {
 
     function subdivision(context, layer, node) {
         if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
-            return planarSubdivisionControl(options.maxSubdivisionLevel || 5)(context, layer, node);
+            return planarSubdivisionControl(options.maxSubdivisionLevel === undefined ? 5 : options.maxSubdivisionLevel)(context, layer, node);
         }
         return false;
     }

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -67,6 +67,7 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
         segment: 16,
         materialOptions: command.layer.materialOptions,
         disableSkirt: command.layer.disableSkirt,
+        crs: command.view.referenceCrs,
     };
 
     const geometry = new TileGeometry(params, command.layer.builder);

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -32,13 +32,7 @@ WMS_Provider.prototype.url = function url(bbox, layer) {
 };
 
 WMS_Provider.prototype.tileTextureCount = function tileTextureCount(tile, layer) {
-    if (tile.extent.crs() == layer.projection) {
-        return 1;
-    } else {
-        const tileMatrixSet = layer.options.tileMatrixSet;
-        OGCWebServiceHelper.computeTileMatrixSetCoordinates(tile, tileMatrixSet);
-        return tile.getCoordsForLayer(layer).length;
-    }
+    return tile.extent.crs() == layer.projection ? 1 : tile.getCoordsForLayer(layer).length;
 };
 
 WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer) {

--- a/src/Renderer/ThreeExtended/OBB.js
+++ b/src/Renderer/ThreeExtended/OBB.js
@@ -123,11 +123,6 @@ OBB.extentToOBB = function extentToOBB(extent, minHeight = 0, maxHeight = 0) {
         throw new Error('The extent crs is not a Geographic Coordinates (EPSG:4326)');
     }
 
-    // Calcule the center world position with the extent.
-    extent.center(tmp.cardinals[8]);
-    const centerWorld = tmp.cardinals[8].as('EPSG:4978', tmp.epsg4978).xyz();
-    tmp.normal.copy(centerWorld).normalize();
-
     const bboxDimension = extent.dimensions(UNIT.RADIAN);
     const phiStart = extent.west(UNIT.RADIAN);
     const phiLength = bboxDimension.x;
@@ -155,8 +150,17 @@ OBB.extentToOBB = function extentToOBB(extent, minHeight = 0, maxHeight = 0) {
     tmp.cardinals[6]._values[1] = thetaStart + thetaLength;
     tmp.cardinals[7]._values[0] = phiStart;
     tmp.cardinals[7]._values[1] = thetaStart + bboxDimension.y * 0.5;
+    extent.center(tmp.cardinals[8]);
 
+    return OBB.cardinals4978ToOBB(tmp.cardinals, minHeight, maxHeight);
+};
+
+OBB.cardinals4978ToOBB = function cardinals4978ToOBB(cardinals, minHeight = 0, maxHeight = 0) {
     var cardin3DPlane = [];
+
+    // Calcule the center world position with the extent.
+    const centerWorld = cardinals[8].as('EPSG:4978', tmp.epsg4978).xyz();
+    tmp.normal.copy(centerWorld).normalize();
 
     tmp.maxV.set(-1000, -1000, -1000);
     tmp.minV.set(1000, 1000, 1000);
@@ -168,8 +172,8 @@ OBB.extentToOBB = function extentToOBB(extent, minHeight = 0, maxHeight = 0) {
         new THREE.Vector3(0, 0, 1), -tmp.cardinals[8].longitude(UNIT.RADIAN));
     tmp.qRotY.multiply(tmp.planeZ);
 
-    for (var i = 0; i < tmp.cardinals.length; i++) {
-        tmp.cardinals[i].as('EPSG:4978', tmp.epsg4978).xyz(tmp.cardinal3D);
+    for (var i = 0; i < cardinals.length; i++) {
+        cardinals[i].as('EPSG:4978', tmp.epsg4978).xyz(tmp.cardinal3D);
         cardin3DPlane.push(tmp.tangentPlaneAtOrigin.projectPoint(tmp.cardinal3D));
         const d = cardin3DPlane[i].distanceTo(tmp.cardinal3D.sub(centerWorld));
         halfMaxHeight = Math.max(halfMaxHeight, d * 0.5);


### PR DESCRIPTION
This PR improves itowns handling of having multiple tile geometries with different CRS.

Until now, geometries are *assumed* to use the same CRS as the view which is often the case.
I believe we should support displaying other CRS too, as long as the transformation from 1 crs to the other is possible.
If not possible or not implemented we should fail early instead of silently accepting data that we can't display.

With that being said, this PR implements tile geometry projection and adds a smallish example to illustrate a possible use.
The example could be improved to look nicer and allow the user to type any CRS instead of hardcoding it: help is welcome, feel free to push improvements directly to the branch :-)

Here's the result with CRS 5514 (see https://epsg.io/5514):
![capture d ecran de 2017-10-06 17-26-36](https://user-images.githubusercontent.com/2198295/31285487-b8030522-aabb-11e7-9d34-377273a92ed7.png)

