### PR TITLE
Feature: rework FrameRequesters to be used from the MainLoop

### DIFF
--- a/examples/globe.js
+++ b/examples/globe.js
@@ -26,7 +26,7 @@ if (!renderer) {
         // since the mini globe will always be seen from a far point of view (see minDistance above)
         maxSubdivisionLevel: 2,
         // Don't instance default controls since miniview's camera will be synced
-        // on the main view's one (see globeView.onAfterRender)
+        // on the main view's one (see globeView.addFrameRequester)
         noControls: true,
     });
 
@@ -36,7 +36,7 @@ if (!renderer) {
     miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
 
     // update miniview's camera with the globeView's camera position
-    globeView.onAfterRender = function onAfterRender() {
+    globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, function () {
         // clamp distance camera from globe
         var distanceCamera = globeView.camera.camera3D.position.length();
         var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);
@@ -45,7 +45,7 @@ if (!renderer) {
         camera.position.copy(globeView.controls.moveTarget()).setLength(distance);
         camera.lookAt(globeView.controls.moveTarget());
         miniView.notifyChange(true);
-    };
+    });
 
     // Add one imagery layer to the miniview
     itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) { miniView.addLayer(layer); });

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -89,18 +89,17 @@
                 });
             });
 
-            // Use preRender to update menu before rendering
-            globeView.preRender = function () {
+            // Use frame requester to update menu before rendering
+            globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, function () {
                 var layers = { id: [] };
                 // globeView.scene is THREE.js scene
                 getLayersColorVisible(globeView.scene, layers);
-                console.log('layers', layers);
                 var colorLayers = globeView.getLayers(function (l) { return l.type == 'color'; });
 
                 colorLayers.forEach(function (layer) {
                     menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1)
                 });
-            };
+            });
         </script>
     </body>
 </html>

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -93,27 +93,25 @@
             }, globe2);
 
             // Globe animation
-            var animator = {
-                t: 0,
-                update: function(dt, ignore) {
-                    this.t = ignore ? 0 : Math.min(1, dt / 1000 + this.t);
+            var t = 0;
+            function animator (dt, ignore) {
+                t = ignore ? 0 : Math.min(1, dt / 1000 + t);
 
-                    layers[front].object3d.position.y = itowns.THREE.Math.lerp(front ? 10000000 : -10000000, 0, this.t);
-                    layers[front].object3d.scale.setScalar(itowns.THREE.Math.lerp(0.3, 1, this.t));
+                layers[front].object3d.position.y = itowns.THREE.Math.lerp(front ? 10000000 : -10000000, 0, t);
+                layers[front].object3d.scale.setScalar(itowns.THREE.Math.lerp(0.3, 1, t));
 
-                    layers[1 - front].object3d.position.y = itowns.THREE.Math.lerp(front ? -10000000 : 10000000, 0, 1 - this.t);
-                    layers[1 - front].object3d.scale.setScalar(itowns.THREE.Math.lerp(0.3, 1, 1 - this.t));
+                layers[1 - front].object3d.position.y = itowns.THREE.Math.lerp(front ? -10000000 : 10000000, 0, 1 - t);
+                layers[1 - front].object3d.scale.setScalar(itowns.THREE.Math.lerp(0.3, 1, 1 - t));
 
-                    layers[0].object3d.updateMatrixWorld(true);
-                    layers[1].object3d.updateMatrixWorld(true);
+                layers[0].object3d.updateMatrixWorld(true);
+                layers[1].object3d.updateMatrixWorld(true);
 
-                    if (this.t < 1) {
-                        globeView.notifyChange(true);
-                    } else {
-                        globeView.removeFrameRequester(animator);
-                    }
+                if (t < 1) {
+                    globeView.notifyChange(true);
+                } else {
+                    globeView.removeFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
                 }
-            };
+            }
 
             // Last but not least, add 'ref' object to three.js scene, otherwise our globes
             // won't be displayed
@@ -126,8 +124,8 @@
                 if (evt.keyCode == 32) {
                     front = 1 - front;
 
-                    animator.t = 0;
-                    globeView.addFrameRequester(animator);
+                    t = 0;
+                    globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
                     globeView.notifyChange(true);
                 }
             }

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -5,7 +5,6 @@ var extent;
 var viewerDiv;
 var view;
 var meshes;
