### PR TITLE
fix (core): allow multiple callback before and after render

### DIFF
--- a/examples/globe.js
+++ b/examples/globe.js
@@ -36,7 +36,7 @@ if (!renderer) {
     miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
 
     // update miniview's camera with the globeView's camera position
-    globeView.onAfterRender = function onAfterRender() {
+    globeView.onAfterRender.push(() => {
         // clamp distance camera from globe
         var distanceCamera = globeView.camera.camera3D.position.length();
         var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);
@@ -45,7 +45,7 @@ if (!renderer) {
         camera.position.copy(globeView.controls.moveTarget()).setLength(distance);
         camera.lookAt(globeView.controls.moveTarget());
         miniView.notifyChange(true);
-    };
+    });
 
     // Add one imagery layer to the miniview
     itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) { miniView.addLayer(layer); });

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -90,17 +90,16 @@
             });
 
             // Use preRender to update menu before rendering
-            globeView.preRender = function () {
+            globeView.onBeforeRender.push(() => {
                 var layers = { id: [] };
                 // globeView.scene is THREE.js scene
                 getLayersColorVisible(globeView.scene, layers);
-                console.log('layers', layers);
                 var colorLayers = globeView.getLayers(function (l) { return l.type == 'color'; });
 
                 colorLayers.forEach(function (layer) {
                     menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1)
                 });
-            };
+            });
         </script>
     </body>
 </html>

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -134,9 +134,7 @@ MainLoop.prototype._step = function _step(view, timestamp) {
 };
 
 MainLoop.prototype._renderView = function _renderView(view) {
-    if (view.preRender) {
-        view.preRender();
-    }
+    view.onBeforeRender.forEach((fn) => { fn.call(this); });
 
     if (view.render) {
         view.render();
@@ -145,8 +143,7 @@ MainLoop.prototype._renderView = function _renderView(view) {
         this.gfxEngine.renderView(view);
     }
 
-    // Mimic three Object3D.onAfterRender (which sadly doesn't work on Scene)
-    view.onAfterRender();
+    view.onAfterRender.forEach((fn) => { fn.call(this); });
 };
 
 export default MainLoop;

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -243,10 +243,8 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     this._fullSizeDepthBuffer = null;
 
     const renderer = this.mainLoop.gfxEngine.renderer;
-    this.preRender = () => {
-        // WARNING, if the prerender is re-defined by the user,
-        // These mechanisms no longer work
-        // TODO: need to fix it
+
+    this.onBeforeRender.push(() => {
         if (this._fullSizeDepthBuffer != null) {
             // clean depth buffer
             this._fullSizeDepthBuffer = null;
@@ -269,7 +267,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         } else if (len >= lim) {
             renderer.setClearColor(0x030508, renderer.getClearAlpha());
         }
-    };
+    });
 
     this.wgs84TileLayer = wgs84TileLayer;
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -74,7 +74,9 @@ function View(crs, viewerDiv, options = {}) {
         this.notifyChange(true);
     }, false);
 
-    this.onAfterRender = () => {};
+    // Mimic THREE.Object3D#onBeforeRender and onAfterRender
+    this.onBeforeRender = [];
+    this.onAfterRender = [];
 
     this._changeSources = new Set();
 }

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -36,7 +36,7 @@ function c3DEngine(rendererOrDiv, options = {}) {
     this.fullSizeRenderTarget.texture.minFilter = THREE.LinearFilter;
     this.fullSizeRenderTarget.texture.generateMipmaps = false;
 
-    this.renderView = function renderScene(view) {
+    this.renderView = function renderView(view) {
         this.renderer.setViewport(0, 0, this.width, this.height);
         this.renderer.clear();
         this.renderer.render(view.scene, view.camera.camera3D);


### PR DESCRIPTION
This commit:
- changes the View#onAfterRender method to an array
- adds the View#onBeforeRender array
- changes the GlobeView#preRender method to onBeforeRender.push
- changes the onAfterRender overloading in globe example
- changes the preRender overloading in layers color example
- modifies MainLoop#_renderView to use onBeforeRender and onAfterRender

Solves #589