### PR TITLE
Fix core threejslayer

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -119,6 +119,12 @@ function _preprocessLayer(view, layer, provider) {
     }
 
     if (!layer.whenReady) {
+        if (layer.type == 'geometry' || layer.type == 'debug') {
+            // layer.threejsLayer *must* be assigned before preprocessing,
+            // because TileProvider.preprocessDataLayer function uses it.
+            layer.threejsLayer = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
+        }
+
         let providerPreprocessing = Promise.resolve();
         if (provider && provider.preprocessDataLayer) {
             providerPreprocessing = provider.preprocessDataLayer(layer, view, view.mainLoop.scheduler);
@@ -143,7 +149,6 @@ function _preprocessLayer(view, layer, provider) {
     } else if (layer.type == 'elevation') {
         defineLayerProperty(layer, 'frozen', false);
     } else if (layer.type == 'geometry' || layer.type == 'debug') {
-        layer.threejsLayer = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
         defineLayerProperty(layer, 'visible', true, () => _syncThreejsLayer(layer, view));
         _syncThreejsLayer(layer, view);
 

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -30,7 +30,7 @@ function c3DEngine(rendererOrDiv, options = {}) {
     this.height = (renderer ? renderer.domElement : viewerDiv).clientHeight;
 
     this.positionBuffer = null;
-    this._nextThreejsLayer = 0;
+    this._nextThreejsLayer = 1;
 
     this.fullSizeRenderTarget = new THREE.WebGLRenderTarget(this.width, this.height);
     this.fullSizeRenderTarget.texture.minFilter = THREE.LinearFilter;


### PR DESCRIPTION
2 fixes commit regarding `threejsLayer` feature:

* fix (core): assign three.js layers before their first usage
    
    This commit makes sure that layer.threejsLayer is initialized soon enough.
    Otherwise root tiles created during the preprocess step would have
    a different threejsLayer than their children.

*  fix(core): avoid hiding all other Object3D when hiding first layer
    
    Previously, the first layer get assigned the value 0 as layer mask. As
    it is the default for all Object3D, when hiding this layer, all the
    other Object3D of the scene would get hidden too.