### PR TITLE
feat(core): re-enable three.js object sorting

### DIFF
--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -117,7 +117,7 @@ function c3DEngine(rendererOrDiv, options = {}) {
 
     this.renderer.setClearColor(0x030508);
     this.renderer.autoClear = false;
-    this.renderer.sortObjects = false;
+    this.renderer.sortObjects = true;
 
     if (!renderer) {
         this.renderer.setPixelRatio(viewerDiv.devicePixelRatio);


### PR DESCRIPTION
It was disabled in ee7cfa0088c2d987868ef9660f3056690555ba93 because it wasn't relevant
when using RTC.
Since we removed RTC from iTowns we can reenable object sorting: it's not very costly
(one mat4 multiplication per object per frame) and it allows us to use the renderOrder
feature from three.js.
