### PR TITLE
fix (geometry): remove tile's layer

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -177,6 +177,9 @@ TileMesh.prototype.getIndexLayerColor = function getIndexLayerColor(idLayer) {
 };
 
 TileMesh.prototype.removeColorLayer = function removeColorLayer(idLayer) {
+    if (this.layerUpdateState && this.layerUpdateState[idLayer]) {
+        delete this.layerUpdateState[idLayer];
+    }
     this.material.removeColorLayer(idLayer);
 };
 


### PR DESCRIPTION
## Description
remove the specified `layerUpdateState` when layer is removed

## Motivation and Context
When you remove and re-add the same layer, the tiles retained the state of the first layer