-var scaler;
 
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 itowns.proj4.defs('EPSG:3946',
@@ -98,24 +97,22 @@ function extrudeBuildings(properties) {
 }
 
 meshes = [];
-scaler = {
-    update: function update(/* dt */) {
-        var i;
-        var mesh;
-        if (meshes.length) {
-            view.notifyChange(true);
-        }
-        for (i = 0; i < meshes.length; i++) {
-            mesh = meshes[i];
-            mesh.scale.z = Math.min(
-                1.0, mesh.scale.z + 0.016);
-            mesh.updateMatrixWorld(true);
-        }
-        meshes = meshes.filter(function filter(m) { return m.scale.z < 1; });
-    },
-};
+function scaler(/* dt */) {
+    var i;
+    var mesh;
+    if (meshes.length) {
+        view.notifyChange(true);
+    }
+    for (i = 0; i < meshes.length; i++) {
+        mesh = meshes[i];
+        mesh.scale.z = Math.min(
+            1.0, mesh.scale.z + 0.016);
+        mesh.updateMatrixWorld(true);
+    }
+    meshes = meshes.filter(function filter(m) { return m.scale.z < 1; });
+}
 
-view.addFrameRequester(scaler);
+view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
 view.addLayer({
     type: 'geometry',
     update: itowns.FeatureProcessing.update,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
-    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js",
+    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js src/Core/MainLoop.js",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -3,6 +3,31 @@ import { EventDispatcher } from 'three';
 export const RENDERING_PAUSED = 0;
 export const RENDERING_SCHEDULED = 1;
 
+/**
+ * MainLoop's update events list that are fired using
+ * {@link View#execFrameRequesters}.
+ *
+ * @property UPDATE_START {string} fired at the start of the update
+ * @property BEFORE_CAMERA_UPDATE {string} fired before the camera update
+ * @property AFTER_CAMERA_UPDATE {string} fired after the camera update
+ * @property BEFORE_LAYER_UPDATE {string} fired before the layer update
+ * @property AFTER_LAYER_UPDATE {string} fired after the layer update
+ * @property BEFORE_RENDER {string} fired before the render
+ * @property AFTER_RENDER {string} fired after the render
+ * @property UPDATE_END {string} fired at the end of the update
+ */
+
+export const MAIN_LOOP_EVENTS = {
+    UPDATE_START: 'update_start',
+    BEFORE_CAMERA_UPDATE: 'before_camera_update',
+    AFTER_CAMERA_UPDATE: 'after_camera_update',
+    BEFORE_LAYER_UPDATE: 'before_camera_update',
+    AFTER_LAYER_UPDATE: 'after_layer_update',
+    BEFORE_RENDER: 'before_render',
+    AFTER_RENDER: 'after_render',
+    UPDATE_END: 'update_end',
+};
+
 function MainLoop(scheduler, engine) {
     this.renderingState = RENDERING_PAUSED;
     this.needsRedraw = false;
@@ -56,31 +81,26 @@ MainLoop.prototype._update = function _update(view, updateSources, dt) {
         view,
     };
 
-    // notify the frameRequesters
-    // Frame requesters should keep calling view.notifyChange in their update
-    // function if they want requestAnimationFrame to go on.
-    if (view._frameRequesters.length > 0) {
-        for (const frameRequester of view._frameRequesters) {
-            if (frameRequester.update) {
-                frameRequester.update(dt, this._updateLoopRestarted);
-            }
-        }
-    }
-
     for (const geometryLayer of view.getLayers((x, y) => !y)) {
         context.geometryLayer = geometryLayer;
         if (geometryLayer.ready && geometryLayer.visible) {
+            view.execFrameRequesters(MAIN_LOOP_EVENTS.BEFORE_LAYER_UPDATE, dt, this._updateLoopRestarted, geometryLayer);
+
             // `preUpdate` returns an array of elements to update
             const elementsToUpdate = geometryLayer.preUpdate(context, geometryLayer, updateSources);
             // `update` is called in `updateElements`.
             updateElements(context, geometryLayer, elementsToUpdate);
             // `postUpdate` is called when this geom layer update process is finished
             geometryLayer.postUpdate(context, geometryLayer, updateSources);
+
+            view.execFrameRequesters(MAIN_LOOP_EVENTS.AFTER_LAYER_UPDATE, dt, this._updateLoopRestarted, geometryLayer);
         }
     }
 };
 
 MainLoop.prototype._step = function _step(view, timestamp) {
+    view.execFrameRequesters(MAIN_LOOP_EVENTS.UPDATE_START, dt, this._updateLoopRestarted);
+
     const willRedraw = this.needsRedraw;
     const dt = timestamp - this._lastTimestamp;
     this._lastTimestamp = timestamp;
@@ -95,7 +115,9 @@ MainLoop.prototype._step = function _step(view, timestamp) {
     // update camera
     const dim = this.gfxEngine.getWindowSize();
 
+    view.execFrameRequesters(MAIN_LOOP_EVENTS.BEFORE_CAMERA_UPDATE, dt, this._updateLoopRestarted);
     view.camera.update(dim.x, dim.y);
+    view.execFrameRequesters(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, dt, this._updateLoopRestarted);
 
     // Disable camera's matrix auto update to make sure the camera's
     // world matrix is never updated mid-update.
@@ -120,7 +142,7 @@ MainLoop.prototype._step = function _step(view, timestamp) {
     // As such there's no continuous update-loop, instead we use a ad-hoc update/render
     // mechanism.
     if (willRedraw) {
-        this._renderView(view);
+        this._renderView(view, dt);
     }
 
     // next time, we'll consider that we've just started the loop if we are still PAUSED now
@@ -131,12 +153,12 @@ MainLoop.prototype._step = function _step(view, timestamp) {
     }
 
     view.camera.camera3D.matrixAutoUpdate = oldAutoUpdate;
+
+    view.execFrameRequesters(MAIN_LOOP_EVENTS.UPDATE_END, dt, this._updateLoopRestarted);
 };
 
-MainLoop.prototype._renderView = function _renderView(view) {
-    if (view.preRender) {
-        view.preRender();
-    }
+MainLoop.prototype._renderView = function _renderView(view, dt) {
+    view.execFrameRequesters(MAIN_LOOP_EVENTS.BEFORE_RENDER, dt, this._updateLoopRestarted);
 
     if (view.render) {
         view.render();
@@ -145,8 +167,7 @@ MainLoop.prototype._renderView = function _renderView(view) {
         this.gfxEngine.renderView(view);
     }
 
-    // Mimic three Object3D.onAfterRender (which sadly doesn't work on Scene)
-    view.onAfterRender();
+    view.execFrameRequesters(MAIN_LOOP_EVENTS.AFTER_RENDER, dt, this._updateLoopRestarted);
 };
 
 export default MainLoop;

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 import View from '../View';
-import { RENDERING_PAUSED } from '../MainLoop';
+import { RENDERING_PAUSED, MAIN_LOOP_EVENTS } from '../MainLoop';
 import { COLOR_LAYERS_ORDER_CHANGED } from '../../Renderer/ColorLayersOrdering';
 import RendererConstant from '../../Renderer/RendererConstant';
 import GlobeControls from '../../Renderer/ThreeExtended/GlobeControls';
@@ -243,10 +243,8 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     this._fullSizeDepthBuffer = null;
 
     const renderer = this.mainLoop.gfxEngine.renderer;
-    this.preRender = () => {
-        // WARNING, if the prerender is re-defined by the user,
-        // These mechanisms no longer work
-        // TODO: need to fix it
+
+    this.addFrameRequester(MAIN_LOOP_EVENTS.BEFORE_RENDER, () => {
         if (this._fullSizeDepthBuffer != null) {
             // clean depth buffer
             this._fullSizeDepthBuffer = null;
@@ -269,7 +267,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         } else if (len >= lim) {
             renderer.setClearColor(0x030508, renderer.getClearAlpha());
         }
-    };
+    });
 
     this.wgs84TileLayer = wgs84TileLayer;
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -7,6 +7,7 @@ export { default as GpxUtils } from './Core/Scheduler/Providers/GpxUtils';
 export { default as PlanarView, createPlanarLayer } from './Core/Prefab/PlanarView';
 export { default as PanoramaView, createPanoramaLayer } from './Core/Prefab/PanoramaView';
 export { default as Fetcher } from './Core/Scheduler/Providers/Fetcher';
+export { MAIN_LOOP_EVENTS } from './Core/MainLoop';
 export { default as View } from './Core/View';
 export { process3dTilesNode, init3dTilesLayer, $3dTilesCulling, $3dTilesSubdivisionControl, pre3dTilesUpdate } from './Process/3dTilesProcessing';
 export { default as FeatureProcessing } from './Process/FeatureProcessing';

--- a/src/Renderer/ThreeExtended/FirstPersonControls.js
+++ b/src/Renderer/ThreeExtended/FirstPersonControls.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { MAIN_LOOP_EVENTS } from '../../Core/MainLoop';
 
 // Note: we could use existing three.js controls (like https://github.com/mrdoob/three.js/blob/dev/examples/js/controls/FirstPersonControls.js)
 // but including these controls in itowns allows use to integrate them tightly with itowns.
@@ -175,7 +176,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
         domElement.addEventListener('mousewheel', onDocumentMouseWheel.bind(this), false);
         domElement.addEventListener('DOMMouseScroll', onDocumentMouseWheel.bind(this), false); // firefox
 
-        this.view.addFrameRequester(this);
+        this.view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.update.bind(this));
 
         // focus policy
         if (options.focusOnMouseOver) {

--- a/src/Renderer/ThreeExtended/FlyControls.js
+++ b/src/Renderer/ThreeExtended/FlyControls.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { MAIN_LOOP_EVENTS } from '../../Core/MainLoop';
 
 const MOVEMENTS = {
     38: { method: 'translateZ', sign: -1 }, // FORWARD: up key
@@ -124,7 +125,7 @@ class FlyControls extends THREE.EventDispatcher {
         domElement.addEventListener('keyup', onKeyUp.bind(this), true);
         domElement.addEventListener('keydown', onKeyDown.bind(this), true);
 
-        this.view.addFrameRequester(this);
+        this.view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.update.bind(this));
 
         // focus policy
         if (options.focusOnMouseOver) {

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -12,6 +12,7 @@ import AnimationPlayer, { Animation, AnimatedExpression } from '../../Core/Anima
 import Coordinates, { C, ellipsoidSizes } from '../../Core/Geographic/Coordinates';
 import { computeTileZoomFromDistanceCamera, computeDistanceCameraFromTileZoom } from '../../Process/GlobeTileProcessing';
 import DEMUtils from './../../utils/DEMUtils';
+import { MAIN_LOOP_EVENTS } from '../../Core/MainLoop';
 
 // TODO:
 // Recast touch for globe
@@ -483,17 +484,13 @@ function GlobeControls(view, target, radius, options = {}) {
         sizeRendering.FOV = this.camera.fov;
     };
 
-    const self = this;
-    const resizeHandler = {
-        update() {
-            const dim = self._view.mainLoop.gfxEngine.getWindowSize();
-            const sizeDiff = (dim.width != sizeRendering.width || dim.height != sizeRendering.height);
-            if (sizeDiff) {
-                self.updateCamera();
-            }
-        },
-    };
-    this._view.addFrameRequester(resizeHandler);
+    this._view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, () => {
+        const dim = this._view.mainLoop.gfxEngine.getWindowSize();
+        const sizeDiff = (dim.width != sizeRendering.width || dim.height != sizeRendering.height);
+        if (sizeDiff) {
+            this.updateCamera();
+        }
+    });
 
     this.getAutoRotationAngle = function getAutoRotationAngle() {
         return 2 * Math.PI / 60 / 60 * this.autoRotateSpeed;

--- a/src/Renderer/ThreeExtended/PlanarControls.js
+++ b/src/Renderer/ThreeExtended/PlanarControls.js
@@ -10,6 +10,7 @@
 */
 
 import * as THREE from 'three';
+import { MAIN_LOOP_EVENTS } from '../../Core/MainLoop';
 
 // event keycode
 const keys = {
@@ -146,10 +147,6 @@ function PlanarControls(view, options = {}) {
     // this allows to use right-click for input without the menu appearing
     this.domElement.addEventListener('contextmenu', onContextMenu.bind(this), false);
 
-    // add this PlanarControl instance to the view's framerequesters
-    // with this, PlanarControl.update() will be called each frame
-    this.view.addFrameRequester(this);
-
     // Updates the view and camera if needed, and handles the animated travel
     this.update = function update(dt, updateLoopRestarted) {
         // We test if camera collide to geometry layer or too close to ground and ajust it's altitude in case
@@ -175,6 +172,10 @@ function PlanarControls(view, options = {}) {
         }
         deltaMousePosition.set(0, 0);
     };
+
+    // add this PlanarControl instance to the view's framerequesters
+    // with this, PlanarControl.update() will be called each frame
+    this.view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.update.bind(this));
 
     /**
     * Initiate a drag movement (translation on xy plane)


### PR DESCRIPTION
## Description

This PR adds eight moments when a `FrameRequester` can be called in the
MainLoop :
- `UPDATE_START`
- `BEFORE_CAMERA_UPDATE`
- `AFTER_CAMERA_UPDATE`
- `BEFORE_LAYER_UPDATE`
- `AFTER_LAYER_UPDATE`
- `BEFORE_RENDER`
- `AFTER_RENDER`
- `UPDATE_END`

They can be used like this anywhere (at least where a view is reachable):
`view.addFrameRequester(frameRequester, itowns.View.BEFORE_CAMERA_UPDATE);`
where `frameRequester` being either a function or a `FrameRequester`.

They are removed following a similar process:
`view.removeFrameRequester(frameRequester, itowns.View.BEFORE_CAMERA_UPDATE);`.

In the MainLoop, they are triggered each time (according to where they
belong) using `view.execFrameRequesters(itowns.View.BEFORE_CAMERA_UPDATE);`.

## Motivation and Context
This change adds some coherence in naming, and allow users to execute commands depending on the rendering update.

Inspired by https://github.com/iTowns/itowns/compare/master...peppsac:feat_attach_point_frame_req, responds to #589 and replaces #590