### PR TITLE
feat(core): compute TMS coordinates from north to south

### DIFF
--- a/examples/orthographic.js
+++ b/examples/orthographic.js
@@ -53,6 +53,7 @@ view.addLayer({
     networkOptions: { crossOrigin: 'anonymous' },
     extent: [extent.west(), extent.east(), extent.south(), extent.north()],
     projection: 'EPSG:3857',
+    origin: 'bottom',
     options: {
         attribution: {
             name: 'OpenStreetMap',

--- a/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
+++ b/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
@@ -114,7 +114,12 @@ export default {
                 projection.getCoordWMTS_WGS84(tileCoord, tile.extent, tileMatrixSet);
         }
     },
-    computeTMSCoordinates(tile, extent) {
+    // The origin parameter is to be set to the correct value, bottom or top
+    // (default being bottom) if the computation of the coordinates needs to be
+    // inverted to match the same scheme as OSM, Google Maps or other system.
+    // See link below for more information
+    // https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/
+    computeTMSCoordinates(tile, extent, origin = 'bottom') {
         if (tile.extent.crs() != extent.crs()) {
             throw new Error('Unsupported configuration. TMS is only supported when geometry has the same crs than TMS layer');
         }
@@ -129,7 +134,12 @@ export default {
 
         // Now that we have computed zoom, we can deduce x and y (or row / column)
         const x = (c.x() - extent.west()) / layerDimension.x;
-        const y = (extent.north() - c.y()) / layerDimension.y;
+        let y;
+        if (origin == 'top') {
+            y = (extent.north() - c.y()) / layerDimension.y;
+        } else {
+            y = (c.y() - extent.south()) / layerDimension.y;
+        }
 
         return [new Extent('TMS', zoom, Math.floor(y * tileCount), Math.floor(x * tileCount))];
     },

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -188,7 +188,7 @@ TileMesh.prototype.getCoordsForLayer = function getCoordsForLayer(layer) {
             throw new Error('unsupported projection wms for this viewer');
         }
     } else if (layer.protocol == 'tms') {
-        return OGCWebServiceHelper.computeTMSCoordinates(this, layer.extent);
+        return OGCWebServiceHelper.computeTMSCoordinates(this, layer.extent, layer.origin);
     } else {
         return [this.extent];
     }


### PR DESCRIPTION
## Description
As it can be read in the link at the end, TMS coordinates differ from other "TMS" coordinates from Google Maps, OSM, Bing etc... The first one goes from south to north, while the latter north to south. In this commit, the parameter `northToSouth` in the method `computeTMSCoordinates` can be set to true to obtain the same result as Google Maps and others.

Source: https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/

## Motivation and Context
No result to see for now, but it is being used in Mapbox Vector Tile integration in iTowns in another branch. While this branch can wait, I also want an input on the name `northToSouth`, as none of the cited provider above gave a name to this convention. WDYT ?
