### PR TITLE
Fix touch controls

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -469,8 +469,7 @@ View.prototype.eventToViewCoords = function eventToViewCoords(event, touchIdx = 
     if (event.touches === undefined || !event.touches.length) {
         return _eventCoords.set(event.offsetX, event.offsetY);
     } else {
-        // originalTarget should always be viewerDiv
-        const br = event.originalTarget.getBoundingClientRect();
+        const br = this.mainLoop.gfxEngine.renderer.domElement.getBoundingClientRect();
         return _eventCoords.set(
             event.touches[touchIdx].clientX - br.x,
             event.touches[touchIdx].clientY - br.y);

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -470,7 +470,7 @@ View.prototype.eventToViewCoords = function eventToViewCoords(event, touchIdx = 
         return _eventCoords.set(event.offsetX, event.offsetY);
     } else {
         // originalTarget should always be viewerDiv
-        const br = event.originalTarget.getClientBoundingRect();
+        const br = event.originalTarget.getBoundingClientRect();
         return _eventCoords.set(
             event.touches[touchIdx].clientX - br.x,
             event.touches[touchIdx].clientY - br.y);


### PR DESCRIPTION
## Description

I have a touch device with me this week :-) I've found some typo and bug:
- typo in `getBoundingClientRect`
- `originalTarget` is mozilla specific

Together this makes the pointcloud touch controls work again.
