### PR TITLE
Add panorama display capabilities

### DIFF
--- a/examples/panorama.html
+++ b/examples/panorama.html
@@ -1,0 +1,104 @@
+<html>
+    <head>
+        <title>Itowns - Panorama example</title>
+
+        <style type="text/css">
+            html {
+                height: 100%;
+            }
+
+            body {
+                margin: 0;
+                overflow: hidden;
+                height: 100%;
+            }
+
+            #viewerDiv {
+                margin : auto auto;
+                width: 100%;
+                height: 100%;
+                padding: 0;
+            }
+        </style>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <div id="viewerDiv"></div>
+
+        <script src="../dist/itowns.js"></script>
+
+        <script src="../dist/debug.js"></script>
+        <script src="GUI/dat.gui/dat.gui.min.js"></script>
+        <script type="text/javascript">
+            /* global itowns, document, renderer */
+            var viewerDiv;
+            var view;
+
+            viewerDiv = document.getElementById('viewerDiv');
+
+            const urls = [
+                'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/panoramas/arles/metadata1.json',
+                'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/panoramas/arles/metadata2.json',
+                'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/panoramas/arles/metadata3.json',
+                'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/panoramas/arles/metadata4.json',
+                'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/panoramas/arles/metadata5.json'];
+
+            const promises = urls.map(url => itowns.Fetcher.json(url, { crossOrigin: 'anonymous' }));
+
+            var activeIndex = 3;
+            Promise.all(promises).then((panoramas) => {
+                const coordinates = new itowns.Coordinates('EPSG:4326', ...panoramas[0]['coordinates']).as('EPSG:4978');
+
+                view = new itowns.PanoramaView(viewerDiv,
+                    coordinates,
+                    panoramas[0]['ratio']);
+
+                let index = 0;
+                const layers = [];
+                for (const pano of panoramas) {
+                    let url = new URL(pano['images'], urls[index]);
+
+                    let _id = url.pathname;
+                    view.addLayer({
+                        visible: index == activeIndex,
+                        url: url.href,
+                        networkOptions: { crossOrigin: 'anonymous' },
+                        type: 'color',
+                        protocol: 'static',
+                        id: _id,
+                        projection: 'EPSG:4326',
+                        updateStrategy: {
+                            options: {},
+                        }
+                    });
+
+                    layers.push(view.getLayers(l => l.id == _id)[0]);
+                    index ++;
+                }
+                view.camera.camera3D.far = 10000;
+                view.notifyChange(true);
+
+                const gui = new dat.GUI();
+                const ddd = new debug.Debug(view, gui);
+                debug.createTileDebugUI(gui, view, view.baseLayer, ddd);
+
+
+                new itowns.FirstPersonControls(view, {
+                    focusOnClick: true,
+                    panoramaRatio: panoramas[0]['ratio'],
+                    moveSpeed: 0,
+                });
+
+                document.addEventListener('contextmenu', (evt) => {
+                    evt.preventDefault();
+                    layers[activeIndex].visible = false;
+                    activeIndex = (activeIndex + 1) % 5;
+                    layers[activeIndex].visible = true;
+                    view.notifyChange(true);
+                });
+            });
+        </script>
+
+    </body>
+</html>

