### PR TITLE
Split OBB.extentToOBB function

### DIFF
--- a/test/obb_unit_test.js
+++ b/test/obb_unit_test.js
@@ -1,8 +1,13 @@
 import * as THREE from 'three';
+import proj4 from 'proj4';
+import assert from 'assert';
+import { UNIT } from '../src/Core/Geographic/Coordinates';
+import Extent from '../src/Core/Geographic/Extent';
+import BuilderEllipsoidTile from '../src/Core/Prefab/Globe/BuilderEllipsoidTile';
+import PlanarTileBuilder from '../src/Core/Prefab/Planar/PlanarTileBuilder';
+import TileGeometry from '../src/Core/TileGeometry';
 import OBB from '../src/Renderer/ThreeExtended/OBB';
-/* global describe, it */
-
-const assert = require('assert');
+/* global describe, it, xit */
 
 const max = new THREE.Vector3(10, 10, 10);
 const min = new THREE.Vector3(-10, -10, -10);
@@ -18,5 +23,55 @@ describe('OBB', function () {
     it('isSphereAboveXYBox should work properly', () => {
         const sphere = { radius: 5, position: new THREE.Vector3(23, 0, 0) };
         assert.equal(obb.isSphereAboveXYBox(sphere), true);
+    });
+});
+
+
+// Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+function assertVerticesAreInOBB(builder, extent) {
+    const params = {
+        extent,
+        disableSkirt: true,
+    };
+
+    const geom = new TileGeometry(params, builder);
+    const inverse = new THREE.Matrix4().getInverse(geom.OBB.matrix);
+
+    let failing = 0;
+    const vec = new THREE.Vector3();
+    for (let i = 0; i < geom.attributes.position.count; i++) {
+        vec.fromArray(geom.attributes.position.array, 3 * i);
+
+        vec.applyMatrix4(inverse);
+        if (!geom.OBB.box3D.containsPoint(vec)) {
+            failing++;
+        }
+    }
+    assert.equal(geom.attributes.position.count - failing, geom.attributes.position.count, 'All points should be inside OBB');
+}
+
+describe('Ellipsoid tiles OBB computation', function () {
+    const builder = new BuilderEllipsoidTile();
+
+    xit('IGNORED see #87 - should compute globe-level 0 OBB correctly', function () {
+        const extent = new Extent('EPSG:4326', -Math.PI, 0, -Math.PI * 0.5, Math.PI * 0.5);
+        extent._internalStorageUnit = UNIT.RADIAN;
+        assertVerticesAreInOBB(builder, extent);
+    });
+
+    xit('IGNORED see #87 - should compute globe-level 2 OBB correctly', function () {
+        const extent = new Extent('EPSG:4326', 0, 0.7853981633974483, -0.7853981633974483, 0);
+        extent._internalStorageUnit = UNIT.RADIAN;
+        assertVerticesAreInOBB(builder, extent);
+    });
+});
+
+describe('Planar tiles OBB computation', function () {
+    const builder = new PlanarTileBuilder();
+
+    it('should compute OBB correctly', function () {
+        const extent = new Extent('EPSG:3946', -100, 100, -50, 50);
+        assertVerticesAreInOBB(builder, extent);
     });
 });


### PR DESCRIPTION
This PR splits OBB.extentToOBB function in 2, moving the real computation
from xyz coords to OBB.cardinalsXYZToOBB.
This will allow to reuse the same code in a different context than the  EPSG:4326 globe.

It also add OBB unit testing code - with some of them being disabled because not all geometry vertices are inside the computed bounding box (see #87). But the tests were used to verify that the function splitting didn't introduce more errors.
