### PR TITLE
feature (controls) : add collision camera/tiles's obb to globeControls

### DIFF
--- a/src/Renderer/ThreeExtended/OBB.js
+++ b/src/Renderer/ThreeExtended/OBB.js
@@ -98,6 +98,25 @@ OBB.prototype._cPointsWorld = function _cPointsWorld(points) {
     return points;
 };
 
+/**
+ * Determines if the sphere is above the XY space of the box
+ *
+ * @param      {Sphere}   sphere  The sphere
+ * @return     {boolean}  True if sphere is above the XY space of the box, False otherwise.
+ */
+OBB.prototype.isSphereAboveXYBox = function isSphereAboveXYBox(sphere) {
+    const localSpherePosition = this.worldToLocal(sphere.position);
+    // get obb closest point to sphere center by clamping
+    const x = Math.max(this.box3D.min.x, Math.min(localSpherePosition.x, this.box3D.max.x));
+    const y = Math.max(this.box3D.min.y, Math.min(localSpherePosition.y, this.box3D.max.y));
+
+    // this is the same as isPointInsideSphere.position
+    const distance = Math.sqrt((x - localSpherePosition.x) * (x - localSpherePosition.x) +
+                           (y - localSpherePosition.y) * (y - localSpherePosition.y));
+
+    return distance < sphere.radius;
+};
+
 // Allocate these variables once and for all
 const tmp = {
     epsg4978: new Coordinates('EPSG:4978', 0, 0),

--- a/test/obb_unit_test.js
+++ b/test/obb_unit_test.js
@@ -1,0 +1,22 @@
+import * as THREE from 'three';
+import OBB from '../src/Renderer/ThreeExtended/OBB';
+/* global describe, it */
+
+const assert = require('assert');
+
+const max = new THREE.Vector3(10, 10, 10);
+const min = new THREE.Vector3(-10, -10, -10);
+const lookAt = new THREE.Vector3(1, 0, 0);
+const translate = new THREE.Vector3(0, 0, 20);
+const obb = new OBB(min, max, lookAt, translate);
+
+describe('OBB', function () {
+    it('should correctly instance obb', () => {
+        assert.equal(obb.natBox.min.x, min.x);
+        assert.equal(obb.natBox.max.x, max.x);
+    });
+    it('isSphereAboveXYBox should work properly', () => {
+        const sphere = { radius: 5, position: new THREE.Vector3(23, 0, 0) };
+        assert.equal(obb.isSphereAboveXYBox(sphere), true);
+    });
+});


### PR DESCRIPTION
## Description
add collision between camera's bounding and tiles's oriented bounding box. Depending on the distance of the camera with obbs, we add a slowdown or constrain to the movement. this constraint or deceleration is suitable for two types of movement MOVE_GLOBE and ORBIT. This constraint or deceleration. It's inversely proportional to the camera / obb distance

## Motivation and Context
the actual collision idoesn't work properly because it uses only the line / tile intersection.
In addition it adds a translation on normal surface without to take into account the movements of the globe control