--- a/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
+++ b/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
@@ -1,0 +1,153 @@
+import * as THREE from 'three';
+import OBB from '../../../Renderer/ThreeExtended/OBB';
+import Coordinates, { UNIT } from '../../Geographic/Coordinates';
+
+function PanoramaTileBuilder(ratio) {
+    this.tmp = {
+        coords: new Coordinates('EPSG:4326', 0, 0),
+        position: new THREE.Vector3(),
+        normal: new THREE.Vector3(0, 0, 1),
+    };
+
+    if (!ratio) {
+        throw new Error('ratio must be defined');
+    }
+    if (ratio === 2) {
+        this.equirectangular = true;
+        this.radius = 100;
+    } else {
+        this.equirectangular = false; // cylindrical proj
+        this.height = 200;
+        this.radius = (ratio * this.height) / (2 * Math.PI);
+    }
+}
+
+PanoramaTileBuilder.prototype.constructor = PanoramaTileBuilder;
+
+PanoramaTileBuilder.prototype.Center = function Center(params) {
+    this.Prepare(params);
+
+    this.uProjecte(0.5, params);
+    this.vProjecte(0.5, params);
+
+    params.center = this.VertexPosition(params).clone();
+
+    return params.center;
+};
+
+// prepare params
+// init projected object -> params.projected
+PanoramaTileBuilder.prototype.Prepare = function Prepare(params) {
+    if (this.equirectangular) {
+        params.projected = {
+            theta: 0,
+            phi: 0,
+            radius: this.radius,
+        };
+    } else {
+        params.projected = {
+            theta: 0,
+            radius: this.radius,
+            y: 0,
+        };
+    }
+};
+
+// coord u tile to projected
+PanoramaTileBuilder.prototype.uProjecte = function uProjecte(u, params) {
+    // both (theta, phi) and (y, z) are swapped in setFromSpherical
+    params.projected.theta = THREE.Math.lerp(
+        params.extent.west(UNIT.RADIAN),
+        params.extent.east(UNIT.RADIAN),
+        u);
+};
+
+// coord v tile to projected
+PanoramaTileBuilder.prototype.vProjecte = function vProjecte(v, params) {
+    if (this.equirectangular) {
+        params.projected.phi = Math.PI * 0.5 +
+            THREE.Math.lerp(
+                params.extent.south(UNIT.RADIAN),
+                params.extent.north(UNIT.RADIAN),
+                v);
+    } else {
+        params.projected.y =
+            this.height *
+            THREE.Math.lerp(params.extent.south(), params.extent.north(), v) / 180;
+    }
+};
+
+// get position 3D cartesian
+PanoramaTileBuilder.prototype.VertexPosition = function VertexPosition(params) {
+    if (this.equirectangular) {
+        this.tmp.position.setFromSpherical(params.projected);
+    } else {
+        this.tmp.position.setFromCylindrical(params.projected);
+    }
+    const swap = this.tmp.position.y;
+    this.tmp.position.y = this.tmp.position.z;
+    this.tmp.position.z = this.equirectangular ? -swap : swap;
+
+    return this.tmp.position;
+};
+
+// get normal for last vertex
+PanoramaTileBuilder.prototype.VertexNormal = function VertexNormal() {
+    return this.tmp.position.clone().negate().normalize();
+};
+
+// get oriented bounding box of tile
+PanoramaTileBuilder.prototype.OBB = function _OBB(params) {
+    if (this.equirectangular) {
+        const pts = [];
+        //      0---1---2
+        //      |       |
+        //      7   8   3
+        //      |       |
+        //      6---5---4
+        const uvs = [
+            [0, 0.0], [0.5, 0], [1, 0.0],
+            [1, 0.5], [1, 1.0], [0.5, 1],
+            [0, 1.0], [0, 0.5], [0.5, 0.5]];
+        for (const uv of uvs) {
+            this.uProjecte(uv[0], params);
+            this.vProjecte(uv[1], params);
+            pts.push(this.VertexPosition(params).clone());
+        }
+        return OBB.cardinalsXYZToOBB(pts, params.extent.center().longitude(UNIT.RADIAN), false);
+    } else {
+        // 3 points: corners + center
+        const pts = [];
+        this.uProjecte(0.5, params);
+        this.vProjecte(0.5, params);
+        pts.push(this.VertexPosition(params).clone());
+        this.uProjecte(0, params);
+        this.vProjecte(0, params);
+        pts.push(this.VertexPosition(params).clone());
+        this.uProjecte(1, params);
+        this.vProjecte(1, params);
+        pts.push(this.VertexPosition(params).clone());
+
+        const direction = params.center.clone();
+        direction.z = 0;
+        direction.normalize();
+
+        const diffExtent = new THREE.Vector3().subVectors(pts[2], pts[1]);
+        const height = diffExtent.z;
+        diffExtent.z = 0;
+
+        const length = diffExtent.length();
+
+        const diff = new THREE.Vector3().subVectors(params.center, pts[1]);
+        diff.z = 0;
+        const thickness = diff.dot(direction);
+
+        const min = new THREE.Vector3(-length * 0.5, -height * 0.5, -thickness * 0.5);
+        const max = new THREE.Vector3(length * 0.5, height * 0.5, thickness * 0.5);
+
+        const translate = new THREE.Vector3(0, 0, thickness * -0.5);
+        return new OBB(min, max, direction, translate);
+    }
+};
+
+export default PanoramaTileBuilder;

