### PR TITLE
Refacto rasterizer: guess the file type based on its content

### DIFF
--- a/examples/globe_vector.js
+++ b/examples/globe_vector.js
@@ -46,6 +46,7 @@ promises.push(globeView.addLayer({
     url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
     protocol: 'rasterizer',
     id: 'ariege',
+    name: 'ariege',
     transparent: true,
     style: {
         fill: 'orange',

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -92,6 +92,7 @@ GeometryLayer.prototype.attach = function attach(layer) {
 GeometryLayer.prototype.detach = function detach(layer) {
     const count = this._attachedLayers.length;
     this._attachedLayers = this._attachedLayers.filter(attached => attached.id != layer.id);
+    layer.parentLayer = null;
     return this._attachedLayers.length < count;
 };
 

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -92,7 +92,6 @@ GeometryLayer.prototype.attach = function attach(layer) {
 GeometryLayer.prototype.detach = function detach(layer) {
     const count = this._attachedLayers.length;
     this._attachedLayers = this._attachedLayers.filter(attached => attached.id != layer.id);
-    layer.parentLayer = null;
     return this._attachedLayers.length < count;
 };
 

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -304,9 +304,6 @@ GlobeView.prototype.addLayer = function addLayer(layer) {
         const colorLayerCount = this.getLayers(l => l.type === 'color').length;
         layer.sequence = colorLayerCount;
         layer.update = updateLayeredMaterialNodeImagery;
-        if (layer.protocol === 'rasterizer') {
-            layer.reprojection = 'EPSG:4326';
-        }
     } else if (layer.type == 'elevation') {
         if (layer.protocol === 'wmts' && layer.options.tileMatrixSet !== 'WGS84G') {
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -156,9 +156,6 @@ PlanarView.prototype.constructor = PlanarView;
 PlanarView.prototype.addLayer = function addLayer(layer) {
     if (layer.type == 'color') {
         layer.update = updateLayeredMaterialNodeImagery;
-        if (layer.protocol === 'rasterizer') {
-            layer.reprojection = this.referenceCrs;
-        }
     } else if (layer.type == 'elevation') {
         layer.update = updateLayeredMaterialNodeElevation;
     }

--- a/src/Core/Scheduler/Providers/Fetcher.js
+++ b/src/Core/Scheduler/Providers/Fetcher.js
@@ -13,6 +13,21 @@ function checkResponse(response) {
 export default {
 
     /**
+     * Wrapper over fetch to get some text
+     *
+     * @param {string} url
+     * @param {Object} options - fetch options (passed directly to fetch)
+     *
+     * @return {Promise}
+     */
+    text(url, options = {}) {
+        return fetch(url, options).then((response) => {
+            checkResponse(response);
+            return response.text();
+        });
+    },
+
+    /**
      * Little wrapper over fetch to get some json
      *
      * @param {string} url

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -11,28 +11,6 @@ import Feature2Texture from '../../../Renderer/ThreeExtended/Feature2Texture';
 import GeoJSON2Features from '../../../Renderer/ThreeExtended/GeoJSON2Features';
 import Fetcher from './Fetcher';
 
-const supportedFormats = [
-    'vector/kml',
-    'vector/gpx',
-    'vector/geojson',
-];
-
-const fetcher = {
-    'vector/kml': Fetcher.xml,
-    'vector/gpx': Fetcher.xml,
-    'vector/geojson': Fetcher.json,
-};
-
-function getExtension(path) {
-    path = String(path);
-    const basename = path.split(/[\\/]/).pop();
-    const pos = basename.lastIndexOf('.');
-    if (basename === '' || pos < 1) {
-        return '';
-    }
-    return basename.slice(pos + 1);
-}
-
 function getExtentFromGpxFile(file) {
     const bound = file.getElementsByTagName('bounds')[0];
     if (bound) {
@@ -51,7 +29,7 @@ function createTextureFromVector(tile, layer) {
     }
 
     if (layer.type == 'color') {
-        const coords = tile.extent.as(layer.projection);
+        const coords = tile.extent;
         const result = { pitch: new THREE.Vector4(0, 0, 1, 1) };
         result.texture = Feature2Texture.createTextureFromFeature(layer.feature, tile.extent, 256, layer.style);
         result.texture.extent = tile.extent;
@@ -73,81 +51,70 @@ export default {
             throw new Error('layer.url is required');
         }
 
-        const extention = getExtension(layer.url).toLowerCase();
-        const format = `vector/${extention}`;
         layer.options = layer.options || {};
+        // KML and GPX specifications all says that they should be in
+        // EPSG:4326. We still support reprojection for them through this
+        // configuration option
+        layer.projection = layer.projection || 'EPSG:4326';
+        const parentCrs = layer.parentLayer.extent.crs();
 
-        if (!supportedFormats.includes(format) && !layer.options.mimetype) {
-            return Promise.reject(new Error('layer.options.mimetype is required'));
-        } else {
-            return fetcher[format](layer.url).then((file) => {
-                // Know if it's an xml file, then it can be kml or gpx
-                if (file.getElementsByTagName) {
-                    if (file.getElementsByTagName('kml')[0]) {
-                        layer.options.mimetype = 'vector/kml';
-                        // KML crs specification : 'EPSG:4326'
-                        layer.projection = layer.projection || 'EPSG:4326';
-                    } else if (file.getElementsByTagName('gpx')[0]) {
-                        // GPX crs specification : 'EPSG:4326'
-                        layer.options.mimetype = 'vector/gpx';
-                        layer.projection = layer.projection || 'EPSG:4326';
-                    } else {
-                        throw new Error('Unsupported xml file data vector');
-                    }
-                // Know if it's an geojson file
-                } else if (file.type == 'Feature' || file.type == 'FeatureCollection') {
-                    layer.options.mimetype = 'vector/geojson';
-                } else {
-                    throw new Error('Unsupported json file data vector');
-                }
+        const options = { buildExtent: true, crsIn: layer.projection };
 
-                if (!(layer.extent instanceof Extent)) {
-                    layer.extent = new Extent(layer.projection, layer.extent);
-                }
-
-                if (!layer.options.zoom) {
-                    layer.options.zoom = { min: 5, max: 21 };
-                }
-
-                layer.format = layer.options.mimetype;
-                layer.style = layer.style || {};
-
-                // Rasterization of data vector
-                // It shouldn't use parent's texture outside the extent
-                // Otherwise artefacts appear at the outer edge
-                layer.noTextureParentOutsideLimit = true;
-                const options = { buildExtent: true, crsIn: layer.projection };
-
-                if (layer.options.mimetype === 'vector/geojson') {
-                    layer.feature = GeoJSON2Features.parse(layer.reprojection, file, layer.extent, options);
-                    layer.extent = layer.feature.extent || layer.feature.geometry.extent;
-                } else if (layer.options.mimetype === 'vector/kml') {
-                    const geojson = togeojson.kml(file);
-                    layer.feature = GeoJSON2Features.parse(layer.reprojection, geojson, layer.extent, options);
-                    layer.extent = layer.feature.extent;
-                } else if (layer.options.mimetype === 'vector/gpx') {
-                    const geojson = togeojson.gpx(file);
-                    layer.style.stroke = layer.style.stroke || 'red';
-                    layer.extent = getExtentFromGpxFile(file);
-                    layer.feature = GeoJSON2Features.parse(layer.reprojection, geojson, layer.extent, options);
-                    layer.extent = layer.feature.extent;
-                }
-                // GeoJSON2Features.parse reprojects in local tile texture space
-                // Rasterizer gives textures in this new reprojection space
-                // layer.projection is now reprojection
-                layer.originalprojection = layer.projection;
-                layer.projection = layer.reprojection;
-            });
+        if (!(layer.extent instanceof Extent)) {
+            layer.extent = new Extent(layer.projection, layer.extent).as(parentCrs);
         }
+
+        if (!layer.options.zoom) {
+            layer.options.zoom = { min: 5, max: 21 };
+        }
+
+        layer.style = layer.style || {};
+
+        // Rasterization of data vector
+        // It shouldn't use parent's texture outside its extent
+        // Otherwise artefacts appear at the outer edge
+        layer.noTextureParentOutsideLimit = true;
+
+        return Fetcher.text(layer.url, layer.networkOptions).then((text) => {
+            let geojson;
+            const trimmedText = text.trim();
+            // We test the start of the string to choose a parser
+            if (trimmedText.startsWith('<')) {
+                // if it's an xml file, then it can be kml or gpx
+                const parser = new DOMParser();
+                const file = parser.parseFromString(text, 'application/xml');
+                if (file.documentElement.tagName.toLowerCase() === 'kml') {
+                    geojson = togeojson.kml(file);
+                } else if (file.documentElement.tagName.toLowerCase() === 'gpx') {
+                    geojson = togeojson.gpx(file);
+                    layer.style.stroke = layer.style.stroke || 'red';
+                    layer.extent = layer.extent.intersect(getExtentFromGpxFile(file).as(layer.extent.crs()));
+                } else if (file.documentElement.tagName.toLowerCase() === 'parsererror') {
+                    throw new Error('Error parsing XML document');
+                } else {
+                    throw new Error('Unsupported xml file, only valid KML and GPX are supported, but no <gpx> or <kml> tag found.',
+                            file);
+                }
+            } else if (trimmedText.startsWith('{') || trimmedText.startsWith('[')) {
+                geojson = JSON.parse(text);
+                if (geojson.type !== 'Feature' && geojson.type !== 'FeatureCollection') {
+                    throw new Error('This json is not a GeoJSON');
+                }
+            } else {
+                throw new Error('Unsupported file: only well-formed KML, GPX or GeoJSON are supported');
+            }
+
+            if (geojson) {
+                layer.feature = GeoJSON2Features.parse(parentCrs, geojson, layer.extent, options);
+                layer.extent = layer.feature.extent || layer.feature.geometry.extent;
+            }
+        });
     },
     tileInsideLimit(tile, layer) {
         return tile.level >= layer.options.zoom.min && tile.level <= layer.options.zoom.max && layer.extent.intersectsExtent(tile.extent);
     },
     executeCommand(command) {
         const layer = command.layer;
-        if (!supportedFormats.includes(layer.format)) {
-            return Promise.reject(new Error(`Unsupported mimetype ${layer.format}`));
-        }
         const tile = command.requester;
 
         return createTextureFromVector(tile, layer);

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -46,7 +46,7 @@ function createTextureFromVector(tile, layer) {
 }
 
 export default {
-    preprocessDataLayer(layer) {
+    preprocessDataLayer(layer, view, scheduler, parentLayer) {
         if (!layer.url) {
             throw new Error('layer.url is required');
         }
@@ -56,7 +56,7 @@ export default {
         // EPSG:4326. We still support reprojection for them through this
         // configuration option
         layer.projection = layer.projection || 'EPSG:4326';
-        const parentCrs = layer.parentLayer.extent.crs();
+        const parentCrs = parentLayer.extent.crs();
 
         const options = { buildExtent: true, crsIn: layer.projection };
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -98,7 +98,7 @@ const _syncGeometryLayerVisibility = function _syncGeometryLayerVisibility(layer
     }
 };
 
-function _preprocessLayer(view, layer, provider) {
+function _preprocessLayer(view, layer, provider, parentLayer) {
     if (!(layer instanceof Layer) && !(layer instanceof GeometryLayer)) {
         const nlayer = new Layer(layer.id);
         // nlayer.id is read-only so delete it from layer before Object.assign
@@ -135,7 +135,7 @@ function _preprocessLayer(view, layer, provider) {
         }
         let providerPreprocessing = Promise.resolve();
         if (provider && provider.preprocessDataLayer) {
-            providerPreprocessing = provider.preprocessDataLayer(layer, view, view.mainLoop.scheduler);
+            providerPreprocessing = provider.preprocessDataLayer(layer, view, view.mainLoop.scheduler, parentLayer);
             if (!(providerPreprocessing && providerPreprocessing.then)) {
                 providerPreprocessing = Promise.resolve();
             }
@@ -295,7 +295,6 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         throw new Error(`Invalid id '${layer.id}': id already used`);
     }
 
-    layer.parentLayer = parentLayer;
     if (parentLayer && !layer.extent) {
         layer.extent = parentLayer.extent;
     }
@@ -304,7 +303,7 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
     if (layer.protocol && !provider) {
         throw new Error(`${layer.protocol} is not a recognized protocol name.`);
     }
-    layer = _preprocessLayer(this, layer, provider);
+    layer = _preprocessLayer(this, layer, provider, parentLayer);
     if (parentLayer) {
         parentLayer.attach(layer);
     } else {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -145,6 +145,10 @@ function _preprocessLayer(view, layer, provider) {
         layer.whenReady = providerPreprocessing.then(() => {
             layer.ready = true;
             return layer;
+        }).catch((e) => {
+            // eslint-disable-next-line no-console
+            console.error(`Error when preprocessing layer ${layer.name}`, e);
+            throw e; // make sure the promise is rejected
         });
     }
 
@@ -291,6 +295,7 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         throw new Error(`Invalid id '${layer.id}': id already used`);
     }
 
+    layer.parentLayer = parentLayer;
     if (parentLayer && !layer.extent) {
         layer.extent = parentLayer.extent;
     }


### PR DESCRIPTION
## Description

We can easily guess the type of these vecto data when we get them. Therefore, `layer.format` is not useful here, and we can avoid guessing the content from the extension, which is not guaranteed to work with http request (and endpoint does not need to have the extension). 

Depends on #664 

