### PR TITLE
example: add one with five different layers

### DIFF
--- a/examples/layers/JSONLayers/Administrative.json
+++ b/examples/layers/JSONLayers/Administrative.json
@@ -1,0 +1,27 @@
+{
+  "type": "color",
+  "url": "https://wxs.ign.fr/an7nvfzojv5wa96dsga5nk8w/geoportail/wmts",
+  "protocol": "wmts",
+  "id": "Administrative",
+  "title": "Administrative delimitations",
+  "visible": false,
+  "opacity": 1,
+  "transparent": true,
+  "updateStrategy": {
+    "type": "0",
+    "options": {}
+  },
+  "networkOptions": {
+    "crossOrigin": "omit"
+  },
+  "options": {
+    "tileMatrixSet": "PM",
+    "mimetype": "image/png",
+    "name": "ADMINISTRATIVEUNITS.BOUNDARIES",
+    "style": "normal",
+    "zoom": {
+      "min": 5,
+      "max": 20
+    }
+  }
+}

--- a/examples/layers/JSONLayers/Cada.json
+++ b/examples/layers/JSONLayers/Cada.json
@@ -1,0 +1,162 @@
+{
+  "type": "color",
+  "url": "https://wxs.ign.fr/an7nvfzojv5wa96dsga5nk8w/geoportail/wmts",
+  "protocol": "wmts",
+  "id": "Cadastre",
+  "title": "Parcelles cadastrales",
+  "visible": false,
+  "opacity": 1,
+  "transparent": true,
+  "updateStrategy": {
+    "type": "0",
+    "options": {}
+  },
+  "networkOptions": {
+    "crossOrigin": "omit"
+  },
+  "options": {
+    "tileMatrixSet": "PM",
+    "tileMatrixSetLimits": {
+      "0": {
+        "minTileRow": "0",
+        "maxTileRow": "1",
+        "minTileCol": "0",
+        "maxTileCol": "1"
+      },
+      "1": {
+        "minTileRow": "0",
+        "maxTileRow": "2",
+        "minTileCol": "0",
+        "maxTileCol": "2"
+      },
+      "2": {
+        "minTileRow": "0",
+        "maxTileRow": "4",
+        "minTileCol": "0",
+        "maxTileCol": "4"
+      },
+      "3": {
+        "minTileRow": "0",
+        "maxTileRow": "8",
+        "minTileCol": "0",
+        "maxTileCol": "8"
+      },
+      "4": {
+        "minTileRow": "0",
+        "maxTileRow": "16",
+        "minTileCol": "0",
+        "maxTileCol": "16"
+      },
+      "5": {
+        "minTileRow": "0",
+        "maxTileRow": "32",
+        "minTileCol": "0",
+        "maxTileCol": "32"
+      },
+      "6": {
+        "minTileRow": "0",
+        "maxTileRow": "64",
+        "minTileCol": "0",
+        "maxTileCol": "64"
+      },
+      "7": {
+        "minTileRow": "0",
+        "maxTileRow": "128",
+        "minTileCol": "0",
+        "maxTileCol": "128"
+      },
+      "8": {
+        "minTileRow": "0",
+        "maxTileRow": "256",
+        "minTileCol": "0",
+        "maxTileCol": "256"
+      },
+      "9": {
+        "minTileRow": "0",
+        "maxTileRow": "512",
+        "minTileCol": "0",
+        "maxTileCol": "512"
+      },
+      "10": {
+        "minTileRow": "0",
+        "maxTileRow": "1024",
+        "minTileCol": "0",
+        "maxTileCol": "1024"
+      },
+      "11": {
+        "minTileRow": "0",
+        "maxTileRow": "2048",
+        "minTileCol": "0",
+        "maxTileCol": "2048"
+      },
+      "12": {
+        "minTileRow": "0",
+        "maxTileRow": "4096",
+        "minTileCol": "0",
+        "maxTileCol": "4096"
+      },
+      "13": {
+        "minTileRow": "0",
+        "maxTileRow": "8192",
+        "minTileCol": "0",
+        "maxTileCol": "8192"
+      },
+      "14": {
+        "minTileRow": "0",
+        "maxTileRow": "16384",
+        "minTileCol": "0",
+        "maxTileCol": "16384"
+      },
+      "15": {
+        "minTileRow": "0",
+        "maxTileRow": "32768",
+        "minTileCol": "0",
+        "maxTileCol": "32768"
+      },
+      "16": {
+        "minTileRow": "0",
+        "maxTileRow": "65536",
+        "minTileCol": "0",
+        "maxTileCol": "65536"
+      },
+      "17": {
+        "minTileRow": "0",
+        "maxTileRow": "131072",
+        "minTileCol": "0",
+        "maxTileCol": "131072"
+      },
+      "18": {
+        "minTileRow": "0",
+        "maxTileRow": "262144",
+        "minTileCol": "0",
+        "maxTileCol": "262144"
+      },
+      "19": {
+        "minTileRow": "0",
+        "maxTileRow": "524288",
+        "minTileCol": "0",
+        "maxTileCol": "524288"
+      },
+      "20": {
+        "minTileRow": "0",
+        "maxTileRow": "1048576",
+        "minTileCol": "0",
+        "maxTileCol": "1048576"
+      },
+      "21": {
+        "minTileRow": "0",
+        "maxTileRow": "2097152",
+        "minTileCol": "0",
+        "maxTileCol": "2097152"
+      }
+    },
+    "mimetype": "image/png",
+    "name": "CADASTRALPARCELS.PARCELS",
+    "style": "bdparcellaire",
+    "zoom": {
+      "min": 5,
+      "max": 20
+    }
+  },
+  "version": "1.0.0"
+}

