### PR TITLE
Add unit test test for scheduler

### DIFF
--- a/src/Core/System/Capabilities.js
+++ b/src/Core/System/Capabilities.js
@@ -1,13 +1,13 @@
 // default values
 let logDepthBufferSupported = false;
 let maxTexturesUnits = 8;
-const internetExplorer = false || !!document.documentMode;
 
 export default {
     isLogDepthBufferSupported() {
         return logDepthBufferSupported;
     },
     isInternetExplorer() {
+        const internetExplorer = false || !!document.documentMode;
         return internetExplorer;
     },
     getMaxTextureUnitsCount() {

--- a/src/Renderer/ThreeExtended/B3dmLoader.js
+++ b/src/Renderer/ThreeExtended/B3dmLoader.js
@@ -33,7 +33,7 @@ function filterUnsupportedSemantics(obj) {
     }
 }
 // parse for RTC values
-function applyOptionalCesiumRTC(data, gltf) {
+function applyOptionalCesiumRTC(data, gltf, textDecoder) {
     const headerView = new DataView(data, 0, 20);
     const contentArray = new Uint8Array(data, 20, headerView.getUint32(12, true));
     const content = textDecoder.decode(new Uint8Array(contentArray));
@@ -44,8 +44,7 @@ function applyOptionalCesiumRTC(data, gltf) {
     }
 }
 
-const textDecoder = new TextDecoder('utf-8');
-B3dmLoader.prototype.parse = function parse(buffer, gltfUpAxis) {
+B3dmLoader.prototype.parse = function parse(buffer, gltfUpAxis, textDecoder) {
     if (!buffer) {
         throw new Error('No array buffer provided.');
     }
@@ -80,7 +79,9 @@ B3dmLoader.prototype.parse = function parse(buffer, gltfUpAxis) {
 
         if (b3dmHeader.BTJSONLength > 0) {
             const sizeBegin = 28 + b3dmHeader.FTJSONLength + b3dmHeader.FTBinaryLength;
-            batchTable = BatchTable.parse(buffer.slice(sizeBegin, b3dmHeader.BTJSONLength + sizeBegin));
+            batchTable = BatchTable.parse(
+                buffer.slice(sizeBegin, b3dmHeader.BTJSONLength + sizeBegin),
+                textDecoder);
         }
         // TODO: missing feature and batch table
         return new Promise((resolve/* , reject */) => {
@@ -98,7 +99,7 @@ B3dmLoader.prototype.parse = function parse(buffer, gltfUpAxis) {
                 // RTC managed
                 applyOptionalCesiumRTC(buffer.slice(28 + b3dmHeader.FTJSONLength +
                     b3dmHeader.FTBinaryLength + b3dmHeader.BTJSONLength +
-                    b3dmHeader.BTBinaryLength), gltf.scene);
+                    b3dmHeader.BTBinaryLength), gltf.scene, textDecoder);
 
                 const b3dm = { gltf, batchTable };
                 resolve(b3dm);

--- a/src/Renderer/ThreeExtended/BatchTable.js
+++ b/src/Renderer/ThreeExtended/BatchTable.js
@@ -1,7 +1,5 @@
-const textDecoder = new TextDecoder('utf-8');
-
 export default {
-    parse(buffer) {
+    parse(buffer, textDecoder) {
         const content = textDecoder.decode(new Uint8Array(buffer));
         const json = JSON.parse(content);
         return json;

--- a/src/Renderer/ThreeExtended/PntsLoader.js
+++ b/src/Renderer/ThreeExtended/PntsLoader.js
@@ -1,9 +1,8 @@
 import * as THREE from 'three';
 import BT from './BatchTable';
 
-const textDecoder = new TextDecoder('utf-8');
 export default {
-    parse: function parse(buffer) {
+    parse: function parse(buffer, textDecoder) {
         if (!buffer) {
             throw new Error('No array buffer provided.');
         }
@@ -40,13 +39,15 @@ export default {
 
             // binary table
             if (pntsHeader.FTBinaryLength > 0) {
-                point = parseFeatureBinary(buffer, byteOffset, pntsHeader.FTJSONLength);
+                point = parseFeatureBinary(buffer, byteOffset, pntsHeader.FTJSONLength, textDecoder);
             }
 
             // batch table
             if (pntsHeader.BTJSONLength > 0) {
                 const sizeBegin = 28 + pntsHeader.FTJSONLength + pntsHeader.FTBinaryLength;
-                batchTable = BT.parseBatchTableJSON(buffer.slice(sizeBegin, pntsHeader.BTJSONLength + sizeBegin));
+                batchTable = BT.parse(
+                    buffer.slice(sizeBegin, pntsHeader.BTJSONLength + sizeBegin),
+                    textDecoder);
             }
 
             const pnts = { point, batchTable };
@@ -57,7 +58,7 @@ export default {
     },
 };
 
-function parseFeatureBinary(array, byteOffset, FTJSONLength) {
+function parseFeatureBinary(array, byteOffset, FTJSONLength, textDecoder) {
     // Init geometry
     const geometry = new THREE.BufferGeometry();
     const material = new THREE.PointsMaterial({ size: 0.05, vertexColors: THREE.VertexColors, sizeAttenuation: true });

--- a/test/scheduler_unit_test.js
+++ b/test/scheduler_unit_test.js
@@ -1,0 +1,59 @@
+/* global describe, it */
+import assert from 'assert';
+import Scheduler from '../src/Core/Scheduler/Scheduler';
+
+const scheduler = new Scheduler();
+global.window = {
+    addEventListener() {},
+    setTimeout,
+};
+
+scheduler.addProtocolProvider('test', {
+    executeCommand: (cmd) => {
+        setTimeout(() => {
+            cmd.done = true;
+            cmd._r(cmd);
+        }, 0);
+        return new Promise((resolve) => {
+            cmd._r = resolve;
+        });
+    },
+});
+
+const view = {
+    notifyChange: () => {},
+};
+
+function cmd(layerId = 'foo', prio = 0) {
+    return {
+        layer: {
+            id: layerId,
+            protocol: 'test',
+        },
+        view,
+        priority: prio,
+    };
+}
+
+describe('Command execution', function () {
+    it('should execute one command', function (done) {
+        scheduler.execute(cmd()).then((c) => {
+            assert.ok(c.done);
+            done();
+        });
+    });
+
+    it('should execute 100 commands', function (done) {
+        const promises = [];
+        for (let i = 0; i < 100; i++) {
+            promises.push(scheduler.execute(cmd()));
+        }
+
+        Promise.all(promises).then((commands) => {
+            for (const cmd of commands) {
+                assert.ok(cmd.done);
+            }
+            done();
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a simple unit test for scheduler.

Some 3dtiles code have been slightly modified to allow to instanciate a `Scheduler` without the need to polyfill `TextDecoder`.

This is some preparatory work for a later PR that would improve commands priority handling.