### PR TITLE
fix (GlobeControls) : moving camera.update call from GlobeControls to…

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -71,7 +71,6 @@ function View(crs, viewerDiv, options = {}) {
         // the container's size. Otherwise we use window' size.
         const newSize = new Vector2(viewerDiv.clientWidth, viewerDiv.clientHeight);
         this.mainLoop.gfxEngine.onWindowResize(newSize.x, newSize.y);
-        this.camera.update(newSize.x, newSize.y);
         this.notifyChange(true);
     }, false);
 

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -456,7 +456,17 @@ function GlobeControls(view, target, radius, options = {}) {
         sizeRendering.FOV = this.camera.fov;
     };
 
-    window.addEventListener('resize', this.updateCamera.bind(this), false);
+    const self = this;
+    const resizeHandler = {
+        update() {
+            const dim = self._view.mainLoop.gfxEngine.getWindowSize();
+            const sizeDiff = (dim.width != sizeRendering.width || dim.height != sizeRendering.height);
+            if (sizeDiff) {
+                self.updateCamera();
+            }
+        },
+    };
+    this._view.addFrameRequester(resizeHandler);
 
     this.getAutoRotationAngle = function getAutoRotationAngle() {
         return 2 * Math.PI / 60 / 60 * this.autoRotateSpeed;


### PR DESCRIPTION
… MainLoop so it won't be missed after a resize

## Description
<!--- Describe your changes in detail -->
removed 
`window.addEventListener('resize', this.updateCamera.bind(this), false);`
as it wasn't always working when the screen was resized...

Modification added in MainLoop with FrameRequester.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

#504 Improvement 

## Screenshots (if appropriate)
