### PR TITLE
refactor(core): unify mesh picking methods

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -152,15 +152,12 @@
                 }
             }
             function picking(event) {
-                // Pick an object with batch id
-                var mouse = globe.eventToNormalizedCoords(event);
-                var raycaster = new itowns.THREE.Raycaster();
                 var htmlInfo = document.getElementById('info');
                 htmlInfo.innerHTML = ' ';
 
-                raycaster.setFromCamera(mouse, globe.camera.camera3D);
-                // calculate objects intersecting the picking ray
-                var intersects = raycaster.intersectObjects($3dTilesLayerRequestVolume.object3d.children, true);
+                const intersects = view.pickObjectsAt(
+                    event,
+                    $3dTilesLayerRequestVolume);
 
                 for (var i = 0; i < intersects.length; i++) {
                     var interAttributes = intersects[i].object.geometry.attributes;

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -33,14 +33,10 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
 
     // point selection on double-click
     function dblClickHandler(event) {
-        var pick;
-        var mouse = view.eventToViewCoords(event);
-        mouse.y = (event.currentTarget.height || event.currentTarget.offsetHeight) - mouse.y;
+        var pick = view.pickObjectsAt(event, pointcloud);
 
-        pick = itowns.PointCloudProcessing.selectAt(view, pointcloud, mouse);
-
-        if (pick) {
-            console.log('Selected point #' + pick.index + ' in Points "' + pick.points.owner.name + '"');
+        if (pick.length) {
+            console.log('Selected point #' + pick[0].index + ' in Points "' + pick[0].object.owner.name + '"');
         }
     }
     view.mainLoop.gfxEngine.renderer.domElement.addEventListener('dblclick', dblClickHandler);

--- a/examples/pointcloud_globe.js
+++ b/examples/pointcloud_globe.js
@@ -31,13 +31,10 @@ function showPointcloud(serverUrl, fileName) {
 
     // point selection on double-click
     function dblClickHandler(event) {
-        var pick;
-        var mouse = view.eventToViewCoords(event);
-        mouse.y = (event.currentTarget.height || event.currentTarget.offsetHeight) - mouse.y;
+        var pick = view.pickObjectsAt(event, pointcloud);
 
-        pick = itowns.PointCloudProcessing.selectAt(view, pointcloud, mouse);
-        if (pick) {
-            console.log('Selected point #' + pick.index + ' in Points "' + pick.points.owner.name + '"');
+        if (pick.length) {
+            console.log('Selected point #' + pick[0].index + ' in Points "' + pick[0].object.owner.name + '"');
         }
     }
     view.mainLoop.gfxEngine.renderer.domElement.addEventListener('dblclick', dblClickHandler);

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -1,4 +1,5 @@
 import { EventDispatcher } from 'three';
+import Picking from '../Picking';
 
 /**
  * Fires when layer sequence change (meaning when the order of the layer changes in the view)
@@ -75,6 +76,9 @@ function GeometryLayer(id, object3d) {
         value: id,
         writable: false,
     });
+
+    // Setup default picking method
+    this.pickObjectsAt = (view, mouse) => Picking.pickObjectsAt(view, mouse, this.object3d);
 
     this.postUpdate = () => {};
 }

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -1,0 +1,147 @@
+import * as THREE from 'three';
+import TileMesh from './TileMesh';
+import RendererConstant from '../Renderer/RendererConstant';
+import { unpack1K } from '../Renderer/LayeredMaterial';
+
+function hideEverythingElse(view, object, threejsLayer = 0) {
+    // We want to render only 'object' and its hierarchy.
+    // So if it uses threejsLayer defined -> force it on the camera
+    // (or use the default one: 0)
+    const prev = view.camera.camera3D.layers.mask;
+
+    view.camera.camera3D.layers.mask = 1 << threejsLayer;
+
+    return () => {
+        view.camera.camera3D.layers.mask = prev;
+    };
+}
+
+const depthRGBA = new THREE.Vector4();
+// TileMesh picking support function
+function screenCoordsToNodeId(view, tileLayer, mouse) {
+    const dim = view.mainLoop.gfxEngine.getWindowSize();
+
+    mouse = mouse || new THREE.Vector2(Math.floor(dim.x / 2), Math.floor(dim.y / 2));
+
+    const restore = tileLayer.level0Nodes.map(n => n.pushRenderState(RendererConstant.ID));
+
+    const undoHide = hideEverythingElse(view, tileLayer.object3d, tileLayer.threejsLayer);
+
+    var buffer = view.mainLoop.gfxEngine.renderViewTobuffer(
+        { camera: view.camera, scene: tileLayer.object3d },
+        view.mainLoop.gfxEngine.fullSizeRenderTarget,
+        mouse.x, dim.y - mouse.y,
+        1, 1);
+
+    undoHide();
+
+    restore.forEach(r => r());
+
+    depthRGBA.fromArray(buffer).divideScalar(255.0);
+
+    // unpack RGBA to float
+    var unpack = unpack1K(depthRGBA, Math.pow(256, 3));
+
+    return Math.round(unpack);
+}
+
+function findLayerIdInParent(obj) {
+    if (obj.layer) {
+        return obj.layer;
+    }
+    if (obj.parent) {
+        return findLayerIdInParent(obj.parent);
+    }
+}
+
+const raycaster = new THREE.Raycaster();
+
+export default {
+    pickTilesAt: (_view, mouse, layer) => {
+        const results = [];
+        const _id = screenCoordsToNodeId(_view, layer, mouse);
+
+        const extractResult = (node) => {
+            if (node.id === _id && node instanceof TileMesh) {
+                results.push({
+                    object: node,
+                    layer: layer.id,
+                });
+            }
+        };
+        for (const n of layer.level0Nodes) {
+            n.traverse(extractResult);
+        }
+        return results;
+    },
+
+    pickPointsAt: (view, mouse, layer) => {
+        if (!layer.root) {
+            return;
+        }
+
+        const dim = view.mainLoop.gfxEngine.getWindowSize();
+
+        // enable picking mode for points material
+        layer.object3d.traverse((o) => {
+            if (o.isPoints && o.baseId) {
+                o.material.enablePicking(true);
+            }
+        });
+
+        const undoHide = hideEverythingElse(view, layer.object3d, layer.threejsLayer);
+
+        // render 1 pixel
+        // TODO: support more than 1 pixel selection
+        const buffer = view.mainLoop.gfxEngine.renderViewTobuffer(
+                { camera: view.camera, scene: layer.object3d },
+                view.mainLoop.gfxEngine.fullSizeRenderTarget,
+                mouse.x, dim.y - mouse.y, 1, 1);
+
+        undoHide();
+
+        // see PointCloudProvider and the construction of unique_id
+        const objId = (buffer[0] << 8) | buffer[1];
+        const index = (buffer[2] << 8) | buffer[3];
+
+        let result;
+        layer.object3d.traverse((o) => {
+            if (o.isPoints && o.baseId) {
+                // disable picking mode
+                o.material.enablePicking(false);
+
+                // if baseId matches objId, the clicked point belongs to `o`
+                if (!result && o.baseId === objId) {
+                    result = {
+                        object: o,
+                        index,
+                        layer: layer.id,
+                    };
+                }
+            }
+        });
+
+        if (result) {
+            return [result];
+        } else {
+            return [];
+        }
+    },
+
+    /*
+     * Default picking method. Uses THREE.Raycaster
+     */
+    pickObjectsAt(view, mouse, object, target = []) {
+        // raycaster use NDC coordinate
+        raycaster.setFromCamera(
+            view.viewToNormalizedCoords(mouse),
+            view.camera.camera3D);
+        const intersects = raycaster.intersectObject(object, true);
+        for (const inter of intersects) {
+            inter.layer = findLayerIdInParent(inter.object);
+            target.push(inter);
+        }
+
+        return target;
+    },
+};

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -5,7 +5,6 @@ import { RENDERING_PAUSED, MAIN_LOOP_EVENTS } from '../MainLoop';
 import { COLOR_LAYERS_ORDER_CHANGED } from '../../Renderer/ColorLayersOrdering';
 import RendererConstant from '../../Renderer/RendererConstant';
 import GlobeControls from '../../Renderer/ThreeExtended/GlobeControls';
-import { unpack1K } from '../../Renderer/LayeredMaterial';
 
 import { GeometryLayer } from '../Layer/Layer';
 
@@ -18,6 +17,7 @@ import { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } 
 import { globeCulling, preGlobeUpdate, globeSubdivisionControl, globeSchemeTileWMTS, globeSchemeTile1 } from '../../Process/GlobeTileProcessing';
 import BuilderEllipsoidTile from './Globe/BuilderEllipsoidTile';
 import SubdivisionControl from '../../Process/SubdivisionControl';
+import Picking from '../Picking';
 
 /**
  * Fires when the view is completely loaded. Controls and view's functions can be called then.
@@ -71,7 +71,6 @@ export const GLOBE_VIEW_EVENTS = {
     LAYER_REMOVED: 'layer-removed',
     COLOR_LAYERS_ORDER_CHANGED,
 };
-
 
 export function createGlobeLayer(id, options) {
     // Configure tiles
@@ -176,6 +175,9 @@ export function createGlobeLayer(id, options) {
         enable: false,
         position: { x: -0.5, y: 0.0, z: 1.0 },
     };
+    // provide custom pick function
+    wgs84TileLayer.pickObjectsAt = (_view, mouse) => Picking.pickTilesAt(_view, mouse, wgs84TileLayer);
+
     return wgs84TileLayer;
 }
 
@@ -360,8 +362,8 @@ GlobeView.prototype.removeLayer = function removeImageryLayer(layerId) {
 };
 
 GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
-    // update the picking ray with the camera and mouse position
-    const selectedId = this.screenCoordsToNodeId(mouse);
+    const picked = this.wgs84TileLayer.pickObjectsAt(this, mouse);
+    const selectedId = picked.length ? picked[0].object.id : undefined;
 
     for (const n of this.wgs84TileLayer.level0Nodes) {
         n.traverse((node) => {
@@ -380,41 +382,12 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
     this.notifyChange(true);
 };
 
-GlobeView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {
-    const dim = this.mainLoop.gfxEngine.getWindowSize();
-
-    mouse = mouse || new THREE.Vector2(Math.floor(dim.x / 2), Math.floor(dim.y / 2));
-
-    const previousRenderState = this._renderState;
-    this.changeRenderState(RendererConstant.ID);
-
-    // Prepare state
-    const prev = this.camera.camera3D.layers.mask;
-    this.camera.camera3D.layers.mask = 1 << this.wgs84TileLayer.threejsLayer;
-
-    var buffer = this.mainLoop.gfxEngine.renderViewTobuffer(
-        this,
-        this.mainLoop.gfxEngine.fullSizeRenderTarget,
-        mouse.x, dim.y - mouse.y,
-        1, 1);
-
-    this.changeRenderState(previousRenderState);
-    this.camera.camera3D.layers.mask = prev;
-
-    var depthRGBA = new THREE.Vector4().fromArray(buffer).divideScalar(255.0);
-
-    // unpack RGBA to float
-    var unpack = unpack1K(depthRGBA, Math.pow(256, 3));
-
-    return Math.round(unpack);
-};
-
 GlobeView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
     const g = this.mainLoop.gfxEngine;
-    const previousRenderState = this._renderState;
-    this.changeRenderState(RendererConstant.DEPTH);
+    const restore = this.wgs84TileLayer.level0Nodes.map(n => n.pushRenderState(RendererConstant.DEPTH));
     const buffer = g.renderViewTobuffer(this, g.fullSizeRenderTarget, x, y, width, height);
-    this.changeRenderState(previousRenderState);
+    restore.forEach(r => r());
+
     return buffer;
 };
 
@@ -476,26 +449,6 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
         { return undefined; }
 
     return pickWorldPosition;
-};
-
-GlobeView.prototype.changeRenderState = function changeRenderState(newRenderState) {
-    if (this._renderState == newRenderState || !this.wgs84TileLayer.level0Nodes) {
-        return;
-    }
-
-    // build traverse function
-    var changeStateFunction = (function getChangeStateFunctionFn() {
-        return function changeStateFunction(object3D) {
-            if (object3D.changeState) {
-                object3D.changeState(newRenderState);
-            }
-        };
-    }());
-
-    for (const n of this.wgs84TileLayer.level0Nodes) {
-        n.traverseVisible(changeStateFunction);
-    }
-    this._renderState = newRenderState;
 };
 
 GlobeView.prototype.setRealisticLightingOn = function setRealisticLightingOn(value) {

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -3,7 +3,6 @@ import * as THREE from 'three';
 import View from '../View';
 import { RENDERING_PAUSED } from '../MainLoop';
 import RendererConstant from '../../Renderer/RendererConstant';
-import { unpack1K } from '../../Renderer/LayeredMaterial';
 
 import { GeometryLayer } from '../Layer/Layer';
 
@@ -12,6 +11,7 @@ import { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } 
 import { planarCulling, planarSubdivisionControl, prePlanarUpdate } from '../../Process/PlanarTileProcessing';
 import PlanarTileBuilder from './Planar/PlanarTileBuilder';
 import SubdivisionControl from '../../Process/SubdivisionControl';
+import Picking from '../Picking';
 
 export function createPlanarLayer(id, extent, options) {
     const tileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
@@ -116,6 +116,8 @@ export function createPlanarLayer(id, extent, options) {
         enable: false,
         position: { x: -0.5, y: 0.0, z: 1.0 },
     };
+    // provide custom pick function
+    tileLayer.pickObjectsAt = (_view, mouse) => Picking.pickTilesAt(_view, mouse, tileLayer);
 
     return tileLayer;
 }
@@ -163,7 +165,8 @@ PlanarView.prototype.addLayer = function addLayer(layer) {
 };
 
 PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
-    const selectedId = this.screenCoordsToNodeId(mouse);
+    const picked = this.tileLayer.pickObjectsAt(this, mouse);
+    const selectedId = picked.length ? picked[0].object.id : undefined;
 
     for (const n of this.tileLayer.level0Nodes) {
         n.traverse((node) => {
@@ -179,37 +182,15 @@ PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
         });
     }
 
-    this.notifyChange();
+    this.notifyChange(true);
 };
 
-PlanarView.prototype.screenCoordsToNodeId = function screenCoordsToNodeId(mouse) {
-    const dim = this.mainLoop.gfxEngine.getWindowSize();
-
-    const previousRenderState = this._renderState;
-    this.changeRenderState(RendererConstant.ID);
-
-    var buffer = this.mainLoop.gfxEngine.renderViewTobuffer(
-        this,
-        this.mainLoop.gfxEngine.fullSizeRenderTarget,
-        mouse.x, dim.y - mouse.y,
-        1, 1);
-
-    this.changeRenderState(previousRenderState);
-
-    var depthRGBA = new THREE.Vector4().fromArray(buffer).divideScalar(255.0);
-
-    // unpack RGBA to float
-    var unpack = unpack1K(depthRGBA, Math.pow(256, 3));
-
-    return Math.round(unpack);
-};
 
 PlanarView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
     const g = this.mainLoop.gfxEngine;
-    const previousRenderState = this._renderState;
-    this.changeRenderState(RendererConstant.DEPTH);
+    const restoreState = this.tileLayer.level0Nodes[0].pushRenderState(RendererConstant.DEPTH);
     const buffer = g.renderViewTobuffer(this, g.fullSizeRenderTarget, x, y, width, height);
-    this.changeRenderState(previousRenderState);
+    restoreState();
     return buffer;
 };
 
@@ -272,26 +253,6 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
         { return undefined; }
 
     return pickWorldPosition;
-};
-
-PlanarView.prototype.changeRenderState = function changeRenderState(newRenderState) {
-    if (this._renderState == newRenderState || !this.tileLayer.level0Nodes) {
-        return;
-    }
-
-    // build traverse function
-    var changeStateFunction = (function getChangeStateFunctionFn() {
-        return function changeStateFunction(object3D) {
-            if (object3D.changeState) {
-                object3D.changeState(newRenderState);
-            }
-        };
-    }());
-
-    for (const n of this.tileLayer.level0Nodes) {
-        n.traverseVisible(changeStateFunction);
-    }
-    this._renderState = newRenderState;
 };
 
 export default PlanarView;

--- a/src/Core/Scheduler/Providers/PointCloudProvider.js
+++ b/src/Core/Scheduler/Providers/PointCloudProvider.js
@@ -3,6 +3,7 @@ import Fetcher from './Fetcher';
 import PointCloudProcessing from '../../../Process/PointCloudProcessing';
 import PotreeBinLoader from './PotreeBinLoader';
 import PotreeCinLoader from './PotreeCinLoader';
+import Picking from '../../Picking';
 
 // Create an A(xis)A(ligned)B(ounding)B(ox) for the child `childIndex` of one aabb.
 // (PotreeConverter protocol builds implicit octree hierarchy by applying the same
@@ -160,6 +161,8 @@ export default {
         layer.update = PointCloudProcessing.update;
         layer.postUpdate = PointCloudProcessing.postUpdate;
 
+        // this probably needs to be moved to somewhere else
+        layer.pickObjectsAt = (view, mouse) => Picking.pickPointsAt(view, mouse, layer);
 
         return Fetcher.json(`${layer.url}/${layer.file}`, layer.fetchOptions).then((cloud) => {
             layer.metadata = cloud;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -1,11 +1,12 @@
-/* global window, requestAnimationFrame */
-import { Scene, EventDispatcher, Vector2 } from 'three';
+/* global window */
+import { Scene, EventDispatcher, Vector2, Object3D } from 'three';
 import Camera from '../Renderer/Camera';
 import MainLoop from './MainLoop';
 import c3DEngine from '../Renderer/c3DEngine';
 import { STRATEGY_MIN_NETWORK_TRAFFIC } from './Layer/LayerUpdateStrategy';
 import { GeometryLayer, Layer, defineLayerProperty } from './Layer/Layer';
 import Scheduler from './Scheduler/Scheduler';
+import Picking from './Picking';
 
 /**
  * Constructs an Itowns View instance
@@ -510,6 +511,90 @@ View.prototype.normalizedToViewCoords = function normalizedToViewCoords(ndcCoord
     _eventCoords.x = (ndcCoords.x + 1) * 0.5 * this.camera.width;
     _eventCoords.y = (ndcCoords.y - 1) * -0.5 * this.camera.height;
     return _eventCoords;
+};
+
+function layerIdToLayer(view, layerId) {
+    const lookup = view.getLayers(l => l.id == layerId);
+    if (!lookup.length) {
+        throw new Error(`Invalid layer id used as where argument (value = ${layerId})`);
+    }
+    return lookup[0];
+}
+
+/**
+ * Return objects from some layers/objects3d under the mouse in this view.
+ *
+ * @param {Object} mouseOrEvt - mouse position in window coordinates (0, 0 = top-left)
+ * or MouseEvent or TouchEvent
+ * @param {...*} where - where to look for objects. Can be either: empty (= look
+ * in all layers with type == 'geometry'), layer ids or layers or a mix of all
+ * the above.
+ * @return {Array} - an array of objects. Each element contains at least an object
+ * property which is the Object3D under the cursor. Then depending on the queried
+ * layer/source, there may be additionnal properties (coming from THREE.Raycaster
+ * for instance).
+ *
+ * @example
+ * view.pickObjectsAt({ x, y })
+ * view.pickObjectsAt({ x, y }, 'wfsBuilding')
+ * view.pickObjectsAt({ x, y }, 'wfsBuilding', myLayer)
+ */
+View.prototype.pickObjectsAt = function pickObjectsAt(mouseOrEvt, ...where) {
+    const results = [];
+    const sources = where.length == 0 ?
+        this.getLayers(l => l.type == 'geometry') :
+        [...where];
+
+    const mouse = (mouseOrEvt.x === undefined) ?
+        this.eventToViewCoords(mouseOrEvt) : mouseOrEvt;
+
+    for (const source of sources) {
+        if (source instanceof GeometryLayer ||
+            source instanceof Layer ||
+            typeof (source) === 'string') {
+            const layer = (typeof (source) === 'string') ?
+                layerIdToLayer(this, source) :
+                source;
+
+            // does this layer have a custom picking function?
+            if (layer.pickObjectsAt) {
+                results.splice(
+                    results.length, 0,
+                    ...layer.pickObjectsAt(this, mouse));
+            } else {
+                //   - it hasn't: this layer is attached to another one
+                let parentLayer;
+                this.getLayers((l, p) => {
+                    if (l.id == layer.id) {
+                        parentLayer = p;
+                    }
+                });
+
+                // raycast using parent layer object3d
+                const obj = Picking.pickObjectsAt(
+                    this,
+                    mouse,
+                    parentLayer.object3d);
+
+                // then filter the results
+                for (const o of obj) {
+                    if (o.layer === layer.id) {
+                        results.push(o);
+                    }
+                }
+            }
+        } else if (source instanceof Object3D) {
+            Picking.pickObjectsAt(
+                this,
+                mouse,
+                source,
+                results);
+        } else {
+            throw new Error(`Invalid where arg (value = ${where}). Expected layers, layer ids or Object3Ds`);
+        }
+    }
+
+    return results;
 };
 
 export default View;

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -300,45 +300,4 @@ export default {
             layer.bboxes.children = layer.bboxes.children.filter(b => !b.removeMe);
         }
     },
-
-    selectAt(view, layer, mouse) {
-        if (!layer.root) {
-            return;
-        }
-
-        // enable picking mode for points material
-        view.scene.traverse((o) => {
-            if (o.isPoints && o.baseId) {
-                o.material.enablePicking(true);
-            }
-        });
-
-        // render 1 pixel
-        // TODO: support more than 1 pixel selection
-        const buffer = view.mainLoop.gfxEngine.renderViewTobuffer(
-                view, view.mainLoop.gfxEngine.fullSizeRenderTarget,
-                mouse.x, mouse.y, 1, 1);
-
-        // see PointCloudProvider and the construction of unique_id
-        const objId = (buffer[0] << 8) | buffer[1];
-        const index = (buffer[2] << 8) | buffer[3];
-
-        let result;
-        view.scene.traverse((o) => {
-            if (o.isPoints && o.baseId) {
-                // disable picking mode
-                o.material.enablePicking(false);
-
-                // if baseId matches objId, the clicked point belongs to `o`
-                if (!result && o.baseId === objId) {
-                    result = {
-                        points: o,
-                        index,
-                    };
-                }
-            }
-        });
-
-        return result;
-    },
 };


### PR DESCRIPTION
The idea of this PR is to expose a single entry point for querying the view.

This method belongs to the View.

Here are a few example usage:
  * view.pickObjectsAt({ x, y })
  * view.pickObjectsAt({ x, y }, 'wfsBuilding')
  * view.pickObjectsAt({ x, y }, 'wfsBuilding', myLayer)
  * view.pickObjectsAt({ x, y }, 'wfsBuilding', myObject3d)

It supports either layers, layer's id or THREE.Object3D.
By default it'll use THREE.Raycaster, but some layer can provide their own implementation.

Currently the layer with a custom implementation are:
  - layers using TileMesh (globe, planar, panorama)
  - pointclouds