### PR TITLE
fix(core): Don't try to add scene to itself

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -309,7 +309,7 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         this._layers.push(layer);
     }
 
-    if (layer.object3d && !layer.object3d.parent) {
+    if (layer.object3d && !layer.object3d.parent && layer.object3d !== this.scene) {
         this.scene.add(layer.object3d);
     }
 


### PR DESCRIPTION
## Description

User can use the scene as layer.object3d. In this case, we shouldn't try
to add it to itself 

## Motivation and context

This fixes `THREE.Object3D.add: object can't be added as a child of itself. ` errors when layer.object3d is the scene object.


