### PR TITLE
perf(protocols): decrease the count of fetch image/xbil

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -287,8 +287,10 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     this.wgs84TileLayer = wgs84TileLayer;
 
     const fn = () => {
-        this.mainLoop.removeEventListener('command-queue-empty', fn);
-        this.dispatchEvent({ type: GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED });
+        if (this._changeSources.size == 0) {
+            this.mainLoop.removeEventListener('command-queue-empty', fn);
+            this.dispatchEvent({ type: GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED });
+        }
     };
 
     this.mainLoop.addEventListener('command-queue-empty', fn);

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -188,6 +188,18 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
 
             initNodeImageryTexturesFromParent(node, node.parent, layer);
         }
+
+        // Proposed new process, two separate processes:
+        //      * FIRST PASS: initNodeXXXFromParent and get out of the function
+        //      * SECOND PASS: Fetch best texture
+
+        // The two-step allows you to filter out unnecessary requests
+        // Indeed in the second pass, their state (not visible or not displayed) can block them to fetch
+        const minLevel = layer.options.zoom ? layer.options.zoom.min : 0;
+        if (node.material.getColorLayerLevelById(layer.id) >= minLevel) {
+            context.view.notifyChange(false, node);
+            return;
+        }
     }
 
     // Node is hidden, no need to update it
@@ -303,6 +315,11 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
         node.layerUpdateState[layer.id] = new LayerUpdateState();
         initNodeElevationTextureFromParent(node, node.parent, layer);
         currentElevation = material.getElevationLayerLevel();
+        const minLevel = layer.options.zoom ? layer.options.zoom.min : 0;
+        if (currentElevation >= minLevel) {
+            context.view.notifyChange(false, node);
+            return;
+        }
     }
 
     // Try to update

--- a/test/globe_test.js
+++ b/test/globe_test.js
@@ -34,6 +34,9 @@ var initialState2 = 0;
 describe('Globe example', function () {
     it('should subdivide like expected', function (done) {
         const listener = () => {
+            if (example.view._changeSources.size > 0) {
+                return;
+            }
             itownsTesting.counters.visible_at_level = [];
             itownsTesting.counters.displayed_at_level = [];
 
@@ -62,6 +65,9 @@ describe('Globe example', function () {
     });
     it('should subdivide like expected and prevent to subdivide for poor elevation level', function (done) {
         example.view.mainLoop.addEventListener('command-queue-empty', () => {
+            if (example.view._changeSources.size > 0) {
+                return;
+            }
             if (initialState2 == 0) {
                 initialState2++;
                 example.view.camera.camera3D.position.copy(

--- a/test/layeredmaterialnodeprocessing_unit_test.js
+++ b/test/layeredmaterialnodeprocessing_unit_test.js
@@ -15,6 +15,9 @@ describe('updateLayeredMaterialNodeImagery', function () {
 
     // Mock scheduler
     const context = {
+        view: {
+            notifyChange: () => true,
+        },
         scheduler: {
             commands: [],
             execute: (cmd) => {
@@ -75,8 +78,13 @@ describe('updateLayeredMaterialNodeImagery', function () {
         tile.material.indexOfColorLayer = () => 0;
         tile.material.isColorLayerDownscaled = () => true;
         tile.material.getColorLayerLevelById = () => 1;
-        updateLayeredMaterialNodeImagery(context, layer, tile);
 
+        // FIRST PASS: init Node From Parent and get out of the function
+        // without any network fetch
+        updateLayeredMaterialNodeImagery(context, layer, tile);
+        assert.equal(context.scheduler.commands.length, 0);
+        // SECOND PASS: Fetch best texture
+        updateLayeredMaterialNodeImagery(context, layer, tile);
         assert.equal(context.scheduler.commands.length, 1);
     });
 

--- a/test/planar_test.js
+++ b/test/planar_test.js
@@ -5,6 +5,9 @@ var example = require('../examples/planar.js');
 describe('Planar example', function () {
     it('should run...', (done) => {
         example.view.mainLoop.addEventListener('command-queue-empty', () => {
+            if (example.view._changeSources.size > 0) {
+                return;
+            }
             itownsTesting.counters.displayed_at_level = [];
 
             for (var obj of example.view.tileLayer.level0Nodes) {


### PR DESCRIPTION
Return after the initialization of imaging/elevation allows
to delay the request for data fetching. where appropriate,
allows to privilege the subdivision and fetch the necessary datas.

example perf: -30% in the count of fetching for the wmts for `examples/globe `

Proposed new process `updateLayeredMaterialNodeXXX`, in two separate processes:
   * _FIRST PASS_ : `initNodeXXXFromParent` and get out of the function
   * _SECOND PASS_ : Fetch best texture

  The two-step allows you to filter out unnecessary requests
  Indeed in the second pass, their state (not visible or not displayed) can block them to fetch