### PR TITLE
feat(core): add the ability to colorize pointclouds

### DIFF
--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -14,10 +14,10 @@ class PointsMaterial extends RawShaderMaterial {
         this.uniforms.pickingMode = new Uniform(false);
         this.uniforms.density = new Uniform(0.01);
         this.uniforms.opacity = new Uniform(1.0);
+        this.uniforms.useCustomColor = new Uniform(false);
+        this.uniforms.customColor = new Uniform(new Color());
 
         if (__DEBUG__) {
-            this.uniforms.useDebugColor = new Uniform(false);
-            this.uniforms.debugColor = new Uniform(new Color());
             this.defines.DEBUG = 1;
         }
 

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -7,10 +7,8 @@ varying vec4 vColor;
 uniform bool pickingMode;
 uniform float opacity;
 
-#ifdef DEBUG
-uniform bool useDebugColor;
-uniform vec3 debugColor;
-#endif
+uniform bool useCustomColor;
+uniform vec3 customColor;
 
 void main() {
     // circular point rendering
@@ -21,14 +19,13 @@ void main() {
         discard;
     }
 
-    gl_FragColor = vColor;
     gl_FragColor.a = opacity;
 
-#ifdef DEBUG
-    if (useDebugColor && !pickingMode) {
-        gl_FragColor = mix(vColor, vec4(debugColor, 1.0), 0.5);
+    if (useCustomColor && !pickingMode) {
+        gl_FragColor = mix(vColor, vec4(customColor, 1.0), 0.5);
+    } else {
+        gl_FragColor = vColor;
     }
-#endif
 
     #include <logdepthbuf_fragment>
 }

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -97,7 +97,7 @@ export default {
                 if (layer._currentDbgNode) {
                     for (const n of layer._currentDbgNode) {
                         if (n.obj) {
-                            n.obj.material.uniforms.useDebugColor.value = false;
+                            n.obj.material.uniforms.useCustomColor.value = false;
                         }
                     }
                 }
@@ -116,7 +116,7 @@ export default {
             // hook update
             layer.update = (context, layer, elt) => {
                 if (elt.obj) {
-                    elt.obj.material.uniforms.useDebugColor.value = false;
+                    elt.obj.material.uniforms.useCustomColor.value = false;
                     if (elt.obj.boxHelper) {
                         elt.obj.boxHelper.material.visible = false;
                     }
@@ -142,8 +142,8 @@ export default {
                     if (stickies.indexOf(elt.name) >= 0) { // is this node the sticky node?
                         layer._currentDbgNode.push(elt);
                         if (elt.obj) {
-                            elt.obj.material.uniforms.useDebugColor.value = true;
-                            elt.obj.material.uniforms.debugColor.value = new itowns.THREE.Color(layer.dbgStickyNodeColor);
+                            elt.obj.material.uniforms.useCustomColor.value = true;
+                            elt.obj.material.uniforms.customColor.value = new itowns.THREE.Color(layer.dbgStickyNodeColor);
                         }
                     } else {
                         for (const name of stickies) {
@@ -159,27 +159,27 @@ export default {
                     }
                 } else if (layer.dbgEnablePointCount) {
                     if (elt.obj && elt.obj.material.visible) {
-                        elt.obj.material.uniforms.useDebugColor.value = true;
+                        elt.obj.material.uniforms.useCustomColor.value = true;
 
                         const pc = elt.obj.geometry.drawRange.count;
                         if (pc < layer.dbgPointCountThreshold1) {
-                            elt.obj.material.uniforms.debugColor.value.setRGB(1, 0, 0);
+                            elt.obj.material.uniforms.customColor.value.setRGB(1, 0, 0);
                             if (layer.dbgDisplayType != 'all' && layer.dbgDisplayType != 'red') {
                                 elt.obj.material.visible = false;
                             }
                         } else if (pc < layer.dbgPointCountThreshold2) {
-                            elt.obj.material.uniforms.debugColor.value.setRGB(0, 1, 0);
+                            elt.obj.material.uniforms.customColor.value.setRGB(0, 1, 0);
                             if (layer.dbgDisplayType != 'all' && layer.dbgDisplayType != 'green') {
                                 elt.obj.material.visible = false;
                             }
                         } else {
-                            elt.obj.material.uniforms.debugColor.value.setRGB(0, 0, 1);
+                            elt.obj.material.uniforms.customColor.value.setRGB(0, 0, 1);
                             if (layer.dbgDisplayType != 'all' && layer.dbgDisplayType != 'blue') {
                                 elt.obj.material.visible = false;
                             }
                         }
                         if (elt.obj.boxHelper) {
-                            elt.obj.boxHelper.material.color.copy(elt.obj.material.uniforms.debugColor.value);
+                            elt.obj.boxHelper.material.color.copy(elt.obj.material.uniforms.customColor.value);
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This actually moves a debug feature into core: it replaces `debugColor`
and `useDebugColor` with `customColor` and `useCustomColor`.

## Motivation and Context

I think it is a useful feature to have in a production context: 
- users can have several pointclouds displayed at the same time, and it's convenient to allow to separate them visually.
- When clouds have neither information of color nor intensity, colorizing them allows to see applied visual improvements. We don't have any on itowns right now, but for example Eye-Dome lightning add some black outlines. You can't see them if the cloud is black too.
