### PR TITLE
Limit the addition of layers

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,20 +48,25 @@ and open the template in the editor.
                 return globeView.addLayer(layer);
             }
 
-            var promises = []
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(addLayerCb));
+            function errorAddLayer(error) {
+                // eslint-disable-next-line no-console
+                console.error(error);
+            }
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Cada.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Administrative.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb));
+            var promises = [];
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(addLayerCb).catch(errorAddLayer));
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Cada.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Administrative.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb).catch(errorAddLayer));
+
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(addLayerCb).catch(errorAddLayer));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb).catch(errorAddLayer));
 
             menuGlobe.addGUI('RealisticLighting', false,
                 function(newValue) { globeView.setRealisticLightingOn(newValue); });

--- a/index.html
+++ b/index.html
@@ -60,10 +60,10 @@ and open the template in the editor.
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(addLayerCb).catch(errorAddLayer));
 
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Cada.json').then(addLayerCb).catch(errorAddLayer));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Administrative.json').then(addLayerCb).catch(errorAddLayer));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb).catch(errorAddLayer));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb).catch(errorAddLayer));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb).catch(errorAddLayer));
+            // promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Administrative.json').then(addLayerCb).catch(errorAddLayer));
+            // promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb).catch(errorAddLayer));
+            // promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb).catch(errorAddLayer));
+            // promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb).catch(errorAddLayer));
 
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(addLayerCb).catch(errorAddLayer));
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb).catch(errorAddLayer));

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -166,6 +166,22 @@ export function createGlobeLayer(id, options) {
         return false;
     }
 
