### PR TITLE
feat(WMS): call getCapabilities during layer preprocessing

### DIFF
--- a/examples/planar_vector.html
+++ b/examples/planar_vector.html
@@ -55,6 +55,7 @@
                 networkOptions: { crossOrigin: 'anonymous' },
                 type: 'color',
                 protocol: 'wms',
+                disableGetCapabilities: true, // their getCap is too slow
                 version: '1.3.0',
                 id: 'wms_imagery',
                 name: 'Ortho2009_vue_ensemble_16cm_CC46',
@@ -68,6 +69,7 @@
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 type: 'elevation',
                 protocol: 'wms',
+                disableGetCapabilities: true, // their getCap is too slow
                 networkOptions: { crossOrigin: 'anonymous' },
                 version: '1.3.0',
                 id: 'wms_elevation',

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -61,6 +61,7 @@
                 networkOptions: { crossOrigin: 'anonymous' },
                 type: 'color',
                 protocol: 'wms',
+                disableGetCapabilities: true, // their getCap call is too slow
                 version: '1.3.0',
                 id: 'wms_imagery',
                 name: 'Ortho2009_vue_ensemble_16cm_CC46',

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,12 @@
         }
       }
     },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -229,6 +235,15 @@
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
           "dev": true
         }
+      }
+    },
+    "acorn-globals": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.0.0"
       }
     },
     "acorn-jsx": {
@@ -348,6 +363,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
     "array-find": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
@@ -403,6 +424,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
     "asn1.js": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
@@ -422,6 +449,12 @@
       "requires": {
         "util": "0.10.3"
       }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -450,10 +483,28 @@
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "babel-cli": {
@@ -1359,6 +1410,16 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "big.js": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -1457,6 +1518,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
       "dev": true
     },
     "browser-stdout": {
@@ -1653,6 +1720,12 @@
         }
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "catharsis": {
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
@@ -1842,6 +1915,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
       "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.14.1",
@@ -2087,6 +2169,21 @@
         "randombytes": "^2.0.0"
       }
     },
+    "cssom": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2103,6 +2200,26 @@
       "dev": true,
       "requires": {
         "es5-ext": "^0.10.9"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "^1.0.4",
+        "whatwg-mimetype": "^2.0.0",
+        "whatwg-url": "^6.4.0"
       }
     },
     "date-now": {
@@ -2215,6 +2332,12 @@
         "rimraf": "^2.2.8"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -2316,10 +2439,29 @@
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "earcut": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.1.tgz",
       "integrity": "sha1-FXY05fPrtCIk5HUBboalts5Va0U="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2500,6 +2642,28 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+      "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
@@ -2926,6 +3090,12 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -3008,6 +3178,12 @@
           }
         }
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -3201,6 +3377,23 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -3266,12 +3459,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3291,7 +3486,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3439,6 +3635,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3806,6 +4003,15 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -3876,6 +4082,36 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        }
+      }
     },
     "has": {
       "version": "1.0.1",
@@ -4025,6 +4261,15 @@
         "wbuf": "^1.1.0"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
+      }
+    },
     "html-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
@@ -4108,6 +4353,17 @@
         }
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
     "https-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
@@ -4134,6 +4390,12 @@
           }
         }
       }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.8",
@@ -4526,6 +4788,12 @@
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "is-unc-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
@@ -4572,6 +4840,12 @@
       "requires": {
         "isarray": "1.0.0"
       }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -4632,6 +4906,13 @@
         "xmlcreate": "^1.0.1"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
     "jsdoc": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
@@ -4660,6 +4941,58 @@
         }
       }
     },
