### PR TITLE
feat(examples): add point features representing route points, in the …

### DIFF
--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -10,6 +10,8 @@ var scaler;
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 itowns.proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+itowns.proj4.defs('EPSG:2154',
+    '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 // Define geographic extent: CRS, min/max X, min/max Y
 extent = new itowns.Extent(
@@ -144,4 +146,42 @@ view.addLayer({
     },
 }, view.tileLayer);
 
+function configPointMaterial(result) {
+    var i = 0;
+    var mesh;
+    for (; i < result.children.length; i++) {
+        mesh = result.children[i];
+
+        mesh.material.size = 15;
+        mesh.material.sizeAttenuation = false;
+    }
+}
+
+function colorPoint(properties) {
+    if (properties.gestion === 'CEREMA') {
+        return new itowns.THREE.Color(0x7F180D);
+    }
+    return new itowns.THREE.Color(0xFFB300);
+}
+
+view.addLayer({
+    type: 'geometry',
+    update: itowns.FeatureProcessing.update,
+    convert: itowns.Feature2Mesh.convert({
+        altitude: 0,
+        color: colorPoint }),
+    onMeshCreated: configPointMaterial,
+    url: 'http://wxs.ign.fr/72hpsel8j8nhb5qgdh07gcyp/geoportail/wfs?',
+    networkOptions: { crossOrigin: 'anonymous' },
+    protocol: 'wfs',
+    version: '2.0.0',
+    id: 'wfsPoint',
+    typeName: 'BDPR_BDD_FXX_LAMB93_20170911:pr',
+    level: 2,
+    projection: 'EPSG:2154',
+    ipr: 'IGN',
+    options: {
+        mimetype: 'json',
+    },
+}, view.tileLayer);
 exports.view = view;


### PR DESCRIPTION
Add point features in the WFS examples

## Description
feat(examples): add point features representing route points

## Motivation and Context
The goal is to show / verify point representation from WFS in an example.
I add theses points layer in the planar WFS example and in the globe WFS example.

## Screenshots
![example_points](https://user-images.githubusercontent.com/15127065/32948851-fde29ac0-cba0-11e7-9b03-318e8462e4a8.png)