### PR TITLE
Browserstack testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ node_js:
 after_success:
   - openssl aes-256-cbc -K $encrypted_822645c864aa_key -iv $encrypted_822645c864aa_iv -in deploy_key.enc -out deploy_key -d
   - bash autodeploy.sh
+
+addons:
+  browserstack:
+    username: "itowns1"
+    access_key:
+      secure: "Z+GaQk+4Zf+lV3FC82OX4Ph+l+qUrv5//iO6JOACcD4gBMJEVJNliIN5BEiPwXITSmVIXh03opJVp9+o2GtYGy0WKPqY+XD4Ql1y7pJ1Hw4EOT5LiVzkTo82eGYRKNDe1gc769Z1CQdTjdcJ2Q7BYWY+4Ul0ke7W4icO+vNU7R+nKUwBVRL0stYdNQxsyx/5PG5itJhx8oiTveuiQxeQAPOwzvV0COefN37fu6xLBMCA4YlP/OATcKgdZ8AoLTOiVyv4BxHc+Kn5DJWZtVowN3q5Galp5lDkdeIdgnLPIRYzlC6N1MVWO9w77XMh0aLTr+aapg+FVs/QJVFroca2xYHw084lJ2qV4oT5CSKZUZfquiZgORpULQB9T6izrJgPAlRdkTBIOt9kX1QGubOsBHAEsqG6PthQrfS5Kz091Kn89N0yJfa+KMiN9TMSZ8cOGfXNnJmq4VHAIOU//QyQGNkrqtd8Yj6q4nzA1ttBUD+8/FNjExOLjCuQp9/T3QtOtsXYt2hnjdjLvIxqOstamPWixhZ/7ea/waq7P/8tGVLonwy3vhIRPYUs20SRFc4rVXoQ2vpyGW5PiPSXW1UKRxVG2DOYHP+TInFSXXXdYfwf4aBY1hopv6kO8NdawaByFOZIhvFOR4jIT7+1rL0VNlxup7n5JwTYRyJtNjlL6TQ="

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: false
+git:
+  depth: 3
+
 language: node_js
 node_js:
   - "lts/*"

--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -85,10 +85,10 @@
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
 
-            var globe = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            var menuGlobe = new GuiTools('menuDiv', globe, 300);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv', view, 300);
 
-            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return globe.addLayer(result) });
+            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return view.addLayer(result) });
 
             // function use :
             // For preupdate Layer geomtry :
@@ -110,7 +110,7 @@
             $3dTilesLayerDiscreteLOD.type = 'geometry';
             $3dTilesLayerDiscreteLOD.visible = true;
 
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerDiscreteLOD);
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayerDiscreteLOD);
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
@@ -131,13 +131,13 @@
             $3dTilesLayerRequestVolume.visible = true;
             $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
 
             // Add the UI Debug
-            var d = new debug.Debug(globe, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globe, globe.wgs84TileLayer, d);
-            debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerDiscreteLOD, d);
-            debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerRequestVolume, d);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.wgs84TileLayer, d);
+            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD, d);
+            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume, d);
 
 
 
@@ -159,7 +159,7 @@
                 var htmlInfo = document.getElementById('info');
                 htmlInfo.innerHTML = ' ';
 
-                raycaster.setFromCamera(mouse, globe.camera.camera3D);
+                raycaster.setFromCamera(mouse, view.camera.camera3D);
                 // calculate objects intersecting the picking ray
                 var intersects = raycaster.intersectObjects($3dTilesLayerRequestVolume.object3d.children, true);
                 for (var i = 0; i < intersects.length; i++) {

--- a/examples/externalscene.js
+++ b/examples/externalscene.js
@@ -5,17 +5,17 @@ var scene = new THREE.Scene();
 
 // iTowns namespace defined here
 var viewerDiv = document.getElementById('viewerDiv');
-var globeView = new itowns.GlobeView(
+var view = new itowns.GlobeView(
         viewerDiv, positionOnGlobe, { scene3D: scene, renderer: renderer });
 
-globeView.mainLoop.name = 'external-ML';
+view.mainLoop.name = 'external-ML';
 
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 
 itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
 itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
 
-exports.globeView = globeView;
+exports.view = view;
 exports.scene = scene;

--- a/examples/globe.html
+++ b/examples/globe.html
@@ -83,17 +83,17 @@
         </script>
         <script src="globe.js"></script>
         <script type="text/javascript">
-            /* global itowns, document, GuiTools, globeView, promises */
+            /* global itowns, document, GuiTools, view, promises */
             var menuGlobe = new GuiTools('menuDiv');
-            menuGlobe.view = globeView;
+            menuGlobe.view = view;
             var divScaleWidget = document.querySelectorAll('.divScaleWidget')[0];
 
             function updateScaleWidget() {
-                var value = globeView.controls.pixelsToMeters(200);
+                var value = view.controls.pixelsToMeters(200);
                 value = Math.floor(value);
                 var digit = Math.pow(10, value.toString().length - 1);
                 value = Math.round(value / digit) * digit;
-                var pix = globeView.controls.metersToPixels(value);
+                var pix = view.controls.metersToPixels(value);
                 var unit = 'm';
                 if (value >= 1000) {
                     value /= 1000;
@@ -104,16 +104,16 @@
             }
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 Promise.all(promises).then(function () {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
+                    menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(view.getLayers(function (l) { return l.type === 'elevation'; }));
                 });
                 updateScaleWidget();
             });
-            globeView.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
+            view.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
                 updateScaleWidget();
             });
         </script>

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -13,9 +13,9 @@ var viewerDiv = document.getElementById('viewerDiv');
 var miniDiv = document.getElementById('miniDiv');
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 
 // Dont' instance mini viewer if it's Test env
@@ -26,7 +26,7 @@ if (!renderer) {
         // since the mini globe will always be seen from a far point of view (see minDistance above)
         maxSubdivisionLevel: 2,
         // Don't instance default controls since miniview's camera will be synced
-        // on the main view's one (see globeView.onAfterRender)
+        // on the main view's one (see view.onAfterRender)
         noControls: true,
     });
 
