### PR TITLE
fix(examples): make examples test friendly

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -85,10 +85,10 @@
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
 
-            var globe = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            var menuGlobe = new GuiTools('menuDiv', globe, 300);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv', view, 300);
 
-            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return globe.addLayer(result) });
+            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return view.addLayer(result) });
 
             // function use :
             // For preupdate Layer geomtry :
@@ -110,7 +110,7 @@
             $3dTilesLayerDiscreteLOD.type = 'geometry';
             $3dTilesLayerDiscreteLOD.visible = true;
 
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerDiscreteLOD);
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayerDiscreteLOD);
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
@@ -131,14 +131,13 @@
             $3dTilesLayerRequestVolume.visible = true;
             $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
-            itowns.View.prototype.addLayer.call(globe, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })
 
             // Add the UI Debug
-            var d = new debug.Debug(globe, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globe, globe.wgs84TileLayer, d);
-            debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerDiscreteLOD, d);
-            debug.create3dTilesDebugUI(menuGlobe.gui, globe, $3dTilesLayerRequestVolume, d);
-
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.wgs84TileLayer, d);
+            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD, d);
+            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume, d);
 
 
 // Picking example - - - - - - - - - - -- - - - -- - - - -- - - - -- - - - -- - - - -- - - - -

--- a/examples/panorama.html
+++ b/examples/panorama.html
@@ -75,13 +75,14 @@
                         protocol: 'static',
                         id: _id,
                         projection: 'EPSG:4326',
+                    }).then(() => {
+                        view.notifyChange(false);
                     });
 
                     layers.push(view.getLayers(function (l) { return (l.id == _id); })[0]);
                     index ++;
                 }
                 view.camera.camera3D.far = 10000;
-                view.notifyChange(true);
 
                 // Setup debug menu
                 var gui = new dat.GUI();
@@ -105,6 +106,8 @@
                     layers[activeIndex].visible = true;
                     view.notifyChange(true);
                 });
+
+                window.view = view;
             });
         </script>
 

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -86,6 +86,7 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
                 Math.floor(100 * pointcloud.counters.displayedCount / pointcloud.counters.pointCount) + '%) (' +
                 view.mainLoop.gfxEngine.renderer.info.memory.geometries + ')';
         };
+        window.view = view;
     }
 
     view.addLayer(pointcloud).then(onLayerReady);

--- a/examples/pointcloud_globe.js
+++ b/examples/pointcloud_globe.js
@@ -59,6 +59,7 @@ function showPointcloud(serverUrl, fileName) {
                 Math.floor(100 * pointcloud.counters.displayedCount / pointcloud.counters.pointCount) + '%) (' +
                 view.mainLoop.gfxEngine.renderer.info.memory.geometries + ')';
         };
+        window.view = view;
     }
 
     itowns.View.prototype.addLayer.call(view, pointcloud).then(onLayerReady);


### PR DESCRIPTION
Make sure itowns' view is always accessible to ease testing (for instance
injecting a test script in an example page to query the View state).

(see also #581) 