### PR TITLE
Improve lots of layer handling

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -111,7 +111,6 @@
             $3dTilesLayerDiscreteLOD.visible = true;
 
             itowns.View.prototype.addLayer.call(globe, $3dTilesLayerDiscreteLOD);
-            globe.scene.add($3dTilesLayerDiscreteLOD.object3d);
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
@@ -133,7 +132,6 @@
             $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
             itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
-            globe.scene.add($3dTilesLayerRequestVolume.object3d);
 
             // Add the UI Debug
             var d = new debug.Debug(globe, menuGlobe.gui);

--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -96,7 +96,7 @@
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
-            var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod', globe.scene);
+            var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod', new itowns.THREE.Group());
 
             $3dTilesLayerDiscreteLOD.preUpdate = preUpdateGeo;
             $3dTilesLayerDiscreteLOD.update = itowns.process3dTilesNode(
@@ -111,12 +111,12 @@
             $3dTilesLayerDiscreteLOD.visible = true;
 
             itowns.View.prototype.addLayer.call(globe, $3dTilesLayerDiscreteLOD);
+            globe.scene.add($3dTilesLayerDiscreteLOD.object3d);
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
 
-            var container = new itowns.THREE.Group();
-            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', container);
+            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', new itowns.THREE.Group());
 
             $3dTilesLayerRequestVolume.preUpdate = preUpdateGeo;
             $3dTilesLayerRequestVolume.update = itowns.process3dTilesNode(
@@ -133,8 +133,7 @@
             $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
             itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
-
-            globe.scene.add(container);
+            globe.scene.add($3dTilesLayerRequestVolume.object3d);
 
             // Add the UI Debug
             var d = new debug.Debug(globe, menuGlobe.gui);
@@ -164,7 +163,7 @@
 
                 raycaster.setFromCamera(mouse, globe.camera.camera3D);
                 // calculate objects intersecting the picking ray
-                var intersects = raycaster.intersectObjects(container.children, true);
+                var intersects = raycaster.intersectObjects($3dTilesLayerRequestVolume.object3d.children, true);
                 for (var i = 0; i < intersects.length; i++) {
                     var interAttributes = intersects[i].object.geometry.attributes;
                     if (interAttributes) {

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -26,7 +26,6 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
 
     // Configure Point Cloud layer
     pointcloud = new itowns.GeometryLayer('pointcloud', new itowns.THREE.Group());
-    view.scene.add(pointcloud.object3d);
     pointcloud.file = fileName || 'infos/sources';
     pointcloud.protocol = 'potreeconverter';
     pointcloud.url = serverUrl;

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -25,7 +25,8 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
 
     // Configure Point Cloud layer
-    pointcloud = new itowns.GeometryLayer('pointcloud', view.scene);
+    pointcloud = new itowns.GeometryLayer('pointcloud', new itowns.THREE.Group());
+    view.scene.add(pointcloud.object3d);
     pointcloud.file = fileName || 'infos/sources';
     pointcloud.protocol = 'potreeconverter';
     pointcloud.url = serverUrl;

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -62,6 +62,10 @@ function GeometryLayer(id, object3d) {
     }
     this._attachedLayers = [];
 
+    if (object3d && object3d.type === 'Group' && object3d.name === '') {
+        object3d.name = id;
+    }
+
     Object.defineProperty(this, 'object3d', {
         value: object3d,
         writable: false,

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -209,8 +209,6 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
 
     const wgs84TileLayer = createGlobeLayer('globe', options);
 
-    this.scene.add(wgs84TileLayer.object3d);
-
     const sun = new THREE.DirectionalLight();
     sun.position.set(-0.5, 0, 1);
     sun.updateMatrixWorld(true);

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -107,7 +107,7 @@ export function createGlobeLayer(id, options) {
         }
     }
 
-    const wgs84TileLayer = new GeometryLayer(id, options.object3d);
+    const wgs84TileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
     wgs84TileLayer.schemeTile = globeSchemeTileWMTS(globeSchemeTile1);
     wgs84TileLayer.extent = wgs84TileLayer.schemeTile[0].clone();
     for (let i = 1; i < wgs84TileLayer.schemeTile.length; i++) {
@@ -194,8 +194,6 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     // Setup View
     View.call(this, 'EPSG:4978', viewerDiv, options);
 
-    options.object3d = options.object3d || this.scene;
-
     // Configure camera
     const positionCamera = new C.EPSG_4326(
         coordCarto.longitude,
@@ -210,6 +208,8 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     this.camera.camera3D.updateMatrixWorld(true);
 
     const wgs84TileLayer = createGlobeLayer('globe', options);
+
+    this.scene.add(wgs84TileLayer.object3d);
 
     const sun = new THREE.DirectionalLight();
     sun.position.set(-0.5, 0, 1);

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -14,7 +14,7 @@ import PlanarTileBuilder from './Planar/PlanarTileBuilder';
 import SubdivisionControl from '../../Process/SubdivisionControl';
 
 export function createPlanarLayer(id, extent, options) {
-    const tileLayer = new GeometryLayer(id, options.object3d);
+    const tileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
     tileLayer.extent = extent;
     tileLayer.schemeTile = [extent];
 
@@ -123,8 +123,6 @@ function PlanarView(viewerDiv, extent, options = {}) {
     // Setup View
     View.call(this, extent.crs(), viewerDiv, options);
 
-    options.object3d = options.object3d || this.scene;
-
     // Configure camera
     const dim = extent.dimensions();
     const positionCamera = extent.center().clone();
@@ -140,6 +138,8 @@ function PlanarView(viewerDiv, extent, options = {}) {
     this.camera.camera3D.updateMatrixWorld(true);
 
     const tileLayer = createPlanarLayer('planar', extent, options);
+
+    this.scene.add(tileLayer.object3d);
 
     this.addLayer(tileLayer);
 

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -139,8 +139,6 @@ function PlanarView(viewerDiv, extent, options = {}) {
 
     const tileLayer = createPlanarLayer('planar', extent, options);
 
-    this.scene.add(tileLayer.object3d);
-
     this.addLayer(tileLayer);
 
     this._renderState = RendererConstant.FINAL;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -309,6 +309,10 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         this._layers.push(layer);
     }
 
+    if (layer.object3d && !layer.object3d.parent) {
+        this.scene.add(layer.object3d);
+    }
+
     this.notifyChange(true);
     return layer.whenReady;
 };


### PR DESCRIPTION
This PR improves iTowns usage when displaying many geometry layers.


Commit 1:
```
feat (core): only use threeJsLayer feature when necessary

Using three.js' layers visibility has a big drawback: we're limited to 31 visibility
groups.
It's quite a low amount, so this commit changes the approach used for visibility:
  - GeometryLayer uses 'layer.object3d.visible' instead
  - layers attached to GeomLayer (like the TileDebug one) still use threeJsLayer,
    because their elements are attached to another layer's objects so they don't
    all share a common parent

Another change included is that now it doesn't make sense to use view.scene as a
default object3d parameter, so this commit switches to a Group instead.
```

Commit 2:
```
feat (core): simplify layer/object3d API

This commit simplifies API usage: layer.object3d is automatically added to the
View's scene - unless it already has a parent.
```