@@ -35,15 +35,15 @@ if (!renderer) {
     // to see the main view "behind"
     miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
 
-    // update miniview's camera with the globeView's camera position
-    globeView.onAfterRender = function onAfterRender() {
+    // update miniview's camera with the view's camera position
+    view.onAfterRender = function onAfterRender() {
         // clamp distance camera from globe
-        var distanceCamera = globeView.camera.camera3D.position.length();
+        var distanceCamera = view.camera.camera3D.position.length();
         var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);
         var camera = miniView.camera.camera3D;
         // Update target miniview's camera
-        camera.position.copy(globeView.controls.moveTarget()).setLength(distance);
-        camera.lookAt(globeView.controls.moveTarget());
+        camera.position.copy(view.controls.moveTarget()).setLength(distance);
+        camera.lookAt(view.controls.moveTarget());
         miniView.notifyChange(true);
     };
 
@@ -60,5 +60,5 @@ promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLaye
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
-exports.view = globeView;
+exports.view = view;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe_fly.html
+++ b/examples/globe_fly.html
@@ -74,17 +74,17 @@
         </script>
         <script src="globe_fly.js"></script>
         <script type="text/javascript">
-            /* global itowns, document, GuiTools, globeView, promises */
+            /* global itowns, document, GuiTools, view, promises */
             var menuGlobe = new GuiTools('menuDiv');
-            menuGlobe.view = globeView;
+            menuGlobe.view = view;
             flyControls.moveSpeed = 10000000;
             menuGlobe.gui.add(flyControls, 'moveSpeed', 10, 10000000).name('Movement speed');
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
                 Promise.all(promises).then(function () {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
+                    menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(view.getLayers(function (l) { return l.type === 'elevation'; }));
                 });
             });
         </script>

--- a/examples/globe_fly.js
+++ b/examples/globe_fly.js
@@ -9,15 +9,15 @@ var viewerDiv = document.getElementById('viewerDiv');
 var promises = [];
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true });
-var flyControls = new itowns.FlyControls(globeView, { focusOnClick: true });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true });
+var flyControls = new itowns.FlyControls(view, { focusOnClick: true });
 flyControls.moveSpeed = 1000;
 
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
 function addLayer(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayer));
 // Add two elevation layers.
@@ -25,5 +25,5 @@ promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLaye
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayer));
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayer));
 
-exports.view = globeView;
+exports.view = view;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe_vector.html
+++ b/examples/globe_vector.html
@@ -73,21 +73,21 @@
         <script src="globe_vector.js"></script>
         <script src="FeatureToolTip.js"></script>
         <script type="text/javascript">
-            /* global itowns, document, GuiTools, globeView, promises, ToolTip */
+            /* global itowns, document, GuiTools, view, promises, ToolTip */
             var menuGlobe = new GuiTools('menuDiv');
 
-            menuGlobe.view = globeView;
+            menuGlobe.view = view;
             // Listen for globe full initialisation event
 
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 Promise.all(promises).then(function () {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
-                    itowns.ColorLayersOrdering.moveLayerToIndex(globeView, 'Ortho', 0);
+                    menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(view.getLayers(function (l) { return l.type === 'elevation'; }));
+                    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
 
-                    new ToolTip(globeView, document.getElementById('viewerDiv'), document.getElementById('tooltipDiv'));
+                    new ToolTip(view, document.getElementById('viewerDiv'), document.getElementById('tooltipDiv'));
                 });
 
 

--- a/examples/globe_vector.js
+++ b/examples/globe_vector.js
@@ -9,9 +9,9 @@ var promises = [];
 var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 
 // Add one imagery layer to the scene
