### PR TITLE
Fix wrong preSSE computation

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -199,7 +199,7 @@ export function pre3dTilesUpdate(context, layer) {
      // TODO: not correct -> see new preSSE
     // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
     const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / context.camera.width);
-    context.camera.preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
+    context.camera.preSSE = hypotenuse / (2.0 * Math.tan(HYFOV * 0.5));
 
     // once in a while, garbage collect
     if (Math.random() > 0.98) {

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -20,7 +20,7 @@ function _preSSE(view) {
     // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
     const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / canvasSize.x);
 
-    return hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
+    return hypotenuse / (2.0 * Math.tan(HYFOV * 0.5));
 }
 
 export function preGlobeUpdate(context, layer) {


### PR DESCRIPTION
## Description
Based on the formula slide 16 of [this presentation](http://52.4.31.236/presentations/Rendering%20the%20Whole%20Wide%20World%20on%20the%20World%20Wide%20Web.pdf), there was a little mistake in our SSE computation.

This fix should increase the number of tiles loaded for a given view. We may need to adjust our SSE threshold if we want to keep the same behaviour as before.

EDIT: tests are failing, I still need to reflect the change of this PR to the testing scripts