### PR TITLE
 Avoid excessive memory allocations that cause GC work

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -256,11 +256,11 @@ Extent.prototype.center = function center(target) {
     return c;
 };
 
-Extent.prototype.dimensions = function dimensions(unit) {
-    return {
-        x: Math.abs(this.east(unit) - this.west(unit)),
-        y: Math.abs(this.north(unit) - this.south(unit)),
-    };
+Extent.prototype.dimensions = function dimensions(unit, target) {
+    target = target || { x: 0, y: 0 };
+    target.x = Math.abs(this.east(unit) - this.west(unit));
+    target.y = Math.abs(this.north(unit) - this.south(unit));
+    return target;
 };
 
 /**

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -362,11 +362,18 @@ Extent.prototype.intersect = function intersect(other) {
 };
 
 
-Extent.prototype.set = function set(west, east, south, north) {
-    this._values[CARDINAL.WEST] = west;
-    this._values[CARDINAL.EAST] = east;
-    this._values[CARDINAL.SOUTH] = south;
-    this._values[CARDINAL.NORTH] = north;
+Extent.prototype.set = function set(...values) {
+    if (_isTiledCRS(this.crs())) {
+        this._zoom = values[0];
+        this._row = values[1];
+        this._col = values[2];
+    } else {
+        Object.keys(CARDINAL).forEach((key) => {
+            const cardinal = CARDINAL[key];
+            this._values[cardinal] = values[cardinal];
+        });
+    }
+    return this;
 };
 
 Extent.prototype.union = function union(extent) {

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -4,7 +4,7 @@
  * Description: Outils de projections cartographiques et de convertion
  */
 import MathExt from '../Math/MathExtended';
-import { UNIT } from './Coordinates';
+import Coordinates, { UNIT } from './Coordinates';
 import Extent from './Extent';
 
 
@@ -26,15 +26,10 @@ Projection.prototype.WGS84ToOneSubY = function WGS84ToOneSubY(latitude) {
     return 0.5 + Math.log(Math.tan(MathExt.PI_OV_FOUR + latitude * 0.5)) * MathExt.INV_TWO_PI;
 };
 
+const min = -86 / 180 * Math.PI;
+const max = 84 / 180 * Math.PI;
 Projection.prototype.WGS84LatitudeClamp = function WGS84LatitudeClamp(latitude) {
-    // var min = -68.1389  / 180 * Math.PI;
-    var min = -86 / 180 * Math.PI;
-    var max = 84 / 180 * Math.PI;
-
-    latitude = Math.max(min, latitude);
-    latitude = Math.min(max, latitude);
-
-    return latitude;
+    return Math.min(max, Math.max(min, latitude));
 };
 
 Projection.prototype.getCoordWMTS_WGS84 = function getCoordWMTS_WGS84(tileCoord, bbox, tileMatrixSet) {
@@ -42,35 +37,11 @@ Projection.prototype.getCoordWMTS_WGS84 = function getCoordWMTS_WGS84(tileCoord,
     if (tileMatrixSet === 'PM') {
         return this.WMTS_WGS84ToWMTS_PM(tileCoord, bbox);
     } else if (tileMatrixSet === 'WGS84G') {
-        return [tileCoord];
+        return [tileCoord.clone()];
     } else {
         throw new Error(`Unsupported TileMatrixSet '${tileMatrixSet}'`);
     }
 };
-
-Projection.prototype.getAllCoordsWMTS = function getAllCoordsWMTS(tileCoord, bbox, tileMatrixSets) {
-    var tilesMT = [];
-
-    for (var key in tileMatrixSets) {
-        if (Object.prototype.hasOwnProperty.call(tileMatrixSets, key)) {
-            tilesMT[key] = this.getCoordsWMTS(tileCoord, bbox, key);
-        }
-    }
-
-    return tilesMT;
-};
-
-Projection.prototype.getCoordsWMTS = function getCoordsWMTS(tileCoord, bbox, tileMatrixSet) {
-    var box = this.getCoordWMTS_WGS84(tileCoord, bbox, tileMatrixSet);
-    var tilesMT = [];
-
-    for (var row = box[0].row; row < box[1].row + 1; row++) {
-        tilesMT.push(new Extent(`WMTS:${tileMatrixSet}`, box[0].zoom, row, box[0].col));
-    }
-
-    return tilesMT;
-};
-
 
 /**
  *
@@ -112,8 +83,10 @@ Projection.prototype.WMTS_WGS84ToWMTS_PM = function WMTS_WGS84ToWMTS_PM(cWMTS, b
     return wmtsBox;
 };
 
-Projection.prototype.WGS84toWMTS = function WGS84toWMTS(bbox) {
-    const dim = bbox.dimensions(UNIT.RADIAN);
+const dim = { x: 0, y: 0 };
+const center = new Coordinates('EPSG:4326', 0, 0, 0);
+Projection.prototype.WGS84toWMTS = function WGS84toWMTS(bbox, target = new Extent('WMTS:WGS84G', 0, 0, 0)) {
+    bbox.dimensions(UNIT.RADIAN, dim);
 
     var zoom = Math.floor(Math.log(MathExt.PI / dim.y) / MathExt.LOG_TWO + 0.5);
 
@@ -123,20 +96,19 @@ Projection.prototype.WGS84toWMTS = function WGS84toWMTS(bbox) {
     var uX = MathExt.TWO_PI / nX;
     var uY = MathExt.PI / nY;
 
-    const center = bbox.center();
+    bbox.center(center);
     var col = Math.floor((MathExt.PI + center.longitude(UNIT.RADIAN)) / uX);
     var row = Math.floor(nY - (MathExt.PI_OV_TWO + center.latitude(UNIT.RADIAN)) / uY);
-
-    return new Extent('WMTS:WGS84G', zoom, row, col);
+    return target.set(zoom, row, col);
 };
 
 Projection.prototype.UnitaryToLongitudeWGS84 = function UnitaryToLongitudeWGS84(u, bbox) {
-    const dim = bbox.dimensions(UNIT.RADIAN);
+    bbox.dimensions(UNIT.RADIAN, dim);
     return bbox.west(UNIT.RADIAN) + u * dim.x;
 };
 
 Projection.prototype.UnitaryToLatitudeWGS84 = function UnitaryToLatitudeWGS84(v, bbox) {
-    const dim = bbox.dimensions(UNIT.RADIAN);
+    bbox.dimensions(UNIT.RADIAN, dim);
     return bbox.south(UNIT.RADIAN) + v * dim.y;
 };
 

--- a/src/Core/Scheduler/Providers/KML_Provider.js
+++ b/src/Core/Scheduler/Providers/KML_Provider.js
@@ -13,6 +13,9 @@ KML_Provider.prototype = Object.create(Provider.prototype);
 
 KML_Provider.prototype.constructor = KML_Provider;
 
+
+const position = new THREE.Vector3();
+const axisX = new THREE.Vector3(1, 0, 0);
 KML_Provider.prototype.loadKMZ = function loadKMZ(longitude, latitude) {
     return this.getUrlCollada(longitude, latitude).then((result) => {
         if (result === undefined)
@@ -22,14 +25,14 @@ KML_Provider.prototype.loadKMZ = function loadKMZ(longitude, latitude) {
             var child = result.scene.children[0];
             var coorCarto = result.coorCarto;
 
-            var position = this.ellipsoid.cartographicToCartesian(coorCarto);
+            this.ellipsoid.cartographicToCartesian(coorCarto, position);
             coorCarto.altitude = 0;
             var normal = this.ellipsoid.geodeticSurfaceNormalCartographic(coorCarto);
 
             var quaternion = new THREE.Quaternion();
-            quaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 2);
+            quaternion.setFromAxisAngle(axisX, Math.PI / 2);
 
-            child.lookAt(new THREE.Vector3().addVectors(position, normal));
+            child.lookAt(position.add(normal));
             child.quaternion.multiply(quaternion);
             child.position.copy(position);
 

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -6,6 +6,7 @@
 
 import * as THREE from 'three';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
+import Extent from '../../Geographic/Extent';
 
 function WMTS_Provider() {
 }
@@ -142,6 +143,8 @@ WMTS_Provider.prototype.tileTextureCount = function tileTextureCount(tile, layer
     return tile.getCoordsForLayer(layer).length;
 };
 
+
+const coordTile = new Extent('WMTS:WGS84', 0, 0, 0);
 WMTS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer, targetLevel) {
     // This layer provides data starting at level = layer.options.zoom.min
     // (the zoom.max property is used when building the url to make
@@ -150,7 +153,8 @@ WMTS_Provider.prototype.tileInsideLimit = function tileInsideLimit(tile, layer, 
         let c = coord;
         // override
         if (targetLevel < c.zoom) {
-            c = OGCWebServiceHelper.WMTS_WGS84Parent(coord, targetLevel);
+            OGCWebServiceHelper.WMTS_WGS84Parent(coord, targetLevel, undefined, coordTile);
+            c = coordTile;
         }
         if (c.zoom < layer.options.zoom.min || c.zoom > layer.options.zoom.max) {
             return false;

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -148,13 +148,11 @@ Scheduler.prototype.execute = function execute(command) {
         // increment before
         q.counters.executing++;
 
-        var runNow = function runNow() {
-            this.runCommand(command, q, true);
-        }.bind(this);
-
         // We use a setTimeout to defer processing but we avoid the
         // queue mechanism (why setTimeout and not Promise? see tasks vs microtasks priorities)
-        window.setTimeout(runNow, 0);
+        window.setTimeout(() => {
+            this.runCommand(command, q, true);
+        }, 0);
     } else {
         command.timestamp = Date.now();
         q.storage.queue(command);

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -53,9 +53,12 @@ export function preGlobeUpdate(context, layer) {
     }
 }
 
+const vT = new THREE.Vector3();
 function pointHorizonCulling(pt) {
     // see https://cesiumjs.org/2013/04/25/Horizon-culling/
-    const vT = pt.applyMatrix4(worldToScaledEllipsoid).sub(cV);
+
+    vT.copy(pt);
+    vT.applyMatrix4(worldToScaledEllipsoid).sub(cV);
 
     const vtMagnitudeSquared = vT.lengthSq();
 
@@ -72,7 +75,7 @@ function horizonCulling(node) {
     const points = node.OBB().pointsWorld;
 
     for (const point of points) {
-        if (!pointHorizonCulling(point.clone())) {
+        if (!pointHorizonCulling(point)) {
             return true;
         }
     }

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -1,9 +1,12 @@
 import Extent from '../Core/Geographic/Extent';
+import Coordinates from '../Core/Geographic/Coordinates';
 import CancelledCommandException from '../Core/Scheduler/CancelledCommandException';
 import ObjectRemovalHelper from './ObjectRemovalHelper';
 
+
+const center = new Coordinates('EPSG:4326', 0, 0, 0);
 function subdivisionExtents(bbox) {
-    const center = bbox.center();
+    bbox.center(center);
 
     const northWest = new Extent(bbox.crs(),
         bbox.west(), center._values[0],

--- a/src/Renderer/ThreeExtended/OBB.js
+++ b/src/Renderer/ThreeExtended/OBB.js
@@ -5,8 +5,18 @@ function OBB(min, max) {
     THREE.Object3D.call(this);
     this.box3D = new THREE.Box3(min.clone(), max.clone());
     this.natBox = this.box3D.clone();
-    this.update();
     this.z = { min: 0, max: 0 };
+    this.pointsWorld = [
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+        new THREE.Vector3(),
+    ];
+    this.update();
 }
 
 OBB.prototype = Object.create(THREE.Object3D.prototype);
@@ -21,8 +31,7 @@ OBB.prototype.clone = function clone() {
 
 OBB.prototype.update = function update() {
     this.updateMatrixWorld(true);
-
-    this.pointsWorld = this._cPointsWorld(this._points());
+    this._cPointsWorld(this._points(this.pointsWorld));
 };
 
 OBB.prototype.updateZ = function updateZ(min, max) {
@@ -32,18 +41,7 @@ OBB.prototype.updateZ = function updateZ(min, max) {
     this.update();
 };
 
-OBB.prototype._points = function _points() {
-    var points = [
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-        new THREE.Vector3(),
-    ];
-
+OBB.prototype._points = function _points(points) {
     points[0].set(this.box3D.max.x, this.box3D.max.y, this.box3D.max.z);
     points[1].set(this.box3D.min.x, this.box3D.max.y, this.box3D.max.z);
     points[2].set(this.box3D.min.x, this.box3D.min.y, this.box3D.max.z);


### PR DESCRIPTION
## Description
add or use optional target to methods to avoid memory allocations
If target is defined then use this to write the result instead of allocating an objet.

## Motivation and Context
Avoid excessive memory allocations that cause GC work.

