### PR TITLE
Re-use identical tile's geometry and oriented the main normal on the Z axis

### DIFF
--- a/examples/planar.html
+++ b/examples/planar.html
@@ -20,6 +20,8 @@
                 padding: 0;
             }
 
+            #menuDiv {position: absolute; top:0px; margin-right: 0px; right: 0px;}
+
             #help {
                 position: absolute;
                 z-index: 0;
@@ -54,6 +56,7 @@
         <meta charset="UTF-8">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="GUI/dat.gui/dat.gui.min.js"></script>
     </head>
     <body>
         <div id="help">
@@ -70,10 +73,21 @@
         </div>
         <div id="viewerDiv"></div>
         <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="GUI/GuiTools.js"></script>
         <script type="text/javascript">
             var renderer; var exports = {};
             var proj4 = itowns.proj4;
         </script>
         <script src="planar.js"></script>
+        <script type="text/javascript">
+            if (view.isDebugMode) {
+                var menuGlobe = new GuiTools('menuDiv', view);
+                menuGlobe.view = view;
+                menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
+                var d = new debug.Debug(view, menuGlobe.gui);
+                debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
+            }
+        </script>
     </body>
 </html>

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -136,8 +136,10 @@ function _convert(coordsIn, newCrs, target) {
         }
     } else {
         if (coordsIn.crs === 'EPSG:4326' && newCrs === 'EPSG:4978') {
-            const cartesian = ellipsoid.cartographicToCartesian(coordsIn);
-            return target.set(newCrs, cartesian);
+            const cartesian = ellipsoid.cartographicToCartesian(coordsIn, coordsIn.geodesicNormal);
+            target.set(newCrs, cartesian);
+            target._normal = coordsIn.geodesicNormal;
+            return target;
         }
 
         if (coordsIn.crs === 'EPSG:4978' && newCrs === 'EPSG:4326') {
@@ -269,6 +271,7 @@ Coordinates.prototype.set = function set(crs, ...coordinates) {
             this._values[i] = 0;
         }
     }
+    this._normal = undefined;
     this._internalStorageUnit = crsToUnit(crs);
     return this;
 };
@@ -280,6 +283,9 @@ Coordinates.prototype.clone = function clone(target) {
         r = target;
     } else {
         r = new Coordinates(this.crs, ...this._values);
+    }
+    if (this._normal) {
+        r._normal = this._normal.clone();
     }
     r._internalStorageUnit = this._internalStorageUnit;
     return r;

--- a/src/Core/Math/Ellipsoid.js
+++ b/src/Core/Math/Ellipsoid.js
@@ -55,11 +55,9 @@ Ellipsoid.prototype.setSize = function setSize(size) {
     this._radiiSquared = new THREE.Vector3(size.x * size.x, size.y * size.y, size.z * size.z);
 };
 
