### PR TITLE
fix(core): disable logdepthbuffer if EXT_frag_depth is missing

### DIFF
--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -89,6 +89,21 @@ function c3DEngine(rendererOrDiv, options = {}) {
         throw new Error('WebGL unsupported');
     }
 
+    if (!renderer && options.logarithmicDepthBuffer) {
+        // We don't support logarithmicDepthBuffer when EXT_frag_depth is missing.
+        // So recreated a renderer if needed.
+        if (!this.renderer.extensions.get('EXT_frag_depth')) {
+            const _canvas = this.renderer.domElement;
+            this.renderer.dispose();
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: _canvas,
+                antialias: options.antialias,
+                alpha: options.alpha,
+                logarithmicDepthBuffer: false,
+            });
+        }
+    }
+
     // Let's allow our canvas to take focus
     // The condition below looks weird, but it's correct: querying tabIndex
     // returns -1 if not set, but we still need to explicitly set it to force


### PR DESCRIPTION
Since r88 threejs allows enabling logdepthbuffer if EXT_frag_depth is missing,
see https://github.com/mrdoob/three.js/pull/11995.

iTowns doesn't handle this case correctly: so for now we recreate the renderer
if we realize that EXT_frag_depth isn't supported.

Before this PR:

![capture d ecran de 2018-02-08 17-21-13](https://user-images.githubusercontent.com/2198295/35984417-afe819d6-0cf4-11e8-8ae7-d1dad33ca3c4.png)

After:
![capture d ecran de 2018-02-08 17-21-47](https://user-images.githubusercontent.com/2198295/35984416-afc110e8-0cf4-11e8-8ccf-9c3b2406d82e.png)

Note: the rendering is broken, but I have another PR that fixes this by setting correct values to camera.near/far (this PR depends on: #635, #637 and a last one not yet submitted).
