### PR TITLE
feat(core): add event to coordinates helpers

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -153,7 +153,7 @@
             }
             function picking(event) {
                 // Pick an object with batch id
-                var mouse = new itowns.THREE.Vector2((event.clientX / window.innerWidth) * 2 - 1, -(event.clientY / window.innerHeight) * 2 + 1);
+                var mouse = globe.eventToNormalizedCoords(event);
                 var raycaster = new itowns.THREE.Raycaster();
                 var htmlInfo = document.getElementById('info');
                 htmlInfo.innerHTML = ' ';
@@ -161,6 +161,7 @@
                 raycaster.setFromCamera(mouse, globe.camera.camera3D);
                 // calculate objects intersecting the picking ray
                 var intersects = raycaster.intersectObjects($3dTilesLayerRequestVolume.object3d.children, true);
+
                 for (var i = 0; i < intersects.length; i++) {
                     var interAttributes = intersects[i].object.geometry.attributes;
                     if (interAttributes) {

--- a/examples/FeatureToolTip.js
+++ b/examples/FeatureToolTip.js
@@ -70,8 +70,8 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                 }
             }
             if (visible) {
-                tooltip.style.left = e.pageX + 'px';
-                tooltip.style.top = e.pageY + 'px';
+                tooltip.style.left = viewer.eventToViewCoords(e).x + 'px';
+                tooltip.style.top = viewer.eventToViewCoords(e).y + 'px';
                 tooltip.style.visibility = 'visible';
             }
         }
@@ -79,15 +79,15 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
 
     function readPosition(e) {
         if (!mouseDown) {
-            buildToolTip(viewer.controls.pickGeoPosition(e.clientX, e.clientY), e);
+            buildToolTip(viewer.controls.pickGeoPosition(viewer.eventToViewCoords(e)), e);
         } else {
-            tooltip.style.left = e.pageX + 'px';
-            tooltip.style.top = e.pageY + 'px';
+            tooltip.style.left = viewer.eventToViewCoords(e).x + 'px';
+            tooltip.style.top = viewer.eventToViewCoords(e).y + 'px';
         }
     }
 
     function pickPosition(e) {
-        buildToolTip(viewer.controls.pickGeoPosition(e.clientX, e.clientY), e);
+        buildToolTip(viewer.controls.pickGeoPosition(viewer.eventToViewCoords(e)), e);
     }
 
     document.addEventListener('mousemove', readPosition, false);

