### PR TITLE
fix(loader): remove two warnings

### DIFF
--- a/src/Renderer/ThreeExtended/B3dmLoader.js
+++ b/src/Renderer/ThreeExtended/B3dmLoader.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import './GLTFLoader';
+import GLTFLoader from './GLTFLoader';
 import BatchTable from './BatchTable';
 
 const matrixChangeUpVectorZtoY = (new THREE.Matrix4()).makeRotationX(Math.PI / 2);
@@ -7,7 +7,7 @@ const matrixChangeUpVectorZtoY = (new THREE.Matrix4()).makeRotationX(Math.PI / 2
 const matrixChangeUpVectorZtoX = (new THREE.Matrix4()).makeRotationZ(-Math.PI / 2);
 
 function B3dmLoader() {
-    this.glTFLoader = new THREE.GLTFLoader();
+    this.glTFLoader = new GLTFLoader();
 }
 
 function filterUnsupportedSemantics(obj) {

--- a/src/Renderer/ThreeExtended/GLTFLoader.js
+++ b/src/Renderer/ThreeExtended/GLTFLoader.js
@@ -12,7 +12,7 @@ import * as THREE from 'three';
  * @author Takahiro / https://github.com/takahirox
  */
 
-THREE.GLTFLoader = ( function () {
+export default (function () {
 
 	function GLTFLoader( manager ) {
 


### PR DESCRIPTION
## Description
Remove warning from GLTFLoader

Prior to this change, we can see these warnings
WARNING in ./src/Renderer/ThreeExtended/B3dmLoader.js
12:26-42 "export 'GLTFLoader' (imported as 'THREE') was not found in 'three'
WARNING in ./src/Renderer/ThreeExtended/GLTFLoader.js
18:0-16 "export 'GLTFLoader' (imported as 'THREE') was not found in 'three'
