### PR TITLE
Layer management

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -88,7 +88,7 @@
             var globe = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             var menuGlobe = new GuiTools('menuDiv', globe, 300);
 
-            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return globe.addLayer(result) });
+            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(globe.baseLayer.addColorLayer);
 
             // function use :
             // For preupdate Layer geomtry :
@@ -96,46 +96,26 @@
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
-            var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod', new itowns.THREE.Group());
+            var $3dTilesLayerDiscreteLOD = itowns.create3dTiles(
+                '3d-tiles-discrete-lod', {
+                    url: 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithDiscreteLOD/tileset.json'
+                });
 
-            $3dTilesLayerDiscreteLOD.preUpdate = preUpdateGeo;
-            $3dTilesLayerDiscreteLOD.update = itowns.process3dTilesNode(
-                itowns.$3dTilesCulling,
-                itowns.$3dTilesSubdivisionControl
-            );
-            $3dTilesLayerDiscreteLOD.name = 'DiscreteLOD';
-            $3dTilesLayerDiscreteLOD.url = 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithDiscreteLOD/tileset.json';
-            $3dTilesLayerDiscreteLOD.protocol = '3d-tiles'
-            $3dTilesLayerDiscreteLOD.overrideMaterials = true;  // custom cesium shaders are not functional
-            $3dTilesLayerDiscreteLOD.type = 'geometry';
-            $3dTilesLayerDiscreteLOD.visible = true;
-
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerDiscreteLOD);
+            globe.addLayer($3dTilesLayerDiscreteLOD);
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
 
-            var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', new itowns.THREE.Group());
-
-            $3dTilesLayerRequestVolume.preUpdate = preUpdateGeo;
-            $3dTilesLayerRequestVolume.update = itowns.process3dTilesNode(
-                itowns.$3dTilesCulling,
-                itowns.$3dTilesSubdivisionControl
-            );
-
-            $3dTilesLayerRequestVolume.name = 'RequestVolume';
-            $3dTilesLayerRequestVolume.url = 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithRequestVolume/tileset.json';
-            $3dTilesLayerRequestVolume.protocol = '3d-tiles'
-            $3dTilesLayerRequestVolume.overrideMaterials = true;  // custom cesium shaders are not functional
-            $3dTilesLayerRequestVolume.type = 'geometry';
-            $3dTilesLayerRequestVolume.visible = true;
-            $3dTilesLayerRequestVolume.sseThreshold = 1;
-            // add an event for have information when you move your mouse on a building
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
+            var $3dTilesLayerRequestVolume = itowns.create3dTiles(
+                '3d-tiles-request-volume', {
+                    url: 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithRequestVolume/tileset.json'
+                });
+            globe.addLayer($3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false);
+            });
 
             // Add the UI Debug
             var d = new debug.Debug(globe, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globe, globe.wgs84TileLayer, d);
+            debug.createTileDebugUI(menuGlobe.gui, globe, globe.baseLayer, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerDiscreteLOD, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerRequestVolume, d);
 

