### PR TITLE
Remove debug code from transpiled sources.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,16 @@
     "presets": ["es2015"],
     "plugins": [
         "transform-runtime",
-        [ "babel-plugin-webpack-loaders", { "config": "./webpack-babel.config.js", "verbose": false }]
+        [ "babel-plugin-webpack-loaders", { "config": "./webpack-babel.config.js", "verbose": false }],
+        ["minify-replace", {
+            "replacements": [{
+                "identifierName": "__DEBUG__",
+                "replacement": {
+                    "type": "booleanLiteral",
+                    "value": false
+                }
+            }]
+        }],
+        ["minify-dead-code-elimination"]
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,6 +342,12 @@
         "lodash": "4.17.4"
       }
     },
+    "babel-helper-evaluate-path": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.2.0.tgz",
+      "integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg==",
+      "dev": true
+    },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
@@ -398,6 +404,12 @@
         "babel-types": "6.25.0"
       }
     },
+    "babel-helper-mark-eval-scopes": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.2.0.tgz",
+      "integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw==",
+      "dev": true
+    },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
@@ -431,6 +443,12 @@
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0"
       }
+    },
+    "babel-helper-remove-or-void": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.2.0.tgz",
+      "integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA==",
+      "dev": true
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
@@ -484,6 +502,24 @@
       "requires": {
         "babel-runtime": "6.23.0"
       }
+    },
+    "babel-plugin-minify-dead-code-elimination": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.2.0.tgz",
+      "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0",
+        "babel-helper-mark-eval-scopes": "0.2.0",
+        "babel-helper-remove-or-void": "0.2.0",
+        "lodash.some": "4.6.0"
+      }
+    },
+    "babel-plugin-minify-replace": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.2.0.tgz",
+      "integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q==",
+      "dev": true
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -3628,6 +3664,12 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-loader": "^7.0.0",
+    "babel-plugin-minify-dead-code-elimination": "^0.2.0",
+    "babel-plugin-minify-replace": "^0.2.0",
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-plugin-webpack-loaders": "^0.9.0",
     "babel-preset-es2015": "^6.22.2",

--- a/webpack-babel.config.js
+++ b/webpack-babel.config.js
@@ -1,5 +1,7 @@
 var path = require('path');
 
+var commonConfig = require('./webpack-common.config.js');
+
 module.exports = {
     output: {
         libraryTarget: 'commonjs2',
@@ -7,21 +9,8 @@ module.exports = {
     },
     module: {
         rules: [
-            // please consider modifying corresponding loaders in webpack.config.js too
-            {
-                test: /\.glsl$/,
-                include: [
-                    path.resolve(__dirname, 'src'),
-                ],
-                loader: 'raw-loader',
-            },
-            {
-                test: /\.json$/,
-                include: [
-                    path.resolve(__dirname, 'utils'),
-                ],
-                loader: 'raw-loader',
-            },
+            commonConfig.glslLoader,
+            commonConfig.jsonLoader,
         ],
     },
 };

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -1,0 +1,21 @@
+var path = require('path');
+
+module.exports = {
+    glslLoader: {
+        // please consider modifying corresponding loaders in webpack-babel.config.js too
+        test: /\.glsl$/,
+        include: [
+            path.resolve(__dirname, 'src'),
+            path.resolve(__dirname, 'test'),
+        ],
+        loader: 'raw-loader',
+    },
+    jsonLoader: {
+        // please consider modifying corresponding loaders in webpack-babel.config.js too
+        test: /\.json$/,
+        include: [
+            path.resolve(__dirname, 'utils'),
+        ],
+        loader: 'raw-loader',
+    },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 var path = require('path');
 var webpack = require('webpack');
 
+var commonConfig = require('./webpack-common.config.js');
+
 var definePlugin = new webpack.DefinePlugin({
     __DEBUG__: JSON.stringify(process.env.NODE_ENV === 'development'),
 });
@@ -57,23 +59,8 @@ module.exports = {
                     babelrc: false,
                 },
             },
-            {
-                // please consider modifying corresponding loaders in webpack-babel.config.js too
-                test: /\.glsl$/,
-                include: [
-                    path.resolve(__dirname, 'src'),
-                    path.resolve(__dirname, 'test'),
-                ],
-                loader: 'raw-loader',
-            },
-            {
-                // please consider modifying corresponding loaders in webpack-babel.config.js too
-                test: /\.json$/,
-                include: [
-                    path.resolve(__dirname, 'utils'),
-                ],
-                loader: 'raw-loader',
-            },
+            commonConfig.glslLoader,
+            commonConfig.jsonLoader,
         ],
     },
     devServer: {


### PR DESCRIPTION
## Description
This contains 2 commits:

- the first one correctly remove debug code from transpiled sources



- the second is a basic refactoring

## Motivation and Context


Before this patch, people using itowns as a module (as it should be used) had to manually define __DEBUG__ in their own module bundler config, otherwise they had some undefined error. This commit correctly strips itowns out of these debug code during transpilation.


