### PR TITLE
fix (3dtiles): don't try to subdivide a children-less node

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -319,6 +319,9 @@ export function process3dTilesNode(cullingTest, subdivisionTest) {
 }
 
 export function $3dTilesSubdivisionControl(context, layer, node) {
+    if (layer.tileIndex.index[node.tileId].children === undefined) {
+        return false;
+    }
     const sse = computeNodeSSE(context.camera, node);
     return sse > layer.sseThreshold;
 }


### PR DESCRIPTION
Fixes #542