@@ -23,7 +23,7 @@ promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLaye
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
-promises.push(globeView.addLayer({
+promises.push(view.addLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
     protocol: 'rasterizer',
@@ -31,7 +31,7 @@ promises.push(globeView.addLayer({
     name: 'kml',
 }));
 
-promises.push(globeView.addLayer({
+promises.push(view.addLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx',
     protocol: 'rasterizer',
@@ -39,7 +39,7 @@ promises.push(globeView.addLayer({
     name: 'Ultra 2009',
 }));
 
-promises.push(globeView.addLayer({
+promises.push(view.addLayer({
     type: 'color',
     url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
     protocol: 'rasterizer',
@@ -51,5 +51,5 @@ promises.push(globeView.addLayer({
     },
 }));
 
-exports.view = globeView;
+exports.view = view;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -46,22 +46,22 @@
         </script>
         <script src="globe_wfs_extruded.js"></script>
         <script type="text/javascript">
-            /* global itowns, document, GuiTools, globeView, promises */
+            /* global itowns, document, GuiTools, view, promises */
             var menuGlobe = new GuiTools('menuDiv');
-            menuGlobe.view = globeView;
+            menuGlobe.view = view;
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 Promise.all(promises).then(function () {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
+                    menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(view.getLayers(function (l) { return l.type === 'elevation'; }));
 
-                    globeView.controls.setTilt(45, true);
+                    view.controls.setTilt(45, true);
                 });
             });
-            const d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.wgs84TileLayer, d);
+            const d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.wgs84TileLayer, d);
 
 
         </script>

--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -9,9 +9,9 @@ var promises = [];
 var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
@@ -37,7 +37,7 @@ function colorLine(properties) {
     return new itowns.THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
 }
 
-globeView.addLayer({
+view.addLayer({
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
         color: colorLine,
@@ -59,7 +59,7 @@ globeView.addLayer({
     options: {
         mimetype: 'geojson',
     },
-}, globeView.tileLayer);
+}, view.tileLayer);
 
 function colorBuildings(properties) {
     if (properties.id.indexOf('bati_remarquable') === 0) {
@@ -82,7 +82,7 @@ function acceptFeature(properties) {
     return !!properties.hauteur;
 }
 
-globeView.addLayer({
+view.addLayer({
     type: 'geometry',
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
@@ -102,7 +102,7 @@ globeView.addLayer({
     options: {
         mimetype: 'json',
     },
-}, globeView.tileLayer);
+}, view.tileLayer);
 
-exports.view = globeView;
+exports.view = view;
 exports.initialPosition = positionOnGlobe;

--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -32,14 +32,14 @@
         </script>
         <script src="gpx.js"></script>
         <script type="text/javascript">
-            /* global itowns, document, globeView */
+            /* global itowns, document, view */
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
-                itowns.GpxUtils.load('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx', globeView.referenceCrs).then(function (gpx) {
+                itowns.GpxUtils.load('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx', view.referenceCrs).then(function (gpx) {
                     if (gpx) {
-                        globeView.scene.add(gpx);
-                        globeView.controls.setTilt(45, true);
+                        view.scene.add(gpx);
+                        view.controls.setTilt(45, true);
                     }
                 });
             });

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -8,12 +8,12 @@ var positionOnGlobe = { longitude: 0.089, latitude: 42.8989, altitude: 80000 };
 var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
 var promises = [];
 
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
@@ -24,4 +24,4 @@ promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLaye
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
-exports.view = globeView;
+exports.view = view;

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -36,11 +36,11 @@
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
             var menuGlobe = new GuiTools('menuDiv');
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            menuGlobe.view = globeView;
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            menuGlobe.view = view;
 
             function addLayerCb(layer) {
-                return globeView.addLayer(layer);
+                return view.addLayer(layer);
             }
 
             var promises = [];
@@ -80,22 +80,22 @@
                 }
             }
 
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 Promise.all(promises).then(function () {
-                    menuGlobe.addImageryLayersGUI(globeView.getLayers(function(l) { return l.type === 'color'; }));
-                    menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
+                    menuGlobe.addImageryLayersGUI(view.getLayers(function(l) { return l.type === 'color'; }));
+                    menuGlobe.addElevationLayersGUI(view.getLayers(function (l) { return l.type === 'elevation'; }));
                 });
             });
 
             // Use preRender to update menu before rendering
-            globeView.preRender = function () {
+            view.preRender = function () {
                 var layers = { id: [] };
-                // globeView.scene is THREE.js scene
-                getLayersColorVisible(globeView.scene, layers);
+                // view.scene is THREE.js scene
+                getLayersColorVisible(view.scene, layers);
                 console.log('layers', layers);
-                var colorLayers = globeView.getLayers(function (l) { return l.type == 'color'; });
+                var colorLayers = view.getLayers(function (l) { return l.type == 'color'; });
 
                 colorLayers.forEach(function (layer) {
                     menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1)

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -74,8 +74,8 @@
                     }
                 }
                 if (node.children) {
-                    for (var child of node.children) {
-                        getLayersColorVisible(child, layers);
+                    for (var i = 0; i < node.children.length; i++) {
+                        getLayersColorVisible(node.children[i], layers);
                     }
                 }
             }

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -58,11 +58,11 @@
             ref[1].updateMatrixWorld();
 
             // Create the first globe
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true, object3d: ref[0] });
-            layers.push(globeView.wgs84TileLayer);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true, object3d: ref[0] });
+            layers.push(view.wgs84TileLayer);
 
             function addLayerCb(layer) {
-                return globeView.addLayer(layer);
+                return view.addLayer(layer);
             }
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
 
@@ -74,8 +74,8 @@
             globe2.noTextureColor = new itowns.THREE.Color(0xd0d5d8);
 
             // add it to the view so it gets updated
-            itowns.View.prototype.addLayer.call(globeView, globe2);
-            itowns.View.prototype.addLayer.call(globeView, {
+            itowns.View.prototype.addLayer.call(view, globe2);
+            itowns.View.prototype.addLayer.call(view, {
                 update: itowns.updateLayeredMaterialNodeImagery,
                 type: 'color',
                 protocol: "wmtsc",
@@ -108,17 +108,17 @@
                     layers[1].object3d.updateMatrixWorld(true);
 
                     if (this.t < 1) {
-                        globeView.notifyChange(true);
+                        view.notifyChange(true);
                     } else {
-                        globeView.removeFrameRequester(animator);
+                        view.removeFrameRequester(animator);
                     }
                 }
             };
 
             // Last but not least, add 'ref' object to three.js scene, otherwise our globes
             // won't be displayed
-            globeView.scene.add(ref[0]);
-            globeView.scene.add(ref[1]);
+            view.scene.add(ref[0]);
+            view.scene.add(ref[1]);
 
 
             // Swap globe place on 'space' key
@@ -127,8 +127,8 @@
                     front = 1 - front;
 
                     animator.t = 0;
-                    globeView.addFrameRequester(animator);
-                    globeView.notifyChange(true);
+                    view.addFrameRequester(animator);
+                    view.notifyChange(true);
                 }
             }
             viewerDiv.focus();
@@ -136,7 +136,7 @@
 
             // Zoom on mouse-wheel
             var onMouseWheel = function onMouseWheel(event) {
-                var geo = new itowns.Coordinates('EPSG:4978', globeView.camera.camera3D.position).as('EPSG:4326');
+                var geo = new itowns.Coordinates('EPSG:4978', view.camera.camera3D.position).as('EPSG:4326');
                 // WebKit / Opera / Explorer 9
                 if (event.wheelDelta !== undefined) {
                     delta = event.wheelDelta;
@@ -150,8 +150,8 @@
                 } else {
                     geo.setAltitude(geo.altitude() * 1.1);
                 }
-                globeView.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
-                globeView.notifyChange(true);
+                view.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
+                view.notifyChange(true);
             };
             viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);
             viewerDiv.addEventListener('mousewheel', onMouseWheel);

--- a/examples/pointcloud.html
+++ b/examples/pointcloud.html
@@ -111,6 +111,7 @@
 
             <!-- POINTCLOUD TABLE SELECTION -->
             <script type="text/javascript">
+                var view;
                 function createResultRow(serverUrl, table) {
                     var tr = document.createElement('tr');
                     var td = document.createElement('td');
@@ -121,7 +122,7 @@
                     i.type = 'submit';
 
                     function onDisplayClicked() {
-                        showPointcloud(serverUrl, undefined, table, false);
+                        view = showPointcloud(serverUrl, undefined, table, false);
                     }
 
                     i.addEventListener('click', onDisplayClicked);
@@ -154,7 +155,7 @@
                         var lastSlashIndex = url.lastIndexOf('/');
                         var filename = url.substr(lastSlashIndex + 1);
 
-                        showPointcloud(url.substr(0, lastSlashIndex), filename, undefined, true);
+                        view = showPointcloud(url.substr(0, lastSlashIndex), filename, undefined, true);
                     } else {
                         itowns.Fetcher.json(url + '/infos/sources').then(function(meta) { buildLopocsResultTable(url, meta); });
                     }

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -89,4 +89,6 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     }
 
     view.addLayer(pointcloud).then(onLayerReady);
+
+    return view;
 }

--- a/examples/positionGlobe.js
+++ b/examples/positionGlobe.js
@@ -15,16 +15,16 @@ var positionOnGlobe = { longitude: 4.22, latitude: 44.844, altitude: 4000 };
 var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
 var promises = [];
 
 var menuGlobe = new GuiTools('menuDiv');
 
-menuGlobe.view = globeView;
+menuGlobe.view = view;
 
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
@@ -35,7 +35,7 @@ promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLaye
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
-exports.view = globeView;
+exports.view = view;
 exports.initialPosition = positionOnGlobe;
 
 
@@ -47,14 +47,14 @@ function addMeshToScene() {
     var mesh = new THREE.Mesh(geometry, material);
 
     // get the position on the globe, from the camera
-    var cameraTargetPosition = globeView.controls.getCameraTargetGeoPosition();
+    var cameraTargetPosition = view.controls.getCameraTargetGeoPosition();
 
     // position of the mesh
     var meshCoord = cameraTargetPosition;
     meshCoord.setAltitude(cameraTargetPosition.altitude() + 30);
 
     // position and orientation of the mesh
-    mesh.position.copy(meshCoord.as(globeView.referenceCrs).xyz());
+    mesh.position.copy(meshCoord.as(view.referenceCrs).xyz());
     mesh.lookAt(new THREE.Vector3(0, 0, 0));
     mesh.rotateX(Math.PI / 2);
 
@@ -62,22 +62,22 @@ function addMeshToScene() {
     mesh.updateMatrixWorld();
 
     // add the mesh to the scene
-    globeView.scene.add(mesh);
+    view.scene.add(mesh);
 
     // make the object usable from outside of the function
-    globeView.mesh = mesh;
+    view.mesh = mesh;
 }
 
 // Listen for globe full initialisation event
-globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
     // eslint-disable-next-line no-console
     console.info('Globe initialized');
     Promise.all(promises).then(function () {
-        menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
-        menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
+        menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
+        menuGlobe.addElevationLayersGUI(view.getLayers(function (l) { return l.type === 'elevation'; }));
 
         addMeshToScene();
 
-        globeView.controls.setTilt(60, true);
+        view.controls.setTilt(60, true);
     });
 });

--- a/examples/postprocessing.js
+++ b/examples/postprocessing.js
@@ -3,7 +3,7 @@ var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 2500
 
 // iTowns namespace defined here
 var viewerDiv = document.getElementById('viewerDiv');
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
 // Simple postprocessing setup
 //
@@ -25,15 +25,15 @@ quad.material = new THREE.ShaderMaterial({
 });
 postprocessScene.add(quad);
 
-globeView.render = function render() {
-    var g = globeView.mainLoop.gfxEngine;
+view.render = function render() {
+    var g = view.mainLoop.gfxEngine;
     var r = g.renderer;
     r.setRenderTarget(g.fullSizeRenderTarget);
     r.clear();
     r.setViewport(0, 0, g.getWindowSize().x, g.getWindowSize().y);
     r.render(
-        globeView.scene,
-        globeView.camera.camera3D, g.fullSizeRenderTarget);
+        view.scene,
+        view.camera.camera3D, g.fullSizeRenderTarget);
 
     quad.material.uniforms.tDiffuse.value = g.fullSizeRenderTarget.texture;
     quad.material.uniforms.tSize.value.set(
@@ -48,11 +48,11 @@ globeView.render = function render() {
 };
 
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 
 itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
 itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
 
-exports.globeView = globeView;
+exports.view = view;
 exports.postprocessScene = postprocessScene;

--- a/examples/split.js
+++ b/examples/split.js
@@ -8,7 +8,7 @@ var positionOnGlobe = { longitude: 3.36, latitude: 51.22, altitude: 480000 };
 var viewerDiv = document.getElementById('viewerDiv');
 
 // Instanciate iTowns GlobeView*
-var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
+var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
 var promises = [];
 
@@ -19,7 +19,7 @@ var splitPosition;
 var xD;
 
 function addLayerCb(layer) {
-    return globeView.addLayer(layer);
+    return view.addLayer(layer);
 }
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
@@ -39,7 +39,7 @@ function splitSliderMove(evt) {
     var s = (evt.clientX - xD) / splitSlider.parentElement.offsetWidth;
     splitSlider.style.left = (100.0 * s) + '%';
     splitPosition = s * window.innerWidth;
-    globeView.notifyChange(true);
+    view.notifyChange(true);
 }
 
 function mouseDown(evt) {
@@ -56,7 +56,7 @@ function changeLayerVisibility(ortho, osm) {
     var orthoIndex;
     var opensmIndex;
 
-    globeView.scene.traverse(function _(obj) {
+    view.scene.traverse(function _(obj) {
         if (obj.material && obj.material.setLayerVisibility && obj.material.visible) {
             material = obj.material;
             orthoIndex = material.indexOfColorLayer(orthoLayer.id);
@@ -73,7 +73,7 @@ window.addEventListener('mouseup', mouseUp, false);
 
 // Rendering code
 function splitRendering() {
-    var g = globeView.mainLoop.gfxEngine;
+    var g = view.mainLoop.gfxEngine;
     var r = g.renderer;
 
     r.setScissorTest(true);
@@ -82,17 +82,17 @@ function splitRendering() {
     changeLayerVisibility(true, false);
 
     r.setScissor(0, 0, splitPosition + 2, window.innerHeight);
-    g.renderView(globeView);
+    g.renderView(view);
 
     // render osm layer on the right
     changeLayerVisibility(false, true);
 
     r.setScissor(splitPosition + 2, 0, window.innerWidth - splitPosition - 2, window.innerHeight);
-    g.renderView(globeView);
+    g.renderView(view);
 }
 
 // Override default rendering method when color layers are ready
-Promise.all(promises).then(function _() { globeView.render = splitRendering; });
+Promise.all(promises).then(function _() { view.render = splitRendering; });
 
-exports.view = globeView;
+exports.view = view;
 exports.initialPosition = positionOnGlobe;

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,11 @@
         "repeat-string": "1.6.1"
       }
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -113,6 +118,34 @@
       "requires": {
         "arrify": "1.0.1",
         "micromatch": "2.3.11"
+      }
+    },
+    "archiver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
+      "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "async": "2.5.0",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.0.6",
+        "tar-stream": "1.5.4",
+        "zip-stream": "1.2.0"
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.4",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.0.6"
       }
     },
     "argparse": {
@@ -184,6 +217,11 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
     "asn1.js": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
@@ -204,11 +242,15 @@
         "util": "0.10.3"
       }
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "async": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -218,6 +260,26 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-cli": {
       "version": "6.24.1",
@@ -1169,8 +1231,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.2.1",
@@ -1184,6 +1245,15 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
     "big.js": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -1195,6 +1265,14 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
       "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
       "dev": true
+    },
+    "bl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "2.0.6"
+      }
     },
     "bluebird": {
       "version": "3.5.1",
@@ -1222,11 +1300,18 @@
         "multicast-dns-service-types": "1.1.0"
       }
     },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1343,6 +1428,11 @@
         "isarray": "1.0.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-indexof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz",
@@ -1411,6 +1501,11 @@
           "dev": true
         }
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "catharsis": {
       "version": "0.8.9",
@@ -1516,8 +1611,7 @@
     "cli-width": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-      "dev": true
+      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
     },
     "cliui": {
       "version": "2.1.0",
@@ -1541,8 +1635,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1559,14 +1652,21 @@
     "color-name": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
-      "dev": true
+      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
     },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.11.0",
@@ -1579,6 +1679,17 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.0.6"
+      }
     },
     "compressible": {
       "version": "2.0.10",
@@ -1623,8 +1734,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1730,6 +1840,20 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "3.5.0",
+        "readable-stream": "2.0.6"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -1787,6 +1911,24 @@
         "which": "1.2.14"
       }
     },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
     "crypto-browserify": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
@@ -1805,6 +1947,40 @@
         "randombytes": "2.0.5"
       }
     },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "css-parse": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
