### PR TITLE
fix(core): handle near pos. in box3 visibility functions

### DIFF
--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -70,14 +70,55 @@ const tmp = {
     box3: new THREE.Box3(),
 };
 
-Camera.prototype.isBox3Visible = function isBox3Visible(box3, matrixWorld) {
+const points = [
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+    new THREE.Vector3(),
+];
+
+function projectBox3PointsInCameraSpace(camera, box3, matrixWorld) {
+    // Projects points in camera space
+    // We don't project directly on screen to avoid artifacts when projecting
+    // points behind the near plane.
+    let m = camera.camera3D.matrixWorldInverse;
     if (matrixWorld) {
-        tmp.matrix.multiplyMatrices(this._viewMatrix, matrixWorld);
-        tmp.frustum.setFromMatrix(tmp.matrix);
-    } else {
-        tmp.frustum.setFromMatrix(this._viewMatrix);
+        m = tmp.matrix.multiplyMatrices(camera.camera3D.matrixWorldInverse, matrixWorld);
     }
-    return tmp.frustum.intersectsBox(box3);
+    points[0].set(box3.min.x, box3.min.y, box3.min.z).applyMatrix4(m);
+    points[1].set(box3.min.x, box3.min.y, box3.max.z).applyMatrix4(m);
+    points[2].set(box3.min.x, box3.max.y, box3.min.z).applyMatrix4(m);
+    points[3].set(box3.min.x, box3.max.y, box3.max.z).applyMatrix4(m);
+    points[4].set(box3.max.x, box3.min.y, box3.min.z).applyMatrix4(m);
+    points[5].set(box3.max.x, box3.min.y, box3.max.z).applyMatrix4(m);
+    points[6].set(box3.max.x, box3.max.y, box3.min.z).applyMatrix4(m);
+    points[7].set(box3.max.x, box3.max.y, box3.max.z).applyMatrix4(m);
+
+    // In camera space objects are along the -Z axis
+    // So if min.z is > -near, the object is invisible
+    let atLeastOneInFrontOfNearPlane = false;
+    for (let i = 0; i < 8; i++) {
+        if (points[i].z <= -camera.camera3D.near) {
+            atLeastOneInFrontOfNearPlane = true;
+        } else {
+            // Clamp to near plane
+            points[i].z = -camera.camera3D.near;
+        }
+    }
+
+    return atLeastOneInFrontOfNearPlane ? points : undefined;
+}
+
+const ndcBox3 = new THREE.Box3(
+    new THREE.Vector3(-1, -1, -1),
+    new THREE.Vector3(1, 1, 1));
+
+Camera.prototype.isBox3Visible = function isBox3Visible(box3, matrixWorld) {
+    return this.box3SizeOnScreen(box3, matrixWorld).intersectsBox(ndcBox3);
 };
 
 Camera.prototype.isSphereVisible = function isSphereVisible(sphere, matrixWorld) {
@@ -91,15 +132,19 @@ Camera.prototype.isSphereVisible = function isSphereVisible(sphere, matrixWorld)
 };
 
 Camera.prototype.box3SizeOnScreen = function box3SizeOnScreen(box3, matrixWorld) {
-    tmp.box3.copy(box3);
+    const pts = projectBox3PointsInCameraSpace(this, box3, matrixWorld);
 
-    if (matrixWorld) {
-        tmp.matrix.multiplyMatrices(this._viewMatrix, matrixWorld);
-        tmp.box3.applyMatrix4(tmp.matrix);
-    } else {
-        tmp.box3.applyMatrix4(this._viewMatrix);
+    // All points are in front of the near plane -> box3 is invisible
+    if (!pts) {
+        return tmp.box3.makeEmpty();
     }
-    return tmp.box3;
+
+    // Project points on screen
+    for (let i = 0; i < 8; i++) {
+        pts[i].applyMatrix4(this.camera3D.projectionMatrix);
+    }
+
+    return tmp.box3.setFromPoints(pts);
 };
 
  /**


### PR DESCRIPTION
Projection matrix produces strange results when projecting a point behind
the camera near plane.
To avoid errors this commits clamp z coordinate to camera.near in camera space,
before projecting.

The issue can be tested in planar.html, by positionning the camera with:
```js
    view.camera.camera3D.position.copy({x: 1841430.8707152607, y: 5173717.817231011, z: 229.93251060258268});
    view.camera.camera3D.rotation.set(-0.7231494579332582, -1.1919412510926017, -2.3305711080202998, "XYZ")
    view.notifyChange(true)
```
In this case box3SizeOnScreen used to return an y value between 0.91 and 1.3 while
the projected tile covers all the screen.
