### PR TITLE
Fix example lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,10 +22,13 @@ module.exports = {
     commonjs: true
   },
   rules: {
+    'no-trailing-spaces': 'warn',
+    'padded-blocks' : 'warn',
+    'no-unused-vars': 'warn',
     'no-plusplus': 'off',
     // this option sets a specific tab width for your code
     // http://eslint.org/docs/rules/indent
-    indent: ['error', 4, {
+    indent: ['warn', 4, {
       SwitchCase: 1,
       VariableDeclarator: 1,
       outerIIFEBody: 1,

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -36,7 +36,7 @@ if (!renderer) {
     miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
 
     // update miniview's camera with the globeView's camera position
-    globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, function () {
+    globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, function updateMiniView() {
         // clamp distance camera from globe
         var distanceCamera = globeView.camera.camera3D.position.length();
         var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);

--- a/examples/positionGlobe.js
+++ b/examples/positionGlobe.js
@@ -69,12 +69,12 @@ function addMeshToScene() {
 }
 
 // Listen for globe full initialisation event
-globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function globeInitialized() {
     // eslint-disable-next-line no-console
     console.info('Globe initialized');
-    Promise.all(promises).then(function () {
-        menuGlobe.addImageryLayersGUI(globeView.getLayers(function (l) { return l.type === 'color'; }));
-        menuGlobe.addElevationLayersGUI(globeView.getLayers(function (l) { return l.type === 'elevation'; }));
+    Promise.all(promises).then(function init() {
+        menuGlobe.addImageryLayersGUI(globeView.getLayers(function filterColor(l) { return l.type === 'color'; }));
+        menuGlobe.addElevationLayersGUI(globeView.getLayers(function filterElevation(l) { return l.type === 'elevation'; }));
 
         addMeshToScene();
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
     "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js src/Core/MainLoop.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
     "doclint": "npm run doc -- -t templates/silent",
-    "test": "npm run lint && npm run build && npm run test-examples && npm run test-unit",
+    "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",
     "test-examples": "npm run transpile && mocha test/globe_test.js && mocha test/planar_test.js && mocha test/postprocessing_test.js && mocha test/externalscene_test.js",
     "build": "webpack -p",


### PR DESCRIPTION
## Description
- fix eslint warnings in the examples
- consider formatting error as warning during development phase

## Motivation and Context
The goal of this PR is to deal with style warning like 'no trailing space' smarter
- To be strict during 'npm test' phase, so Travis will raise error on warning, so Reviewer will see it.
- And during 'npm start' phase, when we are coding, warnings like 'no trailing space' appears as warning and not as error.
