### PR TITLE
Fix(examples): avoid displaying the tooltip before the js loads

### DIFF
--- a/examples/FeatureToolTip.js
+++ b/examples/FeatureToolTip.js
@@ -29,7 +29,7 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
         var point;
         // var
         tooltip.innerHTML = '';
-        tooltip.style.visibility = 'hidden';
+        tooltip.style.display = 'none';
         if (geoCoord) {
             visible = false;
             // convert degree precision
@@ -72,7 +72,7 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
             if (visible) {
                 tooltip.style.left = viewer.eventToViewCoords(e).x + 'px';
                 tooltip.style.top = viewer.eventToViewCoords(e).y + 'px';
-                tooltip.style.visibility = 'visible';
+                tooltip.style.display = 'block';
             }
         }
     }

--- a/examples/globe_vector.html
+++ b/examples/globe_vector.html
@@ -29,9 +29,6 @@
                     display: none;
                 }
             }
-            .viewer:hover .tooltip {
-                display: block;
-            }
             .tooltip {
                 display: none;
                 background-image: linear-gradient(rgba(80, 80, 80,0.95), rgba(60, 60, 60,0.95));


### PR DESCRIPTION
## Description

Before this change, the tooltip can be briefly seen at the top left of the screen when the page loads. We should hide it by default and show it only with javascript, to avoid showing it with the hover before the js has a chance to kick in.
