### PR TITLE
fix: use babel-polyfill and url-polyfill to support IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,7 +226,7 @@
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
-        "babel-polyfill": "6.23.0",
+        "babel-polyfill": "6.26.0",
         "babel-register": "6.24.1",
         "babel-runtime": "6.23.0",
         "chokidar": "1.7.0",
@@ -983,14 +983,36 @@
       }
     },
     "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "dev": true,
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.11.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+              "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+            }
+          }
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+        }
       }
     },
     "babel-preset-es2015": {
@@ -2055,11 +2077,6 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
-    },
-    "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
     },
     "es6-set": {
       "version": "0.1.5",
@@ -5657,6 +5674,11 @@
           "dev": true
         }
       }
+    },
+    "url-polyfill": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.0.8.tgz",
+      "integrity": "sha1-/v3hlqjqbAy1+j/1YEhCrPHD8sY="
     },
     "user-home": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,15 @@
   },
   "homepage": "https://itowns.github.io/",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.20.0",
     "earcut": "^2.1.1",
-    "es6-promise": "^4.0.5",
     "js-priority-queue": "^0.1.5",
     "jszip": "^3.1.3",
     "monotone-convex-hull-2d": "^1.0.1",
     "text-encoding-utf-8": "^1.0.1",
     "togeojson": "^0.16.0",
+    "url-polyfill": "^1.0.8",
     "whatwg-fetch": "^2.0.2"
   },
   "peerDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ var providePlugin = new webpack.ProvidePlugin({
 
 module.exports = {
     entry: {
-        itowns: ['es6-promise', 'whatwg-fetch', path.resolve(__dirname, 'src/MainBundle.js')],
+        itowns: ['babel-polyfill', 'url-polyfill', 'whatwg-fetch', path.resolve(__dirname, 'src/MainBundle.js')],
         debug: [path.resolve(__dirname, 'utils/debug/Main.js')],
     },
     devtool: 'source-map',


### PR DESCRIPTION
This change increases itowns.js bundle size by ~100KB.

Fixes #510 