### PR TITLE
fix(core): stop using wmtsc for OSM layers on globe

### DIFF
--- a/examples/layers/JSONLayers/DARK.json
+++ b/examples/layers/JSONLayers/DARK.json
@@ -1,9 +1,9 @@
 {
     "type": "color",
-    "protocol": "wmtsc",
+    "protocol": "xyz",
 	"networkOptions": { "crossOrigin" : "anonymous" },
     "id": "DARK",
-    "customUrl": "http://a.basemaps.cartocdn.com/dark_all/%TILEMATRIX/%COL/%ROW.png",
+    "url": "http://a.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png",
     "options": {
     	"attribution": {
     		"name":"CARTO",

--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -1,9 +1,9 @@
 {
     "type": "color",
-    "protocol": "wmtsc",
+    "protocol": "xyz",
     "networkOptions": { "crossOrigin" : "anonymous" },
     "id": "OPENSM",
-    "customUrl": "http://osm.oslandia.io/styles/klokantech-basic/%TILEMATRIX/%COL/%ROW.png",
+    "url": "http://osm.oslandia.io/styles/klokantech-basic/${z}/${x}/${y}.png",
     "options": {
         "attribution": {
             "name":"OpenStreetMap",

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -75,22 +75,10 @@
 
             // add it to the view so it gets updated
             itowns.View.prototype.addLayer.call(globeView, globe2);
-            itowns.View.prototype.addLayer.call(globeView, {
-                update: itowns.updateLayeredMaterialNodeImagery,
-                type: 'color',
-                protocol: "wmtsc",
-                id: "DARK",
-                customUrl: "http://a.basemaps.cartocdn.com/light_all/%TILEMATRIX/%COL/%ROW.png",
-                networkOptions: { crossOrigin: 'anonymous' },
-                options: {
-                    attribution: {
-                        "name":"CARTO",
-                        "url": "https://carto.com/"
-                    },
-                    tileMatrixSet: "PM",
-                    mimetype: "image/png"
-                },
-            }, globe2);
+            itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(function _(osm) {
+                osm.update = itowns.updateLayeredMaterialNodeImagery;
+                itowns.View.prototype.addLayer.call(globeView, osm, globe2);
+            });
 
             // Globe animation
             var t = 0;

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -188,7 +188,14 @@ TileMesh.prototype.getCoordsForLayer = function getCoordsForLayer(layer) {
             throw new Error('unsupported projection wms for this viewer');
         }
     } else if (layer.protocol == 'tms' || layer.protocol == 'xyz') {
-        return OGCWebServiceHelper.computeTMSCoordinates(this, layer.extent, layer.origin);
+        // Special globe case: use the P(seudo)M(ercator) coordinates
+        if (this.extent.crs() === 'EPSG:4326' &&
+                (['EPSG:3857', 'EPSG:4326'].indexOf(layer.extent.crs()) >= 0)) {
+            OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, 'PM');
+            return this.wmtsCoords.PM;
+        } else {
+            return OGCWebServiceHelper.computeTMSCoordinates(this, layer.extent, layer.origin);
+        }
     } else {
         return [this.extent];
     }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -258,10 +258,10 @@ function _preprocessLayer(view, layer, provider) {
  * // Example to add an OPENSM Layer
  * view.addLayer({
  *   type: 'color',
- *   protocol:   'wmtsc',
+ *   protocol:   'xyz',
  *   id:         'OPENSM',
  *   fx: 2.5,
- *   customUrl:  'http://b.tile.openstreetmap.fr/osmfr/%TILEMATRIX/%COL/%ROW.png',
+ *   url:  'http://b.tile.openstreetmap.fr/osmfr/${z}/${x}/${y}.png',
  *   options: {
  *       attribution : {
  *           name: 'OpenStreetMap',

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -169,8 +169,8 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
         }
 
         if (material.indexOfColorLayer(layer.id) === -1) {
-            const texturesCount = layer.tileTextureCount ?
-                layer.tileTextureCount(node, layer) : 1;
+            const texturesCount =
+                node.getCoordsForLayer(layer).length;
 
             const paramMaterial = {
                 tileMT: layer.options.tileMatrixSet || node.getCoordsForLayer(layer)[0].crs(),

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -370,7 +370,9 @@ LayeredMaterial.prototype.pushLayer = function pushLayer(param) {
     this.uniforms.paramLayers.value[newIndex] = new THREE.Vector4();
 
     this.setTextureOffsetByLayerIndex(newIndex, offset);
-    this.setLayerUV(newIndex, param.tileMT.includes('PM') ? param.texturesCount : 0);
+    // If there's only one texture: assume it covers the whole tile,
+    // otherwise declare the number of textures
+    this.setLayerUV(newIndex, (param.texturesCount == 1) ? 0 : param.texturesCount);
     this.setLayerFx(newIndex, param.fx);
     this.setLayerOpacity(newIndex, param.opacity);
     this.setLayerVisibility(newIndex, param.visible);


### PR DESCRIPTION
OSM servers uses the 'xyz' protocol so this commit adds proper support for these URL.
The wmstc support is still present (but not used).
