### PR TITLE
fix: restore PM layers texture display

### DIFF
--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -98,7 +98,7 @@ void main() {
                     int pmTextureCount = int(paramsA.y);
                     int textureIndex = int(paramsA.x) + (projWGS84 ? 0 : pmSubTextureIndex);
 
-                    if (!projWGS84 && pmTextureCount <= textureIndex) {
+                    if (!projWGS84 && pmTextureCount <= pmSubTextureIndex) {
                         continue;
                     }
 


### PR DESCRIPTION
This was broken in PR https://github.com/iTowns/itowns/pull/492

This commit fixes the issue by comparing the texture count to the
correct index.

Fixes #525