### PR TITLE
feature (protocols): force loading step of group strategy

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -158,7 +158,10 @@ export function createGlobeLayer(id, options) {
 
     function subdivision(context, layer, node) {
         if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
-            return globeSubdivisionControl(2, options.maxSubdivisionLevel || 17, options.sseSubdivisionThreshold || 1.0)(context, layer, node);
+            return globeSubdivisionControl(2,
+                options.maxSubdivisionLevel || 18,
+                options.sseSubdivisionThreshold || 1.0,
+                options.maxDeltaElevationLevel || 4)(context, layer, node);
         }
         return false;
     }

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -9,7 +9,7 @@ import { GeometryLayer } from '../Layer/Layer';
 
 import { processTiledGeometryNode } from '../../Process/TiledNodeProcessing';
 import { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } from '../../Process/LayeredMaterialNodeProcessing';
-import { planarCulling, planarSubdivisionControl } from '../../Process/PlanarTileProcessing';
+import { planarCulling, planarSubdivisionControl, prePlanarUpdate } from '../../Process/PlanarTileProcessing';
 import PlanarTileBuilder from './Planar/PlanarTileBuilder';
 import SubdivisionControl from '../../Process/SubdivisionControl';
 
@@ -55,6 +55,8 @@ export function createPlanarLayer(id, extent, options) {
     tileLayer.preUpdate = (context, layer, changeSources) => {
         SubdivisionControl.preUpdate(context, layer);
 
+        prePlanarUpdate(context, layer);
+
         if (__DEBUG__) {
             layer._latestUpdateStartingLevel = 0;
         }
@@ -98,7 +100,8 @@ export function createPlanarLayer(id, extent, options) {
 
     function subdivision(context, layer, node) {
         if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
-            return planarSubdivisionControl(options.maxSubdivisionLevel || 5)(context, layer, node);
+            return planarSubdivisionControl(options.maxSubdivisionLevel || 5,
+                options.maxDeltaElevationLevel || 4)(context, layer, node);
         }
         return false;
     }

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -22,9 +22,30 @@ function _isTileBigOnScreen(camera, node) {
     return (dim.x >= 0.3 && dim.y >= 0.3);
 }
 
-export function planarSubdivisionControl(maxLevel) {
+export function prePlanarUpdate(context, layer) {
+    const elevationLayers = context.view.getLayers((l, a) => a && a.id == layer.id && l.type == 'elevation');
+    context.maxElevationLevel = -1;
+    for (const e of elevationLayers) {
+        context.maxElevationLevel = Math.max(e.options.zoom.max, context.maxElevationLevel);
+    }
+    if (context.maxElevationLevel == -1) {
+        context.maxElevationLevel = Infinity;
+    }
+}
+
+export function planarSubdivisionControl(maxLevel, maxDeltaElevationLevel) {
     return function _planarSubdivisionControl(context, layer, node) {
         if (maxLevel <= node.level) {
+            return false;
+        }
+
+        // Prevent to subdivise the node if the current elevation level
+        // we must avoid a tile, with level 20, inherits a level 3 elevation texture.
+        // The induced geometric error is much too large and distorts the SSE
+        const currentElevationLevel = node.material.getElevationLayerLevel();
+        if (node.level < context.maxElevationLevel + maxDeltaElevationLevel &&
+            currentElevationLevel >= 0 &&
+            (node.level - currentElevationLevel) >= maxDeltaElevationLevel) {
             return false;
         }
 


### PR DESCRIPTION
## Description
Force loading step of group strategy and don't use parent texture, if level is step of group

## Motivation and Context
When node use parent's texture elevation which is distant in the hierarchy,
OBB's size can be too big and it can be subdivided unnecessarily and the joints between the tiles are too different (see screenshot)


## Screenshots (if appropriate)
![capture du 2017-10-19 11-27-38](https://user-images.githubusercontent.com/11291849/31764912-ec3f12ca-b4c2-11e7-8146-06734f182011.png)

**New steps to reproduce**
* Start localhost/index.htlm with only ortho layer (size `viewport 1100x1100`)
* when globe is loaded call in console : 
`globeView.controls.setCameraTargetGeoPositionAdvanced({ longitude:  6.886991921801097, latitude: 45.87929727669077, range: 2000});`

**Result in master, ~45 tiles of level 17  and ~420 wmts requests**
![submaster](https://user-images.githubusercontent.com/11291849/34829686-cb9ec9f0-f6e1-11e7-8c9f-5c4aa8d6a9b4.png)

**Result in PR, ~40 tiles of level 16 and ~340 wmts requests**
![downsub](https://user-images.githubusercontent.com/11291849/34829761-0cb0a83c-f6e2-11e7-9445-d67dd0cf0fc3.png)

the error comes from inheritance of textures elevations with a large geometric error and which induces more subdivisions

