### PR TITLE
3D Tiles spherical bounding volume fixes

### DIFF
--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -56,6 +56,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
                     const geometry = new THREE.SphereGeometry(node.boundingVolume.sphere.radius, 32, 32);
                     const material = new THREE.MeshBasicMaterial({ wireframe: true });
                     helper = new THREE.Mesh(geometry, material);
+                    helper.position.copy(node.boundingVolume.sphere.center);
                     node.add(helper);
                     helper.layer = obb_layer_id;
                     // add the ability to hide all the debug obj for one layer at once


### PR DESCRIPTION
## Description
Two small fixes:
- spherical bounding volumes were badly displayed in debug mode
- SSE computation for spherical bounding volumes could yield a negative result (for some reason, the distanceToPoint of the box and sphere object do not behave in the same way, the spherical one can return a negative number)