+    "jsdom": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+      "dev": true,
+      "requires": {
+        "abab": "^1.0.4",
+        "acorn": "^5.3.0",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.3.1 < 0.4.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.0",
+        "escodegen": "^1.9.0",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.2.0",
+        "nwsapi": "^2.0.0",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.3",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^4.0.0",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+          "dev": true
+        },
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -4670,6 +5003,12 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -4686,6 +5025,12 @@
       "requires": {
         "jsonify": "~0.0.0"
       }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -4710,6 +5055,18 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "killable": {
       "version": "1.0.0",
@@ -4749,6 +5106,12 @@
       "requires": {
         "invert-kv": "^1.0.0"
       }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -4897,6 +5260,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "loglevel": {
@@ -5398,6 +5767,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.4.tgz",
+      "integrity": "sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g==",
       "dev": true
     },
     "nyc": {
@@ -7453,6 +7828,12 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7705,6 +8086,12 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -7793,6 +8180,12 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -7827,6 +8220,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "portfinder": {
@@ -7919,6 +8318,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
+      "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
       "dev": true
     },
     "public-encrypt": {
@@ -8207,6 +8612,65 @@
         "is-finite": "^1.0.0"
       }
     },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8372,6 +8836,18 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -8755,6 +9231,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -8780,6 +9273,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-browserify": {
@@ -8887,6 +9386,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
     "table": {
@@ -9040,6 +9545,33 @@
         }
       }
     },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -9063,6 +9595,22 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -9367,6 +9915,17 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -9374,6 +9933,15 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "watchpack": {
@@ -9395,6 +9963,12 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "webpack": {
       "version": "3.11.0",
@@ -10759,10 +11333,36 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
+    "whatwg-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "whatwg-fetch": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "1.2.14",
@@ -10839,6 +11439,12 @@
       "requires": {
         "path-extra": "^1.0.2"
       }
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xmlcreate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,14 +3459,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3486,8 +3484,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3635,7 +3632,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-loader": "^1.7.1",
     "eslint-plugin-import": "^2.13.0",
     "jsdoc": "^3.5.5",
+    "jsdom": "^11.5.1",
     "marked": "^0.3.9",
     "mocha": "^4.1.0",
     "nyc": "^12.0.2",

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -9,6 +9,9 @@ import proj4 from 'proj4';
 import Ellipsoid from '../Math/Ellipsoid';
 
 proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
+// used in some protocol
+// CRS:84 is equivalent to EPSG:4326 - ie, basic WGS84 degrees.
+proj4.defs('CRS:84', proj4.defs('EPSG:4326'));
 
 const projectionCache = {};
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -261,7 +261,7 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  * @property {string} protocol wmts and wms (wmtsc for custom deprecated)
  * @property {string} url Base URL of the repository or of the file(s) to load
  * @property {string} format Format of this layer. See individual providers to check which formats are supported for a given layer type.
- * @property {boolean} disableGetCap set this to true to skip getCapabilities request (if the layer object has already all the needed infos)
+ * @property {boolean} disableGetCapabilities set this to true to skip getCapabilities request (if the layer object has already all the needed infos)
  * @property {NetworkOptions} networkOptions Options for fetching resources over network
  * @property {Object} updateStrategy strategy to load imagery files
  * @property {OptionsWmts|OptionsWms} options WMTS or WMS options

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -261,6 +261,7 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  * @property {string} protocol wmts and wms (wmtsc for custom deprecated)
  * @property {string} url Base URL of the repository or of the file(s) to load
  * @property {string} format Format of this layer. See individual providers to check which formats are supported for a given layer type.
+ * @property {boolean} disableGetCap set this to true to skip getCapabilities request (if the layer object has already all the needed infos)
  * @property {NetworkOptions} networkOptions Options for fetching resources over network
  * @property {Object} updateStrategy strategy to load imagery files
  * @property {OptionsWmts|OptionsWms} options WMTS or WMS options
@@ -359,6 +360,11 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         }
 
         layer.whenReady.then((layer) => {
+            // if we still haven't any validExtent after getCapabilities, we assume
+            // it is the same as the configured extent
+            if (!layer.validExtent) {
+                layer.validExtent = layer.extent;
+            }
             this.notifyChange(parentLayer || layer, false);
             if (!this._frameRequesters[MAIN_LOOP_EVENTS.UPDATE_END] ||
                     this._frameRequesters[MAIN_LOOP_EVENTS.UPDATE_END].indexOf(this._allLayersAreReadyCallback) == -1) {

--- a/src/Provider/WFSProvider.js
+++ b/src/Provider/WFSProvider.js
@@ -22,7 +22,7 @@ function preprocessDataLayer(layer) {
     layer.version = layer.version || '2.0.2';
     layer.opacity = layer.opacity || 1;
     layer.wireframe = layer.wireframe || false;
-    if (!(layer.extent instanceof Extent)) {
+    if (layer.extent && !(layer.extent instanceof Extent)) {
         layer.extent = new Extent(layer.projection, layer.extent);
     }
     layer.url = `${layer.url

--- a/src/Provider/WMSProvider.js
+++ b/src/Provider/WMSProvider.js
@@ -220,7 +220,7 @@ function preprocessDataLayer(layer) {
     }
 
     let getCapPromise;
-    if (layer.disableGetCap) {
+    if (layer.disableGetCapabilities) {
         getCapPromise = Promise.resolve(layer);
         if (!layer.projection) {
             throw new Error(`Layer ${layer.name}: layer.projection is required`);

--- a/src/Provider/WMSProvider.js
+++ b/src/Provider/WMSProvider.js
@@ -232,9 +232,11 @@ function preprocessDataLayer(layer) {
         if (!supportedFormats.includes(layer.format)) {
             throw new Error(`Layer ${layer.name}: unsupported format '${layer.format}', should be one of '${supportedFormats.join('\', \'')}'`);
         }
-    } else {
+    } else if (!layer.projection || !layer.extent || !layer.format) {
         getCapPromise = Fetcher.xml(`${layer.url}?service=WMS&version=${layer.version}&request=GetCapabilities`, layer.networkOptions)
             .then(xml => checkCapabilities(layer, xml));
+    } else {
+        getCapPromise = Promise.resolve(layer);
     }
 
     return getCapPromise.then(() => {

--- a/src/Provider/WMSProvider.js
+++ b/src/Provider/WMSProvider.js
@@ -1,15 +1,199 @@
 /**
- * Generated On: 2015-10-5
- * Class: WMSProvider
- * Description: Provides data from a WMS stream
+ * Description: Provides data from a WMS server
  */
 
 import * as THREE from 'three';
 import Extent from '../Core/Geographic/Extent';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
 import URLBuilder from './URLBuilder';
+import Fetcher from './Fetcher';
+
+const mimeTypeByTagName = {
+    JPEG: 'image/jpeg',
+    PNG: 'image/png',
+    GIF: 'image/gif',
+    PPM: 'image/x‑portable‑pixmap',
+    TIFF: 'image/tiff',
+    GeoTIFF: 'image/tiff',
+    WebCGM: 'image/cgm;Version=4;ProfileId=WebCGM',
+    SVG: 'image/svg+xml',
+    WMS_XML: 'application/vnd.ogc.wms_xml',
+    'GML.1': 'application/gml+xml',
+    'GML.2': 'application/gml+xml',
+    'GML.3': 'application/gml+xml',
+    WBMP: 'image/vnd.wap.wbmp',
+    MIME: 'www/mime', // Not sure of this one (there's also message/rfc822)
+};
+/* For reference, there are also these 2 possible tags that do not translate to mimetype
+   INIMAGE display text in the returned image -->
+   BLANK return an image with all pixels transparent if
+   */
 
 const supportedFormats = ['image/png', 'image/jpg', 'image/jpeg'];
+
+function getCrsPropName(version) {
+    return version === '1.3.0' ? 'CRS' : 'SRS';
+}
+
+function getGeoTagName(version) {
+    return version === '1.3.0' ? 'EX_GeographicBoundingBox' : 'LatLonBoundingBox';
+}
+
+function _parseSupportedCrs(version, xmlLayer) {
+    let supportedCrs = [];
+    const crsPropName = getCrsPropName(version);
+
+    for (const childElem of xmlLayer.children) {
+        if (childElem.tagName === crsPropName) {
+            supportedCrs = supportedCrs.concat(childElem.textContent.trim().split(' '));
+        }
+    }
+    if (xmlLayer.parentNode && xmlLayer.parentNode.tagName === 'Layer') {
+        supportedCrs = supportedCrs.concat(_parseSupportedCrs(version, xmlLayer.parentNode));
+    }
+
+    return supportedCrs;
+}
+
+function parseSupportedCrs(version, xmlLayer) {
+    return new Set(_parseSupportedCrs(version, xmlLayer));
+}
+
+function parseExtent(version, targetCrs, xmlLayer) {
+    let extent = parseLayerBoundingBox(version, targetCrs, xmlLayer);
+    if (extent) {
+        return extent;
+    }
+
+    // fallback to CRS:84 boundingbox
+    extent = parseLayerBoundingBox(version, 'CRS:84', xmlLayer);
+    if (extent) {
+        return extent;
+    }
+
+    // fallback to any other BoundingBox
+    extent = parseLayerBoundingBox(version, null, xmlLayer);
+    if (extent) {
+        return extent;
+    }
+
+    // fallback to imprecise geographic bounds
+    return parseGeoBounds(version, xmlLayer);
+}
+
+function parseLayerBoundingBox(version, targetCrs, xmlLayer) {
+    const crsPropName = getCrsPropName(version);
+    for (const childElem of xmlLayer.children) {
+        if (childElem.tagName === 'BoundingBox' && (!targetCrs || targetCrs === childElem.getAttribute(crsPropName))) {
+            return new Extent(
+                    childElem.getAttribute(crsPropName),
+                    childElem.getAttribute('minx'),
+                    childElem.getAttribute('maxx'),
+                    childElem.getAttribute('miny'),
+                    childElem.getAttribute('maxy'));
+        }
+    }
+    if (xmlLayer.parentNode && xmlLayer.parentNode.tagName === 'Layer') {
+        return parseLayerBoundingBox(version, targetCrs, xmlLayer.parentNode);
+    }
+}
+
+function parseGeoBounds(version, xmlLayer) {
+    const geoTagName = getGeoTagName(version);
+    for (const childElem of xmlLayer.children) {
+        if (childElem.tagName === geoTagName) {
+            return new Extent(
+                    'CRS:84',
+                    childElem.getAttribute('minx'),
+                    childElem.getAttribute('maxx'),
+                    childElem.getAttribute('miny'),
+                    childElem.getAttribute('maxy'));
+        }
+    }
+    if (xmlLayer.parentNode && xmlLayer.parentNode.tagName === 'Layer') {
+        return parseGeoBounds(version, xmlLayer.parentNode);
+    }
+}
+
+function parseSupportedFormats(version, xmlCapa) {
+    if (version === '1.0.0') {
+        return Array.prototype.map.call(
+                xmlCapa.querySelectorAll('Capability > Request > Map > Format > *'),
+                elm => mimeTypeByTagName[elm.tagName]);
+    } else {
+        return Array.prototype.map.call(
+            xmlCapa.querySelectorAll('Capability > Request > GetMap > Format'),
+            elm => elm.textContent.trim());
+    }
+}
+
+function findXmlLayer(name, xml) {
+    const layerNames = xml.querySelectorAll('Layer > Name');
+    for (const n of layerNames) {
+        if (n.textContent.trim() === name) {
+            return n.parentNode;
+        }
+    }
+}
+
+function checkCapabilities(layer, xmlCapa) {
+    const getCapLayer = findXmlLayer(layer.name, xmlCapa);
+
+    if (!getCapLayer) {
+        throw new Error(`Cannot find layer ${layer.name} in capabilities`);
+    }
+
+    // get CRS list
+    const supportedCrs = parseSupportedCrs(layer.version, getCapLayer);
+
+    if (layer.projection) {
+        if (!supportedCrs.has(layer.projection)) {
+            throw new Error(`Layer ${layer.name} does not support projection ${layer.projection}`);
+        }
+    } else if (supportedCrs.size !== 1) {
+        throw new Error(`Cannot infer projection from capabilities for ${layer.name}`);
+    } else {
+        layer.projection = supportedCrs.values().next().value;
+    }
+
+    // check extent
+    layer.validExtent = parseExtent(layer.version, layer.projection, getCapLayer);
+    if (layer.extent && !layer.extent.isInside(layer.validExtent)) {
+        layer.extent = layer.validExtent.intersect(layer.extent);
+        const dimension = layer.extent.dimensions();
+        if (dimension.x === 0 && dimension.y === 0) {
+            throw new Error(`Layer.extent outside of validity extent for layer ${layer.name}`);
+        }
+    } else if (!layer.extent) {
+        layer.extent = layer.validExtent.as(layer.projection);
+    }
+
+    // check format
+    const supportedFormats = parseSupportedFormats(layer.version, xmlCapa);
+    if (layer.format && !supportedFormats.includes(layer.format)) {
+        throw new Error(`Declared layer.format ${layer.format} is not supported by the wms server for ${layer.name}`);
+    } else if (!layer.format) {
+        if (supportedFormats.length === 1) {
+            layer.format = supportedFormats[0];
+        } else {
+            throw new Error('Please specify a format in layer.format');
+        }
+    }
+}
+
+function url(bbox, layer) {
+    const box = bbox.as(layer.projection);
+    const w = box.west();
+    const s = box.south();
+    const e = box.east();
+    const n = box.north();
+
+    const bboxInUnit = layer.axisOrder === 'swne' ?
+        `${s},${w},${n},${e}` :
+        `${w},${s},${e},${n}`;
+
+    return layer.customUrl.replace('%bbox', bboxInUnit);
+}
 
 function tileTextureCount(tile, layer) {
     return tile.extent.crs() == layer.projection ? 1 : tile.getCoordsForLayer(layer).length;
@@ -19,24 +203,9 @@ function preprocessDataLayer(layer) {
     if (!layer.name) {
         throw new Error('layer.name is required.');
     }
-    if (!layer.extent) {
-        throw new Error('layer.extent is required');
-    }
-    if (!layer.projection) {
-        throw new Error('layer.projection is required');
-    }
-
-    if (!(layer.extent instanceof Extent)) {
-        layer.extent = new Extent(layer.projection, layer.extent);
-    }
 
     if (!layer.options.zoom) {
         layer.options.zoom = { min: 0, max: 21 };
-    }
-
-    layer.format = layer.format || 'image/png';
-    if (!supportedFormats.includes(layer.format)) {
-        throw new Error(`Layer ${layer.name}: unsupported format '${layer.format}', should be one of '${supportedFormats.join('\', \'')}'`);
     }
 
     layer.width = layer.heightMapWidth || 256;
@@ -44,32 +213,54 @@ function preprocessDataLayer(layer) {
     layer.style = layer.style || '';
     layer.transparent = layer.transparent || false;
 
-    if (!layer.axisOrder) {
-        // 4326 (lat/long) axis order depends on the WMS version used
-        if (layer.projection == 'EPSG:4326') {
-            // EPSG 4326 x = lat, long = y
-            // version 1.1.0 long/lat while version 1.3.0 mandates xy (so lat,long)
-            layer.axisOrder = (layer.version === '1.1.0' ? 'wsen' : 'swne');
-        } else {
-            // xy,xy order
-            layer.axisOrder = 'wsen';
-        }
-    }
-    let crsPropName = 'SRS';
-    if (layer.version === '1.3.0') {
-        crsPropName = 'CRS';
+    const crsPropName = getCrsPropName(layer.version);
+
+    if (layer.extent && !(layer.extent instanceof Extent) && layer.projection) {
+        layer.extent = new Extent(layer.projection, layer.extent);
     }
 
-    layer.url = `${layer.url
-                  }?SERVICE=WMS&REQUEST=GetMap&LAYERS=${layer.name
-                  }&VERSION=${layer.version
-                  }&STYLES=${layer.style
-                  }&FORMAT=${layer.format
-                  }&TRANSPARENT=${layer.transparent
-                  }&BBOX=%bbox` +
-                  `&${crsPropName}=${layer.projection
-                  }&WIDTH=${layer.width
-                  }&HEIGHT=${layer.width}`;
+    let getCapPromise;
+    if (layer.disableGetCap) {
+        getCapPromise = Promise.resolve(layer);
+        if (!layer.projection) {
+            throw new Error(`Layer ${layer.name}: layer.projection is required`);
+        }
+        if (!layer.extent && !layer.parentExtent) {
+            throw new Error(`Layer ${layer.name}: layer.extent is required`);
+        }
+        layer.format = layer.format || 'image/png';
+        if (!supportedFormats.includes(layer.format)) {
+            throw new Error(`Layer ${layer.name}: unsupported format '${layer.format}', should be one of '${supportedFormats.join('\', \'')}'`);
+        }
+    } else {
+        getCapPromise = Fetcher.xml(`${layer.url}?service=WMS&version=${layer.version}&request=GetCapabilities`, layer.networkOptions)
+            .then(xml => checkCapabilities(layer, xml));
+    }
+
+    return getCapPromise.then(() => {
+        if (!layer.axisOrder) {
+            // 4326 (lat/long) axis order depends on the WMS version used
+            if (layer.projection == 'EPSG:4326') {
+                // EPSG 4326 x = lat, long = y
+                // version 1.1.0 long/lat while version 1.3.0 mandates xy (so lat,long)
+                layer.axisOrder = (layer.version === '1.1.0' ? 'wsen' : 'swne');
+            } else {
+                // xy,xy order
+                layer.axisOrder = 'wsen';
+            }
+        }
+
+        layer.url = `${layer.url
+            }?SERVICE=WMS&REQUEST=GetMap&LAYERS=${layer.name
+            }&VERSION=${layer.version
+            }&STYLES=${layer.style
+            }&FORMAT=${layer.format
+            }&TRANSPARENT=${layer.transparent
+            }&BBOX=%bbox&${crsPropName}=${layer.projection
+            }&WIDTH=${layer.width
+            }&HEIGHT=${layer.width}`;
+        return layer;
+    });
 }
 
 function tileInsideLimit(tile, layer) {
@@ -153,4 +344,13 @@ export default {
     executeCommand,
     tileTextureCount,
     tileInsideLimit,
+};
+
+// exported for testing
+export const _testing = {
+    findXmlLayer,
+    parseSupportedFormats,
+    parseSupportedCrs,
+    parseExtent,
+    checkCapabilities,
 };

--- a/src/Provider/WMSProvider.js
+++ b/src/Provider/WMSProvider.js
@@ -181,20 +181,6 @@ function checkCapabilities(layer, xmlCapa) {
     }
 }
 
-function url(bbox, layer) {
-    const box = bbox.as(layer.projection);
-    const w = box.west();
-    const s = box.south();
-    const e = box.east();
-    const n = box.north();
-
-    const bboxInUnit = layer.axisOrder === 'swne' ?
-        `${s},${w},${n},${e}` :
-        `${w},${s},${e},${n}`;
-
-    return layer.customUrl.replace('%bbox', bboxInUnit);
-}
-
 function tileTextureCount(tile, layer) {
     return tile.extent.crs() == layer.projection ? 1 : tile.getCoordsForLayer(layer).length;
 }

--- a/test/WMS_Provider_unit_test.js
+++ b/test/WMS_Provider_unit_test.js
@@ -1,0 +1,463 @@
+/* global before, describe, it */
+import jsdom from 'jsdom';
+import assert from 'assert';
+import fs from 'fs';
+import provider, { _testing } from '../src/Core/Scheduler/Providers/WMS_Provider';
+import Extent from '../src/Core/Geographic/Extent';
+
+const { JSDOM } = jsdom;
+const window = new JSDOM().window;
+const parser = new window.DOMParser();
+
+function assertExtent(extent, crs, minx, miny, maxx, maxy) {
+    assert.equal(extent._crs, crs);
+    assert.equal(extent.west(), minx, 'West bound incorrectly parsed');
+    assert.equal(extent.south(), miny, 'South bound incorrectly parsed');
+    assert.equal(extent.east(), maxx, 'East bound incorrectly parsed');
+    assert.equal(extent.north(), maxy, 'North bound incorrectly parsed');
+}
+
+describe('WMS Provider >', function () {
+    describe('Preprocessing (GetCapabilities disabled >', function () {
+        it('should throw an error if layer.projection is missing', function () {
+            assert.throws(() => provider.preprocessDataLayer({
+                name: 'test',
+                disableGetCap: true,
+                options: {},
+            }), /Layer test: layer.projection is required/);
+        });
+
+        it('should throw an error if layer.extent is missing', function () {
+            assert.throws(() => provider.preprocessDataLayer({
+                name: 'test',
+                disableGetCap: true,
+                options: {},
+                projection: 'EPSG:3857',
+            }), /Layer test: layer.extent is required/);
+        });
+
+        it('should throw an error if layer.format is not supported', function () {
+            assert.throws(() => provider.preprocessDataLayer({
+                name: 'test',
+                disableGetCap: true,
+                options: {},
+                projection: 'EPSG:3857',
+                extent: { west: 1, east: 2, south: 3, north: 4 },
+                format: 'wrong/format',
+            }), /Layer test: unsupported format 'wrong\/format', should be one of/);
+        });
+
+        it('should default to \'image/png\' format', function () {
+            return provider.preprocessDataLayer({
+                name: 'test',
+                disableGetCap: true,
+                options: {},
+                projection: 'EPSG:3857',
+                extent: { west: 1, east: 2, south: 3, north: 4 },
+            }).then((l) => {
+                assert.equal(l.format, 'image/png');
+            });
+        });
+    });
+
+    describe('GetCapabilities >', function () {
+        describe('CRS parsing >', function () {
+            // we test all versions that should support <SRS>CRS1 CRS2 CRS3</SRS> style
+            for (const version of ['1.0.0', '1.1.0', '1.1.1']) {
+                it(`should parse correctly SRS tag in version ${version} without parent layer`, function () {
+                    const xmlString = `
+                        <Layer>
+                        <SRS>EPSG:1111 EPSG:2222 EPSG:8967</SRS>
+                        </Layer>
+                        `;
+                    const xml = parser.parseFromString(xmlString, 'text/xml');
+
+                    const result = _testing.parseSupportedCrs(version, xml.documentElement);
+                    assert.equal(result.size, 3);
+                    assert(result.has('EPSG:1111'));
+                    assert(result.has('EPSG:2222'));
+                    assert(result.has('EPSG:8967'));
+                });
+
+                it(`should default to parent layer's SRS list in version ${version}`, function () {
+                    const xmlString = `
+                        <Layer>
+                        <SRS>EPSG:4444 EPSG:2222 EPSG:8967</SRS>
+                        <Layer>
+                        <Layer id="toTest">
+                        <Name>Foo</Name>
+                        </Layer>
+                        </Layer>
+                        </Layer>
+                        `;
+                    const xml = parser.parseFromString(xmlString, 'text/xml');
+                    const xmlNode = xml.getElementById('toTest');
+
+                    const result = _testing.parseSupportedCrs(version, xmlNode);
+                    assert.equal(result.size, 3);
+                    assert(result.has('EPSG:4444'));
+                    assert(result.has('EPSG:2222'));
+                    assert(result.has('EPSG:8967'));
+                });
+            }
+
+            for (const version of ['1.1.0', '1.1.1']) {
+                it(`should parse correctly SRS multiple tags in version ${version} without parent layer`, function () {
+                    const xmlString = `
+                        <Layer>
+                        <SRS>EPSG:1111</SRS>
+                        <SRS>EPSG:2222</SRS>
+                        <SRS>EPSG:8967</SRS>
+                        </Layer>
+                        `;
+                    const xml = parser.parseFromString(xmlString, 'text/xml');
+
+                    const result = _testing.parseSupportedCrs(version, xml.documentElement);
+                    assert.equal(result.size, 3);
+                    assert(result.has('EPSG:1111'));
+                    assert(result.has('EPSG:2222'));
+                    assert(result.has('EPSG:8967'));
+                });
+
+                it(`should parse correctly SRS multiple tags in version ${version} with parent layer`, function () {
+                    const xmlString = `
+                        <Layer>
+                        <SRS>EPSG:4444</SRS>
+                        <Layer>
+                        <SRS>EPSG:2222</SRS>
+                        <Layer id="toTest">
+                        <SRS> EPSG:8967</SRS>
+                        <SRS>EPSG:3333</SRS>
+                        <Name>Foo</Name>
+                        </Layer>
+                        </Layer>
+                        </Layer>
+                        `;
+                    const xml = parser.parseFromString(xmlString, 'text/xml');
+                    const xmlNode = xml.getElementById('toTest');
+
+                    const result = _testing.parseSupportedCrs(version, xmlNode);
+                    assert.equal(result.size, 4);
+                    assert(result.has('EPSG:4444'));
+                    assert(result.has('EPSG:2222'));
+                    assert(result.has('EPSG:3333'));
+                    assert(result.has('EPSG:8967'));
+                });
+            }
+
+            it('should parse correctly CRS multiple tags in version 1.3.0 without parent layer', function () {
+                const xmlString = `
+                    <Layer>
+                    <CRS>EPSG:1111</CRS>
+                    <CRS>EPSG:2222</CRS>
+                    <CRS>EPSG:8967</CRS>
+                    </Layer>
+                    `;
+                const xml = parser.parseFromString(xmlString, 'text/xml');
+
+                const result = _testing.parseSupportedCrs('1.3.0', xml.documentElement);
+                assert.equal(result.size, 3);
+                assert(result.has('EPSG:1111'));
+                assert(result.has('EPSG:2222'));
+                assert(result.has('EPSG:8967'));
+            });
+
+            it('should parse correctly CRS multiple tags in version 1.3.0 with parent layer', function () {
+                const xmlString = `
+                    <Layer>
+                    <CRS>EPSG:4444</CRS>
+                    <Layer id="toTest1">
+                    <CRS>EPSG:2222</CRS>
+                    <Layer id="toTest2">
+                    <CRS> EPSG:8967</CRS>
+                    <CRS>EPSG:3333</CRS>
+                    <Name>Foo</Name>
+                    </Layer>
+                    </Layer>
+                    </Layer>
+                    `;
+                const xml = parser.parseFromString(xmlString, 'text/xml');
+                const xmlNode = xml.getElementById('toTest1');
+
+                const result = _testing.parseSupportedCrs('1.3.0', xmlNode);
+
+                assert.equal(result.size, 2);
+                assert(result.has('EPSG:4444'));
+                assert(result.has('EPSG:2222'));
+
+                const result2 = _testing.parseSupportedCrs('1.3.0', xml.getElementById('toTest2'));
+                assert.equal(result2.size, 4);
+                assert(result2.has('EPSG:4444'));
+                assert(result2.has('EPSG:2222'));
+                assert(result2.has('EPSG:3333'));
+                assert(result2.has('EPSG:8967'));
+            });
+        });
+
+        describe('Format parsing >', function () {
+            it('should parse correctly v1.0.0 formats', function () {
+                const xmlString = `
+                    <WMTS_MS_Capabilities>
+                        <Capability>
+                            <Request>
+                                <Map>
+                                    <Format>
+                                        <PNG />
+                                        <JPEG />
+                                        <SVG />
+                                    </Format>
+                                </Map>
+                            </Request>
+                        </Capability>
+                    </WMTS_MS_Capabilities>
+                    `;
+                const xml = parser.parseFromString(xmlString, 'text/xml');
+                const result = _testing.parseSupportedFormats('1.0.0', xml);
+                assert.deepEqual(result, ['image/png', 'image/jpeg', 'image/svg+xml']);
+            });
+
+            for (const version of ['1.1.0', '1.1.1', '1.3.0']) {
+                it(`should correctly parse formats in version ${version}`, function () {
+                    const xmlString = `
+                        <WMTS_MS_Capabilities>
+                            <Capability>
+                                <Request>
+                                    <GetMap>
+                                        <Format>image/png</Format>
+                                        <Format>image/jpeg</Format>
+                                        <Format>image/gif</Format>
+                                    </GetMap>
+                                </Request>
+                            </Capability>
+                        </WMTS_MS_Capabilities>
+                        `;
+                    const xml = parser.parseFromString(xmlString, 'text/xml');
+                    const result = _testing.parseSupportedFormats(version, xml);
+                    assert.deepEqual(result, ['image/png', 'image/jpeg', 'image/gif']);
+                });
+            }
+        });
+
+        describe('Extent parsing >', function () {
+            for (const version of ['1.0.0', '1.1.0', '1.1.1', '1.3.0']) {
+                const geographicBBTagName = version === '1.3.0' ? 'EX_GeographicBoundingBox' : 'LatLonBoundingBox';
+                const crsAttrName = version === '1.3.0' ? 'CRS' : 'SRS';
+                it(`should parse bounding box of given CRS in version ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                            <BoundingBox ${crsAttrName}="CRS:84" minx="1" miny="2" maxx="3" maxy="4" />
+                            <BoundingBox ${crsAttrName}="EPSG:3857" minx="5" miny="6" maxx="7" maxy="8" />
+                        </Layer>`;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').documentElement;
+                    const result = _testing.parseExtent(version, 'EPSG:3857', layerCapa);
+                    assertExtent(result, 'EPSG:3857', 5, 6, 7, 8);
+                });
+
+                it(`should default to parent's bounding box of given CRS in version ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <BoundingBox ${crsAttrName}="EPSG:3857" minx="5" miny="6" maxx="7" maxy="8" />
+                            <Layer id="toTest">
+                                <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                                <BoundingBox ${crsAttrName}="CRS:84" minx="1" miny="2" maxx="3" maxy="4" />
+                            </Layer>
+                        </Layer>`;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').getElementById('toTest');
+                    assertExtent(_testing.parseExtent(version, 'EPSG:3857', layerCapa), 'EPSG:3857', 5, 6, 7, 8);
+                });
+
+                it(`should fallback to CRS:84 bounding box in version ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                            <BoundingBox ${crsAttrName}="CRS:84" minx="1" miny="2" maxx="3" maxy="4" />
+                            <BoundingBox ${crsAttrName}="EPSG:4269" minx="5" miny="6" maxx="7" maxy="8" />
+                        </Layer>`;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').documentElement;
+                    const result = _testing.parseExtent(version, 'EPSG:3857', layerCapa);
+                    assertExtent(result, 'CRS:84', 1, 2, 3, 4);
+                });
+
+                it(`should fallback to parent's CRS:84 bounding box in version ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <BoundingBox ${crsAttrName}="CRS:84" minx="1" miny="2" maxx="3" maxy="4" />
+                            <Layer id="toTest">
+                                <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                                <BoundingBox ${crsAttrName}="EPSG:4269" minx="5" miny="6" maxx="7" maxy="8" />
+                            </Layer>
+                        </Layer>`;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').getElementById('toTest');
+                    assertExtent(_testing.parseExtent(version, 'EPSG:3857', layerCapa), 'CRS:84', 1, 2, 3, 4);
+                });
+
+                it(`should fallback to any other bounding box in version ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                            <BoundingBox ${crsAttrName}="EPSG:4269" minx="5" miny="6" maxx="7" maxy="8" />
+                        </Layer>`;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').documentElement;
+                    const result = _testing.parseExtent(version, 'EPSG:3857', layerCapa);
+                    assertExtent(result, 'EPSG:4269', 5, 6, 7, 8);
+                });
+
+                it(`should fallback to any other parent's bounding box in version ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <BoundingBox ${crsAttrName}="EPSG:4269" minx="5" miny="6" maxx="7" maxy="8" />
+                            <Layer id="toTest">
+                                <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                            </Layer>
+                        </Layer>`;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').getElementById('toTest');
+                    assertExtent(_testing.parseExtent(version, 'EPSG:3857', layerCapa), 'EPSG:4269', 5, 6, 7, 8);
+                });
+
+                // in rigor, this is forbidden by the specs in version 1.3.0, but that's the server problem.
+                it(`should fallback to geographic bound if no bounding box is either present in children or parent in ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                            <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                        </Layer>
+                        `;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').documentElement;
+                    assertExtent(_testing.parseExtent(version, 'EPSG:3857', layerCapa), 'CRS:84', 2, 3, 4, 9);
+                });
+
+
+                it(`should fallback to geographic bound if no bounding box is either present in children or parent in ${version}`, function () {
+                    const layerXml = `
+                        <Layer>
+                        <${geographicBBTagName} minx="2" miny="3" maxx="4" maxy="9" />
+                            <Layer id="toTest">
+                            </Layer>
+                        </Layer>
+                        `;
+                    const layerCapa = parser.parseFromString(layerXml, 'text/xml').getElementById('toTest');
+                    assertExtent(_testing.parseExtent(version, 'EPSG:3857', layerCapa), 'CRS:84', 2, 3, 4, 9);
+                });
+            }
+        });
+
+        describe('GetCap >', function () {
+            let getCapResult;
+            before(function (done) {
+                fs.readFile('./test/fixtures/getCapBgs.xml', (err, data) => {
+                    if (err) done(err);
+
+                    getCapResult = new window.DOMParser().parseFromString(data, 'text/xml');
+                    done();
+                });
+            });
+
+            it('should find the right layer', function () {
+                const layerXml = `
+                    <Layer>
+                        <Name>bazz</Name>
+                        <Layer id="layer">
+                            <Name>foo</Name>
+                            <Layer>
+                                <Name>bar</Name>
+                            </Layer>
+                        </Layer>
+                    </Layer>
+                    `;
+                const layerCapa = parser.parseFromString(layerXml, 'text/xml');
+                const result = _testing.findXmlLayer('foo', layerCapa);
+                assert.equal(result.getAttribute('id'), 'layer');
+            });
+
+            it('should check layer.name', function () {
+                // wrong name
+                const layer = {
+                    name: 'foo',
+                    projection: 'EPSG:3857',
+                    version: '1.3.0',
+                    format: 'image/png',
+                };
+                assert.throws(() => _testing.checkCapabilities(layer, getCapResult), /Cannot find layer foo in capabilities/);
+
+                // good name
+                layer.name = 'GBR_BGS_625k_BLT';
+                _testing.checkCapabilities(layer, getCapResult);
+            });
+
+            it('should check layer projection', function () {
+                const layer = {
+                    name: 'GBR_BGS_625k_BLT',
+                    projection: 'EPSG:3858',
+                    version: '1.3.0',
+                    format: 'image/png',
+                };
+                assert.throws(() => _testing.checkCapabilities(layer, getCapResult), /Layer GBR_BGS_625k_BLT does not support projection EPSG:3858/);
+
+                layer.projection = 'EPSG:3857';
+                _testing.checkCapabilities(layer, getCapResult);
+            });
+
+            it('should check layer format', function () {
+                const layer = {
+                    name: 'GBR_BGS_625k_BLT',
+                    projection: 'EPSG:3857',
+                    version: '1.3.0',
+                    format: 'image/foo',
+                };
+                assert.throws(() => _testing.checkCapabilities(layer, getCapResult), /Declared layer.format image\/foo is not supported by the wms server for GBR_BGS_625k_BLT/);
+
+                layer.format = 'image/png';
+                _testing.checkCapabilities(layer, getCapResult);
+            });
+
+            it('should set layer extent if not configured', function () {
+                const layer = {
+                    name: 'GBR_BGS_625k_BLT',
+                    projection: 'EPSG:3857',
+                    version: '1.3.0',
+                    format: 'image/png',
+                };
+                _testing.checkCapabilities(layer, getCapResult);
+                assert(layer.extent);
+                assertExtent(layer.extent, 'EPSG:3857', -962742, 6.42272e+006, 196776, 8.59402e+006);
+                assertExtent(layer.validExtent, 'EPSG:3857', -962742, 6.42272e+006, 196776, 8.59402e+006);
+            });
+
+            it('should check layer extent and set it to intersection with validityExtent', function () {
+                let layer = {
+                    name: 'GBR_BGS_625k_BLT',
+                    projection: 'EPSG:3857',
+                    version: '1.3.0',
+                    format: 'image/png',
+                    extent: new Extent('EPSG:3857', -90000, 150000, 7e+006, 8e+006),
+                };
+                // should not throw
+                _testing.checkCapabilities(layer, getCapResult);
+                assertExtent(layer.validExtent, 'EPSG:3857', -962742, 6.42272e+006, 196776, 8.59402e+006);
+                assertExtent(layer.extent, 'EPSG:3857', -90000, 7e+006, 150000, 8e+006);
+
+                layer = {
+                    name: 'GBR_BGS_625k_BLT',
+                    projection: 'EPSG:3857',
+                    version: '1.3.0',
+                    format: 'image/png',
+                    extent: new Extent('EPSG:3857', -100000, 150000, 7e+006, 9e+006),
+                };
+                _testing.checkCapabilities(layer, getCapResult);
+                assertExtent(layer.validExtent, 'EPSG:3857', -962742, 6.42272e+006, 196776, 8.59402e+006);
+                assertExtent(layer.extent, 'EPSG:3857', -100000, 7e+006, 150000, 8.59402e+006);
+            });
+
+            it('should throw an exception if layer.extent is completely outside validExtent', function () {
+                const layer = {
+                    name: 'GBR_BGS_625k_BLT',
+                    projection: 'EPSG:3857',
+                    version: '1.3.0',
+                    format: 'image/png',
+                    extent: new Extent('EPSG:3857', 200000, 250000, 7e+006, 9e+006),
+                };
+                assert.throws(() => _testing.checkCapabilities(layer, getCapResult), /Layer.extent outside of validity extent for layer GBR_BGS_625k_BLT/);
+            });
+        });
+    });
+});

