### PR TITLE
fix(core): wrong tile transformation

### DIFF
--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -114,7 +114,7 @@ BuilderEllipsoidTile.prototype.computeSharableExtent = function fnComputeSharabl
 
     return {
         sharableExtent,
-        quaternion: quatToAlignLongitude,
+        quaternion: quatToAlignLongitude.clone(),
         position: this.Center(extent),
     };
 };

--- a/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
+++ b/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
@@ -129,7 +129,7 @@ PanoramaTileBuilder.prototype.computeSharableExtent = function fnComputeSharable
 
     return {
         sharableExtent,
-        quaternion: quatToAlignLongitude,
+        quaternion: quatToAlignLongitude.clone(),
         position: this.Center(extent),
     };
 };

--- a/src/Core/Scheduler/Providers/TileProvider.js
+++ b/src/Core/Scheduler/Providers/TileProvider.js
@@ -41,7 +41,6 @@ TileProvider.prototype.preprocessDataLayer = function preprocessLayer(layer, vie
     });
 };
 
-const worldQuaternion = new THREE.Quaternion();
 TileProvider.prototype.executeCommand = function executeCommand(command) {
     const extent = command.extent;
     if (command.requester &&
@@ -95,11 +94,12 @@ TileProvider.prototype.executeCommand = function executeCommand(command) {
     tile.layer = layer.id;
     tile.layers.set(command.threejsLayer);
 
-    if (parent) {
-        position.applyMatrix4(layer.object3d.matrixWorld);
-        parent.worldToLocal(position);
-        worldQuaternion.setFromRotationMatrix(parent.matrixWorld).inverse().multiply(layer.object3d.quaternion);
-        quaternion.premultiply(worldQuaternion);
+    if (parent && parent instanceof TileMesh) {
+        // get parent extent transformation
+        const pTrans = builder.computeSharableExtent(parent.extent);
+        // place relative to his parent
+        position.sub(pTrans.position).applyQuaternion(pTrans.quaternion.inverse());
+        quaternion.premultiply(pTrans.quaternion);
     }
 
     tile.position.copy(position);


### PR DESCRIPTION
stop use root layer transformation to compute tile transformation
especially for the animation of the root

fix #668 and #642
