### PR TITLE
Fix color layer processing

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -75,7 +75,7 @@ function getIndiceWithPitch(i, pitch, w) {
     const currentX = (i % w) / w;  // normalized
     const currentY = Math.floor(i / w) / w; // normalized
     const newX = pitch.x + currentX * pitch.z;
-    const newY = pitch.y + currentY * pitch.z;
+    const newY = pitch.y + currentY * pitch.w;
     const newIndice = Math.floor(newY * w) * w + Math.floor(newX * w);
     return newIndice;
 }


### PR DESCRIPTION
LayerUpdateState were under-utilized and this lead to many useless computation.
For instance 'tileInsideLimit' was called each time we tried to update a tile, while this could be done once.

The 1st commit of this PR shuffles the code to move all the 'one-time' init at the top of the function.

(the 2nd commit is a followup of a616629d9001a6a988b40598cd4575c60372fbd9 where I forgot 1 user of pitch values)