+      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
+      "requires": {
+        "css": "2.2.1"
+      }
+    },
+    "css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo="
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1821,6 +1997,14 @@
       "dev": true,
       "requires": {
         "es5-ext": "0.10.23"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
       }
     },
     "date-now": {
@@ -1856,6 +2040,21 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
+      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -1870,6 +2069,11 @@
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.0",
@@ -1971,11 +2175,25 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.1.tgz",
       "integrity": "sha1-FXY05fPrtCIk5HUBboalts5Va0U="
     },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
+    },
+    "ejs": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -2011,6 +2229,14 @@
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.18"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -2122,8 +2348,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escope": {
       "version": "3.6.0",
@@ -2513,6 +2738,21 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "requires": {
+        "iconv-lite": "0.4.18",
+        "jschardet": "1.6.0",
+        "tmp": "0.0.33"
+      }
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -2521,6 +2761,21 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2536,6 +2791,12 @@
       "requires": {
         "websocket-driver": "0.6.5"
       }
+    },
+    "fibers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-2.0.0.tgz",
+      "integrity": "sha512-sLxo4rZVk7xLgAjb/6zEzHJfSALx6u6coN1z61XCOF7i6CyTdJawF4+RdpjCSeS8AP66eR2InScbYAz9RAVOgA==",
+      "dev": true
     },
     "figures": {
       "version": "1.7.0",
@@ -2655,6 +2916,27 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
+    },
     "forwarded": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
