### PR TITLE
fix (protocol) : stop using layer's options tileMatrixSet in WMS provider

### DIFF
--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -32,13 +32,7 @@ WMS_Provider.prototype.url = function url(bbox, layer) {
 };
 
 WMS_Provider.prototype.tileTextureCount = function tileTextureCount(tile, layer) {
-    if (tile.extent.crs() == layer.projection) {
-        return 1;
-    } else {
-        const tileMatrixSet = layer.options.tileMatrixSet;
-        OGCWebServiceHelper.computeTileMatrixSetCoordinates(tile, tileMatrixSet);
-        return tile.getCoordsForLayer(layer).length;
-    }
+    return tile.extent.crs() == layer.projection ? 1 : tile.getCoordsForLayer(layer).length;
 };
 
 WMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer) {


### PR DESCRIPTION
WMS layer haven't tileMatrixSet, this PR removes this inconsistency

problem when you use PR #513 