--- a/examples/cubic_planar.js
+++ b/examples/cubic_planar.js
@@ -94,8 +94,7 @@ for (index = 0; index < wmsLayers.length; index++) {
 
     view.addLayer(tileLayer);
 
-    view.addLayer({
-        update: itowns.updateLayeredMaterialNodeImagery,
+    tileLayer.addColorLayer({
         url: 'https://download.data.grandlyon.com/wms/grandlyon',
         networkOptions: { crossOrigin: 'anonymous' },
         type: 'color',
@@ -107,10 +106,9 @@ for (index = 0; index < wmsLayers.length; index++) {
         options: {
             mimetype: 'image/jpeg',
         },
-    }, tileLayer);
+    });
 
-    view.addLayer({
-        update: itowns.updateLayeredMaterialNodeElevation,
+    tileLayer.addElevationLayer({
         url: 'https://download.data.grandlyon.com/wms/grandlyon',
         type: 'elevation',
         protocol: 'wms',
@@ -123,7 +121,7 @@ for (index = 0; index < wmsLayers.length; index++) {
         options: {
             mimetype: 'image/jpeg',
         },
-    }, tileLayer);
+    });
 
     // Since the elevation layer use color textures, specify min/max z
     tileLayer.materialOptions = {

--- a/examples/cubic_planar.js
+++ b/examples/cubic_planar.js
@@ -97,7 +97,6 @@ for (index = 0; index < wmsLayers.length; index++) {
     tileLayer.addColorLayer({
         url: 'https://download.data.grandlyon.com/wms/grandlyon',
         networkOptions: { crossOrigin: 'anonymous' },
-        type: 'color',
         protocol: 'wms',
         version: '1.3.0',
         id: 'wms_imagery' + wms + index,
@@ -110,7 +109,6 @@ for (index = 0; index < wmsLayers.length; index++) {
 
     tileLayer.addElevationLayer({
         url: 'https://download.data.grandlyon.com/wms/grandlyon',
-        type: 'elevation',
         protocol: 'wms',
         networkOptions: { crossOrigin: 'anonymous' },
         version: '1.3.0',

--- a/examples/externalscene.js
+++ b/examples/externalscene.js
@@ -10,12 +10,8 @@ var globeView = new itowns.GlobeView(
 
 globeView.mainLoop.name = 'external-ML';
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
-
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer);
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(globeView.baseLayer.addElevationLayer);
 
 exports.globeView = globeView;
 exports.scene = scene;

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -14,9 +14,6 @@ var miniDiv = document.getElementById('miniDiv');
 
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 
 // Dont' instance mini viewer if it's Test env
 if (!renderer) {
@@ -48,17 +45,19 @@ if (!renderer) {
     };
 
     // Add one imagery layer to the miniview
-    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) { miniView.addLayer(layer); });
+    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) {
+        miniView.baseLayer.addColorLayer(layer);
+    });
 }
 
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(globeView.baseLayer.addElevationLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -45,9 +45,7 @@ if (!renderer) {
     };
 
     // Add one imagery layer to the miniview
-    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) {
-        miniView.baseLayer.addColorLayer(layer);
-    });
+    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(miniView.baseLayer.addColorLayer);
 }
 
 // Add one imagery layer to the scene

--- a/examples/globe_fly.js
+++ b/examples/globe_fly.js
@@ -16,14 +16,11 @@ flyControls.moveSpeed = 1000;
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-function addLayer(layer) {
-    return globeView.addLayer(layer);
-}
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayer));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(globeView.baseLayer.addElevationLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe_vector.js
+++ b/examples/globe_vector.js
@@ -10,20 +10,17 @@ var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(globeView.baseLayer.addElevationLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer));
 
-promises.push(globeView.addLayer({
+promises.push(globeView.baseLayer.addColorLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
     protocol: 'rasterizer',
@@ -31,7 +28,7 @@ promises.push(globeView.addLayer({
     name: 'kml',
 }));
 
-promises.push(globeView.addLayer({
+promises.push(globeView.baseLayer.addColorLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx',
     protocol: 'rasterizer',
@@ -39,7 +36,7 @@ promises.push(globeView.addLayer({
     name: 'Ultra 2009',
 }));
 
-promises.push(globeView.addLayer({
+promises.push(globeView.baseLayer.addColorLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
     protocol: 'rasterizer',

--- a/examples/globe_vector.js
+++ b/examples/globe_vector.js
@@ -21,7 +21,6 @@ promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(glo
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer));
 
 promises.push(globeView.baseLayer.addColorLayer({
-    type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
     protocol: 'rasterizer',
     id: 'Kml',
@@ -29,7 +28,6 @@ promises.push(globeView.baseLayer.addColorLayer({
 }));
 
 promises.push(globeView.baseLayer.addColorLayer({
-    type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx',
     protocol: 'rasterizer',
     id: 'Gpx',
@@ -37,7 +35,6 @@ promises.push(globeView.baseLayer.addColorLayer({
 }));
 
 promises.push(globeView.baseLayer.addColorLayer({
-    type: 'color',
     url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
     protocol: 'rasterizer',
     id: 'ariege',

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -12,16 +12,13 @@ var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: ren
 
 var promises = [];
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(globeView.baseLayer.addElevationLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer));
 
 exports.view = globeView;

--- a/examples/layers/JSONLayers/DARK.json
+++ b/examples/layers/JSONLayers/DARK.json
@@ -1,5 +1,4 @@
 {
-    "type": "color",
     "protocol": "wmtsc",
 	"networkOptions": { "crossOrigin" : "anonymous" },
     "id": "DARK",

--- a/examples/layers/JSONLayers/IGN_MNT.json
+++ b/examples/layers/JSONLayers/IGN_MNT.json
@@ -1,5 +1,4 @@
 {
-    "type":       "elevation",
     "protocol":   "wmts",
     "id":         "IGN_MNT",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -1,5 +1,4 @@
 {
-	"type":       "elevation",
 	"protocol":   "wmts",
 	"id":         "IGN_MNT_HIGHRES",
 	"url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",

--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -1,5 +1,4 @@
 {
-    "type": "color",
     "protocol": "wmtsc",
     "networkOptions": { "crossOrigin" : "anonymous" },
     "id": "OPENSM",

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -1,5 +1,4 @@
 {
-    "type": "color",
     "protocol":   "wmts",
     "id":         "Ortho",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",

--- a/examples/layers/JSONLayers/OrthosCRS.json
+++ b/examples/layers/JSONLayers/OrthosCRS.json
@@ -1,5 +1,4 @@
 {
-    "type": "color",
     "protocol":   "wmts",
     "id":         "OrthoCRS",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",

--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -1,5 +1,4 @@
 {
-    "type": "color",
     "url"       : "https://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/v/wms",
     "networkOptions": {
         "crossOrigin": "anonymous"

--- a/examples/layers/JSONLayers/ScanEX.json
+++ b/examples/layers/JSONLayers/ScanEX.json
@@ -1,5 +1,4 @@
 {
-    "type": "color",
     "protocol":   "wmts",
     "id":         "ScanEX",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -1,6 +1,5 @@
 
 {
-    "type":       "elevation",
     "protocol":   "wmts",
     "id":         "MNT_WORLD_SRTM3",
     "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -39,14 +39,10 @@
             var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             menuGlobe.view = globeView;
 
-            function addLayerCb(layer) {
-                return globeView.addLayer(layer);
-            }
-
             var promises = [];
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(globeView.baseLayer.addColorLayer));
+            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(globeView.baseLayer.addElevationLayer));
 
             function removeDups(a) {
                 var temp = {};

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -73,7 +73,6 @@
             // add it to the view so it gets updated
             globeView.addLayer(globe2);
             globe2.addColorLayer({
-                type: 'color',
                 protocol: "wmtsc",
                 id: "DARK",
                 customUrl: "http://a.basemaps.cartocdn.com/light_all/%TILEMATRIX/%COL/%ROW.png",

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -59,24 +59,20 @@
 
             // Create the first globe
             var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true, object3d: ref[0] });
-            layers.push(globeView.wgs84TileLayer);
+            layers.push(globeView.baseLayer);
 
-            function addLayerCb(layer) {
-                return globeView.addLayer(layer);
-            }
-            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
+            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer);
 
             // create a second smaller globe
-            const globe2 = itowns.createGlobeLayer('globe2', { object3d: ref[1] });
+            const globe2 = itowns.createGlobe('globe2', { object3d: ref[1] });
             layers.push(globe2);
 
             // Defines pole texture
             globe2.noTextureColor = new itowns.THREE.Color(0xd0d5d8);
 
             // add it to the view so it gets updated
-            itowns.View.prototype.addLayer.call(globeView, globe2);
-            itowns.View.prototype.addLayer.call(globeView, {
-                update: itowns.updateLayeredMaterialNodeImagery,
+            globeView.addLayer(globe2);
+            globe2.addColorLayer({
                 type: 'color',
                 protocol: "wmtsc",
                 id: "DARK",
@@ -90,7 +86,7 @@
                     tileMatrixSet: "PM",
                     mimetype: "image/png"
                 },
-            }, globe2);
+            });
 
             // Globe animation
             var animator = {

--- a/examples/orthographic.js
+++ b/examples/orthographic.js
@@ -41,10 +41,10 @@ var dragCameraStart;
 
 // By default itowns' tiles geometry have a "skirt" (ie they have a height),
 // but in case of orthographic we don't need this feature, so disable it
-view.tileLayer.disableSkirt = true;
+view.baseLayer.disableSkirt = true;
 
 // Add an TMS imagery layer
-view.addLayer({
+view.baseLayer.addColorLayer({
     type: 'color',
     protocol: 'tms',
     id: 'OPENSM',

--- a/examples/orthographic.js
+++ b/examples/orthographic.js
@@ -45,7 +45,6 @@ view.baseLayer.disableSkirt = true;
 
 // Add an TMS imagery layer
 view.baseLayer.addColorLayer({
-    type: 'color',
     protocol: 'tms',
     id: 'OPENSM',
     // eslint-disable-next-line no-template-curly-in-string

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -26,7 +26,6 @@ view.baseLayer.disableSkirt = true;
 view.baseLayer.addColorLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     networkOptions: { crossOrigin: 'anonymous' },
-    type: 'color',
     protocol: 'wms',
     version: '1.3.0',
     id: 'wms_imagery',
@@ -44,7 +43,6 @@ view.baseLayer.addColorLayer({
 // Add an WMS elevation layer (see WMS_Provider* for valid options)
 view.baseLayer.addElevationLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
-    type: 'elevation',
     protocol: 'wms',
     networkOptions: { crossOrigin: 'anonymous' },
     id: 'wms_elevation',

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -20,10 +20,10 @@ viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate PlanarView*
 view = new itowns.PlanarView(viewerDiv, extent, { renderer: renderer });
-view.tileLayer.disableSkirt = true;
+view.baseLayer.disableSkirt = true;
 
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
-view.addLayer({
+view.baseLayer.addColorLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     networkOptions: { crossOrigin: 'anonymous' },
     type: 'color',
@@ -42,7 +42,7 @@ view.addLayer({
 });
 
 // Add an WMS elevation layer (see WMS_Provider* for valid options)
-view.addLayer({
+view.baseLayer.addElevationLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     type: 'elevation',
     protocol: 'wms',
@@ -55,8 +55,9 @@ view.addLayer({
         mimetype: 'image/jpeg',
     },
 });
+
 // Since the elevation layer use color textures, specify min/max z
-view.tileLayer.materialOptions = {
+view.baseLayer.materialOptions = {
     useColorTextureElevation: true,
     colorTextureElevationMinZ: 37,
     colorTextureElevationMaxZ: 240,

--- a/examples/planar_vector.js
+++ b/examples/planar_vector.js
@@ -20,10 +20,10 @@ viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate PlanarView*
 view = new itowns.PlanarView(viewerDiv, extent, { renderer: renderer });
-view.tileLayer.disableSkirt = true;
+view.baseLayer.disableSkirt = true;
 
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
-view.addLayer({
+view.baseLayer.addColorLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     networkOptions: { crossOrigin: 'anonymous' },
     type: 'color',
@@ -38,7 +38,7 @@ view.addLayer({
 });
 
 // Add an WMS elevation layer (see WMS_Provider* for valid options)
-view.addLayer({
+view.baseLayer.addElevationLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     type: 'elevation',
     protocol: 'wms',
@@ -53,7 +53,7 @@ view.addLayer({
     },
 });
 
-view.addLayer({
+view.baseLayer.addColorLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.kml',
     protocol: 'rasterizer',
@@ -62,7 +62,7 @@ view.addLayer({
     options: { zoom: { min: 0, max: 6 } },
 });
 
-view.addLayer({
+view.baseLayer.addColorLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.gpx',
     protocol: 'rasterizer',
@@ -73,7 +73,7 @@ view.addLayer({
     },
 });
 
-view.addLayer({
+view.baseLayer.addColorLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.geojson',
     protocol: 'rasterizer',
@@ -89,7 +89,7 @@ view.addLayer({
 });
 
 // Since the elevation layer use color textures, specify min/max z
-view.tileLayer.materialOptions = {
+view.baseLayer.materialOptions = {
     useColorTextureElevation: true,
     colorTextureElevationMinZ: 37,
     colorTextureElevationMaxZ: 240,

--- a/examples/planar_vector.js
+++ b/examples/planar_vector.js
@@ -26,7 +26,6 @@ view.baseLayer.disableSkirt = true;
 view.baseLayer.addColorLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     networkOptions: { crossOrigin: 'anonymous' },
-    type: 'color',
     protocol: 'wms',
     version: '1.3.0',
     id: 'wms_imagery',
@@ -40,7 +39,6 @@ view.baseLayer.addColorLayer({
 // Add an WMS elevation layer (see WMS_Provider* for valid options)
 view.baseLayer.addElevationLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
-    type: 'elevation',
     protocol: 'wms',
     networkOptions: { crossOrigin: 'anonymous' },
     version: '1.3.0',
@@ -54,7 +52,6 @@ view.baseLayer.addElevationLayer({
 });
 
 view.baseLayer.addColorLayer({
-    type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.kml',
     protocol: 'rasterizer',
     id: 'Kml',
@@ -63,7 +60,6 @@ view.baseLayer.addColorLayer({
 });
 
 view.baseLayer.addColorLayer({
-    type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.gpx',
     protocol: 'rasterizer',
     options: { zoom: { min: 0, max: 6 } },
@@ -74,7 +70,6 @@ view.baseLayer.addColorLayer({
 });
 
 view.baseLayer.addColorLayer({
-    type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.geojson',
     protocol: 'rasterizer',
     projection: 'EPSG:3946',

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -25,11 +25,13 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
 
     // Configure Point Cloud layer
-    pointcloud = new itowns.GeometryLayer('pointcloud', new itowns.THREE.Group());
-    pointcloud.file = fileName || 'infos/sources';
-    pointcloud.protocol = 'potreeconverter';
-    pointcloud.url = serverUrl;
-    pointcloud.table = lopocsTable;
+    pointcloud = itowns.createPointcloud(
+        'pointcloud',
+        {
+            file: fileName || 'infos/sources',
+            url: serverUrl,
+            table: lopocsTable,
+        });
 
     // point selection on double-click
     function dblClickHandler(event) {

--- a/examples/positionGlobe.js
+++ b/examples/positionGlobe.js
@@ -23,17 +23,14 @@ var menuGlobe = new GuiTools('menuDiv');
 
 menuGlobe.view = globeView;
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(globeView.baseLayer.addElevationLayer));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/postprocessing.js
+++ b/examples/postprocessing.js
@@ -47,12 +47,8 @@ globeView.render = function render() {
         cam);
 };
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
-
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
+itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer);
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(globeView.baseLayer.addElevationLayer);
 
 exports.globeView = globeView;
 exports.postprocessScene = postprocessScene;

--- a/examples/split.js
+++ b/examples/split.js
@@ -18,19 +18,16 @@ var splitSlider;
 var splitPosition;
 var xD;
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb).then(function _(l) { orthoLayer = l; }));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(addLayerCb).then(function _(l) { osmLayer = l; }));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.baseLayer.addColorLayer).then(function _(l) { orthoLayer = l; }));
+promises.push(itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(globeView.baseLayer.addColorLayer).then(function _(l) { osmLayer = l; }));
 
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb);
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
+itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(globeView.baseLayer.addElevationLayer);
+itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(globeView.baseLayer.addElevationLayer);
 
 // Slide handling
 splitPosition = 0.5 * window.innerWidth;

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -22,10 +22,10 @@ viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate PlanarView*
 view = new itowns.PlanarView(viewerDiv, extent, { renderer: renderer });
-view.tileLayer.disableSkirt = true;
+view.baseLayer.disableSkirt = true;
 
 // Add an WMS imagery layer (see WMS_Provider* for valid options)
-view.addLayer({
+view.baseLayer.addColorLayer({
     url: 'https://download.data.grandlyon.com/wms/grandlyon',
     networkOptions: { crossOrigin: 'anonymous' },
     type: 'color',
@@ -59,7 +59,7 @@ function colorLine(properties) {
     return new itowns.THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
 }
 
-view.addLayer({
+view.baseLayer.addFeatureLayer({
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
         color: colorLine }),
@@ -80,7 +80,7 @@ view.addLayer({
     options: {
         mimetype: 'geojson',
     },
-}, view.tileLayer);
+});
 
 function colorBuildings(properties) {
     if (properties.id.indexOf('bati_remarquable') === 0) {
@@ -114,8 +114,7 @@ scaler = {
 };
 
 view.addFrameRequester(scaler);
-view.addLayer({
-    type: 'geometry',
+view.baseLayer.addFeatureLayer({
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
         color: colorBuildings,
@@ -142,6 +141,6 @@ view.addLayer({
     options: {
         mimetype: 'json',
     },
-}, view.tileLayer);
+});
 
 exports.view = view;

--- a/index.html
+++ b/index.html
@@ -44,13 +44,13 @@ and open the template in the editor.
             menuGlobe.view = globeView;
 
             var promises = []
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(function(result) { return globeView.addLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(function(result) { return globeView.baseLayer.addColorLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(function(result) { return globeView.baseLayer.addColorLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(function(result) { return globeView.baseLayer.addColorLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(function(result) { return globeView.baseLayer.addColorLayer(result); }));
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(function(result) { return globeView.addLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(function(result) { return globeView.baseLayer.addElevationLayer(result); }));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(function(result) { return globeView.baseLayer.addElevationLayer(result); }));
 
             menuGlobe.addGUI('RealisticLighting', false,
                 function(newValue) { globeView.setRealisticLightingOn(newValue); });
@@ -67,7 +67,7 @@ and open the template in the editor.
             });
 
             const d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.wgs84TileLayer, d);
+            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.baseLayer, d);
             window.globeView = globeView;
 </script>
     </body>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
-    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js",
+    "doc": "jsdoc src/Core/View.js src/Core/DefaultGeometryLayers.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",

--- a/src/Core/DefaultGeometryLayers.js
+++ b/src/Core/DefaultGeometryLayers.js
@@ -187,7 +187,7 @@ export function createPlane(id, extent, options) {
  * @function
  * @param {string} id - identifer (must be unique amongst all layers id)
  * @param {Object} options
- * @param {URL} options.url - URL of the tileset
+ * @param {string} options.url - URL of the tileset
  * @param {number} [options.sseThreshold = 16] - refinement threshold
  * @param {number} [options.cleanupDelay = 1000] - delay (in ms) after which unused
  * tiles are removed.
@@ -242,6 +242,7 @@ export function createPointcloud(id, options) {
     const layer = new GeometryLayer(id, options.object3d || new THREE.Group());
     layer.file = options.file;
     layer.protocol = 'potreeconverter';
+    layer.type = 'pointcloud';
     layer.url = options.url.href;
     layer.table = options.lopocsTable;
 

--- a/src/Core/DefaultGeometryLayers.js
+++ b/src/Core/DefaultGeometryLayers.js
@@ -1,0 +1,194 @@
+import * as THREE from 'three';
+
+import { GeometryLayer } from './Layer/Layer';
+import { processTiledGeometryNode } from '../Process/TiledNodeProcessing';
+import SubdivisionControl from '../Process/SubdivisionControl';
+
+import { globeCulling, preGlobeUpdate, globeSubdivisionControl, globeSchemeTileWMTS, globeSchemeTile1 } from '../Process/GlobeTileProcessing';
+import BuilderEllipsoidTile from './Prefab/Globe/BuilderEllipsoidTile';
+
+import { planarCulling, planarSubdivisionControl } from '../Process/PlanarTileProcessing';
+import PlanarTileBuilder from './Prefab/Planar/PlanarTileBuilder';
+
+import { process3dTilesNode, $3dTilesCulling, $3dTilesSubdivisionControl, pre3dTilesUpdate } from '../Process/3dTilesProcessing';
+
+function _commonAncestorLookup(a, b) {
+    if (!a || !b) {
+        return undefined;
+    }
+    if (a.level == b.level) {
+        if (a.id == b.id) {
+            return a;
+        } else if (a.level != 0) {
+            return _commonAncestorLookup(a.parent, b.parent);
+        } else {
+            return undefined;
+        }
+    } else if (a.level < b.level) {
+        return _commonAncestorLookup(a, b.parent);
+    } else {
+        return _commonAncestorLookup(a.parent, b);
+    }
+}
+
+function _tiledNodeInitFunction(layer, parent, node) {
+    node.material.setLightingOn(layer.lighting.enable);
+    node.material.uniforms.lightPosition.value = layer.lighting.position;
+
+    if (layer.noTextureColor) {
+        node.material.uniforms.noTextureColor.value.copy(layer.noTextureColor);
+    }
+
+    if (__DEBUG__) {
+        node.material.uniforms.showOutline = { value: layer.showOutline || false };
+        node.material.wireframe = layer.wireframe || false;
+    }
+}
+
+function _tiledPreUpdate(preUpdateSpecialisation) {
+    return function _(context, layer, changeSources) {
+        SubdivisionControl.preUpdate(context, layer);
+
+        if (__DEBUG__) {
+            layer._latestUpdateStartingLevel = 0;
+        }
+
+        if (preUpdateSpecialisation) {
+            preUpdateSpecialisation(context, layer);
+        }
+        if (changeSources.has(undefined) || changeSources.size == 0) {
+            return layer.level0Nodes;
+        }
+
+        let commonAncestor;
+        for (const source of changeSources.values()) {
+            if (source.isCamera) {
+                // if the change is caused by a camera move, no need to bother
+                // to find common ancestor: we need to update the whole tree:
+                // some invisible tiles may now be visible
+                return layer.level0Nodes;
+            }
+            if (source.layer === layer.id) {
+                if (!commonAncestor) {
+                    commonAncestor = source;
+                } else {
+                    commonAncestor = _commonAncestorLookup(commonAncestor, source);
+                    if (!commonAncestor) {
+                        return layer.level0Nodes;
+                    }
+                }
+                if (commonAncestor.material == null) {
+                    commonAncestor = undefined;
+                }
+            }
+        }
+        if (commonAncestor) {
+            if (__DEBUG__) {
+                layer._latestUpdateStartingLevel = commonAncestor.level;
+            }
+            return [commonAncestor];
+        } else {
+            return layer.level0Nodes;
+        }
+    };
+}
+
+export function createGlobe(id, options) {
+    // Configure tiles
+    const wgs84TileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
+    wgs84TileLayer.schemeTile = globeSchemeTileWMTS(globeSchemeTile1);
+    wgs84TileLayer.extent = wgs84TileLayer.schemeTile[0].clone();
+    for (let i = 1; i < wgs84TileLayer.schemeTile.length; i++) {
+        wgs84TileLayer.extent.union(wgs84TileLayer.schemeTile[i]);
+    }
+    wgs84TileLayer.preUpdate = _tiledPreUpdate(preGlobeUpdate);
+
+    function subdivision(context, layer, node) {
+        if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
+            return globeSubdivisionControl(2, options.maxSubdivisionLevel || 17, options.sseSubdivisionThreshold || 1.0)(context, layer, node);
+        }
+        return false;
+    }
+
+    wgs84TileLayer.update = processTiledGeometryNode(globeCulling(2), subdivision);
+    wgs84TileLayer.builder = new BuilderEllipsoidTile();
+    wgs84TileLayer.onTileCreated = _tiledNodeInitFunction;
+    wgs84TileLayer.type = 'geometry';
+    wgs84TileLayer.protocol = 'tile';
+    wgs84TileLayer.visible = true;
+    wgs84TileLayer.lighting = {
+        enable: false,
+        position: { x: -0.5, y: 0.0, z: 1.0 },
+    };
+
+    return wgs84TileLayer;
+}
+
+
+export function createPlane(id, extent, options) {
+    const tileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
+    tileLayer.extent = extent;
+    tileLayer.schemeTile = [extent];
+
+    tileLayer.preUpdate = _tiledPreUpdate();
+
+    function subdivision(context, layer, node) {
+        if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
+            return planarSubdivisionControl(options.maxSubdivisionLevel || 5)(context, layer, node);
+        }
+        return false;
+    }
+
+    tileLayer.update = processTiledGeometryNode(planarCulling, subdivision);
+    tileLayer.builder = new PlanarTileBuilder();
+    tileLayer.onTileCreated = _tiledNodeInitFunction;
+    tileLayer.type = 'geometry';
+    tileLayer.protocol = 'tile';
+    tileLayer.visible = true;
+    tileLayer.lighting = {
+        enable: false,
+        position: { x: -0.5, y: 0.0, z: 1.0 },
+    };
+
+    return tileLayer;
+}
+
+export function create3dTiles(id, options) {
+    if (options.url) {
+        options.url = new URL(options.url, document.location);
+    }
+    if (!options.url) {
+        throw new Error('options.url must point to the tileset to be used');
+    }
+    const layer = new GeometryLayer(id, options.object3d || new THREE.Group());
+    layer.preUpdate = pre3dTilesUpdate;
+    layer.update = process3dTilesNode(
+        $3dTilesCulling,
+        $3dTilesSubdivisionControl);
+
+    layer.url = options.url.href;
+    layer.protocol = '3d-tiles';
+    layer.overrideMaterials = true;  // custom cesium shaders are not functional
+    layer.type = 'geometry';
+    layer.visible = true;
+    layer.sseThreshold = 1;
+
+    return layer;
+}
+
+export function createPointcloud(id, options) {
+    if (options.url) {
+        options.url = new URL(options.url, document.location);
+    }
+    if (!options.url) {
+        throw new Error('options.url must point to the tileset to be used');
+    }
+
+    const layer = new GeometryLayer(id, options.object3d || new THREE.Group());
+    layer.file = options.file;
+    layer.protocol = 'potreeconverter';
+    layer.url = options.url.href;
+    layer.table = options.lopocsTable;
+
+    return layer;
+}

--- a/src/Core/DefaultGeometryLayers.js
+++ b/src/Core/DefaultGeometryLayers.js
@@ -103,7 +103,7 @@ function _tiledPreUpdate(preUpdateSpecialisation) {
  * by this layer
  * @param {number} [options.maxSubdivisionLevel=17] - The geometry subdivision max depth
  *
- * @return a {GeometryLayer} preconfigured to display a globe.
+ * @return {GeometryLayer} a GeometryLayer preconfigured to display a globe.
  * The returned instance implements the {@link CanDisplayColorLayer},
  * {@link CanDisplayElevationLayer} and {@link CanDisplayFeatureLayer} interfaces.
  */
@@ -149,7 +149,7 @@ export function createGlobe(id, options = {}) {
  * by this layer
  * @param {number} [options.maxSubdivisionLevel=5] - The geometry subdivision max depth
  *
- * @return a {GeometryLayer} preconfigured to display a planar extent.
+ * @return {GeometryLayer} a GeometryLayer preconfigured to display a planar extent.
  * The returned instance implements the {@link CanDisplayColorLayer},
  * {@link CanDisplayElevationLayer} and {@link CanDisplayFeatureLayer} interfaces.
  */
@@ -192,7 +192,7 @@ export function createPlane(id, extent, options) {
  * @param {number} [options.cleanupDelay = 1000] - delay (in ms) after which unused
  * tiles are removed.
  *
- * @return a {GeometryLayer} instance
+ * @return {GeometryLayer}
  */
 export function create3dTiles(id, options) {
     if (options.url) {
@@ -229,7 +229,7 @@ export function create3dTiles(id, options) {
  * @param {string} [options.file = cloud.js] the file containging the metadata
  * @param {Object} [options.fetchOptions] see {@link Fetcher}
  *
- * @return a {GeometryLayer} instance
+ * @return {GeometryLayer}
  */
 export function createPointcloud(id, options) {
     if (options.url) {

--- a/src/Core/DefaultGeometryLayers.js
+++ b/src/Core/DefaultGeometryLayers.js
@@ -93,7 +93,21 @@ function _tiledPreUpdate(preUpdateSpecialisation) {
     };
 }
 
-export function createGlobe(id, options) {
+/**
+ * Creates a Globe geometry, which can be used to draw other layers (color, elevation, ...)
+ *
+ * @function
+ * @param {string} id - identifer (must be unique amongst all layers id)
+ * @param {Object} [options]
+ * @param {Object} [options.object3d=THREE.Group] - The THREE.Object3D that will be the parent of all Object3D built
+ * by this layer
+ * @param {number} [options.maxSubdivisionLevel=17] - The geometry subdivision max depth
+ *
+ * @return a {GeometryLayer} preconfigured to display a globe.
+ * The returned instance implements the {@link CanDisplayColorLayer},
+ * {@link CanDisplayElevationLayer} and {@link CanDisplayFeatureLayer} interfaces.
+ */
+export function createGlobe(id, options = {}) {
     // Configure tiles
     const wgs84TileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
     wgs84TileLayer.schemeTile = globeSchemeTileWMTS(globeSchemeTile1);
@@ -124,7 +138,21 @@ export function createGlobe(id, options) {
     return wgs84TileLayer;
 }
 
-
+/**
+ * Creates a planar geometry, which can be used to draw other layers (color, elevation, ...)
+ *
+ * @function
+ * @param {string} id - identifer (must be unique amongst all layers id)
+ * @param {Extent} extent - the extent of the planar geometry
+ * @param {Object} [options]
+ * @param {Object} [options.object3d=THREE.Group] - The THREE.Object3D that will be the parent of all Object3D built
+ * by this layer
+ * @param {number} [options.maxSubdivisionLevel=5] - The geometry subdivision max depth
+ *
+ * @return a {GeometryLayer} preconfigured to display a planar extent.
+ * The returned instance implements the {@link CanDisplayColorLayer},
+ * {@link CanDisplayElevationLayer} and {@link CanDisplayFeatureLayer} interfaces.
+ */
 export function createPlane(id, extent, options) {
     const tileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
     tileLayer.extent = extent;
@@ -153,6 +181,19 @@ export function createPlane(id, extent, options) {
     return tileLayer;
 }
 
+/**
+ * Creates a 3d-tiles layer to display a tileset.
+ *
+ * @function
+ * @param {string} id - identifer (must be unique amongst all layers id)
+ * @param {Object} options
+ * @param {URL} options.url - url to the tileset
+ * @param {number} [options.sseThreshold = 16] - refinement threshold
+ * @param {number} [options.cleanupDelay = 1000] - delay (in ms) after which unused
+ * tiles are removed.
+ *
+ * @return a {GeometryLayer} instance
+ */
 export function create3dTiles(id, options) {
     if (options.url) {
         options.url = new URL(options.url, document.location);
@@ -168,14 +209,28 @@ export function create3dTiles(id, options) {
 
     layer.url = options.url.href;
     layer.protocol = '3d-tiles';
-    layer.overrideMaterials = true;  // custom cesium shaders are not functional
+    layer.overrideMaterials = options.overrideMaterials === undefined ? true : options.overrideMaterials;
     layer.type = 'geometry';
     layer.visible = true;
-    layer.sseThreshold = 1;
+    layer.sseThreshold = options.sseThreshold || 16;
+    layer.cleanupDelay = options.cleanupDelay || 1000;
 
     return layer;
 }
 
+/**
+ * Creates a geometry layer to display a pointcloud.
+ * The pointcloud data must have been prepared using PotreeConverter.
+ *
+ * @function
+ * @param {string} id - identifer (must be unique amongst all layers id)
+ * @param {Object} options
+ * @param {string} options.url URL to the folder containing options.file
+ * @param {string} [options.file = cloud.js] the file containging the metadata
+ * @param {Object} [options.fetchOptions] see {@link Fetcher}
+ *
+ * @return a {GeometryLayer} instance
+ */
 export function createPointcloud(id, options) {
     if (options.url) {
         options.url = new URL(options.url, document.location);

--- a/src/Core/DefaultGeometryLayers.js
+++ b/src/Core/DefaultGeometryLayers.js
@@ -94,14 +94,14 @@ function _tiledPreUpdate(preUpdateSpecialisation) {
 }
 
 /**
- * Creates a Globe geometry, which can be used to draw other layers (color, elevation, ...)
+ * Creates a globe geometry on which other layers (color, elevation, ...) can be drawn
  *
  * @function
  * @param {string} id - identifer (must be unique amongst all layers id)
  * @param {Object} [options]
  * @param {Object} [options.object3d=THREE.Group] - The THREE.Object3D that will be the parent of all Object3D built
  * by this layer
- * @param {number} [options.maxSubdivisionLevel=17] - The geometry subdivision max depth
+ * @param {number} [options.maxSubdivisionLevel=17] - The geometry subdivision's max depth
  *
  * @return {GeometryLayer} a GeometryLayer preconfigured to display a globe.
  * The returned instance implements the {@link CanDisplayColorLayer},
@@ -147,7 +147,7 @@ export function createGlobe(id, options = {}) {
  * @param {Object} [options]
  * @param {Object} [options.object3d=THREE.Group] - The THREE.Object3D that will be the parent of all Object3D built
  * by this layer
- * @param {number} [options.maxSubdivisionLevel=5] - The geometry subdivision max depth
+ * @param {number} [options.maxSubdivisionLevel=5] - The geometry subdivision's max depth
  *
  * @return {GeometryLayer} a GeometryLayer preconfigured to display a planar extent.
  * The returned instance implements the {@link CanDisplayColorLayer},
@@ -187,7 +187,7 @@ export function createPlane(id, extent, options) {
  * @function
  * @param {string} id - identifer (must be unique amongst all layers id)
  * @param {Object} options
- * @param {URL} options.url - url to the tileset
+ * @param {URL} options.url - URL of the tileset
  * @param {number} [options.sseThreshold = 16] - refinement threshold
  * @param {number} [options.cleanupDelay = 1000] - delay (in ms) after which unused
  * tiles are removed.
@@ -225,7 +225,7 @@ export function create3dTiles(id, options) {
  * @function
  * @param {string} id - identifer (must be unique amongst all layers id)
  * @param {Object} options
- * @param {string} options.url URL to the folder containing options.file
+ * @param {string} options.url URL of the folder containing options.file
  * @param {string} [options.file = cloud.js] the file containging the metadata
  * @param {Object} [options.fetchOptions] see {@link Fetcher}
  *

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -53,6 +53,13 @@ export const defineLayerProperty = function defineLayerProperty(layer, propertyN
     }
 };
 
+/**
+ * A GeometryLayer defines a geometry: globe, plane or pointcloud.
+ * This geometry can then be used to display other datas, like color layers.
+ * @constructor
+ * @param {string} id - unique id
+ * @param {Object} object3d - the THREE.Object3D will be the parent of the object hierarchy
+ */
 function GeometryLayer(id, object3d) {
     if (!id) {
         throw new Error('Missing id parameter (GeometryLayer must have a unique id defined)');
@@ -174,5 +181,78 @@ const ImageryLayers = {
         return copy.map(l => l.id);
     },
 };
+
+/**
+ * Interface implemented by {@link GeometryLayer} instances capable of displaying color layers
+ * @interface
+ */
+function CanDisplayColorLayer() {}
+/**
+ * Add a color layer to display on this geometry
+ *
+ * @function
+ * @name CanDisplayColorLayer#addColorLayer
+ * @param {Object} colorLayer - property bag defining the layer to display.
+ * @param {string} colorLayer.id - unique identifier of this layer
+ * @param {string} colorLayer.protocol - one of wms, wmts, wmtsc, tms, static.
+ * Each protocol has a set of specific options that are documented in XXX.
+ * @param {Extent} extent - Extent covered by the layer. Note that it can be different
+ * than the extent of the underlying geometry.
+ * @param {number} colorLayer.strategy.type - Strategy to use to download elements.
+ */
+/**
+ * Remove a displayed color layer
+ *
+ * @function
+ * @name CanDisplayColorLayer#removeColorLayer
+ * @param {({Layer}|string)} - the layer to remove or its id
+ */
+
+ /**
+ * Interface implemented by {@link GeometryLayer} instances capable of displaying color layers
+ * @interface
+ */
+function CanDisplayElevationLayer() {}
+/**
+ * Use an elevation data source to deform the underlying geometry
+ *
+ * @function
+ * @name CanDisplayElevationLayer#addElevationLayer
+ * @param {Object} elevationLayer - property bag defining the layer to display.
+ * @param {string} elevationLayer.id - unique identifier of this layer
+ * @param {string} elevationLayer.protocol - one of wms, wmts, wmtsc, static.
+ * Each protocol has a set of specific options that are documented in XXX.
+ * @param {Extent} extent - Extent covered by the layer. Note that it can be different
+ * than the extent of the underlying geometry.
+ * @param {number} elevationLayer.strategy.type - Strategy to use to download elements.
+ */
+/**
+ * Remove an elevation layer
+ *
+ * @function
+ * @name CanDisplayElevationLayer#removeElevationLayer
+ * @param {({Layer}|string)} - the layer to remove or its id
+ */
+
+ /**
+ * Interface implemented by {@link GeometryLayer} instances capable of displaying a feature layers
+ * @interface
+ */
+function CanDisplayFeatureLayer() {}
+/**
+ * Display a feature layers on the underlying geometry
+ *
+ * @function
+ * @name CanDisplayFeatureLayer#addFeatureLayer
+ * @param {Object} featureLayer - property bag defining the layer to display.
+ * @param {string} featureLayer.id - unique identifier of this layer. See FeatureProvider for valid options.
+ */
+/**
+ * Remove a feature layer
+ *
+ * @function
+ * @name CanDisplayFeatureLayer#removeFeatureLayer
+ * @param {({Layer}|string)} - the layer to remove or its id
+ */
 
 export { GeometryLayer, Layer, ImageryLayers };

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -186,7 +186,6 @@ const ImageryLayers = {
  * Interface implemented by {@link GeometryLayer} instances capable of displaying color layers
  * @interface
  */
-function CanDisplayColorLayer() {}
 /**
  * Add a color layer to display on this geometry
  *
@@ -212,7 +211,6 @@ function CanDisplayColorLayer() {}
  * Interface implemented by {@link GeometryLayer} instances capable of displaying color layers
  * @interface
  */
-function CanDisplayElevationLayer() {}
 /**
  * Use an elevation data source to deform the underlying geometry
  *
@@ -238,7 +236,6 @@ function CanDisplayElevationLayer() {}
  * Interface implemented by {@link GeometryLayer} instances capable of displaying a feature layers
  * @interface
  */
-function CanDisplayFeatureLayer() {}
 /**
  * Display a feature layers on the underlying geometry
  *

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -55,10 +55,10 @@ export const defineLayerProperty = function defineLayerProperty(layer, propertyN
 
 /**
  * A GeometryLayer defines a geometry: globe, plane or pointcloud.
- * This geometry can then be used to display other datas, like color layers.
+ * This geometry can then be used to display other data, like color layers.
  * @constructor
  * @param {string} id - unique id
- * @param {Object} object3d - the THREE.Object3D will be the parent of the object hierarchy
+ * @param {Object} object3d - the THREE.Object3D that will be the parent of the layer's object hierarchy
  */
 function GeometryLayer(id, object3d) {
     if (!id) {
@@ -194,7 +194,7 @@ const ImageryLayers = {
  * @param {Object} colorLayer - property bag defining the layer to display.
  * @param {string} colorLayer.id - unique identifier of this layer
  * @param {string} colorLayer.protocol - one of wms, wmts, wmtsc, tms, static.
- * Each protocol has a set of specific options that are documented in XXX.
+ * Each protocol has a set of specific options that are documented in their respective providers.
  * @param {Extent} extent - Extent covered by the layer. Note that it can be different
  * than the extent of the underlying geometry.
  * @param {number} colorLayer.strategy.type - Strategy to use to download elements.
@@ -219,7 +219,7 @@ const ImageryLayers = {
  * @param {Object} elevationLayer - property bag defining the layer to display.
  * @param {string} elevationLayer.id - unique identifier of this layer
  * @param {string} elevationLayer.protocol - one of wms, wmts, wmtsc, static.
- * Each protocol has a set of specific options that are documented in XXX.
+ * Each protocol has a set of specific options that are documented in their respective providers.
  * @param {Extent} extent - Extent covered by the layer. Note that it can be different
  * than the extent of the underlying geometry.
  * @param {number} elevationLayer.strategy.type - Strategy to use to download elements.

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -184,7 +184,7 @@ const ImageryLayers = {
 
 /**
  * Interface implemented by {@link GeometryLayer} instances capable of displaying color layers
- * @interface
+ * @interface CanDisplayColorLayer
  */
 /**
  * Add a color layer to display on this geometry
@@ -209,7 +209,7 @@ const ImageryLayers = {
 
  /**
  * Interface implemented by {@link GeometryLayer} instances capable of displaying color layers
- * @interface
+ * @interface CanDisplayElevationLayer
  */
 /**
  * Use an elevation data source to deform the underlying geometry
@@ -234,7 +234,7 @@ const ImageryLayers = {
 
  /**
  * Interface implemented by {@link GeometryLayer} instances capable of displaying a feature layers
- * @interface
+ * @interface CanDisplayFeatureLayer
  */
 /**
  * Display a feature layers on the underlying geometry

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -203,23 +203,8 @@ GlobeView.prototype._preAddLayer = function _preAddLayer(layer) {
  */
 GlobeView.prototype.removeLayer = function removeImageryLayer(layerId) {
     const layer = this.getLayers(l => l.id === layerId)[0];
-    if (layer && layer.type === 'color' && this.baseLayer.detach(layer)) {
-        var cO = function cO(object) {
-            if (object.removeColorLayer) {
-                object.removeColorLayer(layerId);
-            }
-        };
-
-        for (const root of this.baseLayer.level0Nodes) {
-            root.traverse(cO);
-        }
-        const imageryLayers = this.getLayers(l => l.type === 'color');
-        for (const color of imageryLayers) {
-            if (color.sequence > layer.sequence) {
-                color.sequence--;
-            }
-        }
-
+    if (layer && layer.type === 'color') {
+        this.baseLayer.removeColorLayer(layer);
         this.notifyChange(true);
         this.dispatchEvent({
             type: GLOBE_VIEW_EVENTS.LAYER_REMOVED,

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -197,11 +197,6 @@ GlobeView.prototype._preAddLayer = function _preAddLayer(layer) {
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
         }
     }
-
-    this.dispatchEvent({
-        type: GLOBE_VIEW_EVENTS.LAYER_ADDED,
-        layerId: layer.id,
-    });
 };
 
 /**
@@ -217,7 +212,12 @@ GlobeView.prototype.addLayer = function addLayer(layer) {
             'Use globeView.baseLayer.[addColorLayer|addElevationLayer|addFeatureLayer](layer) instead.');
         this._warnAddLayerDeprecated = true;
     }
-    return View.prototype.addLayer.call(this, layer, this.baseLayer);
+    const result = View.prototype.addLayer.call(this, layer, this.baseLayer);
+    this.dispatchEvent({
+        type: GLOBE_VIEW_EVENTS.LAYER_ADDED,
+        layerId: layer.id,
+    });
+    return result;
 };
 
 /**

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -12,7 +12,7 @@ import CoordStars from '../Geographic/CoordStars';
 
 import { C, ellipsoidSizes } from '../Geographic/Coordinates';
 import { createGlobe } from '../DefaultGeometryLayers';
-
+import { GeometryLayer } from '../Layer/Layer';
 /**
  * Fires when the view is completely loaded. Controls and view's functions can be called then.
  * @event GlobeView#initialized
@@ -206,6 +206,10 @@ GlobeView.prototype._preAddLayer = function _preAddLayer(layer) {
  * @return {Promise} see View.addLayer
  */
 GlobeView.prototype.addLayer = function addLayer(layer) {
+    if (layer instanceof GeometryLayer) {
+        return View.prototype.addLayer.call(this, layer);
+    }
+
     if (!this._warnAddLayerDeprecated) {
         // eslint-disable-next-line no-console
         console.warn('globeView.addLayer(colorLayer) has been deprecated.\n' +

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -179,10 +179,20 @@ GlobeView.prototype.constructor = GlobeView;
 
 GlobeView.prototype._preAddLayer = function _preAddLayer(layer) {
     if (layer.type == 'color') {
+        if (!layer.update) {
+            // Note: remove this when GlobeView.addLayer is removed
+            this.baseLayer.addColorLayer(layer, false);
+        }
+
         if (layer.protocol === 'rasterizer') {
             layer.reprojection = 'EPSG:4326';
         }
     } else if (layer.type == 'elevation') {
+        if (!layer.update) {
+            // Note: remove this when GlobeView.addLayer is removed
+            this.baseLayer.addElevationLayer(layer, false);
+        }
+
         if (layer.protocol === 'wmts' && layer.options.tileMatrixSet !== 'WGS84G') {
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
         }
@@ -192,6 +202,22 @@ GlobeView.prototype._preAddLayer = function _preAddLayer(layer) {
         type: GLOBE_VIEW_EVENTS.LAYER_ADDED,
         layerId: layer.id,
     });
+};
+
+/**
+ * Calls View.addLayer using this.baseLayer as the parent layer
+ * @param {Layer} layer: layer to attach to the planar geometry
+ * @deprecated
+ * @return {Promise} see View.addLayer
+ */
+GlobeView.prototype.addLayer = function addLayer(layer) {
+    if (!this._warnAddLayerDeprecated) {
+        // eslint-disable-next-line no-console
+        console.warn('globeView.addLayer(colorLayer) has been deprecated.\n' +
+            'Use globeView.baseLayer.[addColorLayer|addElevationLayer|addFeatureLayer](layer) instead.');
+        this._warnAddLayerDeprecated = true;
+    }
+    return View.prototype.addLayer.call(this, layer, this.baseLayer);
 };
 
 /**

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -177,22 +177,15 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
 GlobeView.prototype = Object.create(View.prototype);
 GlobeView.prototype.constructor = GlobeView;
 
+// Preprocess layer for a Globe if needed
 GlobeView.prototype._preAddLayer = function _preAddLayer(layer) {
-    if (layer.type == 'color') {
-        if (!layer.update) {
-            // Note: remove this when GlobeView.addLayer is removed
-            this.baseLayer.addColorLayer(layer, false);
-        }
+    this._deprecatedPreAddLayer(layer);
 
+    if (layer.type == 'color') {
         if (layer.protocol === 'rasterizer') {
             layer.reprojection = 'EPSG:4326';
         }
     } else if (layer.type == 'elevation') {
-        if (!layer.update) {
-            // Note: remove this when GlobeView.addLayer is removed
-            this.baseLayer.addElevationLayer(layer, false);
-        }
-
         if (layer.protocol === 'wmts' && layer.options.tileMatrixSet !== 'WGS84G') {
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
         }

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -8,7 +8,6 @@ import { unpack1K } from '../../Renderer/LayeredMaterial';
 import { GeometryLayer } from '../Layer/Layer';
 
 import { processTiledGeometryNode } from '../../Process/TiledNodeProcessing';
-import { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } from '../../Process/LayeredMaterialNodeProcessing';
 import { planarCulling, planarSubdivisionControl } from '../../Process/PlanarTileProcessing';
 import PlanarTileBuilder from './Planar/PlanarTileBuilder';
 import SubdivisionControl from '../../Process/SubdivisionControl';
@@ -152,13 +151,33 @@ PlanarView.prototype.constructor = PlanarView;
 
 PlanarView.prototype._preAddLayer = function _preAddLayer(layer) {
     if (layer.type == 'color') {
-        layer.update = updateLayeredMaterialNodeImagery;
+        if (!layer.update) {
+            this.baseLayer.addColorLayer(layer, false);
+        }
         if (layer.protocol === 'rasterizer') {
             layer.reprojection = this.referenceCrs;
         }
     } else if (layer.type == 'elevation') {
-        layer.update = updateLayeredMaterialNodeElevation;
+        if (!layer.update) {
+            this.baseLayer.addElevationLayer(layer, false);
+        }
     }
+};
+
+/**
+ * Calls View.addLayer using this.baseLayer as the parent layer
+ * @param {Layer} layer: layer to attach to the planar geometry
+ * @deprecated
+ * @return {Promise} see View.addLayer
+ */
+PlanarView.prototype.addLayer = function addLayer(layer) {
+    if (!this._warnAddLayerDeprecated) {
+        // eslint-disable-next-line no-console
+        console.warn('globeView.addLayer(colorLayer) has been deprecated.\n' +
+            'Use globeView.baseLayer.[addColorLayer|addElevationLayer|addFeatureLayer](layer) instead.');
+        this._warnAddLayerDeprecated = true;
+    }
+    return View.prototype.addLayer.call(this, layer, this.baseLayer);
 };
 
 PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -144,13 +144,13 @@ function PlanarView(viewerDiv, extent, options = {}) {
     this._renderState = RendererConstant.FINAL;
     this._fullSizeDepthBuffer = null;
 
-    this.tileLayer = tileLayer;
+    this.baseLayer = tileLayer;
 }
 
 PlanarView.prototype = Object.create(View.prototype);
 PlanarView.prototype.constructor = PlanarView;
 
-PlanarView.prototype.addLayer = function addLayer(layer) {
+PlanarView.prototype._preAddLayer = function _preAddLayer(layer) {
     if (layer.type == 'color') {
         layer.update = updateLayeredMaterialNodeImagery;
         if (layer.protocol === 'rasterizer') {
@@ -159,13 +159,12 @@ PlanarView.prototype.addLayer = function addLayer(layer) {
     } else if (layer.type == 'elevation') {
         layer.update = updateLayeredMaterialNodeElevation;
     }
-    return View.prototype.addLayer.call(this, layer, this.tileLayer);
 };
 
 PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
     const selectedId = this.screenCoordsToNodeId(mouse);
 
-    for (const n of this.tileLayer.level0Nodes) {
+    for (const n of this.baseLayer.level0Nodes) {
         n.traverse((node) => {
             // only take of selectable nodes
             if (node.setSelected) {
@@ -231,7 +230,7 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
 
     // Prepare state
     const prev = camera.layers.mask;
-    camera.layers.mask = 1 << this.tileLayer.threejsLayer;
+    camera.layers.mask = 1 << this.baseLayer.threejsLayer;
 
      // Render/Read to buffer
     let buffer;
@@ -275,7 +274,7 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
 };
 
 PlanarView.prototype.changeRenderState = function changeRenderState(newRenderState) {
-    if (this._renderState == newRenderState || !this.tileLayer.level0Nodes) {
+    if (this._renderState == newRenderState || !this.baseLayer.level0Nodes) {
         return;
     }
 
@@ -288,7 +287,7 @@ PlanarView.prototype.changeRenderState = function changeRenderState(newRenderSta
         };
     }());
 
-    for (const n of this.tileLayer.level0Nodes) {
+    for (const n of this.baseLayer.level0Nodes) {
         n.traverseVisible(changeStateFunction);
     }
     this._renderState = newRenderState;

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -171,6 +171,9 @@ PlanarView.prototype._preAddLayer = function _preAddLayer(layer) {
  * @return {Promise} see View.addLayer
  */
 PlanarView.prototype.addLayer = function addLayer(layer) {
+    if (layer instanceof GeometryLayer) {
+        return View.prototype.addLayer.call(this, layer);
+    }
     if (!this._warnAddLayerDeprecated) {
         // eslint-disable-next-line no-console
         console.warn('globeView.addLayer(colorLayer) has been deprecated.\n' +

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -149,17 +149,12 @@ function PlanarView(viewerDiv, extent, options = {}) {
 PlanarView.prototype = Object.create(View.prototype);
 PlanarView.prototype.constructor = PlanarView;
 
+// Preprocess layer for a Plane if needed
 PlanarView.prototype._preAddLayer = function _preAddLayer(layer) {
+    this._deprecatedPreAddLayer(layer);
     if (layer.type == 'color') {
-        if (!layer.update) {
-            this.baseLayer.addColorLayer(layer, false);
-        }
         if (layer.protocol === 'rasterizer') {
             layer.reprojection = this.referenceCrs;
-        }
-    } else if (layer.type == 'elevation') {
-        if (!layer.update) {
-            this.baseLayer.addElevationLayer(layer, false);
         }
     }
 };

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -34,7 +34,7 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
         throw new Error(`Cannot init tiled layer without schemeTile for layer ${layer.id}`);
     }
 
-    layer.addColorLayer = (colorLayer) => {
+    layer.addColorLayer = (colorLayer, addToView = true) => {
         if (colorLayer.protocol === 'rasterizer') {
             colorLayer.reprojection = 'EPSG:4326';
         }
@@ -44,7 +44,9 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
             colorLayer.update = updateLayeredMaterialNodeImagery;
         }
 
-        return view.addLayer(colorLayer, layer);
+        if (addToView) {
+            return view.addLayer(colorLayer, layer);
+        }
     };
     layer.removeColorLayer = (colorLayerOrId) => {
         const layerId = colorLayerOrId.id === undefined ? colorLayerOrId : colorLayerOrId.id;
@@ -73,14 +75,16 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
         }
     };
 
-    layer.addElevationLayer = (elevationLayer) => {
+    layer.addElevationLayer = (elevationLayer, addToView = true) => {
         if (elevationLayer.protocol === 'wmts' && elevationLayer.options.tileMatrixSet !== 'WGS84G') {
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
         }
 
         elevationLayer.update = elevationLayer.update || updateLayeredMaterialNodeElevation;
 
-        return view.addLayer(elevationLayer, layer);
+        if (addToView) {
+            return view.addLayer(elevationLayer, layer);
+        }
     };
     layer.removeElevationLayer = (elevationLayerOrId) => {
         const layerId = elevationLayerOrId.id === undefined ? elevationLayerOrId : elevationLayerOrId.id;

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -61,7 +61,7 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
                 });
             }
             // update color sequence of other color layers
-            const imageryLayers = view.getLayers((l, p) => (p.id == layer.id && l.type === 'color'));
+            const imageryLayers = view.getLayers((l, p) => (p && p.id == layer.id && l.type === 'color'));
             for (const color of imageryLayers) {
                 if (color.sequence > colorLayer.sequence) {
                     color.sequence--;

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -35,6 +35,8 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
     }
 
     layer.addColorLayer = (colorLayer, addToView = true) => {
+        colorLayer.type = 'color';
+
         if (colorLayer.protocol === 'rasterizer') {
             colorLayer.reprojection = 'EPSG:4326';
         }
@@ -80,6 +82,8 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
         }
 
+        elevationLayer.type = 'elevation';
+
         elevationLayer.update = elevationLayer.update || updateLayeredMaterialNodeElevation;
 
         if (addToView) {
@@ -99,7 +103,10 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
         }
     };
 
-    layer.addFeatureLayer = featureLayer => view.addLayer(featureLayer, layer);
+    layer.addFeatureLayer = (featureLayer) => {
+        featureLayer.type = 'feature';
+        view.addLayer(featureLayer, layer);
+    };
     layer.removeFeatureLayer = (featureLayerOrId) => {
         const layerId = featureLayerOrId.id === undefined ? featureLayerOrId : featureLayerOrId.id;
         const featureLayer = view.getLayers(l => l.id === layerId)[0];
@@ -123,8 +130,11 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
             return layer.removeColorLayer(toRemove);
         } else if (layer.type === 'elevation') {
             return layer.removeElevationLayer(toRemove);
-        } else {
+        } else if (layer.type === 'feature') {
             return layer.removeFeatureLayer(toRemove);
+        } else {
+            // eslint-disable-next-line no-console
+            console.warn(`Unknwown layer type ${layer.type}`);
         }
     };
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -97,6 +97,10 @@ const _syncGeometryLayerVisibility = function _syncGeometryLayerVisibility(layer
 };
 
 function _preprocessLayer(view, layer, provider) {
+    if (view._preAddLayer) {
+        view._preAddLayer(layer);
+    }
+
     if (!(layer instanceof Layer) && !(layer instanceof GeometryLayer)) {
         const nlayer = new Layer(layer.id);
         // nlayer.id is read-only so delete it from layer before Object.assign

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -291,6 +291,10 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         throw new Error(`Invalid id '${layer.id}': id already used`);
     }
 
+    if (typeof layer.type != 'string') {
+        throw new Error('layer.type must be a valid string');
+    }
+
     if (parentLayer && !layer.extent) {
         layer.extent = parentLayer.extent;
     }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -322,6 +322,27 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
 };
 
 /**
+ * Removes a layer from the view
+ * @param {string} layerId - the id of the layer to remove
+ */
+View.prototype.removeLayer = function removeLayer(layerId) {
+    const layers = this.getLayers((l => l.id == layerId));
+    if (layers.length === 0) {
+        throw new Error(`No layer with id '${layerId}' to remove`);
+    }
+    const toRemove = this.scene.children.filter((c => c.layer == layerId));
+    for (const obj of toRemove) {
+        const idx = this.scene.children.indexOf(obj);
+        this.scene.children.splice(idx, 1);
+    }
+
+    const idx = this._layers.indexOf(layers[0]);
+    this._layers.splice(idx, 1);
+
+    this.notifyChange(true);
+};
+
+/**
  * Notifies the scene it needs to be updated due to changes exterior to the
  * scene itself (e.g. camera movement).
  * non-interactive events (e.g: texture loaded)

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -77,6 +77,21 @@ function View(crs, viewerDiv, options = {}) {
     this.onAfterRender = () => {};
 
     this._changeSources = new Set();
+
+    // deprecated API handling: remove this when GlobeView (and PlanarView).addLayer is removed
+    this._deprecatedPreAddLayer = (layer) => {
+        if (layer.type == 'color') {
+            if (!layer.update) {
+                // Note: remove this when GlobeView.addLayer is removed
+                this.baseLayer.addColorLayer(layer, false);
+            }
+        } else if (layer.type == 'elevation') {
+            if (!layer.update) {
+                // Note: remove this when GlobeView.addLayer is removed
+                this.baseLayer.addElevationLayer(layer, false);
+            }
+        }
+    };
 }
 
 View.prototype = Object.create(EventDispatcher.prototype);

--- a/src/Main.js
+++ b/src/Main.js
@@ -22,3 +22,5 @@ export { default as GeoJSON2Features } from './Renderer/ThreeExtended/GeoJSON2Fe
 export { default as FeaturesUtils } from './Renderer/ThreeExtended/FeaturesUtils';
 export { CONTROL_EVENTS } from './Renderer/ThreeExtended/GlobeControls';
 export { default as DEMUtils } from './utils/DEMUtils';
+
+export { createGlobe, createPlane, create3dTiles, createPointcloud } from './Core/DefaultGeometryLayers';

--- a/src/Renderer/ColorLayersOrdering.js
+++ b/src/Renderer/ColorLayersOrdering.js
@@ -30,7 +30,7 @@ export const ColorLayersOrdering = {
         if (layer) {
             const previousSequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             ImageryLayers.moveLayerUp(layer, imageryLayers);
-            updateLayersOrdering(view.wgs84TileLayer, imageryLayers);
+            updateLayersOrdering(view.baseLayer, imageryLayers);
             view.dispatchEvent({ type: COLOR_LAYERS_ORDER_CHANGED,
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
@@ -54,7 +54,7 @@ export const ColorLayersOrdering = {
         if (layer) {
             const previousSequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             ImageryLayers.moveLayerDown(layer, imageryLayers);
-            updateLayersOrdering(view.wgs84TileLayer, imageryLayers);
+            updateLayersOrdering(view.baseLayer, imageryLayers);
             view.dispatchEvent({ type: COLOR_LAYERS_ORDER_CHANGED,
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
@@ -79,7 +79,7 @@ export const ColorLayersOrdering = {
         if (layer) {
             const previousSequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             ImageryLayers.moveLayerToIndex(layer, newIndex, imageryLayers);
-            updateLayersOrdering(view.wgs84TileLayer, imageryLayers);
+            updateLayersOrdering(view.baseLayer, imageryLayers);
             view.dispatchEvent({ type: COLOR_LAYERS_ORDER_CHANGED,
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },

--- a/src/Renderer/ColorLayersOrdering.js
+++ b/src/Renderer/ColorLayersOrdering.js
@@ -15,6 +15,9 @@ function updateLayersOrdering(geometryLayer, imageryLayers) {
 
 export const COLOR_LAYERS_ORDER_CHANGED = 'layers-order-changed';
 
+/**
+ * @module ColorLayersOrdering
+ */
 export const ColorLayersOrdering = {
     /**
      * Moves up in the layer list. This function has no effect if the layer is moved to its current index.

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -192,7 +192,7 @@ function updateAltitudeCoordinate(coordinate, layer) {
 
 function clampToGround(root) {
     // diff altitude
-    if (updateAltitudeCoordinate(root.targetGeoPosition, root.view.wgs84TileLayer) != 0) {
+    if (updateAltitudeCoordinate(root.targetGeoPosition, root.view.baseLayer) != 0) {
         root.distance = root.lengthTarget - root.targetGeoPosition.as('EPSG:4978').xyz().length();
     }
     // translation
@@ -799,9 +799,9 @@ function GlobeControls(view, target, radius, options = {}) {
             movingCameraTargetOnGlobe.addVectors(this.camera.position, direction);
         }
         // correction of depth error
-        const tileCrs = this._view.wgs84TileLayer.extent.crs();
+        const tileCrs = this._view.baseLayer.extent.crs();
         coordTarget.set(this._view.referenceCrs, movingCameraTargetOnGlobe).as(tileCrs, coordTile);
-        updateAltitudeCoordinate(coordTile, this._view.wgs84TileLayer);
+        updateAltitudeCoordinate(coordTile, this._view.baseLayer);
         coordTile.as(this._view.referenceCrs).xyz(reposition);
         direction.setLength(reposition.distanceTo(this.camera.position));
         movingCameraTargetOnGlobe.addVectors(this.camera.position, direction);
@@ -1533,8 +1533,8 @@ GlobeControls.prototype.setOrbitalPosition = function setOrbitalPosition(positio
         const deltaTheta = position.heading === undefined ? 0 : position.heading * Math.PI / 180 - this.getHeadingRad();
         const deltaRange = position.range === undefined ? 0 : position.range - this.getRange();
         if (position.range) {
-            this._view.wgs84TileLayer.postUpdate = () => {
-                updateAltitudeCoordinate(geoPosition, this._view.wgs84TileLayer);
+            this._view.baseLayer.postUpdate = () => {
+                updateAltitudeCoordinate(geoPosition, this._view.baseLayer);
                 const errorRange = altitude - geoPosition.altitude();
                 if (errorRange != 0) {
                     if (isAnimated && player.isPlaying()) {
@@ -1550,7 +1550,7 @@ GlobeControls.prototype.setOrbitalPosition = function setOrbitalPosition(positio
         return this.moveOrbitalPosition(deltaRange, deltaTheta, deltaPhi, isAnimated).then(() => {
             this.waitSceneLoaded().then(() => {
                 this.updateCameraTransformation();
-                this._view.wgs84TileLayer.postUpdate = () => {};
+                this._view.baseLayer.postUpdate = () => {};
             });
         });
     });
@@ -1642,13 +1642,13 @@ GlobeControls.prototype.setCameraTargetPosition = function setCameraTargetPositi
         ctrl.progress = 1.0;
         quatGlobe.setFromUnitVectors(vFrom, vTo);
         this.updateCameraTransformation(this.states.MOVE_GLOBE, false);
-        this._view.wgs84TileLayer.postUpdate = () => {
+        this._view.baseLayer.postUpdate = () => {
             clampToGround(ctrl);
             this.updateCameraTransformation(this.states.MOVE_GLOBE, false);
         };
         return this.waitSceneLoaded().then(() => {
             this.updateCameraTransformation(this.states.MOVE_GLOBE);
-            this._view.wgs84TileLayer.postUpdate = () => {};
+            this._view.baseLayer.postUpdate = () => {};
             ctrl.targetGeoPosition = null;
             ctrl.progress = 0.0;
         });
@@ -1874,7 +1874,7 @@ GlobeControls.prototype.setCameraTargetGeoPosition = function setCameraTargetGeo
     return initPromise.then(() => {
         isAnimated = isAnimated === undefined ? this.isAnimationEnabled() : isAnimated;
         ctrl.targetGeoPosition = new C.EPSG_4326(coordinates.longitude, coordinates.latitude, 0);
-        updateAltitudeCoordinate(ctrl.targetGeoPosition, this._view.wgs84TileLayer);
+        updateAltitudeCoordinate(ctrl.targetGeoPosition, this._view.baseLayer);
         const position = ctrl.targetGeoPosition.as('EPSG:4978').xyz();
         position.range = coordinates.range;
         return this.setCameraTargetPosition(position, isAnimated);

--- a/test/globe_test.js
+++ b/test/globe_test.js
@@ -21,7 +21,7 @@ var initialState = true;
 
 describe('Globe example', function () {
     it('should subdivide like expected', function (done) {
-        example.view.mainLoop.addEventListener('command-queue-empty', () => {
+        var testFn = function _() {
             itownsTesting.counters.visible_at_level = [];
             itownsTesting.counters.displayed_at_level = [];
 
@@ -41,14 +41,19 @@ describe('Globe example', function () {
                 example.view.notifyChange(true);
             } else {
                 afterSetRange();
+
+                // test layer removal
+                assert.ok(example.view.removeLayer('Ortho'));
+
+                assert.equal(3, example.view.getLayers().length);
+
                 done();
-                // 'command-queue-empty' can fire multiple times, because GlobeView
-                // fires a notifyChange() event when it receives 'command-queue-empty'
-                // Until this is fixed, we exit() the test here, to make sure we don't
-                // call done() twice
-                process.exit(0);
+
+                example.view.mainLoop.removeEventListener('command-queue-empty', testFn);
             }
-        });
+        };
+        example.view.mainLoop.addEventListener('command-queue-empty', testFn);
+
         itownsTesting.runTest();
     });
 });

--- a/test/globe_test.js
+++ b/test/globe_test.js
@@ -25,7 +25,7 @@ describe('Globe example', function () {
             itownsTesting.counters.visible_at_level = [];
             itownsTesting.counters.displayed_at_level = [];
 
-            for (var obj of example.view.wgs84TileLayer.level0Nodes) {
+            for (var obj of example.view.baseLayer.level0Nodes) {
                 itownsTesting.countVisibleAndDisplayed(obj);
             }
 

--- a/test/planar_test.js
+++ b/test/planar_test.js
@@ -16,6 +16,10 @@ describe('Planar example', function () {
             assert.equal(itownsTesting.counters.displayed_at_level[4], 20);
 
             done();
+
+            // test layer removal
+            assert.ok(example.view.removeLayer('wms_imagery'));
+            assert.equal(2, example.view.getLayers().length);
         });
         itownsTesting.runTest();
     });

--- a/test/planar_test.js
+++ b/test/planar_test.js
@@ -7,7 +7,7 @@ describe('Planar example', function () {
         example.view.mainLoop.addEventListener('command-queue-empty', () => {
             itownsTesting.counters.displayed_at_level = [];
 
-            for (var obj of example.view.tileLayer.level0Nodes) {
+            for (var obj of example.view.baseLayer.level0Nodes) {
                 itownsTesting.countVisibleAndDisplayed(obj);
             }
 


### PR DESCRIPTION
## Description

This PR tries to improve iTowns API for layer management.

## Motivation and Context
Our API is currently a bit confusing so I tried to find something simpler that would support all our use cases.

Here are the proposed simplifications:
- top level / geometry layers are added to a *View* but other layers (eg color layers) are added to geometry layers
- instead of having a unique entry point to add layers `View.addLayer`,  this PR adds different entry point for each supported layer type
- `GlobeView.wgs84TileLayer` and `PlanarView.tileLayer` become `XxxxView.baseLayer`

This PR can be summarized with an example:
```js
// before
globeView.addLayer(colorLayer);
itowns.View.prototype.addLayer.call(globeView, anotherGeomLayer);

// after
globeView.baseLayer.addColorLayer(colorLayer);
globeView.addLayer(anotherGeomLayer);
```

I also cherry-picked the content of PR #468 to add the ability to remove a layer:

```js
mylayer.removeFeatureLayer('tcl_bus'); // removes feature layer
view.removeLayer(layer); // removes a top level layer
```