### PR TITLE
Example WFS on globe : Place points and bus line on the ground

### DIFF
--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -40,6 +40,20 @@ function setMaterialLineWidth(result) {
     }
 }
 
+function altitudeLine(properties, contour) {
+    var altitudes = [];
+    var i = 0;
+    var alt = 0;
+    if (contour.length && contour.length > 0) {
+        for (; i < contour.length; i++) {
+            alt = itowns.DEMUtils.getElevationValueAt(globeView.wgs84TileLayer, contour[i]).z + 2;
+            altitudes.push(alt);
+        }
+        return altitudes;
+    }
+    return 0;
+}
+
 function colorLine(properties) {
     var rgb = properties.couleur.split(' ');
     return new itowns.THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
@@ -49,7 +63,7 @@ globeView.addLayer({
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
         color: colorLine,
-        altitude: 180 }),
+        altitude: altitudeLine }),
     onMeshCreated: setMaterialLineWidth,
     url: 'https://download.data.grandlyon.com/wfs/rdata?',
     protocol: 'wfs',
@@ -132,11 +146,18 @@ function selectRoad(properties) {
     return properties.gestion === 'CEREMA';
 }
 
+function altitudePoint(properties, contour) {
+    if (contour.length && contour.length > 0) {
+        return itowns.DEMUtils.getElevationValueAt(globeView.wgs84TileLayer, contour[0]).z + 5;
+    }
+    return 0;
+}
+
 globeView.addLayer({
     type: 'geometry',
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
-        altitude: 400,
+        altitude: altitudePoint,
         color: colorPoint }),
     onMeshCreated: configPointMaterial,
     filter: selectRoad,


### PR DESCRIPTION
Example WFS on globe : Place points and bus line on the ground

## Description
- example(wfs): Place route points on the ground, and buses lines on the ground. It allows the user to set specific altitude for each point of the line. So the bus line in Lyon follow the relief.
- refactor(wfs): Add contour coordinates to the callback that compute altitude.

## Screenshot
![screenshot-pr-place-on-ground](https://user-images.githubusercontent.com/15127065/33896903-60171820-df64-11e7-9c6a-96e6e792f069.jpg)
