### PR TITLE
refactor(core): improve render view to buffer / target functions

### DIFF
--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -27,11 +27,14 @@ function screenCoordsToNodeId(view, tileLayer, mouse) {
 
     const undoHide = hideEverythingElse(view, tileLayer.object3d, tileLayer.threejsLayer);
 
-    var buffer = view.mainLoop.gfxEngine.renderViewTobuffer(
+    const buffer = view.mainLoop.gfxEngine.renderViewToBuffer(
         { camera: view.camera, scene: tileLayer.object3d },
-        view.mainLoop.gfxEngine.fullSizeRenderTarget,
-        mouse.x, dim.y - mouse.y,
-        1, 1);
+        {
+            x: mouse.x,
+            y: mouse.y,
+            width: 1,
+            height: 1,
+        });
 
     undoHide();
 
@@ -80,8 +83,6 @@ export default {
             return;
         }
 
-        const dim = view.mainLoop.gfxEngine.getWindowSize();
-
         // enable picking mode for points material
         layer.object3d.traverse((o) => {
             if (o.isPoints && o.baseId) {
@@ -93,10 +94,9 @@ export default {
 
         // render 1 pixel
         // TODO: support more than 1 pixel selection
-        const buffer = view.mainLoop.gfxEngine.renderViewTobuffer(
+        const buffer = view.mainLoop.gfxEngine.renderViewToBuffer(
                 { camera: view.camera, scene: layer.object3d },
-                view.mainLoop.gfxEngine.fullSizeRenderTarget,
-                mouse.x, dim.y - mouse.y, 1, 1);
+                { x: mouse.x, y: mouse.y, width: 1, height: 1 });
 
         undoHide();
 

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -387,7 +387,7 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
 GlobeView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
     const g = this.mainLoop.gfxEngine;
     const restore = this.wgs84TileLayer.level0Nodes.map(n => n.pushRenderState(RendererConstant.DEPTH));
-    const buffer = g.renderViewTobuffer(this, g.fullSizeRenderTarget, x, y, width, height);
+    const buffer = g.renderViewToBuffer(this, { x, y, width, height });
     restore.forEach(r => r());
 
     return buffer;
@@ -419,7 +419,7 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
         const id = ((dim.y - mouse.y - 1) * dim.x + mouse.x) * 4;
         buffer = this._fullSizeDepthBuffer.slice(id, id + 4);
     } else {
-        buffer = this.readDepthBuffer(mouse.x, dim.y - mouse.y - 1, 1, 1);
+        buffer = this.readDepthBuffer(mouse.x, mouse.y, 1, 1);
     }
 
     screen.x = (mouse.x / dim.x) * 2 - 1;


### PR DESCRIPTION
Improve these 2 functions and document them.

Work-around a oddity in three.js causing setScissor / setViewport functions
behaving oddly when using a RenderTarget.

Changed coordinates to explicit window-coordinate (0,0: top-left) to avoid
requesting the user to do (height - y).

BREAKING CHANGE: c3DEngine.renderViewTobuffer has been renamed renderViewToBuffer
and has a new signature.

This PR depends on #635 