@@ -2676,14 +2958,21 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
+    },
+    "gaze": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "requires": {
+        "globule": "1.2.0"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -2712,11 +3001,18 @@
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2765,11 +3061,20 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "globule": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -2788,6 +3093,33 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.3.0",
+        "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
+      }
     },
     "has": {
       "version": "1.0.1",
@@ -2832,6 +3164,17 @@
         "minimalistic-assert": "1.0.0"
       }
     },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2842,6 +3185,11 @@
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -2934,6 +3282,16 @@
         }
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
     "https-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
@@ -2943,8 +3301,7 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI=",
-      "dev": true
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
     },
     "ieee754": {
       "version": "1.1.8",
@@ -2998,7 +3355,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -3231,6 +3587,11 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -3260,6 +3621,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
       "version": "0.1.2",
@@ -3302,6 +3668,11 @@
         "isarray": "1.0.0"
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-priority-queue": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/js-priority-queue/-/js-priority-queue-0.1.5.tgz",
@@ -3331,6 +3702,17 @@
       "requires": {
         "xmlcreate": "1.0.2"
       }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jschardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "jsdoc": {
       "version": "3.5.5",
@@ -3372,6 +3754,16 @@
       "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94=",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -3380,6 +3772,11 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
@@ -3404,6 +3801,17 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "jszip": {
       "version": "3.1.3",
@@ -3452,6 +3860,14 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "2.0.6"
+      }
     },
     "lcid": {
       "version": "1.0.0",
@@ -3573,8 +3989,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -3910,17 +4325,20 @@
     "mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-      "dev": true
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
     },
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true,
       "requires": {
         "mime-db": "1.27.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -3938,7 +4356,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3946,14 +4363,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -4143,16 +4558,25 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.0.2"
       }
+    },
+    "npm-install-package": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+      "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU="
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -4165,6 +4589,23 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
       "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw=",
       "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "object-keys": "1.0.11"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -4201,7 +4642,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -4220,6 +4660,22 @@
       "requires": {
         "object-assign": "4.1.1",
         "pinkie-promise": "2.0.1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
       }
     },
     "optionator": {
@@ -4281,8 +4737,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "output-file-sync": {
       "version": "1.1.2",
@@ -4376,8 +4831,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -4418,6 +4872,11 @@
         "safe-buffer": "5.1.1",
         "sha.js": "2.4.8"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -4557,8 +5016,12 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.4.0",
@@ -4569,8 +5032,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -4791,8 +5253,7 @@
     "remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-      "dev": true
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -4813,6 +5274,60 @@
       "dev": true,
       "requires": {
         "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
       }
     },
     "require-directory": {
@@ -4881,6 +5396,11 @@
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
@@ -4890,6 +5410,11 @@
         "exit-hook": "1.1.1",
         "onetime": "1.1.0"
       }
+    },
+    "rgb2hex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
+      "integrity": "sha1-zNVfhgrgxcTqN1BLlY5ELY0SMls="
     },
     "right-align": {
       "version": "0.1.3",
@@ -4961,14 +5486,20 @@
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "3.1.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -5112,8 +5643,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "1.0.0",
@@ -5126,6 +5656,14 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "sockjs": {
       "version": "0.3.18",
@@ -5174,6 +5712,17 @@
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
     "source-map-support": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
@@ -5182,6 +5731,11 @@
       "requires": {
         "source-map": "0.5.6"
       }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -5265,6 +5819,21 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -5335,6 +5904,11 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -5431,6 +6005,17 @@
       "integrity": "sha1-IGvo4YiGC1FEJTdebxrom/sB/Y0=",
       "dev": true
     },
+    "tar-stream": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.0.6",
+        "xtend": "4.0.1"
+      }
+    },
     "text-encoding-utf-8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.1.tgz",
