### PR TITLE
Fix(gis): correctly set extent _internalStorageUnit when intersecting

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -354,11 +354,13 @@ Extent.prototype.intersect = function intersect(other) {
     if (!this.intersectsExtent(other)) {
         return new Extent(this.crs(), 0, 0, 0, 0);
     }
-    return new Extent(this.crs(),
+    const extent = new Extent(this.crs(),
         Math.max(this.west(), other.west(this._internalStorageUnit)),
         Math.min(this.east(), other.east(this._internalStorageUnit)),
         Math.max(this.south(), other.south(this._internalStorageUnit)),
         Math.min(this.north(), other.north(this._internalStorageUnit)));
+    extent._internalStorageUnit = this._internalStorageUnit;
+    return extent;
 };
 
 


### PR DESCRIPTION
## Description

Everthing is in the title, we were setting cardinals in a unit that *could* be different from the default for this crs (as we support it). The new extent must have its internalStorageUnit correctly set.

I need that to finish #597 