### PR TITLE
fix(examples): bad orthographic origin

### DIFF
--- a/examples/orthographic.js
+++ b/examples/orthographic.js
@@ -46,14 +46,13 @@ view.tileLayer.disableSkirt = true;
 // Add an TMS imagery layer
 view.addLayer({
     type: 'color',
-    protocol: 'tms',
+    protocol: 'xyz',
     id: 'OPENSM',
     // eslint-disable-next-line no-template-curly-in-string
     url: 'http://c.tile.stamen.com/watercolor/${z}/${x}/${y}.jpg',
     networkOptions: { crossOrigin: 'anonymous' },
     extent: [extent.west(), extent.east(), extent.south(), extent.north()],
     projection: 'EPSG:3857',
-    origin: 'bottom',
     options: {
         attribution: {
             name: 'OpenStreetMap',

--- a/src/Core/Scheduler/Providers/TMS_Provider.js
+++ b/src/Core/Scheduler/Providers/TMS_Provider.js
@@ -13,6 +13,7 @@ TMS_Provider.prototype.preprocessDataLayer = function preprocessDataLayer(layer)
         throw new Error(`Missing projection property for layer '${layer.id}'`);
     }
     layer.extent = new Extent(layer.projection, ...layer.extent);
+    layer.origin = layer.origin || (layer.protocol == 'xyz' ? 'top' : 'bottom');
     if (!layer.options.zoom) {
         layer.options.zoom = {
             min: 0,

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -96,6 +96,7 @@ Scheduler.prototype.initDefaultProviders = function initDefaultProviders() {
     this.addProtocolProvider('wms', new WMS_Provider());
     this.addProtocolProvider('3d-tiles', new $3dTiles_Provider());
     this.addProtocolProvider('tms', new TMS_Provider());
+    this.addProtocolProvider('xyz', new TMS_Provider());
     this.addProtocolProvider('potreeconverter', PointCloudProvider);
     this.addProtocolProvider('wfs', new WFS_Provider());
     this.addProtocolProvider('rasterizer', Raster_Provider);

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -187,7 +187,7 @@ TileMesh.prototype.getCoordsForLayer = function getCoordsForLayer(layer) {
         } else {
             throw new Error('unsupported projection wms for this viewer');
         }
-    } else if (layer.protocol == 'tms') {
+    } else if (layer.protocol == 'tms' || layer.protocol == 'xyz') {
         return OGCWebServiceHelper.computeTMSCoordinates(this, layer.extent, layer.origin);
     } else {
         return [this.extent];


### PR DESCRIPTION
Forgot to change the origin from `bottom` to `top` in the orthographic example, sorry about that.

See #639 