@@ -5457,8 +6042,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "thunky": {
       "version": "0.1.0",
@@ -5473,6 +6057,14 @@
       "dev": true,
       "requires": {
         "process": "0.11.10"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -5514,6 +6106,14 @@
         }
       }
     },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -5537,6 +6137,20 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "two-product": {
       "version": "1.0.2",
@@ -5639,11 +6253,15 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -5652,8 +6270,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
@@ -5739,11 +6356,26 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "validator": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.1.1.tgz",
+      "integrity": "sha512-1TGGX1GKilfmcEa9rm+9nI9AqIUQK8oj4jZI0DmTGLTPM5jmowBBhyBIHCks73+P1QPZk2i6oOYUq583uOetHQ=="
+    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -5772,6 +6404,243 @@
       "dev": true,
       "requires": {
         "minimalistic-assert": "1.0.0"
+      }
+    },
+    "wdio-dot-reporter": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz",
+      "integrity": "sha1-kpsq2v1J1rBTT9oGjocxm0fjj+U="
+    },
+    "wdio-mocha-framework": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/wdio-mocha-framework/-/wdio-mocha-framework-0.5.11.tgz",
+      "integrity": "sha1-MyCNOjIOp8kpMJO4MTBsnc6rhBY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "mocha": "3.4.2",
+        "wdio-sync": "0.7.0"
+      }
+    },
+    "wdio-sync": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/wdio-sync/-/wdio-sync-0.7.0.tgz",
+      "integrity": "sha1-L7B9JQEh3IH1Y1MWVCw8SaEiAWg=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.25.0",
+        "fibers": "2.0.0",
+        "object.assign": "4.0.4"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.25.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+          "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
+        }
+      }
+    },
+    "webdriverio": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.9.6.tgz",
+      "integrity": "sha1-iPvrmHQOZxToQYNSUiWiIoYGcbo=",
+      "requires": {
+        "archiver": "2.1.0",
+        "babel-runtime": "6.26.0",
+        "css-parse": "2.0.0",
+        "css-value": "0.0.1",
+        "deepmerge": "2.0.1",
+        "ejs": "2.5.7",
+        "gaze": "1.1.2",
+        "glob": "7.1.2",
+        "inquirer": "3.3.0",
+        "json-stringify-safe": "5.0.1",
+        "mkdirp": "0.5.1",
+        "npm-install-package": "2.1.0",
+        "optimist": "0.6.1",
+        "q": "1.5.1",
+        "request": "2.83.0",
+        "rgb2hex": "0.1.0",
+        "safe-buffer": "5.1.1",
+        "supports-color": "5.0.0",
+        "url": "0.11.0",
+        "validator": "9.1.1",
+        "wdio-dot-reporter": "0.0.9",
+        "wgxpath": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "requires": {
+            "color-name": "1.1.2"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.3.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.1.0",
+            "external-editor": "2.0.5",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.0.tgz",
+          "integrity": "sha1-HbJiKfauAvms21QQkHw2zi42KxM=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "webpack": {
@@ -6018,6 +6887,11 @@
       "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
       "dev": true
     },
+    "wgxpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
+      "integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA="
+    },
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
@@ -6069,8 +6943,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -6095,8 +6968,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
@@ -6238,6 +7110,17 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
+      }
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.0.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",
-    "test-examples": "npm run transpile && mocha test/globe_test.js && mocha test/planar_test.js && mocha test/postprocessing_test.js && mocha test/externalscene_test.js",
+    "test-examples": "wdio wdio.conf.js",
     "build": "webpack -p",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
@@ -41,6 +41,7 @@
     "text-encoding-utf-8": "^1.0.1",
     "togeojson": "^0.16.0",
     "url-polyfill": "^1.0.8",
+    "webdriverio": "^4.9.6",
     "whatwg-fetch": "^2.0.2"
   },
   "peerDependencies": {
@@ -73,6 +74,7 @@
     "require-from-string": "^1.2.1",
     "three": "^0.87.0",
     "three.meshline": "^1.0.3",
+    "wdio-mocha-framework": "^0.5.11",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"
   }

--- a/test/specs/3dtiles.html.js
+++ b/test/specs/3dtiles.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('3dtiles.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/3dtiles.html');
+    });
+});

--- a/test/specs/cubic_planar.html.js
+++ b/test/specs/cubic_planar.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('cubic_planar.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/cubic_planar.html');
+    });
+});

--- a/test/specs/examples_are_working.js
+++ b/test/specs/examples_are_working.js
@@ -1,0 +1,35 @@
+/* global browser, view, describe, it */
+const assert = require('assert');
+const fs = require('fs');
+
+browser.timeouts('script', 120000);
+
+function _test(url) {
+    browser.url(`http://localhost:8080/${url}`);
+    var result = browser.executeAsync(
+        function (done) {
+            view.mainLoop.addEventListener('command-queue-empty',
+                function () {
+                    if (view.mainLoop.gfxEngine.renderer.info.render.calls > 0) {
+                        return done(true);
+                    }
+                });
+            view.notifyChange(true);
+        });
+
+    assert.ok(result.value, 'MainLoop jobs should be all done at some point');
+}
+
+// list examples
+fs.readdirSync('examples/').forEach((file) => {
+    if (file === 'index.html') {
+        return;
+    }
+    if (file.indexOf('.html') > 0) {
+        describe(`Example ${file}`, function () {
+            it('Should load and run', function () {
+                _test(`examples/${file}`);
+            });
+        });
+    }
+});

--- a/test/specs/examples_are_working.js
+++ b/test/specs/examples_are_working.js
@@ -4,6 +4,15 @@ const fs = require('fs');
 
 function _test(url) {
     browser.url(`http://localhost:8080/${url}`);
+
+    // waits for 'view' to exist...
+    browser.waitUntil(function () {
+        return browser.execute(function () {
+            return typeof (view) !== 'undefined';
+        }).value;
+    });
+
+    // then run the test
     var result = browser.executeAsync(
         function (done) {
             function check() {

--- a/test/specs/examples_are_working.js
+++ b/test/specs/examples_are_working.js
@@ -2,18 +2,22 @@
 const assert = require('assert');
 const fs = require('fs');
 
-browser.timeouts('script', 120000);
-
 function _test(url) {
     browser.url(`http://localhost:8080/${url}`);
     var result = browser.executeAsync(
         function (done) {
-            view.mainLoop.addEventListener('command-queue-empty',
-                function () {
-                    if (view.mainLoop.gfxEngine.renderer.info.render.calls > 0) {
-                        return done(true);
-                    }
-                });
+            function check() {
+                if (view._layers.length == 0) {
+                    return;
+                }
+                if (view.mainLoop.gfxEngine.renderer.info.render.calls > 0) {
+                    return done(true);
+                }
+            }
+            var u = {
+                update: check,
+            };
+            view.addFrameRequester(u);
             view.notifyChange(true);
         });
 

--- a/test/specs/externalscene.html.js
+++ b/test/specs/externalscene.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('externalscene.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/externalscene.html');
+    });
+});

--- a/test/specs/globe.html.js
+++ b/test/specs/globe.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('globe.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/globe.html');
+    });
+});