--- a/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
+++ b/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
@@ -24,17 +24,6 @@ function PanoramaTileBuilder(ratio) {
 
 PanoramaTileBuilder.prototype.constructor = PanoramaTileBuilder;
 
-PanoramaTileBuilder.prototype.Center = function Center(params) {
-    this.Prepare(params);
-
-    this.uProjecte(0.5, params);
-    this.vProjecte(0.5, params);
-
-    params.center = this.VertexPosition(params).clone();
-
-    return params.center;
-};
-
 // prepare params
 // init projected object -> params.projected
 PanoramaTileBuilder.prototype.Prepare = function Prepare(params) {
@@ -51,6 +40,36 @@ PanoramaTileBuilder.prototype.Prepare = function Prepare(params) {
             y: 0,
         };
     }
+};
+
+PanoramaTileBuilder.prototype.Center = function Center(params) {
+    this.Prepare(params);
+
+    this.uProjecte(0.5, params);
+    this.vProjecte(0.5, params);
+
+    params.center = this.VertexPosition(params).clone();
+
+    return params.center;
+};
+
+// get position 3D cartesian
+PanoramaTileBuilder.prototype.VertexPosition = function VertexPosition(params) {
+    if (this.equirectangular) {
+        this.tmp.position.setFromSpherical(params.projected);
+    } else {
+        this.tmp.position.setFromCylindrical(params.projected);
+    }
+    const swap = this.tmp.position.y;
+    this.tmp.position.y = this.tmp.position.z;
+    this.tmp.position.z = this.equirectangular ? -swap : swap;
+
+    return this.tmp.position;
+};
+
+// get normal for last vertex
+PanoramaTileBuilder.prototype.VertexNormal = function VertexNormal() {
+    return this.tmp.position.clone().negate().normalize();
 };
 
 // coord u tile to projected
@@ -75,25 +94,6 @@ PanoramaTileBuilder.prototype.vProjecte = function vProjecte(v, params) {
             this.height *
             THREE.Math.lerp(params.extent.south(), params.extent.north(), v) / 180;
     }
