### PR TITLE
feat (core): support texture with different x/y scales

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -175,10 +175,10 @@ Extent.prototype.offsetToParent = function offsetToParent(other) {
         const r = (this._row - (this._row % diff)) * invDiff;
         const c = (this._col - (this._col % diff)) * invDiff;
 
-        return new THREE.Vector3(
+        return new THREE.Vector4(
             this._col * invDiff - c,
             this._row * invDiff - r,
-            invDiff);
+            invDiff, invDiff);
     }
 
     const dimension = {
@@ -191,10 +191,15 @@ Extent.prototype.offsetToParent = function offsetToParent(other) {
     const originY =
         (other.north() - this.north(other._internalStorageUnit)) / dimension.y;
 
-    const scale =
+    const scaleX =
         Math.abs(
             this.east(other._internalStorageUnit) - this.west(other._internalStorageUnit)) / dimension.x;
-    return new THREE.Vector3(originX, originY, scale);
+
+    const scaleY =
+        Math.abs(
+            this.north(other._internalStorageUnit) - this.south(other._internalStorageUnit)) / dimension.y;
+
+    return new THREE.Vector4(originX, originY, scaleX, scaleY);
 };
 
 Extent.prototype.west = function west(unit) {
@@ -321,8 +326,10 @@ Extent.prototype.offsetScale = function offsetScale(bbox) {
     var originX = (bbox.west(this._internalStorageUnit) - this.west()) / dimension.x;
     var originY = (bbox.north(this._internalStorageUnit) - this.north()) / dimension.y;
 
-    var scale = Math.abs(bbox.east(this._internalStorageUnit) - bbox.west(this._internalStorageUnit)) / dimension.x;
-    return new THREE.Vector3(originX, originY, scale);
+    var scaleX = Math.abs(bbox.east(this._internalStorageUnit) - bbox.west(this._internalStorageUnit)) / dimension.x;
+    var scaleY = Math.abs(bbox.north(this._internalStorageUnit) - bbox.south(this._internalStorageUnit)) / dimension.y;
+
+    return new THREE.Vector4(originX, originY, scaleX, scaleY);
 };
 
 /**

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -52,7 +52,7 @@ function createTextureFromVector(tile, layer) {
 
     if (layer.type == 'color') {
         const coords = tile.extent.as(layer.projection);
-        const result = { pitch: new THREE.Vector3(0, 0, 1) };
+        const result = { pitch: new THREE.Vector4(0, 0, 1, 1) };
         result.texture = Feature2Texture.createTextureFromFeature(layer.feature, tile.extent, 256, layer.style);
         result.texture.extent = tile.extent;
         result.texture.coords = coords;

--- a/src/Core/Scheduler/Providers/StaticProvider.js
+++ b/src/Core/Scheduler/Providers/StaticProvider.js
@@ -1,4 +1,4 @@
-import { Vector3 } from 'three';
+import { Vector4 } from 'three';
 import Extent from '../../Geographic/Extent';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
 import Fetcher from './Fetcher';
@@ -48,7 +48,7 @@ function getTexture(tile, layer) {
         // adjust pitch
         const result = {
             texture,
-            pitch: new Vector3(0, 0, 1),
+            pitch: new Vector4(0, 0, 1, 1),
         };
 
         result.texture.extent = selection.extent;

--- a/src/Core/Scheduler/Providers/TMS_Provider.js
+++ b/src/Core/Scheduler/Providers/TMS_Provider.js
@@ -45,7 +45,7 @@ TMS_Provider.prototype.executeCommand = function executeCommand(command) {
         result.texture.coords = coordTMSParent || coordTMS;
         result.pitch = coordTMSParent ?
             coordTMS.offsetToParent(coordTMSParent) :
-            new THREE.Vector3(0, 0, 1);
+            new THREE.Vector4(0, 0, 1, 1);
         return result;
     });
 };

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -126,7 +126,7 @@ WMS_Provider.prototype.getColorTexture = function getColorTexture(tile, layer, t
 
     const coords = extent.as(layer.projection);
     const url = this.url(coords, layer);
-    const pitch = tileCoords ? new THREE.Vector3(0, 0, 1) : tile.extent.offsetToParent(extent);
+    const pitch = tileCoords ? new THREE.Vector4(0, 0, 1, 1) : tile.extent.offsetToParent(extent);
     const result = { pitch };
 
     return OGCWebServiceHelper.getColorTextureByUrl(url, layer.networkOptions).then((texture) => {

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -73,7 +73,7 @@ WMTS_Provider.prototype.url = function url(coWMTS, layer) {
  * @returns {Promise<portableXBIL>}
  */
 WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, targetZoom) {
-    const pitch = new THREE.Vector3(0.0, 0.0, 1.0);
+    const pitch = new THREE.Vector4(0.0, 0.0, 1.0, 1.0);
     let coordWMTS = tile.getCoordsForLayer(layer)[0];
 
     if (targetZoom && targetZoom !== coordWMTS.zoom) {
@@ -112,7 +112,7 @@ WMTS_Provider.prototype.getColorTexture = function getColorTexture(coordWMTS, la
         const result = {};
         result.texture = texture;
         result.texture.coords = coordWMTS;
-        result.pitch = new THREE.Vector3(0, 0, 1);
+        result.pitch = new THREE.Vector4(0, 0, 1, 1);
 
         return result;
     });

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -97,7 +97,7 @@ TileMesh.prototype.setTextureElevation = function setTextureElevation(elevation)
         return;
     }
 
-    const offsetScale = elevation.pitch || new THREE.Vector3(0, 0, 1);
+    const offsetScale = elevation.pitch || new THREE.Vector4(0, 0, 1, 1);
     this.setBBoxZ(elevation.min, elevation.max);
 
     this.material.setTexture(elevation.texture, l_ELEVATION, 0, offsetScale);

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -18,7 +18,6 @@ var emptyTexture = new THREE.Texture();
 emptyTexture.coords = { zoom: EMPTY_TEXTURE_ZOOM };
 
 const layerTypesCount = 2;
-var vector = new THREE.Vector3(0.0, 0.0, 0.0);
 var vector4 = new THREE.Vector4(0.0, 0.0, 0.0, 0.0);
 var fooTexture;
 
@@ -38,7 +37,7 @@ export function unpack1K(color, factor) {
 
 var getColorAtIdUv = function getColorAtIdUv(nbTex) {
     if (!fooTexture) {
-        fooTexture = 'vec4 colorAtIdUv(sampler2D dTextures[TEX_UNITS],vec3 offsetScale[TEX_UNITS],int id, vec2 uv){\n';
+        fooTexture = 'vec4 colorAtIdUv(sampler2D dTextures[TEX_UNITS],vec4 offsetScale[TEX_UNITS],int id, vec2 uv){\n';
         fooTexture += ' if (id == 0) return texture2D(dTextures[0],  pitUV(uv,offsetScale[0]));\n';
 
         for (var l = 1; l < nbTex; l++) {
@@ -122,8 +121,8 @@ const LayeredMaterial = function LayeredMaterial(options) {
     // Uniform three js needs no empty array
     // WARNING TODO: prevent empty slot, but it's not the solution
     this.offsetScale[l_COLOR] = Array(nbSamplers);
-    this.offsetScale[l_ELEVATION] = [vector];
-    fillArray(this.offsetScale[l_COLOR], vector);
+    this.offsetScale[l_ELEVATION] = [vector4];
+    fillArray(this.offsetScale[l_COLOR], vector4);
 
     this.textures[l_ELEVATION] = [emptyTexture];
     this.textures[l_COLOR] = Array(nbSamplers);
@@ -321,7 +320,7 @@ LayeredMaterial.prototype.removeColorLayer = function removeColorLayer(layer) {
     // refill remove textures
     for (let i = 0, max = texturesCount; i < max; i++) {
         this.textures[l_COLOR].push(emptyTexture);
-        this.offsetScale[l_COLOR].push(vector);
+        this.offsetScale[l_COLOR].push(vector4);
     }
 
     // Update slot start texture layer
@@ -357,7 +356,7 @@ LayeredMaterial.prototype.setTexture = function setTexture(texture, layerType, s
 
     // BEWARE: array [] -> size: 0; array [10]="wao" -> size: 11
     this.textures[layerType][slot] = texture || emptyTexture;
-    this.offsetScale[layerType][slot] = offsetScale || new THREE.Vector3(0.0, 0.0, 1.0);
+    this.offsetScale[layerType][slot] = offsetScale || new THREE.Vector4(0.0, 0.0, 1.0, 1.0);
 };
 
 LayeredMaterial.prototype.setColorLayerParameters = function setColorLayerParameters(params) {

--- a/src/Renderer/Shader/Chunk/pitUV.glsl
+++ b/src/Renderer/Shader/Chunk/pitUV.glsl
@@ -1,8 +1,8 @@
-vec2    pitUV(vec2 uvIn, vec3 pit)
+vec2    pitUV(vec2 uvIn, vec4 pit)
 {
     vec2  uv;
     uv.x = uvIn.x* pit.z + pit.x;
-    uv.y = 1.0 -( (1.0 - uvIn.y) * pit.z + pit.y);
+    uv.y = 1.0 -( (1.0 - uvIn.y) * pit.w + pit.y);
 
     return uv;
 }

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -13,7 +13,7 @@ const vec4 CRed = vec4( 1.0, 0.0, 0.0, 1.0);
 
 
 uniform sampler2D   dTextures_01[TEX_UNITS];
-uniform vec3        offsetScale_L01[TEX_UNITS];
+uniform vec4        offsetScale_L01[TEX_UNITS];
 
 // offset texture | Projection | fx | Opacity
 uniform vec4        paramLayers[8];


### PR DESCRIPTION
Until now we assumed that textures proportion matched geometry proportion.
This commits breaks this assumption by using a 2 floats instead of 1 for
specifying the region used.