--- a/test/specs/globe_fly.html.js
+++ b/test/specs/globe_fly.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('globe_fly.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/globe_fly.html');
+    });
+});

--- a/test/specs/globe_vector.html.js
+++ b/test/specs/globe_vector.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('globe_vector.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/globe_vector.html');
+    });
+});

--- a/test/specs/globe_wfs_extruded.html.js
+++ b/test/specs/globe_wfs_extruded.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('globe_wfs_extruded.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/globe_wfs_extruded.html');
+    });
+});

--- a/test/specs/gpx.html.js
+++ b/test/specs/gpx.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('gpx.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/gpx.html');
+    });
+});

--- a/test/specs/layersColorVisible.html.js
+++ b/test/specs/layersColorVisible.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('layersColorVisible.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/layersColorVisible.html');
+    });
+});

--- a/test/specs/multiglobe.html.js
+++ b/test/specs/multiglobe.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('multiglobe.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/multiglobe.html');
+    });
+});

--- a/test/specs/orthographic.html.js
+++ b/test/specs/orthographic.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('orthographic.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/orthographic.html');
+    });
+});

--- a/test/specs/planar.html.js
+++ b/test/specs/planar.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('globe.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/globe.html');
+    });
+});

--- a/test/specs/planar_vector.html.js
+++ b/test/specs/planar_vector.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('planar_vector.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/planar_vector.html');
+    });
+});

--- a/test/specs/pointcloud.html.js
+++ b/test/specs/pointcloud.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('pointcloud.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/pointcloud.html');
+    });
+});

--- a/test/specs/positionGlobe.html.js
+++ b/test/specs/positionGlobe.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('positionGlobe.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/positionGlobe.html');
+    });
+});

--- a/test/specs/postprocessing.html.js
+++ b/test/specs/postprocessing.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('postprocessing.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/postprocessing.html');
+    });
+});

--- a/test/specs/split.html.js
+++ b/test/specs/split.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('split.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/split.html');
+    });
+});

--- a/test/specs/support.js
+++ b/test/specs/support.js
@@ -1,15 +1,14 @@
-/* global browser, view, describe, it */
+/* global browser, view */
 const assert = require('assert');
-const fs = require('fs');
 
-function _test(url) {
+function basicTest(url) {
     browser.url(`http://localhost:8080/${url}`);
 
     // waits for 'view' to exist...
     browser.waitUntil(function () {
         return browser.execute(function () {
             return typeof (view) !== 'undefined';
-        }).value;
+        }, 10000).value;
     });
 
     // then run the test
