### PR TITLE
Fix (Debug) Allow point size of 0

### DIFF
--- a/src/Core/Scheduler/Providers/PointCloudProvider.js
+++ b/src/Core/Scheduler/Providers/PointCloudProvider.js
@@ -139,7 +139,7 @@ export default {
         layer.fetchOptions = layer.fetchOptions || {};
         layer.octreeDepthLimit = layer.octreeDepthLimit || -1;
         layer.pointBudget = layer.pointBudget || 15000000;
-        layer.pointSize = layer.pointSize || 4;
+        layer.pointSize = layer.pointSize === 0 || !isNaN(layer.pointSize) ? layer.pointSize : 4;
         layer.overdraw = layer.overdraw || 2;
         layer.type = 'geometry';
 

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -40,7 +40,7 @@ export default {
         layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count')
             .onChange(() => view.notifyChange(true));
         const surf = layer.debugUI.addFolder('Surface Method params');
-        surf.add(layer, 'pointSize', 1, 15).name('Point Size')
+        surf.add(layer, 'pointSize', 0, 15).name('Point Size')
             .onChange(() => view.notifyChange(true));
         surf.add(layer, 'overdraw', 1, 5).name('Overdraw')
             .onChange(() => view.notifyChange(true));


### PR DESCRIPTION
This enables the use of adaptative point size in PointsVS.glsl.
