### PR TITLE
pointcloud object3d fix

### DIFF
--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -18,7 +18,7 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
         '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 ' +
         '+y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
-    debugGui = new dat.GUI();
+    debugGui = new dat.GUI({ width: 400 });
 
     // TODO: do we really need to disable logarithmicDepthBuffer ?
     view = new itowns.View('EPSG:3946', viewerDiv, { renderer: { logarithmicDepthBuffer: true } });

--- a/src/Core/Scheduler/Providers/PointCloudProvider.js
+++ b/src/Core/Scheduler/Providers/PointCloudProvider.js
@@ -226,7 +226,6 @@ export default {
             points.material.transparent = layer.opacity < 1.0;
             points.material.uniforms.opacity.value = layer.opacity;
             points.updateMatrix();
-            points.updateMatrixWorld(true);
             points.layers.set(layer.threejsLayer);
             points.layer = layer.id;
             return points;

--- a/src/Core/Scheduler/Providers/PointCloudProvider.js
+++ b/src/Core/Scheduler/Providers/PointCloudProvider.js
@@ -135,6 +135,18 @@ export default {
         if (!layer.file) {
             layer.file = 'cloud.js';
         }
+        if (!layer.group) {
+            layer.group = new THREE.Group();
+            layer.object3d.add(layer.group);
+            layer.group.updateMatrixWorld();
+        }
+
+        if (!layer.bboxes) {
+            layer.bboxes = new THREE.Group();
+            layer.object3d.add(layer.bboxes);
+            layer.bboxes.updateMatrixWorld();
+        }
+
         // default options
         layer.fetchOptions = layer.fetchOptions || {};
         layer.octreeDepthLimit = layer.octreeDepthLimit || -1;

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -103,6 +103,7 @@ function initBoundingBox(elt, layer) {
     elt.obj.boxHelper.material.linewidth = 2;
     elt.obj.boxHelper.layers.mask = layer.bboxes.layers.mask;
     layer.bboxes.add(elt.obj.boxHelper);
+    elt.obj.boxHelper.updateMatrixWorld();
 }
 
 function shouldDisplayNode(context, layer, elt) {
@@ -116,14 +117,14 @@ function shouldDisplayNode(context, layer, elt) {
 
     const cl = (elt.tightbbox ? elt.tightbbox : elt.bbox);
 
-    const visible = context.camera.isBox3Visible(cl);
+    const visible = context.camera.isBox3Visible(cl, layer.object3d.matrixWorld);
     const surfaceOnScreen = 0;
 
     if (visible) {
         if (cl.containsPoint(context.camera.camera3D.position)) {
             shouldBeLoaded = 1;
         } else {
-            const surfaceOnScreen = box3SurfaceOnScreen(context.camera, cl);
+            const surfaceOnScreen = box3SurfaceOnScreen(context.camera, cl, layer.object3d.matrixWorld);
 
             // no point indicates shallow hierarchy, so we definitely want to load its children
             if (numPoints == 0) {
@@ -176,13 +177,12 @@ export default {
 
         if (!layer.group) {
             layer.group = new THREE.Group();
-            context.view.scene.add(layer.group);
+            layer.object3d.add(layer.group);
         }
 
         if (!layer.bboxes) {
             layer.bboxes = new THREE.Group();
-            layer.bboxes.layers.set(context.view.mainLoop.gfxEngine.getUniqueThreejsLayer());
-            context.view.scene.add(layer.bboxes);
+            layer.object3d.add(layer.bboxes);
         }
 
         // Start updating from hierarchy root
@@ -204,8 +204,7 @@ export default {
                     if (__DEBUG__) {
                         elt.obj.material.uniforms.density.value = elt.density;
 
-                        const boundingBoxEnabled = context.view.camera.camera3D.layers.mask & layer.bboxes.layers.mask;
-                        if (boundingBoxEnabled) {
+                        if (layer.bboxes.visible) {
                             if (!elt.obj.boxHelper) {
                                 initBoundingBox(elt, layer);
                             }
@@ -246,6 +245,7 @@ export default {
                         // make sure to add it here, otherwise it might never
                         // be added nor cleaned
                         layer.group.add(elt.obj);
+                        elt.obj.updateMatrixWorld(true);
 
                         elt.obj.owner = elt;
                         elt.promise = null;

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -175,16 +175,6 @@ export default {
             return [];
         }
 
-        if (!layer.group) {
-            layer.group = new THREE.Group();
-            layer.object3d.add(layer.group);
-        }
-
-        if (!layer.bboxes) {
-            layer.bboxes = new THREE.Group();
-            layer.object3d.add(layer.bboxes);
-        }
-
         // Start updating from hierarchy root
         return [layer.root];
     },

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -39,6 +39,10 @@ export default {
             .onChange(() => view.notifyChange(true));
         layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count')
             .onChange(() => view.notifyChange(true));
+        layer.debugUI.add(layer.object3d.position, 'z', -50, 50).name('Z translation').onChange(() => {
+            layer.object3d.updateMatrixWorld();
+            view.notifyChange(true);
+        });
         const surf = layer.debugUI.addFolder('Surface Method params');
         surf.add(layer, 'pointSize', 0, 15).name('Point Size')
             .onChange(() => view.notifyChange(true));
@@ -102,13 +106,8 @@ export default {
                     }
                 }
                 layer._currentDbgNode = [];
-                const context = args[0];
                 if (layer.bboxes) {
-                    if (layer.dbgDisplaybbox) {
-                        context.view.camera.camera3D.layers.mask |= layer.bboxes.layers.mask;
-                    } else {
-                        context.view.camera.camera3D.layers.mask &= ~layer.bboxes.layers.mask;
-                    }
+                    layer.bboxes.visible = layer.dbgDisplaybbox;
                 }
                 return oldPreUpdate(...args);
             };


### PR DESCRIPTION
## Description

Really honour layer.object3d when using pointclouds.

## Motivation and Context

One of the interesting things in using a custom object3d is to have it translated/rotationed/shown or hidden. But this isn't really working with the current code because some part of it ignored this local object3d transforms.
