### PR TITLE
fix (core): don't update non ready layers

### DIFF
--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -40,7 +40,9 @@ function updateElements(context, geometryLayer, elements) {
 
         // update attached layers
         for (const attachedLayer of geometryLayer._attachedLayers) {
-            attachedLayer.update(context, attachedLayer, element);
+            if (attachedLayer.ready) {
+                attachedLayer.update(context, attachedLayer, element);
+            }
         }
         updateElements(context, geometryLayer, newElementsToUpdate);
     }
@@ -67,7 +69,7 @@ MainLoop.prototype._update = function _update(view, updateSources, dt) {
 
     for (const geometryLayer of view.getLayers((x, y) => !y)) {
         context.geometryLayer = geometryLayer;
-        if (geometryLayer.ready) {
+        if (geometryLayer.ready && geometryLayer.visible) {
             // `preUpdate` returns an array of elements to update
             const elementsToUpdate = geometryLayer.preUpdate(context, geometryLayer, updateSources);
             // `update` is called in `updateElements`.

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -137,7 +137,7 @@ export default {
         }
     },
     tileInsideLimit(tile, layer) {
-        return layer.ready && tile.level >= layer.options.zoom.min && tile.level <= layer.options.zoom.max && layer.extent.intersectsExtent(tile.extent);
+        return tile.level >= layer.options.zoom.min && tile.level <= layer.options.zoom.max && layer.extent.intersectsExtent(tile.extent);
     },
     executeCommand(command) {
         const layer = command.layer;

--- a/src/Process/SubdivisionControl.js
+++ b/src/Process/SubdivisionControl.js
@@ -10,7 +10,7 @@ export default {
         // Prevent subdivision if node is covered by at least one elevation layer
         // and if node doesn't have a elevation texture yet.
         for (const e of context.elevationLayers) {
-            if (!e.frozen && e.tileInsideLimit(node, e) && !node.isElevationLayerLoaded()) {
+            if (!e.frozen && e.ready && e.tileInsideLimit(node, e) && !node.isElevationLayerLoaded()) {
                 // no stop subdivision in the case of a loading error
                 if (node.layerUpdateState[e.id] && node.layerUpdateState[e.id].inError()) {
                     continue;
@@ -21,7 +21,7 @@ export default {
 
         // Prevent subdivision if missing color texture
         for (const c of context.colorLayers) {
-            if (c.frozen || !c.visible) {
+            if (c.frozen || !c.visible || !c.ready) {
                 continue;
             }
             // no stop subdivision in the case of a loading error


### PR DESCRIPTION
We already do this for GeometryLayer and it's needed for other layers as well.

Fixes #567
