### PR TITLE
fix(wfs): use bigger integer data type for indices array

### DIFF
--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -70,7 +70,7 @@ globeView.addLayer({
     version: '2.0.0',
     id: 'tcl_bus',
     typeName: 'tcl_sytral.tcllignebus',
-    level: 14,
+    level: 9,
     projection: 'EPSG:3946',
     extent: {
         west: 1822174.60,

--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -176,7 +176,7 @@ function coordinateToLines(coordinates, properties, options) {
 
     geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
     geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
-    geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
+    geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(indices), 1));
     return new THREE.LineSegments(geometry);
 }
 


### PR DESCRIPTION
## Description
fix(wfs): use bigger integer data type for indices array

## Motivation and Context
Prior to this change, there was a bug, visible in the wfs globe example :
if you we set buse line WFS layer Level to 10 or less, you will see bugged lines.
The bug comes from the big size of the created LineSegments.


![screenshot-lines-bug](https://user-images.githubusercontent.com/15127065/34168871-f508740c-e4e5-11e7-9a4a-489f50f422fa.jpg)





![screenshot-lines-ok](https://user-images.githubusercontent.com/15127065/34168909-0af4c446-e4e6-11e7-9490-71357073fae7.jpg)

