### PR TITLE
Fix (controls): compute more correcly rotations in FlyControls

### DIFF
--- a/src/Renderer/ThreeExtended/FlyControls.js
+++ b/src/Renderer/ThreeExtended/FlyControls.js
@@ -1,8 +1,5 @@
 import * as THREE from 'three';
 
-const maxFOV = 90;
-const rotationFactor = 0.0022; // determined empirically
-
 const MOVEMENTS = {
     38: { method: 'translateZ', sign: -1 }, // FORWARD: up key
     40: { method: 'translateZ', sign: 1 }, // BACKWARD: down key
@@ -33,9 +30,12 @@ function onTouchStart(event) {
 
 function onPointerMove(pointerX, pointerY) {
     if (this._isMouseDown === true) {
-        const fovCorrection = this._camera3D.fov / maxFOV; // 1 at maxFOV
-        this._camera3D.rotateY((pointerX - this._onMouseDownMouseX) * rotationFactor * fovCorrection);
-        this._camera3D.rotateX((pointerY - this._onMouseDownMouseY) * rotationFactor * fovCorrection);
+        // in rigor we have tan(theta) = tan(cameraFOV) * deltaH / H
+        // (where deltaH is the vertical amount we moved, and H the renderer height)
+        // we loosely approximate tan(x) by x
+        const pxToAngleRatio = THREE.Math.degToRad(this._camera3D.fov) / this.view.mainLoop.gfxEngine.height;
+        this._camera3D.rotateY((pointerX - this._onMouseDownMouseX) * pxToAngleRatio);
+        this._camera3D.rotateX((pointerY - this._onMouseDownMouseY) * pxToAngleRatio);
         this._onMouseDownMouseX = pointerX;
         this._onMouseDownMouseY = pointerY;
         this.view.notifyChange(false, this._camera3D);


### PR DESCRIPTION
## Description
Use a better (albeit still approximate) heuristic to calculate horizontal and vertical movement with mouse drag.

## Motivation and Context

2 advantages to this patch:
- it unifies things with FirstPersonControls
- it removes a magic and opaque constant