--- a/test/WMS_Provider_unit_test.js
+++ b/test/WMS_Provider_unit_test.js
@@ -22,7 +22,7 @@ describe('WMS Provider >', function () {
         it('should throw an error if layer.projection is missing', function () {
             assert.throws(() => provider.preprocessDataLayer({
                 name: 'test',
-                disableGetCap: true,
+                disableGetCapabilities: true,
                 options: {},
             }), /Layer test: layer.projection is required/);
         });
@@ -30,7 +30,7 @@ describe('WMS Provider >', function () {
         it('should throw an error if layer.extent is missing', function () {
             assert.throws(() => provider.preprocessDataLayer({
                 name: 'test',
-                disableGetCap: true,
+                disableGetCapabilities: true,
                 options: {},
                 projection: 'EPSG:3857',
             }), /Layer test: layer.extent is required/);
@@ -39,7 +39,7 @@ describe('WMS Provider >', function () {
         it('should throw an error if layer.format is not supported', function () {
             assert.throws(() => provider.preprocessDataLayer({
                 name: 'test',
-                disableGetCap: true,
+                disableGetCapabilities: true,
                 options: {},
                 projection: 'EPSG:3857',
                 extent: { west: 1, east: 2, south: 3, north: 4 },
@@ -50,7 +50,7 @@ describe('WMS Provider >', function () {
         it('should default to \'image/png\' format', function () {
             return provider.preprocessDataLayer({
                 name: 'test',
-                disableGetCap: true,
+                disableGetCapabilities: true,
                 options: {},
                 projection: 'EPSG:3857',
                 extent: { west: 1, east: 2, south: 3, north: 4 },

--- a/test/fixtures/getCapBgs.xml
+++ b/test/fixtures/getCapBgs.xml
@@ -1,0 +1,688 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<WMS_Capabilities version="1.3.0" updateSequence="2014-09-26T10:54:00Z"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
+
+<!-- MapServer version 7.0.2 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=SVGCAIRO SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS SUPPORTS=GEOS INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
+
+<Service>
+  <Name>WMS</Name>
+  <Title>BGS Bedrock and Superficial geology</Title>
+  <Abstract>The 1:625k DiGMap data covering the whole of the United Kingdom is available in this OGC WMS service for all uses - including commercial use subject to the conditions in the Access Constraints section. It is being served as a contribution to the OneGeology initiative (www.onegeology.org). Separate bedrock geology and superficial deposits layers are available in this service. Layers available for bedrock are lithostratigraphy, age, and lithology. Layers available for superficial deposits layer are lithostratigraphy and lithology.  A layer is also provided for the UK Continental Shelf BGS 1:1M simplified seabed sediments. For information about more of the British Geological Survey&#39;s maps that are available digitally please visit http://www.bgs.ac.uk/products/digitalmaps/digmapgb.html</Abstract>
+  <KeywordList>
+      <Keyword>OneGeology</Keyword>
+      <Keyword>geology</Keyword>
+      <Keyword>map</Keyword>
+      <Keyword>United Kingdom</Keyword>
+      <Keyword>bedrock</Keyword>
+      <Keyword>superficial</Keyword>
+      <Keyword>lithology</Keyword>
+      <Keyword>lithostratigraphy</Keyword>
+      <Keyword>age</Keyword>
+      <Keyword>MD_LANG@ENG</Keyword>
+      <Keyword>MD_DATE@2014-01-06</Keyword>
+      <Keyword vocabulary="GEMET">Geology</Keyword>
+      <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+  </KeywordList>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+  <ContactInformation>
+    <ContactPersonPrimary>
+      <ContactPerson>Mr Matthew Harrison</ContactPerson>
+      <ContactOrganization>British Geological Survey (BGS)</ContactOrganization>
+    </ContactPersonPrimary>
+      <ContactPosition>Science Director Informatics</ContactPosition>
+    <ContactAddress>
+        <AddressType>postal</AddressType>
+        <Address>Environmental Science Centre</Address>
+        <City>Keyworth</City>
+        <StateOrProvince>Nottinghamshire</StateOrProvince>
+        <PostCode>NG12 5GG</PostCode>
+        <Country>United Kingdom</Country>
+    </ContactAddress>
+      <ContactVoiceTelephone>+44 (0)115 936 3100</ContactVoiceTelephone>
+      <ContactFacsimileTelephone>+44 (0)115 936 3200</ContactFacsimileTelephone>
+  <ContactElectronicMailAddress>enquiries@bgs.ac.uk</ContactElectronicMailAddress>
+  </ContactInformation>
+  <Fees>none</Fees>
+  <AccessConstraints>The 1:625k DiGMap data is made available for all uses - including commercial use, however the British Geological Survey (BGS) at all times retains the copyright in this material and you are not permitted, without an appropriate licence, to set up a service selling on this material. Your own use of any information provided by the British Geological Survey (BGS) is at your own risk. Neither BGS nor the Natural Environment Research Council (NERC) gives any warranty, condition or representation as to the quality, accuracy or completeness of the information or its suitability for any use or purpose. All implied conditions relating to the quality or suitability of the information, and all liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.</AccessConstraints>
+  <MaxWidth>3072</MaxWidth>
+  <MaxHeight>3072</MaxHeight>
+</Service>
+
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/png</Format>
+      <Format>image/tiff</Format>
+      <Format>image/x-aaigrid</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/png; mode=8bit</Format>
+      <Format>application/x-pdf</Format>
+      <Format>image/svg+xml</Format>
+      <Format>application/vnd.google-earth.kml+xml</Format>
+      <Format>application/vnd.google-earth.kmz</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/html</Format>
+      <Format>application/vnd.ogc.gml</Format>
+      <Format>text/xml</Format>
+      <Format>text/plain</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+    <sld:DescribeLayer>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </sld:DescribeLayer>
+    <sld:GetLegendGraphic>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/png; mode=8bit</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </sld:GetLegendGraphic>
+    <ms:GetStyles>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </ms:GetStyles>
+  </Request>
+  <Exception>
+    <Format>XML</Format>
+    <Format>INIMAGE</Format>
+    <Format>BLANK</Format>
+  </Exception>
+  <sld:UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0" InlineFeature="0" RemoteWCS="0"/>
+  <inspire_vs:ExtendedCapabilities>
+    <inspire_common:MetadataUrl xsi:type="inspire_common:resourceLocatorType">
+      <inspire_common:URL>http://metadata.bgs.ac.uk/geonetwork/srv/en/csw?SERVICE=CSW&amp;REQUEST=GetRecordById&amp;elementSetName=full&amp;OutputSchema=http://www.isotc211.org/2005/gmd&amp;ID=7822e848-822d-45a5-8584-56d352fd2170&amp;</inspire_common:URL>
+      <inspire_common:MediaType>application/xml</inspire_common:MediaType>
+    </inspire_common:MetadataUrl>
+    <inspire_common:SupportedLanguages>
+      <inspire_common:DefaultLanguage><inspire_common:Language>eng</inspire_common:Language></inspire_common:DefaultLanguage>
+    </inspire_common:SupportedLanguages>
+    <inspire_common:ResponseLanguage><inspire_common:Language>eng</inspire_common:Language></inspire_common:ResponseLanguage>
+  </inspire_vs:ExtendedCapabilities>
+  <Layer>
+    <Name>BGS_EN_Bedrock_and_Superficial_Geology</Name>
+    <Title>BGS bedrock and superficial geology</Title>
+    <Abstract>The 1:625k DiGMap data covering the whole of the United Kingdom is available in this OGC WMS service for all uses - including commercial use subject to the conditions in the Access Constraints section. It is being served as a contribution to the OneGeology initiative (www.onegeology.org). Separate bedrock geology and superficial deposits layers are available in this service. Layers available for bedrock are lithostratigraphy, age, and lithology. Layers available for superficial deposits layer are lithostratigraphy and lithology.  A layer is also provided for the UK Continental Shelf BGS 1:1M simplified seabed sediments. For information about more of the British Geological Survey&#39;s maps that are available digitally please visit http://www.bgs.ac.uk/products/digitalmaps/digmapgb.html</Abstract>
+    <KeywordList>
+        <Keyword>OneGeology</Keyword>
+        <Keyword>geology</Keyword>
+        <Keyword>map</Keyword>
+        <Keyword>United Kingdom</Keyword>
+        <Keyword>bedrock</Keyword>
+        <Keyword>superficial</Keyword>
+        <Keyword>lithology</Keyword>
+        <Keyword>lithostratigraphy</Keyword>
+        <Keyword>age</Keyword>
+        <Keyword>MD_LANG@ENG</Keyword>
+        <Keyword>MD_DATE@2014-01-06</Keyword>
+        <Keyword vocabulary="GEMET">Geology</Keyword>
+        <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+    </KeywordList>
+    <CRS>CRS:84</CRS>
+    <CRS>EPSG:27700</CRS>
+    <CRS>EPSG:29902</CRS>
+    <CRS>EPSG:3034</CRS>
+    <CRS>EPSG:3413</CRS>
+    <CRS>EPSG:3857</CRS>
+    <CRS>EPSG:4258</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:900913</CRS>
+    <EX_GeographicBoundingBox>
+        <westBoundLongitude>-8.6476</westBoundLongitude>
+        <eastBoundLongitude>1.76943</eastBoundLongitude>
+        <southBoundLatitude>49.8639</southBoundLatitude>
+        <northBoundLatitude>60.8622</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox CRS="CRS:84"
+                minx="-8.6476" miny="49.8639" maxx="1.76943" maxy="60.8622" />
+    <BoundingBox CRS="EPSG:27700"
+                minx="-77493.4" miny="-4039.86" maxx="670977" maxy="1.23824e+006" />
+    <BoundingBox CRS="EPSG:29902"
+                minx="153489" miny="-154594" maxx="901891" maxy="1.10946e+006" />
+    <BoundingBox CRS="EPSG:3034"
+                minx="2.60232e+006" miny="2.71888e+006" maxx="3.88362e+006" maxy="3.56176e+006" />
+    <BoundingBox CRS="EPSG:3413"
+                minx="1.91073e+006" miny="-3.64649e+006" maxx="3.29885e+006" maxy="-2.20789e+006" />
+    <BoundingBox CRS="EPSG:3857"
+                minx="-962646" miny="6.42274e+006" maxx="196972" maxy="8.59425e+006" />
+    <BoundingBox CRS="EPSG:4258"
+                minx="49.8639" miny="-8.6476" maxx="60.8622" maxy="1.76943" />
+    <BoundingBox CRS="EPSG:4326"
+                minx="49.8639" miny="-8.6476" maxx="60.8622" maxy="1.76943" />
+    <BoundingBox CRS="EPSG:900913"
+                minx="-962646" miny="6.42274e+006" maxx="196972" maxy="8.59425e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+    <AuthorityURL name="BritishGeologicalSurvey">
+      <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+    </AuthorityURL>
+    <Style>
+       <Name>default</Name>
+       <Title>default</Title>
+       <LegendURL width="563" height="6420">
+          <Format>image/png</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=BGS_EN_Bedrock_and_Superficial_Geology&amp;format=image/png&amp;STYLE=default"/>
+       </LegendURL>
+    </Style>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>GBR_BGS_625k_BLT</Name>
+        <Title>GBR BGS 1:625k Bedrock Lithology</Title>
+        <Abstract>GBR BGS 1:625k scale Bedrock Lithology</Abstract>
+        <KeywordList>
+            <Keyword>OneGeology</Keyword>
+            <Keyword>geology</Keyword>
+            <Keyword>bedrock</Keyword>
+            <Keyword>lithology</Keyword>
+            <Keyword>continent@Europe</Keyword>
+            <Keyword>subcontinent@Northern Europe</Keyword>
+            <Keyword>geographicarea@United Kingdom</Keyword>
+            <Keyword>dataprovider@British Geological Survey</Keyword>
+            <Keyword>serviceprovider@British Geological Survey</Keyword>
+            <Keyword>DS_TOPIC@geoscientificinformation</Keyword>
+            <Keyword>DS_DATE@2008-04-10</Keyword>
+            <Keyword>GeoSciML32_wfs_age_or_litho_queryable</Keyword>
+            <Keyword>WFSgsml31filter_age_litho</Keyword>
+            <Keyword>GeoSciML_wfs_age_or_litho_queryable</Keyword>
+        </KeywordList>
+        <CRS>CRS:84</CRS>
+        <CRS>EPSG:27700</CRS>
+        <CRS>EPSG:29902</CRS>
+        <CRS>EPSG:3034</CRS>
+        <CRS>EPSG:3413</CRS>
+        <CRS>EPSG:3857</CRS>
+        <CRS>EPSG:4258</CRS>
+        <CRS>EPSG:4326</CRS>
+        <CRS>EPSG:900913</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-8.64846</westBoundLongitude>
+            <eastBoundLongitude>1.76767</eastBoundLongitude>
+            <southBoundLatitude>49.8638</southBoundLatitude>
+            <northBoundLatitude>60.8612</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84"
+                    minx="-8.64846" miny="49.8638" maxx="1.76767" maxy="60.8612" />
+        <BoundingBox CRS="EPSG:27700"
+                    minx="-77556.4" miny="-4051.91" maxx="670851" maxy="1.23813e+006" />
+        <BoundingBox CRS="EPSG:29902"
+                    minx="153426" miny="-154606" maxx="901766" maxy="1.10933e+006" />
+        <BoundingBox CRS="EPSG:3034"
+                    minx="2.60232e+006" miny="2.71882e+006" maxx="3.88352e+006" maxy="3.56165e+006" />
+        <BoundingBox CRS="EPSG:3413"
+                    minx="1.91076e+006" miny="-3.64654e+006" maxx="3.29876e+006" maxy="-2.20805e+006" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-962742" miny="6.42272e+006" maxx="196776" maxy="8.59402e+006" />
+        <BoundingBox CRS="EPSG:4258"
+                    minx="49.8638" miny="-8.64846" maxx="60.8612" maxy="1.76767" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="49.8638" miny="-8.64846" maxx="60.8612" maxy="1.76767" />
+        <BoundingBox CRS="EPSG:900913"
+                    minx="-962742" miny="6.42272e+006" maxx="196776" maxy="8.59402e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+        <AuthorityURL name="BritishGeologicalSurvey">
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+        </AuthorityURL>
+        <MetadataURL type="TC211">
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/discoverymetadata/13480426.html"/>
+        </MetadataURL>
+        <DataURL>
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/products/digitalmaps/digmapgb_625.html"/>
+        </DataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="499" height="1720">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=GBR_BGS_625k_BLT&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>GBR_BGS_625k_BLS</Name>
+        <Title>GBR BGS 1:625k Bedrock Lithostratigraphy</Title>
+        <Abstract>GBR BGS 1:625k scale Bedrock Lithostratigraphy (including Lithogenic units)</Abstract>
+        <KeywordList>
+            <Keyword>OneGeology</Keyword>
+            <Keyword>geology</Keyword>
+            <Keyword>bedrock</Keyword>
+            <Keyword>lithostratigraphy</Keyword>
+            <Keyword>continent@Europe</Keyword>
+            <Keyword>subcontinent@Northern Europe</Keyword>
+            <Keyword>geographicarea@United Kingdom</Keyword>
+            <Keyword>dataprovider@British Geological Survey</Keyword>
+            <Keyword>serviceprovider@British Geological Survey</Keyword>
+            <Keyword>DS_TOPIC@geoscientificinformation</Keyword>
+            <Keyword>DS_DATE@2008-04-10</Keyword>
+            <Keyword>GeoSciML32_wfs_age_or_litho_queryable</Keyword>
+            <Keyword>WFSgsml31filter_age_litho</Keyword>
+            <Keyword>GeoSciML_wfs_age_or_litho_queryable</Keyword>
+        </KeywordList>
+        <CRS>CRS:84</CRS>
+        <CRS>EPSG:27700</CRS>
+        <CRS>EPSG:29902</CRS>
+        <CRS>EPSG:3034</CRS>
+        <CRS>EPSG:3413</CRS>
+        <CRS>EPSG:3857</CRS>
+        <CRS>EPSG:4258</CRS>
+        <CRS>EPSG:4326</CRS>
+        <CRS>EPSG:900913</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-8.64846</westBoundLongitude>
+            <eastBoundLongitude>1.76767</eastBoundLongitude>
+            <southBoundLatitude>49.8638</southBoundLatitude>
+            <northBoundLatitude>60.8612</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84"
+                    minx="-8.64846" miny="49.8638" maxx="1.76767" maxy="60.8612" />
+        <BoundingBox CRS="EPSG:27700"
+                    minx="-77556.4" miny="-4051.91" maxx="670851" maxy="1.23813e+006" />
+        <BoundingBox CRS="EPSG:29902"
+                    minx="153426" miny="-154606" maxx="901766" maxy="1.10933e+006" />
+        <BoundingBox CRS="EPSG:3034"
+                    minx="2.60232e+006" miny="2.71882e+006" maxx="3.88352e+006" maxy="3.56165e+006" />
+        <BoundingBox CRS="EPSG:3413"
+                    minx="1.91076e+006" miny="-3.64654e+006" maxx="3.29876e+006" maxy="-2.20805e+006" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-962742" miny="6.42272e+006" maxx="196776" maxy="8.59402e+006" />
+        <BoundingBox CRS="EPSG:4258"
+                    minx="49.8638" miny="-8.64846" maxx="60.8612" maxy="1.76767" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="49.8638" miny="-8.64846" maxx="60.8612" maxy="1.76767" />
+        <BoundingBox CRS="EPSG:900913"
+                    minx="-962742" miny="6.42272e+006" maxx="196776" maxy="8.59402e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+        <AuthorityURL name="BritishGeologicalSurvey">
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+        </AuthorityURL>
+        <MetadataURL type="TC211">
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/discoverymetadata/13480426.html"/>
+        </MetadataURL>
+        <DataURL>
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/products/digitalmaps/digmapgb_625.html"/>
+        </DataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="563" height="3080">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=GBR_BGS_625k_BLS&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>GBR_BGS_625k_BA</Name>
+        <Title>GBR BGS 1:625k Bedrock Age</Title>
+        <Abstract>GBR BGS 1:625k scale Bedrock Age</Abstract>
+        <KeywordList>
+            <Keyword>OneGeology</Keyword>
+            <Keyword>geology</Keyword>
+            <Keyword>bedrock</Keyword>
+            <Keyword>age</Keyword>
+            <Keyword>chronostratigraphy</Keyword>
+            <Keyword>continent@Europe</Keyword>
+            <Keyword>subcontinent@Northern Europe</Keyword>
+            <Keyword>geographicarea@United Kingdom</Keyword>
+            <Keyword>dataprovider@British Geological Survey</Keyword>
+            <Keyword>serviceprovider@British Geological Survey</Keyword>
+            <Keyword>DS_TOPIC@geoscientificinformation</Keyword>
+            <Keyword>DS_DATE@2008-04-10</Keyword>
+            <Keyword>GeoSciML32_wfs_age_or_litho_queryable</Keyword>
+            <Keyword>WFSgsml31filter_age_litho</Keyword>
+            <Keyword>GeoSciML_wfs_age_or_litho_queryable</Keyword>
+        </KeywordList>
+        <CRS>CRS:84</CRS>
+        <CRS>EPSG:27700</CRS>
+        <CRS>EPSG:29902</CRS>
+        <CRS>EPSG:3034</CRS>
+        <CRS>EPSG:3413</CRS>
+        <CRS>EPSG:3857</CRS>
+        <CRS>EPSG:4258</CRS>
+        <CRS>EPSG:4326</CRS>
+        <CRS>EPSG:900913</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-8.64846</westBoundLongitude>
+            <eastBoundLongitude>1.76767</eastBoundLongitude>
+            <southBoundLatitude>49.8638</southBoundLatitude>
+            <northBoundLatitude>60.8612</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84"
+                    minx="-8.64846" miny="49.8638" maxx="1.76767" maxy="60.8612" />
+        <BoundingBox CRS="EPSG:27700"
+                    minx="-77556.4" miny="-4051.91" maxx="670851" maxy="1.23813e+006" />
+        <BoundingBox CRS="EPSG:29902"
+                    minx="153426" miny="-154606" maxx="901766" maxy="1.10933e+006" />
+        <BoundingBox CRS="EPSG:3034"
+                    minx="2.60232e+006" miny="2.71882e+006" maxx="3.88352e+006" maxy="3.56165e+006" />
+        <BoundingBox CRS="EPSG:3413"
+                    minx="1.91076e+006" miny="-3.64654e+006" maxx="3.29876e+006" maxy="-2.20805e+006" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-962742" miny="6.42272e+006" maxx="196776" maxy="8.59402e+006" />
+        <BoundingBox CRS="EPSG:4258"
+                    minx="49.8638" miny="-8.64846" maxx="60.8612" maxy="1.76767" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="49.8638" miny="-8.64846" maxx="60.8612" maxy="1.76767" />
+        <BoundingBox CRS="EPSG:900913"
+                    minx="-962742" miny="6.42272e+006" maxx="196776" maxy="8.59402e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+        <AuthorityURL name="BritishGeologicalSurvey">
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+        </AuthorityURL>
+        <MetadataURL type="TC211">
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/discoverymetadata/13480426.html"/>
+        </MetadataURL>
+        <DataURL>
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/products/digitalmaps/digmapgb_625.html"/>
+        </DataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="127" height="1080">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=GBR_BGS_625k_BA&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>GBR_BGS_625k_SLT</Name>
+        <Title>GBR BGS 1:625k Superficial Lithology</Title>
+        <Abstract>GBR BGS 1:625k scale Superficial Deposits Lithology</Abstract>
+        <KeywordList>
+            <Keyword>OneGeology</Keyword>
+            <Keyword>geology</Keyword>
+            <Keyword>superficial</Keyword>
+            <Keyword>lithology</Keyword>
+            <Keyword>continent@Europe</Keyword>
+            <Keyword>subcontinent@Northern Europe</Keyword>
+            <Keyword>geographicarea@United Kingdom</Keyword>
+            <Keyword>dataprovider@British Geological Survey</Keyword>
+            <Keyword>serviceprovider@British Geological Survey</Keyword>
+            <Keyword>DS_TOPIC@geoscientificinformation</Keyword>
+            <Keyword>DS_DATE@2008-04-10</Keyword>
+        </KeywordList>
+        <CRS>CRS:84</CRS>
+        <CRS>EPSG:27700</CRS>
+        <CRS>EPSG:29902</CRS>
+        <CRS>EPSG:3034</CRS>
+        <CRS>EPSG:3413</CRS>
+        <CRS>EPSG:3857</CRS>
+        <CRS>EPSG:4258</CRS>
+        <CRS>EPSG:4326</CRS>
+        <CRS>EPSG:900913</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-7.62927</westBoundLongitude>
+            <eastBoundLongitude>1.7645</eastBoundLongitude>
+            <southBoundLatitude>49.8902</southBoundLatitude>
+            <northBoundLatitude>60.8489</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84"
+                    minx="-7.62927" miny="49.8902" maxx="1.7645" maxy="60.8489" />
+        <BoundingBox CRS="EPSG:27700"
+                    minx="-4156.5" miny="-1118.71" maxx="670476" maxy="1.23158e+006" />
+        <BoundingBox CRS="EPSG:29902"
+                    minx="220200" miny="-151606" maxx="901154" maxy="1.10794e+006" />
+        <BoundingBox CRS="EPSG:3034"
+                    minx="2.60516e+006" miny="2.78814e+006" maxx="3.869e+006" maxy="3.56133e+006" />
+        <BoundingBox CRS="EPSG:3413"
+                    minx="1.9575e+006" miny="-3.59567e+006" maxx="3.29624e+006" maxy="-2.20915e+006" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-849286" miny="6.42728e+006" maxx="196424" maxy="8.59121e+006" />
+        <BoundingBox CRS="EPSG:4258"
+                    minx="49.8902" miny="-7.62927" maxx="60.8489" maxy="1.7645" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="49.8902" miny="-7.62927" maxx="60.8489" maxy="1.7645" />
+        <BoundingBox CRS="EPSG:900913"
+                    minx="-849286" miny="6.42728e+006" maxx="196424" maxy="8.59121e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+        <AuthorityURL name="BritishGeologicalSurvey">
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+        </AuthorityURL>
+        <MetadataURL type="TC211">
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/discoverymetadata/13480426.html"/>
+        </MetadataURL>
+        <DataURL>
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/products/digitalmaps/digmapgb_625.html"/>
+        </DataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="133" height="160">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=GBR_BGS_625k_SLT&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>GBR_BGS_625k_SLS</Name>
+        <Title>GBR BGS 1:625k Superficial Lithostratigraphy</Title>
+        <Abstract>GBR BGS 1:625k scale Superficial Deposits Lithostratigraphy (including Lithomorphogenetic units)</Abstract>
+        <KeywordList>
+            <Keyword>OneGeology</Keyword>
+            <Keyword>geology</Keyword>
+            <Keyword>superficial</Keyword>
+            <Keyword>lithostratigraphy</Keyword>
+            <Keyword>continent@Europe</Keyword>
+            <Keyword>subcontinent@Northern Europe</Keyword>
+            <Keyword>geographicarea@United Kingdom</Keyword>
+            <Keyword>dataprovider@British Geological Survey</Keyword>
+            <Keyword>serviceprovider@British Geological Survey</Keyword>
+            <Keyword>DS_TOPIC@geoscientificinformation</Keyword>
+            <Keyword>DS_DATE@2008-04-10</Keyword>
+        </KeywordList>
+        <CRS>CRS:84</CRS>
+        <CRS>EPSG:27700</CRS>
+        <CRS>EPSG:29902</CRS>
+        <CRS>EPSG:3034</CRS>
+        <CRS>EPSG:3413</CRS>
+        <CRS>EPSG:3857</CRS>
+        <CRS>EPSG:4258</CRS>
+        <CRS>EPSG:4326</CRS>
+        <CRS>EPSG:900913</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-7.62927</westBoundLongitude>
+            <eastBoundLongitude>1.7645</eastBoundLongitude>
+            <southBoundLatitude>49.8902</southBoundLatitude>
+            <northBoundLatitude>60.8489</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84"
+                    minx="-7.62927" miny="49.8902" maxx="1.7645" maxy="60.8489" />
+        <BoundingBox CRS="EPSG:27700"
+                    minx="-4156.5" miny="-1118.71" maxx="670476" maxy="1.23158e+006" />
+        <BoundingBox CRS="EPSG:29902"
+                    minx="220200" miny="-151606" maxx="901154" maxy="1.10794e+006" />
+        <BoundingBox CRS="EPSG:3034"
+                    minx="2.60516e+006" miny="2.78814e+006" maxx="3.869e+006" maxy="3.56133e+006" />
+        <BoundingBox CRS="EPSG:3413"
+                    minx="1.9575e+006" miny="-3.59567e+006" maxx="3.29624e+006" maxy="-2.20915e+006" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-849286" miny="6.42728e+006" maxx="196424" maxy="8.59121e+006" />
+        <BoundingBox CRS="EPSG:4258"
+                    minx="49.8902" miny="-7.62927" maxx="60.8489" maxy="1.7645" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="49.8902" miny="-7.62927" maxx="60.8489" maxy="1.7645" />
+        <BoundingBox CRS="EPSG:900913"
+                    minx="-849286" miny="6.42728e+006" maxx="196424" maxy="8.59121e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+        <AuthorityURL name="BritishGeologicalSurvey">
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+        </AuthorityURL>
+        <MetadataURL type="TC211">
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/discoverymetadata/13480426.html"/>
+        </MetadataURL>
+        <DataURL>
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/products/digitalmaps/digmapgb_625.html"/>
+        </DataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="324" height="280">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=GBR_BGS_625k_SLS&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>UKCoShelf_BGS_1M_SBS</Name>
+        <Title>UKContShelf BGS 1:1M Seabed Sediments</Title>
+        <Abstract>UKContShelf BGS 1:1M Seabed Sediments. Your use of any information provided by the British Geological Survey (BGS) is at your own risk. Neither BGS nor the Natural Environment Research Council (NERC) gives any warranty, condition or representation as to the quality, accuracy or completeness of the information or its suitability for any use or purpose. All implied conditions relating to the quality or suitability of the information, and all liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.</Abstract>
+        <KeywordList>
+            <Keyword>OneGeology</Keyword>
+            <Keyword>geology</Keyword>
+            <Keyword>marine geology</Keyword>
+            <Keyword>seabed</Keyword>
+            <Keyword>sediments</Keyword>
+            <Keyword>continent@Europe</Keyword>
+            <Keyword>subcontinent@Northern Europe</Keyword>
+            <Keyword>geographicarea@United Kingdom</Keyword>
+            <Keyword>dataprovider@British Geological Survey</Keyword>
+            <Keyword>serviceprovider@British Geological Survey</Keyword>
+            <Keyword>DS_TOPIC@geoscientificinformation</Keyword>
+            <Keyword>DS_DATE@2008-07-11</Keyword>
+        </KeywordList>
+        <CRS>CRS:84</CRS>
+        <CRS>EPSG:27700</CRS>
+        <CRS>EPSG:29902</CRS>
+        <CRS>EPSG:3034</CRS>
+        <CRS>EPSG:3413</CRS>
+        <CRS>EPSG:3857</CRS>
+        <CRS>EPSG:4258</CRS>
+        <CRS>EPSG:4326</CRS>
+        <CRS>EPSG:900913</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-12</westBoundLongitude>
+            <eastBoundLongitude>3.39852</eastBoundLongitude>
+            <southBoundLatitude>48.2351</southBoundLatitude>
+            <northBoundLatitude>63.8908</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="CRS:84"
+                    minx="-12" miny="48.2351" maxx="3.39852" maxy="63.8908" />
+        <BoundingBox CRS="EPSG:27700"
+                    minx="-342047" miny="-185109" maxx="800912" maxy="1.59585e+006" />
+        <BoundingBox CRS="EPSG:29902"
+                    minx="-97073.7" miny="-335737" maxx="1.04617e+006" maxy="1.45748e+006" />
+        <BoundingBox CRS="EPSG:3034"
+                    minx="2.41668e+006" miny="2.44354e+006" maxx="4.25094e+006" maxy="3.67799e+006" />
+        <BoundingBox CRS="EPSG:3413"
+                    minx="1.56657e+006" miny="-3.96504e+006" maxx="3.53533e+006" maxy="-1.90973e+006" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-1.33583e+006" miny="6.14606e+006" maxx="378321" maxy="9.3221e+006" />
+        <BoundingBox CRS="EPSG:4258"
+                    minx="48.2351" miny="-12" maxx="63.8908" maxy="3.39852" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="48.2351" miny="-12" maxx="63.8908" maxy="3.39852" />
+        <BoundingBox CRS="EPSG:900913"
+                    minx="-1.33583e+006" miny="6.14606e+006" maxx="378321" maxy="9.3221e+006" />
+    <Attribution>
+        <Title>British Geological Survey (BGS)</Title>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.bgs.ac.uk/"/>
+        <LogoURL width="275" height="60">
+             <Format>image/gif</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/img/bgs_c_t_275x60.gif"/>
+          </LogoURL>
+    </Attribution>
+        <AuthorityURL name="BritishGeologicalSurvey">
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://data.bgs.ac.uk/ref/BritishGeologicalSurvey"/>
+        </AuthorityURL>
+        <MetadataURL type="TC211">
+          <Format>application/xml; charset=UTF-8</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://metadata.bgs.ac.uk/geonetwork/srv/en/csw?service=CSW&amp;request=GetRecordById&amp;elementSetName=full&amp;OutputSchema=http://www.isotc211.org/2005/gmd&amp;ID=9df8df52-d786-37a8-e044-0003ba9b0d98&amp;"/>
+        </MetadataURL>
+        <DataURL>
+          <Format>text/html</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.bgs.ac.uk/products/digitalmaps/digmapgb_625.html"/>
+        </DataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="131" height="100">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://ogc.bgs.ac.uk/cgi-bin/BGS_Bedrock_and_Superficial_Geology/wms?language=eng&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=UKCoShelf_BGS_1M_SBS&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+  </Layer>
+</Capability>
+</WMS_Capabilities>

--- a/test/unit/WMS_Provider_unit_test.js
+++ b/test/unit/WMS_Provider_unit_test.js
@@ -2,8 +2,8 @@
 import jsdom from 'jsdom';
 import assert from 'assert';
 import fs from 'fs';
-import provider, { _testing } from '../src/Core/Scheduler/Providers/WMS_Provider';
-import Extent from '../src/Core/Geographic/Extent';
+import provider, { _testing } from '../../src/Provider/WMSProvider';
+import Extent from '../../src/Core/Geographic/Extent';
 
 const { JSDOM } = jsdom;
 const window = new JSDOM().window;


### PR DESCRIPTION
## Description

Add GetCapabilities query for WMS layers. This PR implement the fetching of capabilities and set or check the following informations:
- projection
- extent
- format

BREAKING CHANGE:

- WMS layer will now query getCapabilities. If you want to disable this  behaviour (because you already provide all the informations in the json object), you need to set layer.disableGetCap to true.

- previously we had layer.format and layer.options.mimetype coexisting, with no clear difference in role. This commit removes layer.options.mimetype to only keep layer.format. This is needed to reliably check configured format.

## Motivation and Context

Supporting getCapabilities in our providers is a necessary step to present a usable SIG application for the outside world, let's start this.

Moreover, if we want itowns to be able to display a layer from its url only, we need to be able to query capabilities from these layers.

Work that would need to follow this PR:
- support getCapabilities for WFS and WMTS 
- add the possibility to create an entire scene (view + layers) with just a WMS/WMTS/WFS url.

This is a first pass at fixing #285.