-
+const k = new THREE.Vector3();
 Ellipsoid.prototype.cartographicToCartesian = function cartographicToCartesian(coordCarto) {
-    // var n;
-    var k = new THREE.Vector3();
-    var n = this.geodeticSurfaceNormalCartographic(coordCarto);
+    const n = coordCarto.geodesicNormal.clone();
 
     k.multiplyVectors(this._radiiSquared, n);
 

--- a/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
+++ b/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import OBB from '../../../Renderer/ThreeExtended/OBB';
 import Coordinates, { UNIT } from '../../Geographic/Coordinates';
+import Extent from '../../Geographic/Extent';
 
 function PanoramaTileBuilder(ratio) {
     this.tmp = {
@@ -14,9 +15,11 @@ function PanoramaTileBuilder(ratio) {
     }
     if (ratio === 2) {
         this.equirectangular = true;
+        this.type = 's';
         this.radius = 100;
     } else {
         this.equirectangular = false; // cylindrical proj
+        this.type = 'c';
         this.height = 200;
         this.radius = (ratio * this.height) / (2 * Math.PI);
     }
@@ -26,14 +29,19 @@ PanoramaTileBuilder.prototype.constructor = PanoramaTileBuilder;
 
 // prepare params
 // init projected object -> params.projected
+const axisX = new THREE.Vector3(0, 1, 0);
 PanoramaTileBuilder.prototype.Prepare = function Prepare(params) {
+    const angle = (params.extent.north(UNIT.RADIAN) + params.extent.south(UNIT.RADIAN)) * 0.5;
+
     if (this.equirectangular) {
+        params.quatNormalToZ = new THREE.Quaternion().setFromAxisAngle(axisX, (Math.PI * 0.5 - angle));
         params.projected = {
             theta: 0,
             phi: 0,
             radius: this.radius,
         };
     } else {
+        params.quatNormalToZ = new THREE.Quaternion().setFromAxisAngle(axisX, (Math.PI * 0.5));
         params.projected = {
             theta: 0,
             radius: this.radius,
@@ -42,15 +50,13 @@ PanoramaTileBuilder.prototype.Prepare = function Prepare(params) {
     }
 };
 
-PanoramaTileBuilder.prototype.Center = function Center(params) {
+PanoramaTileBuilder.prototype.Center = function Center(extent) {
+    const params = { extent };
     this.Prepare(params);
-
     this.uProjecte(0.5, params);
     this.vProjecte(0.5, params);
 
-    params.center = this.VertexPosition(params).clone();
-
-    return params.center;
+    return this.VertexPosition(params).clone();
 };
 
 // get position 3D cartesian
@@ -60,9 +66,8 @@ PanoramaTileBuilder.prototype.VertexPosition = function VertexPosition(params) {
     } else {
         this.tmp.position.setFromCylindrical(params.projected);
     }
-    const swap = this.tmp.position.y;
-    this.tmp.position.y = this.tmp.position.z;
-    this.tmp.position.z = this.equirectangular ? -swap : swap;
+
+    this.tmp.position.set(this.tmp.position.z, this.tmp.position.x, this.tmp.position.y);
 
     return this.tmp.position;
 };
@@ -75,20 +80,20 @@ PanoramaTileBuilder.prototype.VertexNormal = function VertexNormal() {
 // coord u tile to projected
 PanoramaTileBuilder.prototype.uProjecte = function uProjecte(u, params) {
     // both (theta, phi) and (y, z) are swapped in setFromSpherical
-    params.projected.theta = THREE.Math.lerp(
-        params.extent.west(UNIT.RADIAN),
+    params.projected.theta = Math.PI - THREE.Math.lerp(
         params.extent.east(UNIT.RADIAN),
-        u);
+        params.extent.west(UNIT.RADIAN),
+        1 - u);
 };
 
 // coord v tile to projected
 PanoramaTileBuilder.prototype.vProjecte = function vProjecte(v, params) {
     if (this.equirectangular) {
-        params.projected.phi = Math.PI * 0.5 +
+        params.projected.phi = Math.PI * 0.5 -
             THREE.Math.lerp(
-                params.extent.south(UNIT.RADIAN),
                 params.extent.north(UNIT.RADIAN),
-                v);
+                params.extent.south(UNIT.RADIAN),
+                1 - v);
     } else {
         params.projected.y =
             this.height *
@@ -97,57 +102,36 @@ PanoramaTileBuilder.prototype.vProjecte = function vProjecte(v, params) {
 };
 
 // get oriented bounding box of tile
-PanoramaTileBuilder.prototype.OBB = function _OBB(params) {
-    if (this.equirectangular) {
-        const pts = [];
-        //      0---1---2
-        //      |       |
-        //      7   8   3
-        //      |       |
-        //      6---5---4
-        const uvs = [
-            [0, 0.0], [0.5, 0], [1, 0.0],
-            [1, 0.5], [1, 1.0], [0.5, 1],
-            [0, 1.0], [0, 0.5], [0.5, 0.5]];
-        for (const uv of uvs) {
-            this.uProjecte(uv[0], params);
-            this.vProjecte(uv[1], params);
-            pts.push(this.VertexPosition(params).clone());
-        }
-        return OBB.cardinalsXYZToOBB(pts, params.extent.center().longitude(UNIT.RADIAN), false);
-    } else {
-        // 3 points: corners + center
-        const pts = [];
-        this.uProjecte(0.5, params);
-        this.vProjecte(0.5, params);
-        pts.push(this.VertexPosition(params).clone());
-        this.uProjecte(0, params);
-        this.vProjecte(0, params);
-        pts.push(this.VertexPosition(params).clone());
-        this.uProjecte(1, params);
-        this.vProjecte(1, params);
-        pts.push(this.VertexPosition(params).clone());
+PanoramaTileBuilder.prototype.OBB = function _OBB(boundingBox) {
+    return new OBB(boundingBox.min, boundingBox.max);
+};
 
-        const direction = params.center.clone();
-        direction.z = 0;
-        direction.normalize();
+const axisY = new THREE.Vector3(0, 1, 0);
+const axisZ = new THREE.Vector3(0, 0, 1);
+const quatToAlignLongitude = new THREE.Quaternion();
+const quatToAlignLatitude = new THREE.Quaternion();
 
-        const diffExtent = new THREE.Vector3().subVectors(pts[2], pts[1]);
-        const height = diffExtent.z;
-        diffExtent.z = 0;
+PanoramaTileBuilder.prototype.computeSharableExtent = function fnComputeSharableExtent(extent) {
+    // Compute sharable extent to pool the geometries
+    // the geometry in common extent is identical to the existing input
+    // with a transformation (translation, rotation)
+    const sizeLongitude = Math.abs(extent.west() - extent.east()) / 2;
+    const sharableExtent = new Extent(extent.crs(), -sizeLongitude, sizeLongitude, extent.south(), extent.north());
+    sharableExtent._internalStorageUnit = extent._internalStorageUnit;
 
-        const length = diffExtent.length();
+    // compute rotation to transform tile to position it
+    // this transformation take into account the transformation of the parents
+    const rotLon = extent.west(UNIT.RADIAN) - sharableExtent.west(UNIT.RADIAN);
+    const rotLat = Math.PI * 0.5 - (!this.equirectangular ? 0 : (extent.north(UNIT.RADIAN) + extent.south(UNIT.RADIAN)) * 0.5);
+    quatToAlignLongitude.setFromAxisAngle(axisZ, -rotLon);
+    quatToAlignLatitude.setFromAxisAngle(axisY, -rotLat);
+    quatToAlignLongitude.multiply(quatToAlignLatitude);
 
-        const diff = new THREE.Vector3().subVectors(params.center, pts[1]);
-        diff.z = 0;
-        const thickness = diff.dot(direction);
-
-        const min = new THREE.Vector3(-length * 0.5, -height * 0.5, -thickness * 0.5);
-        const max = new THREE.Vector3(length * 0.5, height * 0.5, thickness * 0.5);
-
-        const translate = new THREE.Vector3(0, 0, thickness * -0.5);
-        return new OBB(min, max, direction, translate);
-    }
+    return {
+        sharableExtent,
+        quaternion: quatToAlignLongitude,
+        position: this.Center(extent),
+    };
 };
 
 export default PanoramaTileBuilder;

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -3,16 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
-/*
- * A Faire
- * Les tuiles de longitude identique ont le maillage et ne demande pas 1 seule calcul pour la génération du maillage
- *
- *
- *
- *
- */
-
+import * as THREE from 'three';
 import Provider from './Provider';
 import TileGeometry from '../../TileGeometry';
 import TileMesh from '../../TileMesh';
@@ -21,6 +12,7 @@ import { requestNewTile } from '../../../Process/TiledNodeProcessing';
 
 function TileProvider() {
     Provider.call(this, null);
+    this.cacheGeometry = new Map();
 }
 
 TileProvider.prototype = Object.create(Provider.prototype);
@@ -49,47 +41,79 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
     });
 };
 
+const worldQuaternion = new THREE.Quaternion();
 TileProvider.prototype.executeCommand = function executeCommand(command) {
-    var extent = command.extent;
+    const extent = command.extent;
     if (command.requester &&
         !command.requester.material) {
         // request has been deleted
         return Promise.reject(new CancelledCommandException(command));
     }
+    const layer = command.layer;
+    const builder = layer.builder;
+    const parent = command.requester;
+    const level = (command.level === undefined) ? (parent.level + 1) : command.level;
 
-    var parent = command.requester;
+    const { sharableExtent, quaternion, position } = builder.computeSharableExtent(extent);
+    const south = sharableExtent.south().toFixed(6);
+    const segment = layer.segments || 16;
+    const key = `${builder.type}_${layer.disableSkirt ? 0 : 1}_${segment}_${level}_${south}`;
 
+    let geometry = this.cacheGeometry.get(key);
+    // build geometry if doesn't exist
+    if (!geometry) {
+        const paramsGeometry = {
+            extent: sharableExtent,
+            level,
+            segment,
+            disableSkirt: layer.disableSkirt,
+        };
+
+        geometry = new TileGeometry(paramsGeometry, builder);
+        this.cacheGeometry.set(key, geometry);
+
+        geometry._count = 0;
+        geometry.dispose = () => {
+            geometry._count--;
+            if (geometry._count == 0) {
+                THREE.BufferGeometry.prototype.dispose.call(geometry);
+                this.cacheGeometry.delete(key);
+            }
+        };
+    }
 
     // build tile
-    var params = {
-        layerId: command.layer.id,
+    const params = {
+        layerId: layer.id,
         extent,
-        level: (command.level === undefined) ? (parent.level + 1) : command.level,
-        segment: command.layer.segments || 16,
-        materialOptions: command.layer.materialOptions,
-        disableSkirt: command.layer.disableSkirt,
+        level,
+        materialOptions: layer.materialOptions,
     };
 
-    const geometry = new TileGeometry(params, command.layer.builder);
-
-    var tile = new TileMesh(geometry, params);
-
-    tile.layer = command.layer.id;
+    geometry._count++;
+    const tile = new TileMesh(geometry, params);
+    tile.layer = layer.id;
     tile.layers.set(command.threejsLayer);
 
     if (parent) {
-        params.center.sub(parent.geometry.center);
+        position.applyMatrix4(layer.object3d.matrixWorld);
+        parent.worldToLocal(position);
+        worldQuaternion.setFromRotationMatrix(parent.matrixWorld).inverse().multiply(layer.object3d.quaternion);
+        quaternion.premultiply(worldQuaternion);
     }
 
-    tile.position.copy(params.center);
-    tile.material.transparent = command.layer.opacity < 1.0;
-    tile.material.uniforms.opacity.value = command.layer.opacity;
+    tile.position.copy(position);
+    tile.quaternion.copy(quaternion);
+
+    tile.material.transparent = layer.opacity < 1.0;
+    tile.material.uniforms.opacity.value = layer.opacity;
     tile.setVisibility(false);
     tile.updateMatrix();
+
     if (parent) {
         tile.setBBoxZ(parent.OBB().z.min, parent.OBB().z.max);
-    } else if (command.layer.materialOptions && command.layer.materialOptions.useColorTextureElevation) {
-        tile.setBBoxZ(command.layer.materialOptions.colorTextureElevationMinZ, command.layer.materialOptions.colorTextureElevationMaxZ);
+    } else if (layer.materialOptions && layer.materialOptions.useColorTextureElevation) {
+        tile.setBBoxZ(layer.materialOptions.colorTextureElevationMinZ, layer.materialOptions.colorTextureElevationMaxZ);
     }
 
     return Promise.resolve(tile);

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -75,6 +75,10 @@ function View(crs, viewerDiv, options = {}) {
     }, false);
 
     this._changeSources = new Set();
+
+    if (__DEBUG__) {
+        this.isDebugMode = true;
+    }
 }
 
 View.prototype = Object.create(EventDispatcher.prototype);

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -89,13 +89,13 @@ export function globeCulling(minLevelForHorizonCulling) {
     };
 }
 
+const v = new THREE.Vector3();
 function computeNodeSSE(camera, node) {
-    const v = new THREE.Vector3();
     v.setFromMatrixScale(node.matrixWorld);
-    const boundingSphereCenter = new THREE.Vector3().addVectors(node.geometry.boundingSphere.center, node.boundingSphereOffset).applyMatrix4(node.matrixWorld);
+    const boundingSphereCenter = node.boundingSphere.center.clone().applyMatrix4(node.matrixWorld);
     const distance = Math.max(
         0.0,
-        camera.camera3D.position.distanceTo(boundingSphereCenter) - node.geometry.boundingSphere.radius * v.x);
+        camera.camera3D.position.distanceTo(boundingSphereCenter) - node.boundingSphere.radius * v.x);
 
     // Removed because is false computation, it doesn't consider the altitude of node
     // Added small oblique weight (distance is not enough, tile orientation is needed)

--- a/src/Process/PanoramaTileProcessing.js
+++ b/src/Process/PanoramaTileProcessing.js
@@ -7,9 +7,13 @@ export function panoramaCulling(node, camera) {
 }
 
 function _isTileBiggerThanTexture(camera, textureSize, quality, node) {
+    const obb = node.OBB();
+
+    obb.updateMatrixWorld();
     const onScreen = camera.box3SizeOnScreen(
-        node.geometry.OBB.box3D,
-        node.geometry.OBB.matrixWorld);
+        obb.box3D,
+        obb.matrixWorld);
+
     onScreen.min.z = 0;
     onScreen.max.z = 0;
 

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -7,7 +7,7 @@ export function planarCulling(node, camera) {
 }
 
 function _isTileBigOnScreen(camera, node) {
-    const onScreen = camera.box3SizeOnScreen(node.geometry.OBB.box3D, node.matrixWorld);
+    const onScreen = camera.box3SizeOnScreen(node.OBB().box3D, node.matrixWorld);
 
     // onScreen.x/y/z are [-1, 1] so divide by 2
     // (so x = 0.4 means the object width on screen is 40% of the total screen width)

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -69,7 +69,6 @@ function subdivideNode(context, layer, node) {
             for (const child of children) {
                 node.add(child);
                 child.updateMatrixWorld(true);
-                child.OBB().update();
 
                 child.material.uniforms.lightPosition.value =
                     node.material.uniforms.lightPosition.value;

--- a/src/Renderer/Shader/TileVS.glsl
+++ b/src/Renderer/Shader/TileVS.glsl
@@ -16,6 +16,7 @@ uniform int         loadedTexturesCount[8];
 
 uniform mat4        projectionMatrix;
 uniform mat4        modelViewMatrix;
+uniform mat4        modelMatrix;
 
 varying vec2        vUv_WGS84;
 varying float       vUv_PM;
@@ -36,8 +37,6 @@ void main() {
         vUv_PM = uv_pm;
 
         vec4 vPosition;
-
-        vNormal = normal;
 
         if(loadedTexturesCount[0] > 0) {
             vec2    vVv = vec2(
@@ -68,10 +67,12 @@ void main() {
             #error Must define either RGBA_TEXTURE_ELEVATION, DATA_TEXTURE_ELEVATION or COLOR_TEXTURE_ELEVATION
             #endif
 
-            vPosition = vec4( position +  vNormal  * dv ,1.0 );
+            vPosition = vec4( position +  normal  * dv ,1.0 );
         } else {
             vPosition = vec4( position ,1.0 );
         }
+
+        vNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
 
         gl_Position = projectionMatrix * modelViewMatrix * vPosition;
         #include <logdepthbuf_vertex>

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -797,6 +797,8 @@ function GlobeControls(view, target, radius, options = {}) {
         }
         // correction of depth error
         const tileCrs = this._view.wgs84TileLayer.extent.crs();
+        coordTarget._normal = null;
+        coordTile._normal = null;
         coordTarget.set(this._view.referenceCrs, movingCameraTargetOnGlobe).as(tileCrs, coordTile);
         updateAltitudeCoordinate(coordTile, this._view.wgs84TileLayer);
         coordTile.as(this._view.referenceCrs).xyz(reposition);

--- a/test/obb_unit_test.js
+++ b/test/obb_unit_test.js
@@ -7,13 +7,18 @@ import BuilderEllipsoidTile from '../src/Core/Prefab/Globe/BuilderEllipsoidTile'
 import PlanarTileBuilder from '../src/Core/Prefab/Planar/PlanarTileBuilder';
 import TileGeometry from '../src/Core/TileGeometry';
 import OBB from '../src/Renderer/ThreeExtended/OBB';
-/* global describe, it, xit */
+/* global describe, it */
 
 const max = new THREE.Vector3(10, 10, 10);
 const min = new THREE.Vector3(-10, -10, -10);
 const lookAt = new THREE.Vector3(1, 0, 0);
 const translate = new THREE.Vector3(0, 0, 20);
-const obb = new OBB(min, max, lookAt, translate);
+const obb = new OBB(min, max);
+obb.lookAt(lookAt);
+obb.translateX(translate.x);
+obb.translateY(translate.y);
+obb.translateZ(translate.z);
+obb.update();
 
 describe('OBB', function () {
     it('should correctly instance obb', () => {
@@ -54,13 +59,13 @@ function assertVerticesAreInOBB(builder, extent) {
 describe('Ellipsoid tiles OBB computation', function () {
     const builder = new BuilderEllipsoidTile();
 
-    xit('IGNORED see #87 - should compute globe-level 0 OBB correctly', function () {
+    it('should compute globe-level 0 OBB correctly', function () {
         const extent = new Extent('EPSG:4326', -Math.PI, 0, -Math.PI * 0.5, Math.PI * 0.5);
         extent._internalStorageUnit = UNIT.RADIAN;
         assertVerticesAreInOBB(builder, extent);
     });
 
-    xit('IGNORED see #87 - should compute globe-level 2 OBB correctly', function () {
+    it('should compute globe-level 2 OBB correctly', function () {
         const extent = new Extent('EPSG:4326', 0, 0.7853981633974483, -0.7853981633974483, 0);
         extent._internalStorageUnit = UNIT.RADIAN;
         assertVerticesAreInOBB(builder, extent);

--- a/test/planar_test.js
+++ b/test/planar_test.js
@@ -11,9 +11,9 @@ describe('Planar example', function () {
                 itownsTesting.countVisibleAndDisplayed(obj);
             }
 
-            assert.equal(itownsTesting.counters.displayed_at_level[2], 6);
-            assert.equal(itownsTesting.counters.displayed_at_level[3], 11);
-            assert.equal(itownsTesting.counters.displayed_at_level[4], 20);
+            assert.equal(itownsTesting.counters.displayed_at_level[2], 7);
+            assert.equal(itownsTesting.counters.displayed_at_level[3], 8);
+            assert.equal(itownsTesting.counters.displayed_at_level[4], 16);
 
             done();
         });


### PR DESCRIPTION
## Description
Re-use identical tile's geometry and oriented the main normal on the Z axis
* The normal in the center of the geometry is aligned with the Z axis.
* Bounding boxes can use the Parent's worldMatrix (tile).

The geometry normal is computed with correct geodesic normal.
The bounding boxes is calculated by THREE.js.

## Motivation and Context
* reduce memory
* increase performance
* work tile's space, by example wfs (fix #558 issue)
* simplify obb computation
* reduce/fix obb calculation errors see #87 issues
* fix obb/culling for pano tile

**WARNING**
change subdivision count in PLANAR test, the bounding sphere are bigger, so the subdivision are changed