-};
-
-// get position 3D cartesian
-PanoramaTileBuilder.prototype.VertexPosition = function VertexPosition(params) {
-    if (this.equirectangular) {
-        this.tmp.position.setFromSpherical(params.projected);
-    } else {
-        this.tmp.position.setFromCylindrical(params.projected);
-    }
-    const swap = this.tmp.position.y;
-    this.tmp.position.y = this.tmp.position.z;
-    this.tmp.position.z = this.equirectangular ? -swap : swap;
-
-    return this.tmp.position;
-};
-
-// get normal for last vertex
-PanoramaTileBuilder.prototype.VertexNormal = function VertexNormal() {
-    return this.tmp.position.clone().negate().normalize();
 };
 
 // get oriented bounding box of tile

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -1,0 +1,206 @@
+import * as THREE from 'three';
+
+import View from '../View';
+
+import { GeometryLayer } from '../Layer/Layer';
+import Extent from '../Geographic/Extent';
+import { processTiledGeometryNode } from '../../Process/TiledNodeProcessing';
+import { updateLayeredMaterialNodeImagery } from '../../Process/LayeredMaterialNodeProcessing';
+import { panoramaCulling, panoramaSubdivisionControl } from '../../Process/PanoramaTileProcessing';
+import PanoramaTileBuilder from './Panorama/PanoramaTileBuilder';
+import SubdivisionControl from '../../Process/SubdivisionControl';
+
+export function createPanoramaLayer(id, coordinates, ratio, options = {}) {
+    const tileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
+
+    coordinates.xyz(tileLayer.object3d.position);
+    tileLayer.object3d.quaternion.setFromUnitVectors(
+        new THREE.Vector3(0, 0, 1), coordinates.geodesicNormal);
+    tileLayer.object3d.updateMatrixWorld(true);
+
+    // FIXME: add CRS = '0' support
+    tileLayer.extent = new Extent('EPSG:4326', {
+        west: -180,
+        east: 180,
+        north: 90,
+        south: -90,
+    });
+
+    if (ratio == 2) {
+        // equirectangular -> spherical geometry
+        tileLayer.schemeTile = [
+            new Extent('EPSG:4326', {
+                west: -180,
+                east: 0,
+                north: 90,
+                south: -90,
+            }), new Extent('EPSG:4326', {
+                west: 0,
+                east: 180,
+                north: 90,
+                south: -90,
+            })];
+    } else {
+        // cylindrical geometry
+        tileLayer.schemeTile = [
+            new Extent('EPSG:4326', {
+                west: -180,
+                east: -90,
+                north: 90,
+                south: -90,
+            }), new Extent('EPSG:4326', {
+                west: -90,
+                east: 0,
+                north: 90,
+                south: -90,
+            }), new Extent('EPSG:4326', {
+                west: 0,
+                east: 90,
+                north: 90,
+                south: -90,
+            }), new Extent('EPSG:4326', {
+                west: 90,
+                east: 180,
+                north: 90,
+                south: -90,
+            })];
+    }
+    tileLayer.disableSkirt = true;
+
+    // Configure tiles
+    const nodeInitFn = function nodeInitFn(layer, parent, node) {
+        if (layer.noTextureColor) {
+            node.material.uniforms.noTextureColor.value.copy(layer.noTextureColor);
+        }
+        node.material.depthWrite = false;
+
+        if (__DEBUG__) {
+            node.material.uniforms.showOutline = { value: layer.showOutline || false };
+            node.material.wireframe = layer.wireframe || false;
+        }
+    };
+
+    function _commonAncestorLookup(a, b) {
+        if (!a || !b) {
+            return undefined;
+        }
+        if (a.level == b.level) {
+            if (a.id == b.id) {
+                return a;
+            } else if (a.level != 0) {
+                return _commonAncestorLookup(a.parent, b.parent);
+            } else {
+                return undefined;
+            }
+        } else if (a.level < b.level) {
+            return _commonAncestorLookup(a, b.parent);
+        } else {
+            return _commonAncestorLookup(a.parent, b);
+        }
+    }
+
+    tileLayer.preUpdate = (context, layer, changeSources) => {
+        SubdivisionControl.preUpdate(context, layer);
+
+        if (__DEBUG__) {
+            layer._latestUpdateStartingLevel = 0;
+        }
+
+        if (changeSources.has(undefined) || changeSources.size == 0) {
+            return layer.level0Nodes;
+        }
+
+        let commonAncestor;
+        for (const source of changeSources.values()) {
+            if (source.isCamera) {
+                // if the change is caused by a camera move, no need to bother
+                // to find common ancestor: we need to update the whole tree:
+                // some invisible tiles may now be visible
+                return layer.level0Nodes;
+            }
+            if (source.layer === layer.id) {
+                if (!commonAncestor) {
+                    commonAncestor = source;
+                } else {
+                    commonAncestor = _commonAncestorLookup(commonAncestor, source);
+                    if (!commonAncestor) {
+                        return layer.level0Nodes;
+                    }
+                }
+                if (commonAncestor.material == null) {
+                    commonAncestor = undefined;
+                }
+            }
+        }
+        if (commonAncestor) {
+            if (__DEBUG__) {
+                layer._latestUpdateStartingLevel = commonAncestor.level;
+            }
+            return [commonAncestor];
+        } else {
+            return layer.level0Nodes;
+        }
+    };
+
+
+    function subdivision(context, layer, node) {
+        if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
+            return panoramaSubdivisionControl(
+                options.maxSubdivisionLevel || 10, new THREE.Vector2(512, 512 / ratio))(context, layer, node);
+        }
+        return false;
+    }
+
+    tileLayer.update = processTiledGeometryNode(panoramaCulling, subdivision);
+    tileLayer.builder = new PanoramaTileBuilder(ratio);
+    tileLayer.onTileCreated = nodeInitFn;
+    tileLayer.type = 'geometry';
+    tileLayer.protocol = 'tile';
+    tileLayer.visible = true;
+    tileLayer.lighting = {
+        enable: false,
+        position: { x: -0.5, y: 0.0, z: 1.0 },
+    };
+
+    return tileLayer;
+}
+
+function PanoramaView(viewerDiv, coordinates, ratio, options = {}) {
+    THREE.Object3D.DefaultUp.set(0, 0, 1);
+
+    // Setup View
+    View.call(this, coordinates.crs, viewerDiv, options);
+
+    // Configure camera
+    coordinates.xyz(this.camera.camera3D.position);
+    this.camera.camera3D.fov = 45;
+
+    this.camera.camera3D.near = 0.1;
+    this.camera.camera3D.far = 1000;
+    this.camera.camera3D.up = coordinates.geodesicNormal;
+    this.camera.camera3D.quaternion.setFromUnitVectors(
+        new THREE.Vector3(0, 1, 0), coordinates.geodesicNormal);
+    this.camera.camera3D.updateProjectionMatrix();
+    this.camera.camera3D.updateMatrixWorld();
+
+    const tileLayer = createPanoramaLayer('panorama', coordinates, ratio, options);
+    this.scene.add(tileLayer.object3d);
+
+    View.prototype.addLayer.call(this, tileLayer);
+
+    this.baseLayer = tileLayer;
+}
+
+PanoramaView.prototype = Object.create(View.prototype);
+PanoramaView.prototype.constructor = PanoramaView;
+
+PanoramaView.prototype.addLayer = function addLayer(layer) {
+    if (layer.type == 'color') {
+        layer.update = updateLayeredMaterialNodeImagery;
+    } else {
+        throw new Error(`Unsupported layer type ${layer.type} (PanoramaView only support 'color' layers)`);
+    }
+    return View.prototype.addLayer.call(this, layer, this.baseLayer);
+};
+
+export default PanoramaView;

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -184,7 +184,6 @@ function PanoramaView(viewerDiv, coordinates, ratio, options = {}) {
     this.camera.camera3D.updateMatrixWorld();
 
     const tileLayer = createPanoramaLayer('panorama', coordinates, ratio, options);
-    this.scene.add(tileLayer.object3d);
 
     View.prototype.addLayer.call(this, tileLayer);
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -5,6 +5,7 @@ export { STRATEGY_MIN_NETWORK_TRAFFIC, STRATEGY_GROUP, STRATEGY_PROGRESSIVE, STR
 export { default as GlobeView, GLOBE_VIEW_EVENTS, createGlobeLayer } from './Core/Prefab/GlobeView';
 export { default as GpxUtils } from './Core/Scheduler/Providers/GpxUtils';
 export { default as PlanarView, createPlanarLayer } from './Core/Prefab/PlanarView';
+export { default as PanoramaView, createPanoramaLayer } from './Core/Prefab/PanoramaView';
 export { default as Fetcher } from './Core/Scheduler/Providers/Fetcher';
 export { default as View } from './Core/View';
 export { process3dTilesNode, init3dTilesLayer, $3dTilesCulling, $3dTilesSubdivisionControl, pre3dTilesUpdate } from './Process/3dTilesProcessing';

--- a/src/Process/PanoramaTileProcessing.js
+++ b/src/Process/PanoramaTileProcessing.js
@@ -1,0 +1,35 @@
+function frustumCullingOBB(node, camera) {
+    return camera.isBox3Visible(node.OBB().box3D, node.OBB().matrixWorld);
+}
+
+export function panoramaCulling(node, camera) {
+    return !frustumCullingOBB(node, camera);
+}
+
+function _isTileBiggerThanTexture(camera, textureSize, node) {
+    const onScreen = camera.box3SizeOnScreen(
+        node.geometry.OBB.box3D,
+        node.geometry.OBB.matrixWorld);
+    onScreen.min.z = 0;
+    onScreen.max.z = 0;
+
+    // give a small boost to central tiles
+    const boost = 1 + Math.max(0, 1 - onScreen.getCenter().length());
+
+    const dim = {
+        x: 0.5 * (onScreen.max.x - onScreen.min.x) * camera.width,
+        y: 0.5 * (onScreen.max.y - onScreen.min.y) * camera.height,
+    };
+
+    return (boost * dim.x >= textureSize.x && boost * dim.y >= textureSize.y);
+}
+
+export function panoramaSubdivisionControl(maxLevel, textureSize) {
+    return function _panoramaSubdivisionControl(context, layer, node) {
+        if (maxLevel <= node.level) {
+            return false;
+        }
+
+        return _isTileBiggerThanTexture(context.camera, textureSize, node);
+    };
+}


### PR DESCRIPTION
This PR adds all the needed code to display panoramas.
Panoramas can use either:
  - an equirectangular projection: in which case they're drawn using a sphere
  - a cylindrical projection: drawn on a cylinder

The underlying geometry is tiled which allows to display high resolution panoramas,
for instance using the StaticProvider.

The 2nd commit adds an example using the feature.

Note: this PR depends on PRs #556 #555 #554 and #559 
