### PR TITLE
refacto: Harmonize the mimetype configuration

### DIFF
--- a/examples/cubic_planar.js
+++ b/examples/cubic_planar.js
@@ -104,9 +104,7 @@ for (index = 0; index < wmsLayers.length; index++) {
         id: 'wms_imagery' + wms + index,
         name: wms,
         projection: 'EPSG:3946',
-        options: {
-            mimetype: 'image/jpeg',
-        },
+        format: 'image/jpeg',
     }, tileLayer);
 
     view.addLayer({
@@ -120,9 +118,7 @@ for (index = 0; index < wmsLayers.length; index++) {
         name: 'MNT2012_Altitude_10m_CC46',
         projection: 'EPSG:3946',
         heightMapWidth: 256,
-        options: {
-            mimetype: 'image/jpeg',
-        },
+        format: 'image/jpeg',
     }, tileLayer);
 
     // Since the elevation layer use color textures, specify min/max z

--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -88,9 +88,7 @@ globeView.addLayer({
         south: 5138876.75,
         north: 5205890.19,
     },
-    options: {
-        mimetype: 'geojson',
-    },
+    format: 'application/geojson',
 }, globeView.tileLayer);
 
 function colorBuildings(properties) {
@@ -153,9 +151,7 @@ globeView.addLayer({
     level: 14,
     projection: 'EPSG:4326',
     ipr: 'IGN',
-    options: {
-        mimetype: 'json',
-    },
+    format: 'application/json',
 }, globeView.tileLayer);
 
 function configPointMaterial(result) {
@@ -201,9 +197,7 @@ globeView.addLayer({
     level: 12,
     projection: 'EPSG:2154',
     ipr: 'IGN',
-    options: {
-        mimetype: 'json',
-    },
+    format: 'application/json',
 }, globeView.tileLayer);
 
 exports.view = globeView;

--- a/examples/layers/JSONLayers/Administrative.json
+++ b/examples/layers/JSONLayers/Administrative.json
@@ -7,6 +7,7 @@
   "visible": false,
   "opacity": 1,
   "transparent": true,
+  "format": "image/png",
   "updateStrategy": {
     "type": "0",
     "options": {}
@@ -16,7 +17,6 @@
   },
   "options": {
     "tileMatrixSet": "PM",
-    "mimetype": "image/png",
     "name": "ADMINISTRATIVEUNITS.BOUNDARIES",
     "style": "normal",
     "zoom": {

--- a/examples/layers/JSONLayers/Cada.json
+++ b/examples/layers/JSONLayers/Cada.json
@@ -14,6 +14,7 @@
   "networkOptions": {
     "crossOrigin": "omit"
   },
+  "format": "image/png",
   "options": {
     "tileMatrixSet": "PM",
     "tileMatrixSetLimits": {
@@ -150,7 +151,6 @@
         "maxTileCol": "2097152"
       }
     },
-    "mimetype": "image/png",
     "name": "CADASTRALPARCELS.PARCELS",
     "style": "bdparcellaire",
     "zoom": {

--- a/examples/layers/JSONLayers/DARK.json
+++ b/examples/layers/JSONLayers/DARK.json
@@ -4,12 +4,12 @@
 	"networkOptions": { "crossOrigin" : "anonymous" },
     "id": "DARK",
     "url": "http://a.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png",
+    "format": "image/png",
     "options": {
     	"attribution": {
     		"name":"CARTO",
     		"url": "https://carto.com/"
     	},
-        "tileMatrixSet": "PM",
-        "mimetype": "image/png"
+        "tileMatrixSet": "PM"
     }
 }

--- a/examples/layers/JSONLayers/Denomination.json
+++ b/examples/layers/JSONLayers/Denomination.json
@@ -7,6 +7,7 @@
   "visible": false,
   "opacity": 1,
   "transparent": true,
+  "format": "image/png",
   "updateStrategy": {
     "type": "0",
     "options": {}
@@ -16,7 +17,6 @@
   },
   "options": {
     "tileMatrixSet": "PM",
-    "mimetype": "image/png",
     "name": "GEOGRAPHICALNAMES.NAMES",
     "style": "normal",
     "zoom": {

--- a/examples/layers/JSONLayers/IGN_MNT.json
+++ b/examples/layers/JSONLayers/IGN_MNT.json
@@ -10,13 +10,13 @@
             "groups": [3, 7, 11]
         }
     },
+    "format": "image/x-bil;bits=32",
     "options": {
         "attribution" : {
             "name":"IGN",
             "url":"http://www.ign.fr/"
         },
         "name": "ELEVATION.ELEVATIONGRIDCOVERAGE",
-        "mimetype": "image/x-bil;bits=32",
         "tileMatrixSet": "WGS84G",
         "tileMatrixSetLimits": {
             "3": {

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -10,13 +10,13 @@
 			"groups": [11, 14]
 		}
 	},
+	"format": "image/x-bil;bits=32",
 	"options": {
 		"attribution" : {
 			"name":"IGN",
 			"url":"http://www.ign.fr/"
 		},
 		"name": "ELEVATION.ELEVATIONGRIDCOVERAGE.HIGHRES",
-		"mimetype": "image/x-bil;bits=32",
 		"tileMatrixSet": "WGS84G",
 		"tileMatrixSetLimits": {
 			"11": {

--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -4,12 +4,12 @@
     "networkOptions": { "crossOrigin" : "anonymous" },
     "id": "OPENSM",
     "url": "http://osm.oslandia.io/styles/klokantech-basic/${z}/${x}/${y}.png",
+    "format": "image/png",
     "options": {
         "attribution": {
             "name":"OpenStreetMap",
             "url": "http://www.openstreetmap.org/"
         },
-        "tileMatrixSet": "PM",
-        "mimetype": "image/png"
+        "tileMatrixSet": "PM"
     }
 }

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -10,13 +10,13 @@
         "type": "0",
         "options": {}
     },
+    "format": "image/jpeg",
     "options": {
         "attribution" : {
             "name":"IGN",
             "url":"http://www.ign.fr/"
         },
         "name": "ORTHOIMAGERY.ORTHOPHOTOS",
-        "mimetype": "image/jpeg",
         "tileMatrixSet": "PM",
         "tileMatrixSetLimits": {
             "2": {

--- a/examples/layers/JSONLayers/OrthosCRS.json
+++ b/examples/layers/JSONLayers/OrthosCRS.json
@@ -11,13 +11,13 @@
         "type": 0,
         "options": {}
     },
+    "format": "image/jpeg",
     "options": {
         "name": "ORTHOIMAGERY.ORTHOPHOTOS.CRS84",
         "attribution" : {
             "name":"IGN",
             "url":"http://www.ign.fr/"
         },
-        "mimetype": "image/jpeg",
         "tileMatrixSet": "WGS84G",
         "tileMatrixSetLimits": {
 

--- a/examples/layers/JSONLayers/Railways.json
+++ b/examples/layers/JSONLayers/Railways.json
@@ -7,6 +7,7 @@
   "visible": false,
   "opacity": 1,
   "transparent": true,
+  "format": "image/png",
   "updateStrategy": {
     "type": "0",
     "options": {}
@@ -16,7 +17,6 @@
   },
   "options": {
     "tileMatrixSet": "PM",
-    "mimetype": "image/png",
     "name": "TRANSPORTNETWORKS.RAILWAYS",
     "style": "normal",
     "zoom": {

--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -25,8 +25,8 @@
         "type": 0,
         "options": {}
     },
+    "format"  : "image/png",
     "options": {
-        "mimetype"  : "image/png",
         "attribution" : {
             "name":"IGN",
             "url":"http://www.ign.fr/"

--- a/examples/layers/JSONLayers/ScanEX.json
+++ b/examples/layers/JSONLayers/ScanEX.json
@@ -11,13 +11,13 @@
         "type": 0,
         "options": {}
     },
+    "format": "image/jpeg",
     "options": {
         "attribution" : {
             "name":"IGN",
             "url":"http://www.ign.fr/"
         },
         "name": "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD",
-        "mimetype": "image/jpeg",
         "tileMatrixSet": "PM",
         "tileMatrixSetLimits": {
             "0": {

--- a/examples/layers/JSONLayers/Transport.json
+++ b/examples/layers/JSONLayers/Transport.json
@@ -7,6 +7,7 @@
   "visible": false,
   "opacity": 1,
   "transparent": true,
+  "format": "image/png",
   "updateStrategy": {
     "type": "0",
     "options": {}
@@ -16,7 +17,6 @@
   },
   "options": {
     "tileMatrixSet": "PM",
-    "mimetype": "image/png",
     "name": "TRANSPORTNETWORKS.ROADS",
     "style": "normal",
     "zoom": {

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -11,9 +11,9 @@
             "groups": [3, 7, 9]
         }
     },
+    "format": "image/x-bil;bits=32",
     "options": {
         "name": "ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3",
-        "mimetype": "image/x-bil;bits=32",
         "tileMatrixSet": "WGS84G",
         "tileMatrixSetLimits": {
             "3": {

--- a/examples/planar.js
+++ b/examples/planar.js
@@ -32,9 +32,7 @@ view.addLayer({
     id: 'wms_imagery',
     name: 'Ortho2009_vue_ensemble_16cm_CC46',
     projection: 'EPSG:3946',
-    options: {
-        mimetype: 'image/jpeg',
-    },
+    format: 'image/jpeg',
     updateStrategy: {
         type: itowns.STRATEGY_DICHOTOMY,
         options: {},
@@ -51,9 +49,7 @@ view.addLayer({
     name: 'MNT2012_Altitude_10m_CC46',
     projection: 'EPSG:3946',
     heightMapWidth: 256,
-    options: {
-        mimetype: 'image/jpeg',
-    },
+    format: 'image/jpeg',
 });
 // Since the elevation layer use color textures, specify min/max z
 view.tileLayer.materialOptions = {

--- a/examples/planar_vector.js
+++ b/examples/planar_vector.js
@@ -33,9 +33,7 @@ view.addLayer({
     name: 'Ortho2009_vue_ensemble_16cm_CC46',
     projection: 'EPSG:3946',
     transparent: true,
-    options: {
-        mimetype: 'image/jpeg',
-    },
+    format: 'image/jpeg',
 });
 
 // Add an WMS elevation layer (see WMS_Provider* for valid options)
@@ -49,9 +47,7 @@ view.addLayer({
     name: 'MNT2012_Altitude_10m_CC46',
     projection: view.referenceCrs,
     heightMapWidth: 256,
-    options: {
-        mimetype: 'image/jpeg',
-    },
+    format: 'image/jpeg',
 });
 
 view.addLayer({

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -37,9 +37,7 @@ view.addLayer({
     projection: 'EPSG:3946',
     transparent: false,
     extent: extent,
-    options: {
-        mimetype: 'image/jpeg',
-    },
+    format: 'image/jpeg',
 });
 
 view.camera.camera3D.position.set(1839739, 5171618, 910);
@@ -78,9 +76,7 @@ view.addLayer({
         south: 5138876.75,
         north: 5205890.19,
     },
-    options: {
-        mimetype: 'geojson',
-    },
+    format: 'application/geojson',
 }, view.tileLayer);
 
 function colorBuildings(properties) {
@@ -138,9 +134,7 @@ view.addLayer({
         north: 46.03,
     },
     ipr: 'IGN',
-    options: {
-        mimetype: 'json',
-    },
+    format: 'application/json',
 }, view.tileLayer);
 
 function configPointMaterial(result) {
@@ -177,8 +171,6 @@ view.addLayer({
     level: 2,
     projection: 'EPSG:2154',
     ipr: 'IGN',
-    options: {
-        mimetype: 'json',
-    },
+    format: 'application/json',
 }, view.tileLayer);
 exports.view = view;

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -51,7 +51,6 @@ export default {
             throw new Error('layer.url is required');
         }
 
-        layer.options = layer.options || {};
         // KML and GPX specifications all says that they should be in
         // EPSG:4326. We still support reprojection for them through this
         // configuration option

--- a/src/Core/Scheduler/Providers/StaticProvider.js
+++ b/src/Core/Scheduler/Providers/StaticProvider.js
@@ -48,7 +48,7 @@ function getTexture(tile, layer) {
     }
 
 
-    const fn = layer.options.mimetype.indexOf('image/x-bil') === 0 ?
+    const fn = layer.format.indexOf('image/x-bil') === 0 ?
         OGCWebServiceHelper.getXBilTextureByUrl :
         OGCWebServiceHelper.getColorTextureByUrl;
     return fn(buildUrl(layer, selection.image), layer.networkOptions).then((texture) => {
@@ -91,7 +91,6 @@ export default {
             layer.extent = new Extent(layer.projection, ...layer.extent);
         }
 
-        layer.options = layer.options || {};
         layer.canTileTextureBeImproved = this.canTileTextureBeImproved;
         layer.url = new URL(layer.url, window.location);
         return Fetcher.json(layer.url.href).then((metadata) => {
@@ -105,17 +104,17 @@ export default {
                 });
             }
         }).then(() => {
-            if (!layer.options.mimetype) {
-                // fetch the first image to detect mimetype
+            if (!layer.format) {
+                // fetch the first image to detect format
                 if (layer.images.length) {
                     const url = buildUrl(layer, layer.images[0].image);
                     return fetch(url, layer.networkOptions).then((response) => {
-                        layer.options.mimetype = response.headers.get('Content-type');
-                        if (layer.options.mimetype === 'application/octet-stream') {
-                            layer.options.mimetype = 'image/x-bil';
+                        layer.format = response.headers.get('Content-type');
+                        if (layer.format === 'application/octet-stream') {
+                            layer.format = 'image/x-bil';
                         }
-                        if (!layer.options.mimetype) {
-                            throw new Error('Could not detect layer\'s mimetype');
+                        if (!layer.format) {
+                            throw new Error(`${layer.name}: could not detect layer format, please configure 'layer.format'.`);
                         }
                     });
                 }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -110,6 +110,14 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
         tmp.id = layer.id;
     }
 
+    layer.options = layer.options || {};
+    // TODO remove this warning and fallback after the release following v2.3.0
+    if (!layer.format && layer.options.mimetype) {
+        // eslint-disable-next-line no-console
+        console.warn('layer.options.mimetype is deprecated, please use layer.format');
+        layer.format = layer.options.mimetype;
+    }
+
     if (!layer.updateStrategy) {
         layer.updateStrategy = {
             type: STRATEGY_MIN_NETWORK_TRAFFIC,
@@ -146,10 +154,6 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
         layer.whenReady = providerPreprocessing.then(() => {
             layer.ready = true;
             return layer;
-        }).catch((e) => {
-            // eslint-disable-next-line no-console
-            console.error(`Error when preprocessing layer ${layer.name}`, e);
-            throw e; // make sure the promise is rejected
         });
     }
 
@@ -202,7 +206,6 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  * @property {Attribution} attribution The intellectual property rights for the layer
  * @property {Object} extent Geographic extent of the service
  * @property {string} name
- * @property {string} mimetype
  */
 
 /**
@@ -212,7 +215,6 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  * @property {string} attribution.name The name of the owner of the data
  * @property {string} attribution.url The website of the owner of the data
  * @property {string} name
- * @property {string} mimetype
  * @property {string} tileMatrixSet
  * @property {Array.<Object>} tileMatrixSetLimits The limits for the tile matrix set
  * @property {number} tileMatrixSetLimits.minTileRow Minimum row for tiles at the level
@@ -239,6 +241,7 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  * @property {string} type the layer's type : 'color', 'elevation', 'geometry'
  * @property {string} protocol wmts and wms (wmtsc for custom deprecated)
  * @property {string} url Base URL of the repository or of the file(s) to load
+ * @property {string} format Format of this layer. See individual providers to check which formats are supported for a given layer type.
  * @property {NetworkOptions} networkOptions Options for fetching resources over network
  * @property {Object} updateStrategy strategy to load imagery files
  * @property {OptionsWmts|OptionsWms} options WMTS or WMS options
@@ -267,13 +270,13 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  *   id:         'OPENSM',
  *   fx: 2.5,
  *   url:  'http://b.tile.openstreetmap.fr/osmfr/${z}/${x}/${y}.png',
+ *   format: 'image/png',
  *   options: {
  *       attribution : {
  *           name: 'OpenStreetMap',
  *           url: 'http://www.openstreetmap.org/',
  *       },
  *       tileMatrixSet: 'PM',
- *       mimetype: 'image/png',
  *    },
  * });
  *


### PR DESCRIPTION
## Description

Previously we had layer.format and layer.options.mimetype coexisting, with no difference in role. This commits removes layer.options.mimetype in favor of the former.

I'm not sure of which component to put in the commit title though.