+    /**
+     * Counts the number of texture samplers for color layers.
+     * @param      {Array} colorLayers The color layers
+     * @return     {number} Number of texture samplers for color layers.
+     */
+    wgs84TileLayer.countTextureSamplersForColorLayers = (colorLayers) => {
+        let occupancy = 0;
+        for (const layer of colorLayers) {
+            const projection = layer.projection || layer.options.projection;
+            // 'EPSG:3857' occupies the maximum 3 textures on tiles
+            // 'EPSG:4326' occupies 1 textures on tile
+            occupancy += projection == 'EPSG:3857' ? 3 : 1;
+        }
+        return occupancy;
+    };
+
     wgs84TileLayer.update = processTiledGeometryNode(globeCulling(2), subdivision);
     wgs84TileLayer.builder = new BuilderEllipsoidTile();
     wgs84TileLayer.onTileCreated = nodeInitFn;

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -29,7 +29,9 @@ function preprocessDataLayer(layer) {
         options.tileMatrixSet = options.tileMatrixSet || 'WGS84';
         options.mimetype = options.mimetype || 'image/png';
         options.style = options.style || 'normal';
-        options.projection = options.projection || 'EPSG:3857';
+        if (!options.projection) {
+            options.projection = options.tileMatrixSet == 'PM' ? 'EPSG:3857' : 'EPSG:4326';
+        }
         let newBaseUrl = `${layer.url}` +
             `?LAYER=${options.name}` +
             `&FORMAT=${options.mimetype}` +

--- a/src/Core/System/Capabilities.js
+++ b/src/Core/System/Capabilities.js
@@ -1,11 +1,28 @@
+import SampleTestFS from '../../Renderer/Shader/SampleTestFS.glsl';
+import SampleTestVS from '../../Renderer/Shader/SampleTestVS.glsl';
+
 // default values
 let logDepthBufferSupported = false;
 let maxTexturesUnits = 8;
+
+function _WebGLShader(renderer, type, string) {
+    const gl = renderer.context;
+    const shader = gl.createShader(type);
+
+    gl.shaderSource(shader, string);
+    gl.compileShader(shader);
+    return shader;
+}
+
+function isFirefox() {
+    return navigator && navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+}
 
 export default {
     isLogDepthBufferSupported() {
         return logDepthBufferSupported;
     },
+    isFirefox,
     isInternetExplorer() {
         const internetExplorer = false || !!document.documentMode;
         return internetExplorer;
@@ -17,16 +34,33 @@ export default {
         const gl = renderer.context;
         maxTexturesUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
 
-        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
-        if (debugInfo !== null) {
-            const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
-            if (vendor.indexOf('mesa') > -1 || vendor.indexOf('Mesa') > -1) {
-                maxTexturesUnits = Math.min(16, maxTexturesUnits);
+        const program = gl.createProgram();
+        const glVertexShader = _WebGLShader(renderer, gl.VERTEX_SHADER, SampleTestVS);
+
+        let fragmentShader = `#define SAMPLE ${maxTexturesUnits}\n`;
+        fragmentShader += SampleTestFS;
+
+        const glFragmentShader = _WebGLShader(renderer, gl.FRAGMENT_SHADER, fragmentShader);
+
+        gl.attachShader(program, glVertexShader);
+        gl.attachShader(program, glFragmentShader);
+        gl.linkProgram(program);
+
+        if (gl.getProgramParameter(program, gl.LINK_STATUS) === false) {
+            // eslint-disable-next-line no-console
+            console.warn(`Sampler limit exceeded: it's down from ${maxTexturesUnits} to 16`);
+            if (isFirefox()) {
+                // eslint-disable-next-line no-console
+                console.warn('it can come from a bug mesa/firefox \n\n' +
+                    'Error compile shader when using more than 16 sampler uniforms\n\n' +
+                    'https://bugzilla.mozilla.org/show_bug.cgi?id=777028');
             }
-        } else {
             maxTexturesUnits = Math.min(16, maxTexturesUnits);
         }
 
+        gl.deleteProgram(program);
+        gl.deleteShader(glVertexShader);
+        gl.deleteShader(glFragmentShader);
         logDepthBufferSupported = renderer.capabilities.logarithmicDepthBuffer;
     },
 };

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -317,7 +317,7 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
             if (sumColorLayers <= getMaxTextureSamplerCount()) {
                 parentLayer.attach(layer);
             } else {
-                throw new Error('Cant add color layer: the maximum layer is reached');
+                throw new Error(`Cant add color layer ${layer.id}: the maximum layer is reached`);
             }
         } else {
             parentLayer.attach(layer);

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -17,9 +17,8 @@ function initNodeImageryTexturesFromParent(node, parent, layer) {
         for (const c of coords) {
             for (const texture of parent.material.getLayerTextures(l_COLOR, layer.id)) {
                 if (c.isInside(texture.coords)) {
-                    const result = c.offsetToParent(texture.coords);
-                    node.material.textures[l_COLOR][textureIndex] = texture;
-                    node.material.offsetScale[l_COLOR][textureIndex] = result;
+                    const offset = c.offsetToParent(texture.coords);
+                    node.material.setTextureColorByIndex(textureIndex, texture, offset);
                     textureIndex++;
                     break;
                 }
@@ -47,8 +46,8 @@ function initNodeElevationTextureFromParent(node, parent, layer) {
     if (parent.material && parent.material.getElevationLayerLevel() > node.material.getElevationLayerLevel()) {
         const coords = node.getCoordsForLayer(layer);
 
-        const texture = parent.material.textures[l_ELEVATION][0];
-        const pitch = coords[0].offsetToParent(parent.material.textures[l_ELEVATION][0].coords);
+        const texture = parent.material.getTextureByIndex(l_ELEVATION, 0);
+        const pitch = coords[0].offsetToParent(texture.coords);
         const elevation = {
             texture,
             pitch,
@@ -86,8 +85,8 @@ function getIndiceWithPitch(i, pitch, w) {
 function insertSignificantValuesFromParent(texture, node, parent, layer) {
     if (parent.material && parent.material.getElevationLayerLevel() > EMPTY_TEXTURE_ZOOM) {
         const coords = node.getCoordsForLayer(layer);
-        const textureParent = parent.material.textures[l_ELEVATION][0];
-        const pitch = coords[0].offsetToParent(parent.material.textures[l_ELEVATION][0].coords);
+        const textureParent = parent.material.getTextureByIndex(l_ELEVATION, 0);
+        const pitch = coords[0].offsetToParent(textureParent.coords);
         const tData = texture.image.data;
         const l = tData.length;
 

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -74,14 +74,45 @@ var moveElementsArraySafe = function moveElementsArraySafe(array,index, howMany,
 };
 /* eslint-enable */
 
+const arrayColorLength = 15;
+const nbSamplersElevation = 1;
+
+function getTextureSamplerCount() {
+    const maxTexturesUnits = Capabilities.getMaxTextureUnitsCount();
+    const nbSamplersColor = Math.min(maxTexturesUnits - nbSamplersElevation);
+    const sizeColor_01 = nbSamplersColor > arrayColorLength ? arrayColorLength : nbSamplersColor;
+    const sizeColor_02 = nbSamplersColor > arrayColorLength ? arrayColorLength : 0;
+    return { sizeColor_01, sizeColor_02 };
+}
+
+export function getMaxTextureSamplerCount() {
+    const { sizeColor_01, sizeColor_02 } = getTextureSamplerCount();
+    return sizeColor_01 + sizeColor_02;
+}
+
 const LayeredMaterial = function LayeredMaterial(options) {
     THREE.RawShaderMaterial.call(this);
 
-    const maxTexturesUnits = Capabilities.getMaxTextureUnitsCount();
-    const nbSamplers = Math.min(maxTexturesUnits - 1, 16 - 1);
+    this.defines = {};
+
+    // There are two separate color samplers with same size
+    //
+    // Why separate samplers?
+    //      getColorAtIdUv can't have more than 16 statements because of compilation memory error
+    //      so we can not have a single sampler array of 31 textures
+    // Why same size?
+    //      If there was 2 arrays of 15 and 16 samplers
+    //      so it would require two functions getColorAtIdUv with signatures of different parameters
+    const { sizeColor_01, sizeColor_02 } = getTextureSamplerCount();
+    const maxColorLayerCount = sizeColor_01 + sizeColor_02;
+
     this.vertexShader = TileVS;
 
-    this.fragmentShaderHeader = `${PrecisionQualifier}\nconst int   TEX_UNITS   = ${nbSamplers.toString()};\n`;
+    this.fragmentShaderHeader = `${PrecisionQualifier}
+        const int TEX_UNITS = ${arrayColorLength.toString()};
+        const int MAXCOUNTLAYER = ${maxColorLayerCount.toString()};
+    `;
+
     this.fragmentShaderHeader += pitUV;
 
     if (__DEBUG__) {
@@ -102,41 +133,55 @@ const LayeredMaterial = function LayeredMaterial(options) {
     }
 
     // see GLOBE FS
-    this.fragmentShaderHeader += getColorAtIdUv(nbSamplers);
+    this.fragmentShaderHeader += getColorAtIdUv(arrayColorLength);
 
     this.fragmentShader = this.fragmentShaderHeader + TileFS;
     this.vertexShader = PrecisionQualifier + vsOptions + TileVS;
 
-    // handle on textures uniforms
-    this.textures = [];
-    // handle on textures offsetScale uniforms
-    this.offsetScale = [];
     // handle Loaded textures count by layer's type uniforms
     this.loadedTexturesCount = [0, 0];
 
     // Uniform three js needs no empty array
     // WARNING TODO: prevent empty slot, but it's not the solution
-    this.offsetScale[l_COLOR] = Array(nbSamplers);
-    this.offsetScale[l_ELEVATION] = [vector4];
-    fillArray(this.offsetScale[l_COLOR], vector4);
+    const offsetScale_elevation = [vector4];
+    const textureElevation = [emptyTexture];
 
-    this.textures[l_ELEVATION] = [emptyTexture];
-    this.textures[l_COLOR] = Array(nbSamplers);
-    var paramLayers = Array(8);
-    this.layerTexturesCount = Array(8);
 
-    fillArray(this.textures[l_COLOR], emptyTexture);
+    const paramLayers = Array(maxColorLayerCount);
+    this.layerTexturesCount = Array(maxColorLayerCount);
     fillArray(paramLayers, vector4);
     fillArray(this.layerTexturesCount, 0);
 
     // Elevation texture
-    this.uniforms.dTextures_00 = new THREE.Uniform(this.textures[l_ELEVATION]);
+    this.uniforms.texElevation = new THREE.Uniform(textureElevation);
+    // Elevation texture cropping
+    this.uniforms.offsetScale_elevation = new THREE.Uniform(offsetScale_elevation);
 
-    // Color textures's layer
-    this.uniforms.dTextures_01 = new THREE.Uniform(this.textures[l_COLOR]);
+    // First array sampler
+    // Color textures's layer 1
+    const texColor_01 = Array(sizeColor_01);
+    // array color texture offset 1
+    const offsetScale_color_01 = Array(sizeColor_01);
+    fillArray(texColor_01, emptyTexture);
+    fillArray(offsetScale_color_01, vector4);
+    this.uniforms.texColor_01 = new THREE.Uniform(texColor_01);
+    this.uniforms.offsetScale_color_01 = new THREE.Uniform(offsetScale_color_01);
+
+    // Second array sampler
+    if (sizeColor_02) {
+        this.defines.SECOND_SAMPLER = 1;
+        const texColor_02 = Array(sizeColor_02);
+        const offsetScale_color_02 = Array(sizeColor_02);
+        fillArray(texColor_02, emptyTexture);
+        fillArray(offsetScale_color_02, vector4);
+        this.uniforms.texColor_02 = new THREE.Uniform(texColor_02);
+        this.uniforms.offsetScale_color_02 = new THREE.Uniform(offsetScale_color_02);
+    }
 
     // Visibility layer
-    this.uniforms.visibility = new THREE.Uniform([true, true, true, true, true, true, true, true]);
+    const visibility = Array(maxColorLayerCount);
+    fillArray(visibility, true);
+    this.uniforms.visibility = new THREE.Uniform(visibility);
 
     // Loaded textures count by layer's type
     this.uniforms.loadedTexturesCount = new THREE.Uniform(this.loadedTexturesCount);
@@ -147,12 +192,6 @@ const LayeredMaterial = function LayeredMaterial(options) {
     // Layer setting
     // Offset color texture slot | Projection | fx | Opacity
     this.uniforms.paramLayers = new THREE.Uniform(paramLayers);
-
-    // Elevation texture cropping
-    this.uniforms.offsetScale_L00 = new THREE.Uniform(this.offsetScale[l_ELEVATION]);
-
-    // Color texture cropping
-    this.uniforms.offsetScale_L01 = new THREE.Uniform(this.offsetScale[l_COLOR]);
 
     // Light position
     this.uniforms.lightPosition = new THREE.Uniform(new THREE.Vector3(-0.5, 0.0, 1.0));
@@ -173,12 +212,8 @@ const LayeredMaterial = function LayeredMaterial(options) {
     this.elevationLayersId = [];
 
     if (Capabilities.isLogDepthBufferSupported()) {
-        this.defines = {
-            USE_LOGDEPTHBUF: 1,
-            USE_LOGDEPTHBUF_EXT: 1,
-        };
-    } else {
-        this.defines = {};
+        this.defines.USE_LOGDEPTHBUF = 1;
+        this.defines.USE_LOGDEPTHBUF_EXT = 1;
     }
 
     if (__DEBUG__) {
@@ -193,16 +228,16 @@ const LayeredMaterial = function LayeredMaterial(options) {
                 const count = this.getTextureCountByLayerIndex(index);
                 let total = 0;
                 for (let i = 0; i < this.loadedTexturesCount[1]; i++) {
-                    if (!this.uniforms.dTextures_01.value[i].image) {
+                    if (!this.getTextureColorByIndex(i).image) {
                         throw new Error(`${node.id} - Missing texture at index ${i} for layer ${layer.id}`);
                     }
 
                     const critere1 = (offset <= i && i < (offset + count));
                     const search = layer.name ? `LAYERS=${layer.name}&` : `LAYER=${layer.options.name}&`;
-                    const critere2 = this.uniforms.dTextures_01.value[i].image.currentSrc.indexOf(search) > 0;
+                    const critere2 = this.getTextureColorByIndex(i).image.currentSrc.indexOf(search) > 0;
 
                     if (critere1 && !critere2) {
-                        throw new Error(`${node.id} - Texture should belong to ${layer.id} but comes from ${this.uniforms.dTextures_01.value[i].image.currentSrc}`);
+                        throw new Error(`${node.id} - Texture should belong to ${layer.id} but comes from ${this.getTextureColorByIndex(i).image.currentSrc}`);
                     } else if (!critere1 && critere2) {
                         throw new Error(`${node.id} - Texture shouldn't belong to ${layer.id}`);
                     } else if (critere1) {
@@ -228,9 +263,10 @@ LayeredMaterial.prototype.dispose = function dispose() {
     });
 
     for (let l = 0; l < layerTypesCount; l++) {
-        for (let i = 0, max = this.textures[l].length; i < max; i++) {
-            if (this.textures[l][i] instanceof THREE.Texture) {
-                this.textures[l][i].dispose();
+        for (let i = 0, max = Capabilities.getMaxTextureUnitsCount(); i < max; i++) {
+            const texture = this.getTextureByIndex(l, i);
+            if (texture instanceof THREE.Texture) {
+                texture.dispose();
             }
         }
     }
@@ -240,8 +276,13 @@ LayeredMaterial.prototype.setSequence = function setSequence(sequenceLayer) {
     let offsetLayer = 0;
     let offsetTexture = 0;
 
-    const originalOffsets = new Array(...this.uniforms.offsetScale_L01.value);
-    const originalTextures = new Array(...this.uniforms.dTextures_01.value);
+    const originalOffsets = new Array(...this.uniforms.offsetScale_color_01.value);
+    const originalTextures = new Array(...this.uniforms.texColor_01.value);
+
+    if (this.uniforms.texColor_02) {
+        originalOffsets.push(...this.uniforms.offsetScale_color_02.value);
+        originalTextures.push(...this.uniforms.texColor_02.value);
+    }
 
     for (let l = 0; l < sequenceLayer.length; l++) {
         const layer = sequenceLayer[l];
@@ -260,10 +301,8 @@ LayeredMaterial.prototype.setSequence = function setSequence(sequenceLayer) {
             const oldOffset = this.getTextureOffsetByLayerIndex(newIndex);
             // consecutive values are copied from original
             for (let i = 0; i < texturesCount; i++) {
-                this.uniforms.offsetScale_L01.value[offsetTexture + i] = originalOffsets[oldOffset + i];
-                this.uniforms.dTextures_01.value[offsetTexture + i] = originalTextures[oldOffset + i];
+                this.setTextureColorByIndex(offsetTexture + i, originalTextures[oldOffset + i], originalOffsets[oldOffset + i]);
             }
-
 
             this.setTextureOffsetByLayerIndex(newIndex, offsetTexture);
             offsetTexture += texturesCount;
@@ -280,6 +319,14 @@ LayeredMaterial.prototype.removeColorLayer = function removeColorLayer(layer) {
 
     if (layerIndex === -1) {
         return;
+    }
+
+    const originalTextures = new Array(...this.uniforms.texColor_01.value);
+    const originalOffsets = new Array(...this.uniforms.offsetScale_color_01.value);
+
+    if (this.uniforms.texColor_02) {
+        originalOffsets.push(...this.uniforms.offsetScale_color_02.value);
+        originalTextures.push(...this.uniforms.texColor_02.value);
     }
 
     const offset = this.getTextureOffsetByLayerIndex(layerIndex);
@@ -302,21 +349,29 @@ LayeredMaterial.prototype.removeColorLayer = function removeColorLayer(layer) {
     this.uniforms.visibility.value.push(true);
 
     // Dispose Layers textures
+    let loadedTexturesLayerCount = 0;
+
     for (let i = offset, max = offset + texturesCount; i < max; i++) {
-        if (this.textures[l_COLOR][i] instanceof THREE.Texture) {
-            this.textures[l_COLOR][i].dispose();
+        const texture = this.getTextureColorByIndex(i);
+        if (texture instanceof THREE.Texture) {
+            texture.dispose();
+            if (texture.coords.zoom > EMPTY_TEXTURE_ZOOM) {
+                loadedTexturesLayerCount++;
+            }
+            originalTextures.push(emptyTexture);
+            originalOffsets.push(vector4);
         }
     }
 
-    const removedTexturesLayer = this.textures[l_COLOR].splice(offset, texturesCount);
-    this.offsetScale[l_COLOR].splice(offset, texturesCount);
+    originalTextures.splice(offset, texturesCount);
+    originalOffsets.splice(offset, texturesCount);
 
-    const loadedTexturesLayerCount = removedTexturesLayer.reduce((sum, texture) => sum + (texture.coords.zoom > EMPTY_TEXTURE_ZOOM), 0);
+    this.uniforms.texColor_01.value = originalTextures.slice(0, arrayColorLength);
+    this.uniforms.offsetScale_color_01.value = originalOffsets.slice(0, arrayColorLength);
 
-    // refill remove textures
-    for (let i = 0, max = texturesCount; i < max; i++) {
-        this.textures[l_COLOR].push(emptyTexture);
-        this.offsetScale[l_COLOR].push(vector4);
+    if (this.uniforms.texColor_02) {
+        this.uniforms.texColor_02.value = originalTextures.slice(0, arrayColorLength);
+        this.uniforms.offsetScale_color_02.value = originalOffsets.slice(0, arrayColorLength);
     }
 
     // Update slot start texture layer
@@ -325,9 +380,6 @@ LayeredMaterial.prototype.removeColorLayer = function removeColorLayer(layer) {
     }
 
     this.loadedTexturesCount[l_COLOR] -= loadedTexturesLayerCount;
-
-    this.uniforms.offsetScale_L01.value = this.offsetScale[l_COLOR];
-    this.uniforms.dTextures_01.value = this.textures[l_COLOR];
 };
 
 LayeredMaterial.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layer) {
@@ -345,14 +397,11 @@ LayeredMaterial.prototype.setTexturesLayer = function setTexturesLayer(textures,
     }
 };
 
-LayeredMaterial.prototype.setTexture = function setTexture(texture, layerType, slot, offsetScale) {
-    if (this.textures[layerType][slot] === undefined || this.textures[layerType][slot].image === undefined) {
+LayeredMaterial.prototype.setTexture = function setTexture(texture = emptyTexture, layerType, slot, offsetScale = new THREE.Vector4(0.0, 0.0, 1.0, 1.0)) {
+    if (this.getTextureByIndex(layerType, slot) === undefined || this.getTextureByIndex(layerType, slot).image === undefined) {
         this.loadedTexturesCount[layerType] += 1;
     }
-
-    // BEWARE: array [] -> size: 0; array [10]="wao" -> size: 11
-    this.textures[layerType][slot] = texture || emptyTexture;
-    this.offsetScale[layerType][slot] = offsetScale || new THREE.Vector4(0.0, 0.0, 1.0, 1.0);
+    this.setTextureByIndex(layerType, slot, texture, offsetScale);
 };
 
 LayeredMaterial.prototype.setColorLayerParameters = function setColorLayerParameters(params) {
@@ -398,6 +447,57 @@ LayeredMaterial.prototype.getTextureCountByLayerIndex = function getTextureCount
     return this.layerTexturesCount[index];
 };
 
+LayeredMaterial.prototype.getTextureByIndex = function getTextureByIndex(layerType, index) {
+    if (layerType == l_COLOR) {
+        return this.getTextureColorByIndex(index);
+    } else if (layerType == l_ELEVATION) {
+        return this.uniforms.texElevation.value[index];
+    }
+};
+
+LayeredMaterial.prototype.getOffsetByIndex = function getOffsetByIndex(layerType, index) {
+    if (layerType == l_COLOR) {
+        return this.getOffsetColorByIndex(index);
+    } else if (layerType == l_ELEVATION) {
+        return this.uniforms.offsetScale_elevation.value[index];
+    }
+};
+
+LayeredMaterial.prototype.setTextureByIndex = function setTextureByIndex(layerType, index, texture, offsetScale) {
+    if (layerType == l_COLOR) {
+        this.setTextureColorByIndex(index, texture, offsetScale);
+    } else if (layerType == l_ELEVATION) {
+        this.uniforms.texElevation.value[index] = texture;
+        this.uniforms.offsetScale_elevation.value[index] = offsetScale;
+    }
+};
+
+LayeredMaterial.prototype.getTextureColorByIndex = function getTextureColorByIndex(index) {
+    if (index < arrayColorLength) {
+        return this.uniforms.texColor_01.value[index];
+    } else if (this.uniforms.texColor_02) {
+        return this.uniforms.texColor_02.value[index - arrayColorLength];
+    }
+};
+
+LayeredMaterial.prototype.getOffsetColorByIndex = function getOffsetColorByIndex(index) {
+    if (index < arrayColorLength) {
+        return this.uniforms.offsetScale_color_01.value[index];
+    } else if (this.uniforms.offsetScale_color_02) {
+        return this.uniforms.offsetScale_color_02.value[index - arrayColorLength];
+    }
+};
+
+LayeredMaterial.prototype.setTextureColorByIndex = function setTextureColorByIndex(index, texture, offset = new THREE.Vector4(0.0, 0.0, 1.0, 1.0)) {
+    if (index < arrayColorLength) {
+        this.uniforms.texColor_01.value[index] = texture;
+        this.uniforms.offsetScale_color_01.value[index] = offset;
+    } else if (this.uniforms.texColor_02) {
+        this.uniforms.texColor_02.value[index - arrayColorLength] = texture;
+        this.uniforms.offsetScale_color_02.value[index - arrayColorLength] = offset;
+    }
+};
+
 LayeredMaterial.prototype.getLayerTextureOffset = function getLayerTextureOffset(layerId) {
     const index = this.indexOfColorLayer(layerId);
     return index > -1 ? this.getTextureOffsetByLayerIndex(index) : -1;
@@ -441,8 +541,8 @@ LayeredMaterial.prototype.getLoadedTexturesCount = function getLoadedTexturesCou
 };
 
 LayeredMaterial.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layerId, zoom) {
-    return this.textures[l_COLOR][this.getLayerTextureOffset(layerId)] &&
-        this.textures[l_COLOR][this.getLayerTextureOffset(layerId)].coords.zoom < zoom;
+    return this.getTextureColorByIndex(this.getLayerTextureOffset(layerId)) &&
+        this.getTextureColorByIndex(this.getLayerTextureOffset(layerId)).coords.zoom < zoom;
 };
 
 LayeredMaterial.prototype.getColorLayerLevelById = function getColorLayerLevelById(colorLayerId) {
@@ -451,18 +551,18 @@ LayeredMaterial.prototype.getColorLayerLevelById = function getColorLayerLevelBy
         return EMPTY_TEXTURE_ZOOM;
     }
     const slot = this.getTextureOffsetByLayerIndex(index);
-    const texture = this.textures[l_COLOR][slot];
+    const texture = this.getTextureColorByIndex(slot);
 
     return texture ? texture.coords.zoom : EMPTY_TEXTURE_ZOOM;
 };
 
 LayeredMaterial.prototype.getElevationLayerLevel = function getElevationLayerLevel() {
-    return this.textures[l_ELEVATION][0].coords.zoom;
+    return this.getTextureByIndex(l_ELEVATION, 0).coords.zoom;
 };
 
 LayeredMaterial.prototype.getLayerTextures = function getLayerTextures(layerType, layerId) {
     if (layerType === l_ELEVATION) {
-        return this.textures[l_ELEVATION];
+        return this.uniforms.texElevation.value;
     }
 
     const index = this.indexOfColorLayer(layerId);
@@ -470,7 +570,11 @@ LayeredMaterial.prototype.getLayerTextures = function getLayerTextures(layerType
     if (index !== -1) {
         const count = this.getTextureCountByLayerIndex(index);
         const textureIndex = this.getTextureOffsetByLayerIndex(index);
-        return this.textures[l_COLOR].slice(textureIndex, textureIndex + count);
+        const textures = [];
+        for (var i = textureIndex; i < textureIndex + count; i++) {
+            textures.push(this.getTextureColorByIndex(i));
+        }
+        return textures;
     } else {
         throw new Error(`Invalid layer id "${layerId}"`);
     }

--- a/src/Renderer/Shader/SampleTestFS.glsl
+++ b/src/Renderer/Shader/SampleTestFS.glsl
@@ -1,0 +1,4 @@
+uniform sampler2D uni[SAMPLE];
+void main() {
+    gl_FragColor += texture2D(uni[SAMPLE-1], vec2(0));
+}

--- a/src/Renderer/Shader/SampleTestVS.glsl
+++ b/src/Renderer/Shader/SampleTestVS.glsl
@@ -1,0 +1,3 @@
+void main() {
+    gl_Position = vec4( 0.0, 0.0, 0.0, 1.0 );
+}

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -15,14 +15,9 @@ const vec4 CRed = vec4( 1.0, 0.0, 0.0, 1.0);
 uniform sampler2D   texColor_01[TEX_UNITS];
 uniform vec4        offsetScale_color_01[TEX_UNITS];
 
-#if defined(SECOND_SAMPLER)
-uniform sampler2D   texColor_02[TEX_UNITS];
-uniform vec4        offsetScale_color_02[TEX_UNITS];
-#endif
-
 // offset texture | Projection | fx | Opacity
-uniform vec4        paramLayers[MAXCOUNTLAYER];
-uniform bool        visibility[MAXCOUNTLAYER];
+uniform vec4        paramLayers[TEX_UNITS];
+uniform bool        visibility[TEX_UNITS];
 
 uniform float       distanceFog;
 uniform int         colorLayersCount;
@@ -62,25 +57,6 @@ vec4 applyLightColorToInvisibleEffect(vec4 color, float intensity) {
 #include <packing>
 uniform int  uuid;
 #endif
-
-vec4 getColorAtIdUv(int id, vec2 uv) {
-    if (id < TEX_UNITS) {
-        return colorAtIdUv(
-            texColor_01,
-            offsetScale_color_01,
-            id,
-            uv);
-    }
-#if defined(SECOND_SAMPLER)
-    else {
-        return colorAtIdUv(
-            texColor_02,
-            offsetScale_color_02,
-            id - TEX_UNITS,
-            uv);
-    }
-#endif
-}
 
 void main() {
     #include <logdepthbuf_fragment>
@@ -122,7 +98,7 @@ void main() {
         bool validTexture = false;
 
         // TODO Optimisation des uv1 peuvent copier pas lignes!!
-        for (int layer = 0; layer < MAXCOUNTLAYER; layer++) {
+        for (int layer = 0; layer < TEX_UNITS; layer++) {
             if(layer == colorLayersCount) {
                 break;
             }
@@ -152,7 +128,9 @@ void main() {
                         // get value in array, the index must be constant
                         // Strangely it's work with function returning a global variable, doesn't work on Chrome Windows
                         // vec4 layerColor = texture2D(dTextures_01[getTextureIndex()],  pitUV(projWGS84 ? vUv_WGS84 : uvPM,pitScale_L01[getTextureIndex()]));
-                        vec4 layerColor = getColorAtIdUv(
+                        vec4 layerColor = colorAtIdUv(
+                            texColor_01,
+                            offsetScale_color_01,
                             textureIndex,
                             projWGS84 ? vUv_WGS84 : uvPM);
 

--- a/src/Renderer/Shader/TileVS.glsl
+++ b/src/Renderer/Shader/TileVS.glsl
@@ -10,8 +10,8 @@ attribute vec2      uv_wgs84;
 attribute vec3      position;
 attribute vec3      normal;
 
-uniform sampler2D   dTextures_00[1];
-uniform vec3        offsetScale_L00[1];
+uniform sampler2D   texElevation[1];
+uniform vec3        offsetScale_elevation[1];
 uniform int         loadedTexturesCount[8];
 
 uniform mat4        projectionMatrix;
@@ -40,11 +40,11 @@ void main() {
 
         if(loadedTexturesCount[0] > 0) {
             vec2    vVv = vec2(
-                vUv_WGS84.x * offsetScale_L00[0].z + offsetScale_L00[0].x,
-                (1.0 - vUv_WGS84.y) * offsetScale_L00[0].z + offsetScale_L00[0].y);
+                vUv_WGS84.x * offsetScale_elevation[0].z + offsetScale_elevation[0].x,
+                (1.0 - vUv_WGS84.y) * offsetScale_elevation[0].z + offsetScale_elevation[0].y);
 
             #if defined(RGBA_TEXTURE_ELEVATION)
-                vec4 rgba = texture2D( dTextures_00[0], vVv ) * 255.0;
+                vec4 rgba = texture2D( texElevation[0], vVv ) * 255.0;
 
                 rgba.rgba = rgba.abgr;
 
@@ -58,9 +58,9 @@ void main() {
                 }
 
             #elif defined(DATA_TEXTURE_ELEVATION)
-                float   dv  = max(texture2D( dTextures_00[0], vVv ).w, 0.);
+                float   dv  = max(texture2D( texElevation[0], vVv ).w, 0.);
             #elif defined(COLOR_TEXTURE_ELEVATION)
-                float   dv  = max(texture2D( dTextures_00[0], vVv ).r, 0.);
+                float   dv  = max(texture2D( texElevation[0], vVv ).r, 0.);
                 dv = _minElevation + dv * (_maxElevation - _minElevation);
             #else
 

--- a/src/utils/DEMUtils.js
+++ b/src/utils/DEMUtils.js
@@ -383,7 +383,7 @@ function _readZ(layer, method, coord, nodes, cache) {
     // Assuming that tiles are split in 4 children, we lookup the parent that
     // really owns this texture
     const stepsUpInHierarchy = Math.round(Math.log2(1.0 /
-        tileWithValidElevationTexture.material.offsetScale[l_ELEVATION][0].z));
+        tileWithValidElevationTexture.material.getOffsetByIndex(l_ELEVATION, 0).z));
     for (let i = 0; i < stepsUpInHierarchy; i++) {
         tileWithValidElevationTexture = tileWithValidElevationTexture.parent;
     }

--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -120,6 +120,16 @@ global.renderer = {
         getExtension() {
             return null;
         },
+        createProgram: () => {},
+        shaderSource: () => {},
+        compileShader: () => {},
+        attachShader: () => {},
+        linkProgram: () => {},
+        getProgramInfoLog: () => {},
+        getProgramParameter: () => {},
+        deleteProgram: () => {},
+        deleteShader: () => {},
+        createShader: () => {},
         MAX_TEXTURE_IMAGE_UNITS: 8,
     },
     capabilities: {


### PR DESCRIPTION
## Description
Adjust the ability to add more color layers based on gpu's capabilities
and limit the addition of layers so that the abilities don't exceed

## Motivation and Context
Before the capabilities were clamp to 15 color layers
and if the limit is exceeded it will cause malfunction

**example if you exceed limit**
![bug layer](https://user-images.githubusercontent.com/11291849/35269392-1e6f1e5c-002c-11e8-9851-52fd4b05bdaa.png)