--- a/examples/layers/JSONLayers/Denomination.json
+++ b/examples/layers/JSONLayers/Denomination.json
@@ -1,0 +1,27 @@
+{
+  "type": "color",
+  "url": "https://wxs.ign.fr/an7nvfzojv5wa96dsga5nk8w/geoportail/wmts",
+  "protocol": "wmts",
+  "id": "Denomination",
+  "title": "Geographical denomination in France",
+  "visible": false,
+  "opacity": 1,
+  "transparent": true,
+  "updateStrategy": {
+    "type": "0",
+    "options": {}
+  },
+  "networkOptions": {
+    "crossOrigin": "omit"
+  },
+  "options": {
+    "tileMatrixSet": "PM",
+    "mimetype": "image/png",
+    "name": "GEOGRAPHICALNAMES.NAMES",
+    "style": "normal",
+    "zoom": {
+      "min": 5,
+      "max": 20
+    }
+  }
+}

--- a/examples/layers/JSONLayers/Railways.json
+++ b/examples/layers/JSONLayers/Railways.json
@@ -1,0 +1,27 @@
+{
+  "type": "color",
+  "url": "https://wxs.ign.fr/an7nvfzojv5wa96dsga5nk8w/geoportail/wmts",
+  "protocol": "wmts",
+  "id": "Railways",
+  "title": "Railways in France",
+  "visible": false,
+  "opacity": 1,
+  "transparent": true,
+  "updateStrategy": {
+    "type": "0",
+    "options": {}
+  },
+  "networkOptions": {
+    "crossOrigin": "omit"
+  },
+  "options": {
+    "tileMatrixSet": "PM",
+    "mimetype": "image/png",
+    "name": "TRANSPORTNETWORKS.RAILWAYS",
+    "style": "normal",
+    "zoom": {
+      "min": 5,
+      "max": 20
+    }
+  }
+}

--- a/examples/layers/JSONLayers/Transport.json
+++ b/examples/layers/JSONLayers/Transport.json
@@ -1,0 +1,27 @@
+{
+  "type": "color",
+  "url": "https://wxs.ign.fr/an7nvfzojv5wa96dsga5nk8w/geoportail/wmts",
+  "protocol": "wmts",
+  "id": "Transport",
+  "title": "Transport in France",
+  "visible": false,
+  "opacity": 1,
+  "transparent": true,
+  "updateStrategy": {
+    "type": "0",
+    "options": {}
+  },
+  "networkOptions": {
+    "crossOrigin": "omit"
+  },
+  "options": {
+    "tileMatrixSet": "PM",
+    "mimetype": "image/png",
+    "name": "TRANSPORTNETWORKS.ROADS",
+    "style": "normal",
+    "zoom": {
+      "min": 5,
+      "max": 20
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -43,14 +43,25 @@ and open the template in the editor.
             var menuGlobe = new GuiTools('menuDiv', globeView);
             menuGlobe.view = globeView;
 
-            var promises = []
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(function(result) { return globeView.addLayer(result); }));
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(function(result) { return globeView.addLayer(result); }));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(function(result) { return globeView.addLayer(result); }));
+            function addLayerCb(layer) {
+                return globeView.addLayer(layer);
+            }
+
+            var promises = []
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(addLayerCb));
+
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Cada.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Administrative.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb));
+
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
+            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
             menuGlobe.addGUI('RealisticLighting', false,
                 function(newValue) { globeView.setRealisticLightingOn(newValue); });


### PR DESCRIPTION
The goal is to provide a (not so ugly) usecase with sufficient layers to test the behavior of itowns with several layers, while charging and displaying them.

There also is a sixth layer commented, that can be added to push the number of texture further than 16, and thus test some issue such as #583 and #584.

Layers added are:

- Administrative delimitations (France)
- Roads (France)
- Railways (France)
- Cadastral plan (France)
- Denomination of locations (town, lake, mountain etc...)

![multiple_layers](https://user-images.githubusercontent.com/741255/33773868-a8c96f92-dc39-11e7-90b0-4cc3e9df52e5.png)
