### PR TITLE
refactor (geometry): simplify TileGeometry code

### DIFF
--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -62,6 +62,7 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
 
     // build tile
     var params = {
+        layerId: command.layer.id,
         extent,
         level: (command.level === undefined) ? (parent.level + 1) : command.level,
         segment: 16,

--- a/src/Core/TileGeometry.js
+++ b/src/Core/TileGeometry.js
@@ -35,24 +35,13 @@ function TileGeometry(params, builder) {
     this.center = builder.Center(params).clone();
     this.OBB = builder.OBB(params);
 
-    // TODO : free array
-
-    var bufferAttribs = this.computeBuffers(params, builder);
+    const bufferAttribs = this.computeBuffers(params, builder);
 
     this.setIndex(bufferAttribs.index);
     this.addAttribute('position', bufferAttribs.position);
     this.addAttribute('normal', bufferAttribs.normal);
     this.addAttribute('uv_wgs84', bufferAttribs.uv.wgs84);
     this.addAttribute('uv_pm', bufferAttribs.uv.pm);
-
-    bufferAttribs.position = null;
-    bufferAttribs.normal = null;
-    bufferAttribs.uv.pm = null;
-
-    // Update cache
-    if (!cache.getRessource(params.segment)) {
-        cache.addRessource(params.segment, bufferAttribs);
-    }
 
     // ---> for SSE
     this.computeBoundingSphere();
@@ -65,42 +54,46 @@ TileGeometry.prototype.constructor = TileGeometry;
 
 TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder) {
     // Create output buffers.
-    var outBuffers = new Buffers();
-    // Create temp buffers
-    var scratchBuffers = new Buffers();
+    const outBuffers = new Buffers();
 
-    var nSeg = params.segment || 32;
+    const nSeg = params.segment || 32;
     // segments count :
     // Tile : (nSeg + 1) * (nSeg + 1)
     // Skirt : 8 * (nSeg - 1)
-    var nVertex = (nSeg + 1) * (nSeg + 1) + (params.disableSkirt ? 0 : 8 * (nSeg - 1)); // correct pour uniquement les vertex
-    var triangles = (nSeg) * (nSeg) * 2 + (params.disableSkirt ? 0 : 16 * (nSeg - 1) * 2); // correct pour uniquement les vertex
+    const nVertex = (nSeg + 1) * (nSeg + 1) + (params.disableSkirt ? 0 : 8 * (nSeg - 1)); // correct pour uniquement les vertex
+    const triangles = (nSeg) * (nSeg) * 2 + (params.disableSkirt ? 0 : 16 * (nSeg - 1) * 2); // correct pour uniquement les vertex
 
-    scratchBuffers.position = new Float32Array(nVertex * 3);
-    scratchBuffers.normal = new Float32Array(nVertex * 3);
-    scratchBuffers.uv.pm = new Float32Array(nVertex);
+    outBuffers.position = new THREE.BufferAttribute(new Float32Array(nVertex * 3), 3);
+    outBuffers.normal = new THREE.BufferAttribute(new Float32Array(nVertex * 3), 3);
+    outBuffers.uv.pm = new THREE.BufferAttribute(new Float32Array(nVertex), 1);
 
-    // Read previously cached values
-    var cachedBuffers = cache.getRessource(params.segment);
+    // Read previously cached values (index and uv.wgs84 only depend on the # of triangles)
+    const cacheKey = params.layerId + triangles;
+    const cachedBuffers = cache.getRessource(cacheKey);
+    const mustBuildIndexAndWGS84 = !cachedBuffers;
     if (cachedBuffers) {
         outBuffers.index = cachedBuffers.index;
-        outBuffers.uv.wgs84 = cachedBuffers.uv.wgs84;
+        outBuffers.uv.wgs84 = cachedBuffers.uvwgs84;
     } else {
-        scratchBuffers.index = new Uint32Array(triangles * 3);
-        scratchBuffers.uv.wgs84 = new Float32Array(nVertex * 2);
+        outBuffers.index = new THREE.BufferAttribute(
+            new Uint32Array(triangles * 3), 1);
+        outBuffers.uv.wgs84 = new THREE.BufferAttribute(
+            new Float32Array(nVertex * 2), 2);
+
+        // Update cache
+        cache.addRessource(cacheKey, {
+            index: outBuffers.index,
+            uvwgs84: outBuffers.uv.wgs84,
+        });
     }
 
     var widthSegments = Math.max(2, Math.floor(nSeg) || 2);
     var heightSegments = Math.max(2, Math.floor(nSeg) || 2);
 
     var idVertex = 0;
-    let x;
-    let y;
     const vertices = [];
     let skirt = [];
     const skirtEnd = [];
-    let u;
-    let v;
 
     builder.Prepare(params);
 
@@ -108,54 +101,48 @@ TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder)
     var UV_PM = function UV_PM() {};
 
     // Define UV computation functions if needed
-    if (outBuffers.uv.wgs84 === null) {
+    if (mustBuildIndexAndWGS84) {
         UV_WGS84 = function UV_WGS84(out, id, u, v) {
-            out.uv.wgs84[id * 2 + 0] = u;
-            out.uv.wgs84[id * 2 + 1] = v;
+            out.uv.wgs84.array[id * 2 + 0] = u;
+            out.uv.wgs84.array[id * 2 + 1] = v;
         };
     }
-    if (outBuffers.uv.pm === null && builder.getUV_PM) {
+    if (builder.getUV_PM) {
         UV_PM = function UV_PM(out, id, u) {
-            out.uv.pm[id] = u;
+            out.uv.pm.array[id] = u;
         };
     }
 
-    let id_m3;
-    let v1;
-    let v2;
-    let v3;
-    let v4;
-
-    for (y = 0; y <= heightSegments; y++) {
+    for (let y = 0; y <= heightSegments; y++) {
         var verticesRow = [];
 
-        v = y / heightSegments;
+        const v = y / heightSegments;
 
         builder.vProjecte(v, params);
 
         var uv_pm = builder.getUV_PM ? builder.getUV_PM(params) : undefined;
 
-        for (x = 0; x <= widthSegments; x++) {
-            u = x / widthSegments;
+        for (let x = 0; x <= widthSegments; x++) {
+            const u = x / widthSegments;
 
             builder.uProjecte(u, params);
 
             var vertex = builder.VertexPosition(params, params.projected);
 
-            id_m3 = idVertex * 3;
+            const id_m3 = idVertex * 3;
 
-            scratchBuffers.position[id_m3 + 0] = vertex.x - this.center.x;
-            scratchBuffers.position[id_m3 + 1] = vertex.y - this.center.y;
-            scratchBuffers.position[id_m3 + 2] = vertex.z - this.center.z;
+            outBuffers.position.array[id_m3 + 0] = vertex.x - this.center.x;
+            outBuffers.position.array[id_m3 + 1] = vertex.y - this.center.y;
+            outBuffers.position.array[id_m3 + 2] = vertex.z - this.center.z;
 
             var normal = builder.VertexNormal(params);
 
-            scratchBuffers.normal[id_m3 + 0] = normal.x;
-            scratchBuffers.normal[id_m3 + 1] = normal.y;
-            scratchBuffers.normal[id_m3 + 2] = normal.z;
+            outBuffers.normal.array[id_m3 + 0] = normal.x;
+            outBuffers.normal.array[id_m3 + 1] = normal.y;
+            outBuffers.normal.array[id_m3 + 2] = normal.z;
 
-            UV_WGS84(scratchBuffers, idVertex, u, v);
-            UV_PM(scratchBuffers, idVertex, uv_pm);
+            UV_WGS84(outBuffers, idVertex, u, v);
+            UV_PM(outBuffers, idVertex, uv_pm);
 
             if (!params.disableSkirt) {
                 if (y !== 0 && y !== heightSegments) {
@@ -180,30 +167,27 @@ TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder)
             skirt = skirt.concat(verticesRow.slice().reverse());
         }
     }
-    // We compute the actual size of tile segment to use later for the skirt.
-    const segmentSize = new THREE.Vector3().fromArray(scratchBuffers.position).distanceTo(
-        new THREE.Vector3().fromArray(scratchBuffers.position, 3));
 
     if (!params.disableSkirt) {
         skirt = skirt.concat(skirtEnd.reverse());
     }
 
     function bufferize(va, vb, vc, idVertex) {
-        scratchBuffers.index[idVertex + 0] = va;
-        scratchBuffers.index[idVertex + 1] = vb;
-        scratchBuffers.index[idVertex + 2] = vc;
+        outBuffers.index.array[idVertex + 0] = va;
+        outBuffers.index.array[idVertex + 1] = vb;
+        outBuffers.index.array[idVertex + 2] = vc;
         return idVertex + 3;
     }
 
-    var idVertex2 = 0;
+    let idVertex2 = 0;
 
-    if (outBuffers.index === null) {
-        for (y = 0; y < heightSegments; y++) {
-            for (x = 0; x < widthSegments; x++) {
-                v1 = vertices[y][x + 1];
-                v2 = vertices[y][x];
-                v3 = vertices[y + 1][x];
-                v4 = vertices[y + 1][x + 1];
+    if (mustBuildIndexAndWGS84) {
+        for (let y = 0; y < heightSegments; y++) {
+            for (let x = 0; x < widthSegments; x++) {
+                const v1 = vertices[y][x + 1];
+                const v2 = vertices[y][x];
+                const v3 = vertices[y + 1][x];
+                const v4 = vertices[y + 1][x + 1];
 
                 idVertex2 = bufferize(v4, v2, v1, idVertex2);
                 idVertex2 = bufferize(v4, v3, v2, idVertex2);
@@ -211,18 +195,20 @@ TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder)
         }
     }
 
-    var iStart = idVertex;
+    const iStart = idVertex;
 
     // TODO: WARNING beware skirt's size influences performance
     // The size of the skirt is now a ratio of the size of the tile.
     // To be perfect it should depend on the real elevation delta but too heavy to compute
     if (!params.disableSkirt) {
-        const r = segmentSize; // Tile size divided by the number of segments
+        // We compute the actual size of tile segment to use later for the skirt.
+        const segmentSize = new THREE.Vector3().fromArray(outBuffers.position.array).distanceTo(
+            new THREE.Vector3().fromArray(outBuffers.position.array, 3));
 
         var buildIndexSkirt = function buildIndexSkirt() {};
         var buildUVSkirt = function buildUVSkirt() {};
 
-        if (outBuffers.index === null) {
+        if (mustBuildIndexAndWGS84) {
             buildIndexSkirt = function buildIndexSkirt(id, v1, v2, v3, v4) {
                 id = bufferize(v1, v2, v3, id);
                 id = bufferize(v1, v3, v4, id);
@@ -230,62 +216,43 @@ TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder)
             };
 
             buildUVSkirt = function buildUVSkirt(id) {
-                scratchBuffers.uv.wgs84[idVertex * 2 + 0] = scratchBuffers.uv.wgs84[id * 2 + 0];
-                scratchBuffers.uv.wgs84[idVertex * 2 + 1] = scratchBuffers.uv.wgs84[id * 2 + 1];
+                outBuffers.uv.wgs84.array[idVertex * 2 + 0] = outBuffers.uv.wgs84.array[id * 2 + 0];
+                outBuffers.uv.wgs84.array[idVertex * 2 + 1] = outBuffers.uv.wgs84.array[id * 2 + 1];
             };
         }
 
-        for (var i = 0; i < skirt.length; i++) {
-            var id = skirt[i];
-            id_m3 = idVertex * 3;
-            var id2_m3 = id * 3;
+        for (let i = 0; i < skirt.length; i++) {
+            const id = skirt[i];
+            const id_m3 = idVertex * 3;
+            const id2_m3 = id * 3;
 
-            scratchBuffers.position[id_m3 + 0] = scratchBuffers.position[id2_m3 + 0] - scratchBuffers.normal[id2_m3 + 0] * r;
-            scratchBuffers.position[id_m3 + 1] = scratchBuffers.position[id2_m3 + 1] - scratchBuffers.normal[id2_m3 + 1] * r;
-            scratchBuffers.position[id_m3 + 2] = scratchBuffers.position[id2_m3 + 2] - scratchBuffers.normal[id2_m3 + 2] * r;
+            outBuffers.position.array[id_m3 + 0] = outBuffers.position.array[id2_m3 + 0]
+                - outBuffers.normal.array[id2_m3 + 0] * segmentSize;
+            outBuffers.position.array[id_m3 + 1] = outBuffers.position.array[id2_m3 + 1]
+                - outBuffers.normal.array[id2_m3 + 1] * segmentSize;
+            outBuffers.position.array[id_m3 + 2] = outBuffers.position.array[id2_m3 + 2]
+                - outBuffers.normal.array[id2_m3 + 2] * segmentSize;
 
-            scratchBuffers.normal[id_m3 + 0] = scratchBuffers.normal[id2_m3 + 0];
-            scratchBuffers.normal[id_m3 + 1] = scratchBuffers.normal[id2_m3 + 1];
-            scratchBuffers.normal[id_m3 + 2] = scratchBuffers.normal[id2_m3 + 2];
+            outBuffers.normal.array[id_m3 + 0] = outBuffers.normal.array[id2_m3 + 0];
+            outBuffers.normal.array[id_m3 + 1] = outBuffers.normal.array[id2_m3 + 1];
+            outBuffers.normal.array[id_m3 + 2] = outBuffers.normal.array[id2_m3 + 2];
 
             buildUVSkirt(id);
 
-            scratchBuffers.uv.pm[idVertex] = scratchBuffers.uv.pm[id];
+            outBuffers.uv.pm.array[idVertex] = outBuffers.uv.pm.array[id];
 
-            var idf = (i + 1) % skirt.length;
+            const idf = (i + 1) % skirt.length;
 
-            v1 = id;
-            v2 = idVertex;
-            v3 = idVertex + 1;
-            v4 = skirt[idf];
-
-            if (idf === 0) {
-                v3 = iStart;
-            }
+            const v1 = id;
+            const v2 = idVertex;
+            const v3 = (idf === 0) ? iStart : idVertex + 1;
+            const v4 = skirt[idf];
 
             idVertex2 = buildIndexSkirt(idVertex2, v1, v2, v3, v4);
 
             idVertex++;
         }
     }
-
-    // Copy missing buffer in outBuffers from scratchBuffers
-    // TODO : free array
-    if (outBuffers.index === null) {
-        outBuffers.index = new THREE.BufferAttribute(scratchBuffers.index, 1);
-    }
-    outBuffers.position = new THREE.BufferAttribute(scratchBuffers.position, 3);
-    outBuffers.normal = new THREE.BufferAttribute(scratchBuffers.normal, 3);
-    if (outBuffers.uv.wgs84 === null) {
-        outBuffers.uv.wgs84 = new THREE.BufferAttribute(scratchBuffers.uv.wgs84, 2);
-    }
-    outBuffers.uv.pm = new THREE.BufferAttribute(scratchBuffers.uv.pm, 1);
-
-    scratchBuffers.position = null;
-    scratchBuffers.bufferIndex = null;
-    scratchBuffers.normal = null;
-    scratchBuffers.uv.wgs84 = null;
-    scratchBuffers.uv.pm = null;
 
     return outBuffers;
 };


### PR DESCRIPTION
This commit simplifies the code of TileGeometry and fixes a cache
bug: the invariant used as cache key (nsegments) failed when mixing
geometries with/without skirt.