--- a/examples/orthographic.js
+++ b/examples/orthographic.js
@@ -68,7 +68,7 @@ viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);
 viewerDiv.addEventListener('mousewheel', onMouseWheel);
 
 viewerDiv.addEventListener('mousedown', function mouseDown(event) {
-    dragStartPosition = new itowns.THREE.Vector2(event.clientX, event.clientY);
+    dragStartPosition = view.eventToViewCoords(event).clone();
     dragCameraStart = {
         left: view.camera.camera3D.left,
         right: view.camera.camera3D.right,
@@ -80,10 +80,12 @@ viewerDiv.addEventListener('mousemove', function mouseMove(event) {
     var width;
     var deltaX;
     var deltaY;
+    var newpos;
     if (dragStartPosition) {
+        newpos = view.eventToViewCoords(event);
         width = view.camera.camera3D.right - view.camera.camera3D.left;
-        deltaX = width * (event.clientX - dragStartPosition.x) / -viewerDiv.clientWidth;
-        deltaY = width * (event.clientY - dragStartPosition.y) / viewerDiv.clientHeight;
+        deltaX = width * (newpos.x - dragStartPosition.x) / -viewerDiv.clientWidth;
+        deltaY = width * (newpos.y - dragStartPosition.y) / viewerDiv.clientHeight;
 
         view.camera.camera3D.left = dragCameraStart.left + deltaX;
         view.camera.camera3D.right = dragCameraStart.right + deltaX;

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -34,10 +34,8 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     // point selection on double-click
     function dblClickHandler(event) {
         var pick;
-        var mouse = {
-            x: event.offsetX,
-            y: (event.currentTarget.height || event.currentTarget.offsetHeight) - event.offsetY,
-        };
+        var mouse = view.eventToViewCoords(event);
+        mouse.y = (event.currentTarget.height || event.currentTarget.offsetHeight) - mouse.y;
 
         pick = itowns.PointCloudProcessing.selectAt(view, pointcloud, mouse);
 

--- a/examples/pointcloud_globe.js
+++ b/examples/pointcloud_globe.js
@@ -32,13 +32,10 @@ function showPointcloud(serverUrl, fileName) {
     // point selection on double-click
     function dblClickHandler(event) {
         var pick;
-        var mouse = {
-            x: event.offsetX,
-            y: (event.currentTarget.height || event.currentTarget.offsetHeight) - event.offsetY,
-        };
+        var mouse = view.eventToViewCoords(event);
+        mouse.y = (event.currentTarget.height || event.currentTarget.offsetHeight) - mouse.y;
 
         pick = itowns.PointCloudProcessing.selectAt(view, pointcloud, mouse);
-
         if (pick) {
             console.log('Selected point #' + pick.index + ' in Points "' + pick.points.owner.name + '"');
         }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -458,4 +458,55 @@ View.prototype.execFrameRequesters = function execFrameRequesters(when, dt, upda
     }
 };
 
+const _eventCoords = new Vector2();
+/**
+ * Extract view coordinates from a mouse-event / touch-event
+ * @param {event} event - event can be a MouseEvent or a TouchEvent
+ * @param {number} touchIdx - finger index when using a TouchEvent (default: 0)
+ * @return {THREE.Vector2} - view coordinates (in pixels, 0-0 = top-left of the View)
+ */
+View.prototype.eventToViewCoords = function eventToViewCoords(event, touchIdx = 0) {
+    if (event.touches === undefined || !event.touches.length) {
+        return _eventCoords.set(event.offsetX, event.offsetY);
+    } else {
+        // originalTarget should always be viewerDiv
+        const br = event.originalTarget.getClientBoundingRect();
+        return _eventCoords.set(
+            event.touches[touchIdx].clientX - br.x,
+            event.touches[touchIdx].clientY - br.y);
+    }
+};
+
+/**
+ * Extract normalized coordinates (NDC) from a mouse-event / touch-event
+ * @param {event} event - event can be a MouseEvent or a TouchEvent
+ * @param {number} touchIdx - finger index when using a TouchEvent (default: 0)
+ * @return {THREE.Vector2} - NDC coordinates (x and y are [-1, 1])
+ */
+View.prototype.eventToNormalizedCoords = function eventToNormalizedCoords(event, touchIdx = 0) {
+    return this.viewToNormalizedCoords(this.eventToViewCoords(event, touchIdx));
+};
+
+/**
+ * Convert view coordinates to normalized coordinates (NDC)
+ * @param {Vector2} viewCoords (in pixels, 0-0 = top-left of the View)
+ * @return {THREE.Vector2} - NDC coordinates (x and y are [-1, 1])
+ */
+View.prototype.viewToNormalizedCoords = function viewToNormalizedCoords(viewCoords) {
+    _eventCoords.x = 2 * (viewCoords.x / this.camera.width) - 1;
+    _eventCoords.y = -2 * (viewCoords.y / this.camera.height) + 1;
+    return _eventCoords;
+};
+
+/**
+ * Convert NDC coordinates to view coordinates
+ * @param {Vector2} ndcCoords
+ * @return {THREE.Vector2} - view coordinates (in pixels, 0-0 = top-left of the View)
+ */
+View.prototype.normalizedToViewCoords = function normalizedToViewCoords(ndcCoords) {
+    _eventCoords.x = (ndcCoords.x + 1) * 0.5 * this.camera.width;
+    _eventCoords.y = (ndcCoords.y - 1) * -0.5 * this.camera.height;
+    return _eventCoords;
+};
+
 export default View;

--- a/src/Renderer/ThreeExtended/FlyControls.js
+++ b/src/Renderer/ThreeExtended/FlyControls.js
@@ -16,8 +16,9 @@ function onDocumentMouseDown(event) {
     event.preventDefault();
     this._isMouseDown = true;
 
-    this._onMouseDownMouseX = event.clientX;
-    this._onMouseDownMouseY = event.clientY;
+    const coords = this.view.eventToViewCoords(event);
+    this._onMouseDownMouseX = coords.x;
+    this._onMouseDownMouseY = coords.y;
 }
 
 function onTouchStart(event) {
@@ -29,16 +30,18 @@ function onTouchStart(event) {
 }
 
 
-function onPointerMove(pointerX, pointerY) {
+function onPointerMove(event) {
     if (this._isMouseDown === true) {
+        const coords = this.view.eventToViewCoords(event);
+
         // in rigor we have tan(theta) = tan(cameraFOV) * deltaH / H
         // (where deltaH is the vertical amount we moved, and H the renderer height)
         // we loosely approximate tan(x) by x
         const pxToAngleRatio = THREE.Math.degToRad(this._camera3D.fov) / this.view.mainLoop.gfxEngine.height;
-        this._camera3D.rotateY((pointerX - this._onMouseDownMouseX) * pxToAngleRatio);
-        this._camera3D.rotateX((pointerY - this._onMouseDownMouseY) * pxToAngleRatio);
-        this._onMouseDownMouseX = pointerX;
-        this._onMouseDownMouseY = pointerY;
+        this._camera3D.rotateY((coords.x - this._onMouseDownMouseX) * pxToAngleRatio);
+        this._camera3D.rotateX((coords.y - this._onMouseDownMouseY) * pxToAngleRatio);
+        this._onMouseDownMouseX = coords.x;
+        this._onMouseDownMouseY = coords.y;
         this.view.notifyChange(false, this._camera3D);
     }
 }
@@ -116,8 +119,8 @@ class FlyControls extends THREE.EventDispatcher {
         domElement.addEventListener('mousedown', onDocumentMouseDown.bind(this), false);
         domElement.addEventListener('touchstart', onTouchStart.bind(this), false);
         const bindedPM = onPointerMove.bind(this);
-        domElement.addEventListener('mousemove', e => bindedPM(e.clientX, e.clientY), false);
-        domElement.addEventListener('touchmove', e => bindedPM(e.touches[0].pageX, e.touches[0].pageY), false);
+        domElement.addEventListener('mousemove', bindedPM, false);
+        domElement.addEventListener('touchmove', bindedPM, false);
         domElement.addEventListener('mouseup', onDocumentMouseUp.bind(this), false);
         domElement.addEventListener('touchend', onDocumentMouseUp.bind(this), false);
         domElement.addEventListener('mousewheel', onDocumentMouseWheel.bind(this), false);

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -907,11 +907,9 @@ function GlobeControls(view, target, radius, options = {}) {
             if (this.enabled === false) return;
 
             event.preventDefault();
-
-            const staticPos = window.getComputedStyle(event.target.parentElement).position !== 'static';
-            const bounds = staticPos ? event.target.getBoundingClientRect() : { left: 0, top: 0 };
-            const x = event.clientX - event.target.offsetLeft - bounds.left;
-            const y = event.clientY - event.target.offsetTop - bounds.top;
+            const coords = this._view.eventToViewCoords(event);
+            const x = coords.x;
+            const y = coords.y;
 
             if (state === this.states.ORBIT || state === this.states.PANORAMIC) {
                 rotateEnd.set(x, y);
@@ -1067,10 +1065,9 @@ function GlobeControls(view, target, radius, options = {}) {
             event.preventDefault();
             state = inputToState(event.button, currentKey, this.states);
 
-            const staticPos = window.getComputedStyle(event.target.parentElement).position !== 'static';
-            const bounds = staticPos ? event.target.getBoundingClientRect() : { left: 0, top: 0 };
-            const x = event.clientX - event.target.offsetLeft - bounds.left;
-            const y = event.clientY - event.target.offsetTop - bounds.top;
+            const coords = this._view.eventToViewCoords(event);
+            const x = coords.x;
+            const y = coords.y;
 
             switch (state) {
                 case this.states.ORBIT:
@@ -1125,12 +1122,7 @@ function GlobeControls(view, target, radius, options = {}) {
 
         // Double click throws move camera's target with animation
         if (!currentKey) {
-            const staticPos = window.getComputedStyle(event.target.parentElement).position !== 'static';
-            const bounds = staticPos ? event.target.getBoundingClientRect() : { left: 0, top: 0 };
-            ptScreenClick.x = event.clientX - event.target.offsetLeft - bounds.left;
-            ptScreenClick.y = event.clientY - event.target.offsetTop - bounds.top;
-
-            const point = view.getPickingPositionFromDepth(ptScreenClick);
+            const point = view.getPickingPositionFromDepth(this._view.eventToViewCoords(event));
 
             if (point) {
                 animatedScale = 0.6;
@@ -1926,24 +1918,12 @@ GlobeControls.prototype.setCameraTargetGeoPositionAdvanced = function setCameraT
 
 /**
  * Pick a position on the globe at the given position in lat,lon. See {@linkcode Coordinates} for conversion.
- * @param {number | MouseEvent} mouse - The x-position inside the Globe element or a mouse event.
+ * @param {Vector2} windowCoords - window coordinates
  * @param {number=} y - The y-position inside the Globe element.
  * @return {Coordinates} position
  */
-GlobeControls.prototype.pickGeoPosition = function pickGeoPosition(mouse, y) {
-    var screenCoords = {
-        x: mouse,
-        y,
-    };
-
-    if (mouse instanceof MouseEvent) {
-        const staticPos = window.getComputedStyle(mouse.target.parentElement).position !== 'static';
-        const bounds = staticPos ? mouse.target.getBoundingClientRect() : { left: 0, top: 0 };
-        screenCoords.x = mouse.clientX - mouse.target.offsetLeft - bounds.left;
-        screenCoords.y = mouse.clientY - mouse.target.offsetTop - bounds.top;
-    }
-
-    var pickedPosition = this._view.getPickingPositionFromDepth(screenCoords);
+GlobeControls.prototype.pickGeoPosition = function pickGeoPosition(windowCoords) {
+    var pickedPosition = this._view.getPickingPositionFromDepth(windowCoords);
 
     if (!pickedPosition) {
         return;


### PR DESCRIPTION
This commits introduces 4 functions to deal with mouse coordinates.

They provide:
  - event (mouse or touch) to window coordinates (in pixels)
  - event (mouse or touch) to normalized coords (eg: as used by THREE.Raycaster)
  - window <-> normalized conversions

@zarov this PR replaces some code you introduced in https://github.com/iTowns/itowns/commit/f3d77724200e651077ff0c9857d5e6b4e3d284f6#diff-df61a67eee71572718ef066564a3a0afR907 Could you test and confirm that this PR doesn't change the behavior?
