### PR TITLE
fix (protocols): stop parsing unnecessarily xbil buffer

### DIFF
--- a/src/Core/Scheduler/Providers/IoDriver_XBIL.js
+++ b/src/Core/Scheduler/Providers/IoDriver_XBIL.js
@@ -17,7 +17,7 @@ IoDriver_XBIL.prototype.computeMinMaxElevation = function computeMinMaxElevation
     let max = -1000000;
 
     if (!buffer) {
-        return { min: undefined, max: undefined };
+        return { min: null, max: null };
     }
 
     const sizeX = offsetScale ? Math.floor(offsetScale.z * width) : buffer.length;
@@ -39,7 +39,7 @@ IoDriver_XBIL.prototype.computeMinMaxElevation = function computeMinMaxElevation
     }
 
     if (max === -1000000 || min === 1000000) {
-        return { min: undefined, max: undefined };
+        return { min: null, max: null };
     }
     return { min, max };
 };

--- a/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
+++ b/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
@@ -79,6 +79,8 @@ export default {
             texture.generateMipmaps = false;
             texture.magFilter = THREE.LinearFilter;
             texture.minFilter = THREE.LinearFilter;
+            texture.min = result.min;
+            texture.max = result.max;
             cache.addRessource(url, texture);
             cachePending.delete(url);
 

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -5,7 +5,7 @@
  */
 
 import * as THREE from 'three';
-import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from './OGCWebServiceHelper';
+import OGCWebServiceHelper from './OGCWebServiceHelper';
 
 function WMTS_Provider() {
 }
@@ -85,18 +85,12 @@ WMTS_Provider.prototype.getXbilTexture = function getXbilTexture(tile, layer, ta
     const url = this.url(coordWMTS, layer);
 
     return OGCWebServiceHelper.getXBilTextureByUrl(url, layer.networkOptions).then((texture) => {
-        const { min, max } = OGCWebServiceHelper.ioDXBIL.computeMinMaxElevation(
-            texture.image.data,
-            SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-            pitch);
-
         texture.coords = coordWMTS;
-
         return {
             texture,
             pitch,
-            min: min === undefined ? 0 : min,
-            max: max === undefined ? 0 : max,
+            min: !texture.min ? 0 : texture.min,
+            max: !texture.max ? 0 : texture.max,
         };
     });
 };


### PR DESCRIPTION
The buffer was parsed (`computeMinMaxElevation`) twice in the `IoDriver_XBIL.prototype.read` and `WMTS_Provider.prototype.getXbilTexture`