### PR TITLE
feat (protocols): improve StaticProvider.tileInsideLimit performance

### DIFF
--- a/src/Core/Scheduler/Providers/StaticProvider.js
+++ b/src/Core/Scheduler/Providers/StaticProvider.js
@@ -102,6 +102,11 @@ export default {
         if (!layer.images) {
             return false;
         }
+        // images search is quite costly so let's try to take a shortcut
+        if (layer.id in tile.layerUpdateState) {
+            return true;
+        }
+
         for (const entry of layer.images) {
             if (tile.extent.isInside(entry.extent)) {
                 return true;


### PR DESCRIPTION
When a StaticProvider has many images to choose from it becomes quite costly
to browse all of them each time we need to know if a tile is covered by the
layer.
This commit adds a shortcut: if the node already has a LayerUpdateState object
for this layer, this means we already determined the node is indeed covered by
the layer.
