### PR TITLE
feat(wfs): add a function to filter feature

### DIFF
--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -78,6 +78,10 @@ function extrudeBuildings(properties) {
     return properties.hauteur;
 }
 
+function acceptFeature(properties) {
+    return !!properties.hauteur;
+}
+
 globeView.addLayer({
     type: 'geometry',
     update: itowns.FeatureProcessing.update,
@@ -85,6 +89,7 @@ globeView.addLayer({
         color: colorBuildings,
         altitude: altitudeBuildings,
         extrude: extrudeBuildings }),
+    filter: acceptFeature,
     url: 'http://wxs.ign.fr/72hpsel8j8nhb5qgdh07gcyp/geoportail/wfs?',
     networkOptions: { crossOrigin: 'anonymous' },
     protocol: 'wfs',

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -101,7 +101,7 @@ WFS_Provider.prototype.getFeatures = function getFeatures(crs, tile, layer) {
 
     layer.convert = layer.convert ? layer.convert : Feature2Mesh.convert({});
 
-    return Fetcher.json(url, layer.networkOptions).then(geojson => assignLayer(layer.convert(GeoJSON2Features.parse(crs, geojson, tile.extent)), layer));
+    return Fetcher.json(url, layer.networkOptions).then(geojson => assignLayer(layer.convert(GeoJSON2Features.parse(crs, geojson, tile.extent, { filter: layer.filter })), layer));
 };
 
 WFS_Provider.prototype.getPointOrder = function getPointOrder(crs) {

--- a/src/Renderer/ThreeExtended/GeoJSON2Features.js
+++ b/src/Renderer/ThreeExtended/GeoJSON2Features.js
@@ -155,6 +155,9 @@ function readGeometry(crsIn, crsOut, json, filteringExtent, options) {
 }
 
 function readFeature(crsIn, crsOut, json, filteringExtent, options) {
+    if (options.filter && !options.filter(json.properties)) {
+        return;
+    }
     const feature = {};
     feature.geometry = readGeometry(crsIn, crsOut, json.geometry, filteringExtent, options);
 


### PR DESCRIPTION
## Description
feat(wfs): add a function to filter feature

## Motivation and Context
The goal of this PR is to filter the features to show, using properties.
In the example 'globe wfs extruded', we can see how it is used to clean bad data.
