### PR TITLE
fix (controls): positioning error during camera movements

### DIFF
--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1105,6 +1105,12 @@ function GlobeControls(view, target, radius, options = {}) {
     var ondblclick = function ondblclick(event) {
         if (this.enabled === false) return;
 
+        if (!this.isAnimationEnabled()) {
+             // eslint-disable-next-line no-console
+            console.warn('double click without animation is disabled, waiting fix in future refactoring');
+            return;
+        }
+
         // Double click throws move camera's target with animation
         if (!currentKey) {
             ptScreenClick.x = event.clientX - event.target.offsetLeft;
@@ -1114,7 +1120,7 @@ function GlobeControls(view, target, radius, options = {}) {
 
             if (point) {
                 animatedScale = 0.6;
-                this.setCameraTargetPosition(point, this.isAnimationEnabled());
+                this.setCameraTargetPosition(point);
             }
         }
     };
@@ -1619,8 +1625,11 @@ GlobeControls.prototype.setCameraTargetPosition = function setCameraTargetPositi
         return player.play(animationZoomCenter).then(() => {
             this.resetControls();
             this.waitSceneLoaded().then(() => {
-                this.updateCameraTransformation();
-                ctrl.targetGeoPosition = null;
+                animatedScale = 0;
+                if (player.isStopped()) {
+                    this.updateCameraTransformation();
+                    ctrl.targetGeoPosition = null;
+                }
             });
         });
     } else {

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1428,6 +1428,12 @@ function GlobeControls(view, target, radius, options = {}) {
     window.addEventListener('keydown', onKeyDown.bind(this), false);
     window.addEventListener('keyup', onKeyUp.bind(this), false);
 
+    // Reset key/mouse when window loose focus
+    window.addEventListener('blur', () => {
+        onKeyUp.bind(this)();
+        onMouseUp.bind(this)();
+    });
+
     // Initialisation Globe Target and movingGlobeTarget
     setCameraTargetObjectPosition(target);
     movingCameraTargetOnGlobe.copy(target);

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1626,6 +1626,7 @@ GlobeControls.prototype.setCameraTargetPosition = function setCameraTargetPositi
     } else {
         ctrl.progress = 1.0;
         quatGlobe.setFromUnitVectors(vFrom, vTo);
+        this.updateCameraTransformation(this.states.MOVE_GLOBE, false);
         this._view.wgs84TileLayer.postUpdate = () => {
             clampToGround(ctrl);
             this.updateCameraTransformation(this.states.MOVE_GLOBE, false);


### PR DESCRIPTION
There was positioning error during camera movements with `globeControls`

**First commit**
In `setCameraTargetPosition` without animation, the final position was wrong because the transformation was simply not applied.
Can be tested through the function `setCameraTargetGeoPosition`

**second commit**
Other positioning error come from with double click.
Because it's in conflict with the simple click that calls the `setCameraTargetPosition` too.
For double click event:
  * with animation enabled problem is fixed
  * with animation disabled is forced to enable