@@ -22,6 +21,7 @@ function _test(url) {
                 if (view.mainLoop.gfxEngine.renderer.info.render.calls > 0) {
                     return done(true);
                 }
+                view.notifyChange(true);
             }
             var u = {
                 update: check,
@@ -33,16 +33,4 @@ function _test(url) {
     assert.ok(result.value, 'MainLoop jobs should be all done at some point');
 }
 
-// list examples
-fs.readdirSync('examples/').forEach((file) => {
-    if (file === 'index.html') {
-        return;
-    }
-    if (file.indexOf('.html') > 0) {
-        describe(`Example ${file}`, function () {
-            it('Should load and run', function () {
-                _test(`examples/${file}`);
-            });
-        });
-    }
-});
+module.exports.basicTest = basicTest;

--- a/test/specs/wfs.html.js
+++ b/test/specs/wfs.html.js
@@ -1,0 +1,9 @@
+/* global describe, it */
+const support = require('./support');
+
+
+describe('wfs.html', function () {
+    it('Should load and run', function () {
+        support.basicTest('examples/wfs.html');
+    });
+});

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -47,7 +47,9 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 10,
+    maxSession: 1,
+    maxSessions: 1,
+    maxInstances: 1,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -70,6 +70,7 @@ exports.config = {
             'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
         }, {
             browserName: 'safari',
+            version: 11,
             'browserstack.local': 'true',
             'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
         },

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,0 +1,273 @@
+const { spawn } = require('child_process');
+let myNpmProcess;
+
+exports.config = {
+
+    //
+    // =================
+    // Service Providers
+    // =================
+    // WebdriverIO supports Sauce Labs, Browserstack, and Testing Bot (other cloud providers
+    // should work too though). These services define specific user and key (or access key)
+    // values you need to put in here in order to connect to these services.
+    //
+    user: process.env.BROWSERSTACK_USER,
+    key: process.env.BROWSERSTACK_ACCESS_KEY,
+
+
+    //
+    // ==================
+    // Specify Test Files
+    // ==================
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
+    //
+    specs: [
+        './test/specs/**/*.js'
+    ],
+    // Patterns to exclude.
+    exclude: [
+        // 'path/to/excluded/files'
+    ],
+    //
+    // ============
+    // Capabilities
+    // ============
+    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+    // time. Depending on the number of capabilities, WebdriverIO launches several test
+    // sessions. Within your capabilities you can overwrite the spec and exclude options in
+    // order to group specific specs to a specific capability.
+    //
+    // First, you can define how many instances should be started at the same time. Let's
+    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+    // files and you set maxInstances to 10, all spec files will get tested at the same time
+    // and 30 processes will get spawned. The property handles how many capabilities
+    // from the same test should run tests.
+    //
+    maxInstances: 10,
+    //
+    // If you have trouble getting all important capabilities together, check out the
+    // Sauce Labs platform configurator - a great tool to configure your capabilities:
+    // https://docs.saucelabs.com/reference/platforms-configurator
+    //
+    capabilities: [ {
+            browserName: 'chrome',
+            'browserstack.local': 'true',
+            'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
+        }, {
+            browserName: 'firefox',
+            'browserstack.local': 'true',
+            'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
+        }, {
+            browserName: 'internet explorer',
+            version: 11,
+            'browserstack.local': 'true',
+            'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
+        }, {
+            browserName: 'safari',
+            'browserstack.local': 'true',
+            'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
+        },
+    ],
+    //
+    // ===================
+    // Test Configurations
+    // ===================
+    // Define all options that are relevant for the WebdriverIO instance here
+    //
+    // By default WebdriverIO commands are executed in a synchronous way using
+    // the wdio-sync package. If you still want to run your tests in an async way
+    // e.g. using promises you can set the sync option to false.
+    sync: true,
+    //
+    // Level of logging verbosity: silent | verbose | command | data | result | error
+    logLevel: 'result',
+    //
+    // Enables colors for log output.
+    coloredLogs: true,
+    //
+    // Warns when a deprecated command is used
+    deprecationWarnings: true,
+    //
+    // If you only want to run your tests until a specific amount of tests have failed use
+    // bail (default is 0 - don't bail, run all tests).
+    bail: 0,
+    //
+    // Saves a screenshot to a given path if a command fails.
+    screenshotPath: './errorShots/',
+    //
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
+    baseUrl: 'http://localhost',
+    //
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 10000,
+    //
+    // Default timeout in milliseconds for request
+    // if Selenium Grid doesn't send response
+    connectionRetryTimeout: 90000,
+    //
+    // Default request retries count
+    connectionRetryCount: 3,
+    //
+    // Initialize the browser instance with a WebdriverIO plugin. The object should have the
+    // plugin name as key and the desired plugin options as properties. Make sure you have
+    // the plugin installed before running any tests. The following plugins are currently
+    // available:
+    // WebdriverCSS: https://github.com/webdriverio/webdrivercss
+    // WebdriverRTC: https://github.com/webdriverio/webdriverrtc
+    // Browserevent: https://github.com/webdriverio/browserevent
+    // plugins: {
+    //     webdrivercss: {
+    //         screenshotRoot: 'my-shots',
+    //         failedComparisonsRoot: 'diffs',
+    //         misMatchTolerance: 0.05,
+    //         screenWidth: [320,480,640,1024]
+    //     },
+    //     webdriverrtc: {},
+    //     browserevent: {}
+    // },
+    //
+    // Test runner services
+    // Services take over a specific job you don't want to take care of. They enhance
+    // your test setup with almost no effort. Unlike plugins, they don't add new
+    // commands. Instead, they hook themselves up into the test process.
+    // services: [],//
+    // Framework you want to run your specs with.
+    // The following are supported: Mocha, Jasmine, and Cucumber
+    // see also: http://webdriver.io/guide/testrunner/frameworks.html
+    //
+    // Make sure you have the wdio adapter package for the specific framework installed
+    // before running any tests.
+    framework: 'mocha',
+    //
+    // Test reporter for stdout.
+    // The only one supported by default is 'dot'
+    // see also: http://webdriver.io/guide/reporters/dot.html
+    // reporters: ['dot'],
+    //
+    // Options to be passed to Mocha.
+    // See the full list at http://mochajs.org/
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 60000
+    },
+    //
+    // =====
+    // Hooks
+    // =====
+    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+    // it and to build services around it. You can either apply a single function or an array of
+    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+    // resolved to continue.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
+    onPrepare: function (config, capabilities) {
+        myNpmProcess = spawn('npm', ['start']);
+    },
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // beforeSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // before: function (capabilities, specs) {
+    // },
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
+    // beforeCommand: function (commandName, args) {
+    // },
+
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
+    // beforeSuite: function (suite) {
+    // },
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
+    // beforeTest: function (test) {
+    // },
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
+    // beforeHook: function () {
+    // },
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
+    // afterHook: function () {
+    // },
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+     * @param {Object} test test details
+     */
+    // afterTest: function (test) {
+    // },
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
+    // afterSuite: function (suite) {
+    // },
+
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
+    // afterCommand: function (commandName, args, result, error) {
+    // },
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // after: function (result, capabilities, specs) {
+    // },
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // afterSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
+    onComplete: function(exitCode, config, capabilities) {
+        myNpmProcess.kill();
+    }
+}

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -29,7 +29,7 @@ exports.config = {
     ],
     // Patterns to exclude.
     exclude: [
-        // 'path/to/excluded/files'
+        './test/specs/support.js'
     ],
     //
     // ============
@@ -47,8 +47,8 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxSession: 1,
-    maxSessions: 1,
+    // maxSession: 1,
+    // maxSessions: 1,
     maxInstances: 1,
     //
     // If you have trouble getting all important capabilities together, check out the
@@ -66,6 +66,7 @@ exports.config = {
         }, {
             browserName: 'internet explorer',
             version: 11,
+            os_version: 10,
             'browserstack.local': 'true',
             'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER
         }, {
@@ -87,7 +88,7 @@ exports.config = {
     sync: true,
     //
     // Level of logging verbosity: silent | verbose | command | data | result | error
-    logLevel: 'result',
+    logLevel: 'silent',
     //
     // Enables colors for log output.
     coloredLogs: true,


### PR DESCRIPTION
http://browserstack.com/ is a service allowing to test a web app on various browser / OS.
They also offer a free plan to open-source project so I subscribed one and started playing with it.

A few things:
- this relies on Selenium and can all the tests can be run locally (you just need to have a selenium server running on your machine and a webdriver installed). For instance, here's how to run the tests on a local Chromium:
   * install chromium-driver
   * download selenium and start it: `java -jar -Dwebdriver.chrome.driver=/usr/bin/chromedriver  selenium-server-standalone-3.5.3.jar`
   * run the test (from itowns2): `./node_modules/.bin/wdio wdio.conf.js`
- travis has a BrowserStack integration (see `addons` section in .travis.yml
- I only wrote a very basic test - but once setup we could write more interesting ones
- timeouts are painful: low timeout values can cause failures, big values can stall the test pipeline for a long time if there's a real bug...
- we can run 5 parallel test and queue 5 more. If we try to execute another test when the queue is full the test will fail...
- the free plan only allows access to 5 users
- browserstack is pretty cool: you can watch the test running, see the screenshot of failed tests, etc
- this test mode should replace the `itowns-testing.js` test mode IMHO. When done, we won't need to keep splitting our examples in separate  `html`  and `js` files.

Open questions:
- I'd like to run browserstack tests only once per branch. I don't think it's useul to run them for 2 versions of node. Any idea on how to achieve this?
- I run `npm start` before launching the tests (see wdio.conf.js). I'm not sure this is the best way...

So, WDYT?

