### PR TITLE
chore: add out/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /node_modules/
 /dist/
 /lib/
+/out/


### PR DESCRIPTION
Really quick PR: the `out/` folder is generated by running `npm run doc`, and it is not to be commited.

It bothers me to have a dirty index after generating the documentation ;) 