### PR TITLE
fix (controls) : fixes for GlobeControls

### DIFF
--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -94,7 +94,7 @@ const EPS = 0.000001;
 const rotateStart = new THREE.Vector2();
 const rotateEnd = new THREE.Vector2();
 const rotateDelta = new THREE.Vector2();
-const spherical = new THREE.Spherical(1.0, 0.01, Math.PI * 0.5);
+const spherical = new THREE.Spherical(1.0, 0.01, 0);
 const snapShotSpherical = new THREE.Spherical(1.0, 0.01, Math.PI * 0.5);
 const sphericalDelta = new THREE.Spherical(1.0, 0, 0);
 const sphericalTo = new THREE.Spherical();
@@ -128,8 +128,8 @@ var animatedScale = 0.0;
 const positionObject = (function getPositionObjectFn()
 {
     const quaterionX = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 2);
-    return function positionObject(newPosition, object)
-    {
+    return function positionObject(newPosition, object) {
+        object.up = THREE.Object3D.DefaultUp;
         object.position.copy(newPosition);
         object.lookAt(newPosition.clone().multiplyScalar(1.1));
         object.quaternion.multiply(quaterionX);
@@ -1603,7 +1603,7 @@ GlobeControls.prototype.getTilt = function getTilt() {
  * @return {Angle} number - The angle of the rotation in degrees.
  */
 GlobeControls.prototype.getHeading = function getHeading() {
-    return spherical.theta * 180 / Math.PI;
+    return (THREE.Math.radToDeg(spherical.theta) + 360) % 360;
 };
 
 GlobeControls.prototype.getTiltRad = function getTiltRad() {

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1319,8 +1319,15 @@ function GlobeControls(view, target, radius, options = {}) {
     update();
 
     if (enableTargetHelper) {
-        cameraTargetOnGlobe.add(new THREE.AxisHelper(500000));
+        const helperTarget = new THREE.AxisHelper(500000);
+        cameraTargetOnGlobe.add(helperTarget);
         this._view.scene.add(pickingHelper);
+        const layerTHREEjs = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
+        cameraTargetOnGlobe.layers.set(layerTHREEjs);
+        helperTarget.layers.set(layerTHREEjs);
+        pickingHelper.layers.set(layerTHREEjs);
+        cameraTargetOnGlobe.layers.set(layerTHREEjs);
+        this.camera.layers.enable(layerTHREEjs);
     }
 
     // Start position

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1048,7 +1048,9 @@ function GlobeControls(view, target, radius, options = {}) {
         }
     };
 
+    let wheelTimer;
     var onMouseWheel = function onMouseWheel(event) {
+        clearTimeout(wheelTimer);
         player.stop().then(() => {
             if (!this.enabled || !this.states.DOLLY.enable) return;
 
@@ -1082,6 +1084,15 @@ function GlobeControls(view, target, radius, options = {}) {
                 });
             }
             snapShotSpherical.copy(spherical);
+
+            // Prevent updating target as long as the wheel rotates
+            wheelTimer = setTimeout(() => {
+                this.waitSceneLoaded().then(() => {
+                    if (state == this.states.NONE) {
+                        this.updateCameraTransformation();
+                    }
+                });
+            }, 250);
 
             this.dispatchEvent(this.startEvent);
             this.dispatchEvent(this.endEvent);

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -327,6 +327,8 @@ function defer() {
     return deferedPromise;
 }
 
+let initPromise;
+
 /* globals document,window */
 
 /**
@@ -1339,9 +1341,8 @@ function GlobeControls(view, target, radius, options = {}) {
     _handlerMouseMove = onMouseMove.bind(this);
     _handlerMouseUp = onMouseUp.bind(this);
 
-    this.waitSceneLoaded().then(() => {
+    initPromise = this.waitSceneLoaded().then(() => {
         this.updateCameraTransformation();
-        this._view.notifyChange(true, this.camera);
     });
 }
 
@@ -1401,14 +1402,16 @@ GlobeControls.prototype.setRange = function setRange(range, isAnimated) {
  * @return {Promise<void>}
  */
 GlobeControls.prototype.setOrbitalPosition = function setOrbitalPosition(position, isAnimated) {
-    isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
-    const deltaPhi = position.tilt === undefined ? 0 : position.tilt * Math.PI / 180 - this.getTiltRad();
-    const deltaTheta = position.heading === undefined ? 0 : position.heading * Math.PI / 180 - this.getHeadingRad();
-    const deltaRange = position.range === undefined ? 0 : position.range - this.getRange();
-    return this.moveOrbitalPosition(deltaRange, deltaTheta, deltaPhi, isAnimated).then(() => {
-        this._view.notifyChange(true);
-        return this.waitSceneLoaded().then(() => {
-            this.updateCameraTransformation();
+    return initPromise.then(() => {
+        isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
+        const deltaPhi = position.tilt === undefined ? 0 : position.tilt * Math.PI / 180 - this.getTiltRad();
+        const deltaTheta = position.heading === undefined ? 0 : position.heading * Math.PI / 180 - this.getHeadingRad();
+        const deltaRange = position.range === undefined ? 0 : position.range - this.getRange();
+        return this.moveOrbitalPosition(deltaRange, deltaTheta, deltaPhi, isAnimated).then(() => {
+            this._view.notifyChange(true);
+            return this.waitSceneLoaded().then(() => {
+                this.updateCameraTransformation();
+            });
         });
     });
 };
@@ -1731,11 +1734,13 @@ GlobeControls.prototype.setScale = function setScale(scale, pitch, isAnimated) {
  * @return {Promise} A promise that resolves when the next 'globe initilazed' event fires.
  */
 GlobeControls.prototype.setCameraTargetGeoPosition = function setCameraTargetGeoPosition(coordinates, isAnimated) {
-    isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
-    const position = new C.EPSG_4326(coordinates.longitude, coordinates.latitude, 0)
-        .as('EPSG:4978').xyz();
-    position.range = coordinates.range;
-    return this.setCameraTargetPosition(position, isAnimated);
+    return initPromise.then(() => {
+        isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
+        const position = new C.EPSG_4326(coordinates.longitude, coordinates.latitude, 0)
+            .as('EPSG:4978').xyz();
+        position.range = coordinates.range;
+        return this.setCameraTargetPosition(position, isAnimated);
+    });
 };
 
 /**


### PR DESCRIPTION
**Fixes multi bug in globeControls**

- fix (control): bad camera's heading convention in `globeControls`

- fix (controls): in `GlobeControls.setCameraTargetPosition` the final position isn't the desired position
The problem was due to altitude changes during the displacement
fix #486 

- fix (controls): in `GlobeControls.setOrbitalPosition`, the final position isn't the desired position
The problem was due to altitude changes during the displacement

- fix (controls): fix error target with pick depth position
For the large ranges pick depth position is too imprecise
More robust calculation with `DEMUtils`

- fix (controls): add target update target for wheel event
Target wasn't updated after range change
fix #411 

- fix (controls): wait initialization before move camera
if you change camera's position before `init`,
the movement doesn't oppose
fix #300

- fix (controls): add `THREE.layer` for helper axis
Because helper fakes pick position
because Helper axis write in depth buffer

