### PR TITLE
Refactor(core): unify SSE computation methods

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -139,6 +139,7 @@
             debug.createTileDebugUI(menuGlobe.gui, view, view.wgs84TileLayer, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume, d);
+            debug.ScreenSpaceErrorInspector.create(menuGlobe.gui, view);
 
 
 // Picking example - - - - - - - - - - -- - - - -- - - - -- - - - -- - - - -- - - - -- - - - -

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -88,6 +88,7 @@
                 menuGlobe.addImageryLayersGUI(view.getLayers(function (l) { return l.type === 'color'; }));
                 var d = new debug.Debug(view, menuGlobe.gui);
                 debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
+                debug.ScreenSpaceErrorInspector.create(menuGlobe.gui, view);
             }
         </script>
     </body>

--- a/examples/pointcloud.js
+++ b/examples/pointcloud.js
@@ -85,4 +85,5 @@ function showPointcloud(serverUrl, fileName, lopocsTable) {
     }
 
     view.addLayer(pointcloud).then(onLayerReady);
+    debug.ScreenSpaceErrorInspector.create(debugGui, view);
 }

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@ and open the template in the editor.
 
             var promises = [];
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(addLayerCb));
+            /*
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(addLayerCb));
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(addLayerCb));
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(addLayerCb));
@@ -57,7 +58,7 @@ and open the template in the editor.
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb));
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb));
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb));
-
+*/
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
             promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@ and open the template in the editor.
 
             const d = new debug.Debug(globeView, menuGlobe.gui);
             debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.wgs84TileLayer, d);
+            debug.ScreenSpaceErrorInspector.create(menuGlobe.gui, globeView);
             window.globeView = globeView;
 </script>
     </body>

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -159,7 +159,6 @@ export function createGlobeLayer(id, options) {
         if (SubdivisionControl.hasEnoughTexturesToSubdivide(context, layer, node)) {
             return globeSubdivisionControl(2,
                 options.maxSubdivisionLevel || 18,
-                options.sseSubdivisionThreshold || 1.0,
                 options.maxDeltaElevationLevel || 4)(context, layer, node);
         }
         return false;

--- a/src/Core/ScreenSpaceError.js
+++ b/src/Core/ScreenSpaceError.js
@@ -1,0 +1,88 @@
+import * as THREE from 'three';
+
+const v = new THREE.Vector3();
+const m = new THREE.Matrix4();
+const m2 = new THREE.Matrix4();
+const m3 = new THREE.Matrix4();
+
+function compute(vector, matrix, camera, distance, _3d) {
+    const basis = [
+        new THREE.Vector3(vector.x, 0, 0),
+        new THREE.Vector3(0, vector.y, 0),
+    ];
+
+    if (_3d) {
+        basis.push(new THREE.Vector3(0, 0, vector.z));
+    }
+
+    m2.identity();
+    m2.extractRotation(matrix);
+    m3.identity();
+    m3.extractRotation(camera.camera3D.matrixWorldInverse);
+
+    for (const b of basis) {
+        // Apply rotation
+        b.applyMatrix4(m2);
+        // Apply inverse camera rotation
+        b.applyMatrix4(m3);
+        // Move at 'distance' from camera
+        b.z += -distance;
+        // Project on screen
+        b.applyMatrix4(camera.camera3D.projectionMatrix);
+        // cancel z component
+        b.z = 0;
+        b.x = b.x * camera.width * 0.5;
+        b.y = b.y * camera.height * 0.5;
+    }
+
+    const lengthsq = basis.map(b => b.lengthSq());
+    const min = Math.min.apply(Math, lengthsq);
+    return Math.sqrt(min);
+}
+
+function findBox3Distance(camera, box3, matrix) {
+    // TODO: can be cached
+    m.getInverse(matrix);
+    // Move camera position in box3 basis
+    // (we don't transform box3 to camera basis because box3 are AABB)
+    const pt = camera.camera3D.position
+        .clone(v).applyMatrix4(m);
+    // Compute distance between the camera / box3
+    return box3.distanceToPoint(pt);
+}
+
+function computeSizeFromGeometricError(box3, geometricError) {
+    const size = box3.getSize();
+    // Build a vector with the same ratio than box3,
+    // and with the biggest component being geometricError
+    size.multiplyScalar(geometricError /
+        Math.max(size.x, Math.max(size.y, size.z)));
+    return size;
+}
+
+export default {
+    MODE_2D: 1,
+
+    MODE_3D: 2,
+
+    computeFromBox3(camera, box3, matrix, geometricError, mode) {
+        const distance = findBox3Distance(camera, box3, matrix);
+
+        if (distance <= geometricError) {
+            return {
+                sse: Infinity,
+                distance,
+            };
+        }
+
+        const size = computeSizeFromGeometricError(box3, geometricError);
+
+        const sse = compute(size, matrix, camera, distance, mode == this.MODE_3D);
+
+        return {
+            sse,
+            distance,
+            size,
+        };
+    },
+};

--- a/src/Core/ScreenSpaceError.js
+++ b/src/Core/ScreenSpaceError.js
@@ -41,18 +41,6 @@ function computeVectorSizeAtDistance(vector, matrix, camera, distance, _3d) {
     }
 
     return basis.map(b => b.length());
-
-    const sse = {
-        x: basis[0].length(),
-        y: basis[1].length(),
-    };
-    if (_3d) {
-        sse.z = basis[2].length();
-    }
-    return sse;
-    const lengthsq = basis.map(b => b.lengthSq());
-    const min = Math.min.apply(Math, lengthsq);
-    return Math.sqrt(min);
 }
 
 function findBox3Distance(camera, box3, matrix) {

--- a/src/Core/ScreenSpaceError.js
+++ b/src/Core/ScreenSpaceError.js
@@ -10,20 +10,17 @@ const basis = [
     new THREE.Vector3(0, 0, 1),
 ];
 
-function computeVectorSizeAtDistance(vector, matrix, camera, distance, _3d) {
+function computeVectorSizeAtDistance(vector, matrix, camera, distance) {
     basis[0].set(vector.x, 0, 0);
     basis[1].set(0, vector.y, 0);
-
-    if (_3d) {
-        basis[2].set(0, 0, vector.z);
-    }
+    basis[2].set(0, 0, vector.z);
 
     m2.identity();
     m2.extractRotation(matrix);
     m3.identity();
     m3.extractRotation(camera.camera3D.matrixWorldInverse);
 
-    for (let i = 0; i < (_3d ? 3 : 2); i++) {
+    for (let i = 0; i < 3; i++) {
         const b = basis[i];
 
         // Apply rotation
@@ -64,17 +61,7 @@ function computeSizeFromGeometricError(box3, geometricError) {
 }
 
 export default {
-    /*
-     * Compute SSE based on the 2D bounding-box (ignore z size)
-     */
-    MODE_2D: 1,
-
-    /*
-     * Compute SSE based on the 3D bounding-box
-     */
-    MODE_3D: 2,
-
-    computeFromBox3(camera, box3, matrix, geometricError, mode) {
+    computeFromBox3(camera, box3, matrix, geometricError) {
         const distance = findBox3Distance(camera, box3, matrix);
 
         if (distance <= geometricError) {
@@ -86,7 +73,7 @@ export default {
 
         const size = computeSizeFromGeometricError(box3, geometricError);
 
-        const sse = computeVectorSizeAtDistance(size, matrix, camera, distance, mode == this.MODE_3D);
+        const sse = computeVectorSizeAtDistance(size, matrix, camera, distance);
 
         return {
             sse,

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -143,7 +143,8 @@ TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
 };
 
 TileMesh.prototype.updateGeometricError = function updateGeometricError() {
-    this.geometricError = 2 * this.boundingSphere.radius;
+    const size = this.obb.box3D.getSize();
+    this.geometricError = Math.max(size.x, size.y);
 };
 
 TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layerId) {

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -143,7 +143,7 @@ TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
 };
 
 TileMesh.prototype.updateGeometricError = function updateGeometricError() {
-    this.geometricError = this.boundingSphere.radius;
+    this.geometricError = 2 * this.boundingSphere.radius;
 };
 
 TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layerId) {

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -8,7 +8,7 @@ import * as THREE from 'three';
 import LayeredMaterial from '../Renderer/LayeredMaterial';
 import { l_ELEVATION } from '../Renderer/LayeredMaterialConstants';
 import RendererConstant from '../Renderer/RendererConstant';
-import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from '../Provider/OGCWebServiceHelper';
+import OGCWebServiceHelper from '../Provider/OGCWebServiceHelper';
 import { is4326 } from './Geographic/Coordinates';
 
 function TileMesh(geometry, params) {
@@ -143,9 +143,7 @@ TileMesh.prototype.setBBoxZ = function setBBoxZ(min, max) {
 };
 
 TileMesh.prototype.updateGeometricError = function updateGeometricError() {
-    // The geometric error is calculated to have a correct texture display.
-    // For the projection of a texture's texel to be less than or equal to one pixel
-    this.geometricError = this.boundingSphere.radius / SIZE_TEXTURE_TILE;
+    this.geometricError = this.boundingSphere.radius;
 };
 
 TileMesh.prototype.setTexturesLayer = function setTexturesLayer(textures, layerType, layerId) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -26,3 +26,4 @@ export { default as PlanarControls } from './Renderer/ThreeExtended/PlanarContro
 export { default as FeaturesUtils } from './Renderer/ThreeExtended/FeaturesUtils';
 export { CONTROL_EVENTS } from './Renderer/ThreeExtended/GlobeControls';
 export { default as DEMUtils } from './utils/DEMUtils';
+export { default as ScreenSpaceError } from './Core/ScreenSpaceError';

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import ScreenSpaceError from '../Core/ScreenSpaceError';
 
 function requestNewTile(view, scheduler, geometryLayer, metadata, parent, redraw) {
     const command = {
@@ -225,25 +226,30 @@ const worldPosition = new THREE.Vector3();
 function computeNodeSSE(camera, node) {
     node.distance = 0;
     if (node.boundingVolume.region) {
-        worldPosition.setFromMatrixPosition(node.boundingVolume.region.matrixWorld);
-        cameraLocalPosition.copy(camera.camera3D.position).sub(worldPosition);
-        node.distance = node.boundingVolume.region.box3D.distanceToPoint(cameraLocalPosition);
-    } else if (node.boundingVolume.box) {
+        return ScreenSpaceError.computeFromBox3(
+            camera,
+            node.boundingVolume.region.box3D,
+            node.boundingVolume.region.matrixWorld,
+            node.geometricError,
+            ScreenSpaceError.MODE_2D);
+    }
+    if (node.boundingVolume.box) {
+        return ScreenSpaceError.computeFromBox3(
+            camera,
+            node.boundingVolume.box,
+            node.matrixWorld,
+            node.geometricError,
+            ScreenSpaceError.MODE_3D);
+    }
+    if (node.boundingVolume.sphere) {
+        // TODO USE http://iquilezles.org/www/articles/sphereproj/sphereproj.htm
         worldPosition.setFromMatrixPosition(node.matrixWorld);
         cameraLocalPosition.copy(camera.camera3D.position).sub(worldPosition);
-        node.distance = node.boundingVolume.box.distanceToPoint(cameraLocalPosition);
-    } else if (node.boundingVolume.sphere) {
-        worldPosition.setFromMatrixPosition(node.matrixWorld);
-        cameraLocalPosition.copy(camera.camera3D.position).sub(worldPosition);
-        node.distance = Math.max(0.0, node.boundingVolume.sphere.distanceToPoint(cameraLocalPosition));
+        const distance = Math.max(0.0, node.boundingVolume.sphere.distanceToPoint(cameraLocalPosition));
+        return camera.preSSE * (node.geometricError / distance);
     } else {
         return Infinity;
     }
-    if (node.distance === 0) {
-        // This test is needed in case geometricError = distance = 0
-        return Infinity;
-    }
-    return camera.preSSE * (node.geometricError / node.distance);
 }
 
 export function init3dTilesLayer(view, scheduler, layer) {
@@ -312,6 +318,8 @@ export function process3dTilesNode(cullingTest, subdivisionTest) {
                 });
             }
             return returnValue;
+        } else {
+            node.sse = Infinity;
         }
 
         markForDeletion(layer, node);
@@ -324,6 +332,6 @@ export function $3dTilesSubdivisionControl(context, layer, node) {
     if (layer.tileIndex.index[node.tileId].children === undefined) {
         return false;
     }
-    const sse = computeNodeSSE(context.camera, node);
-    return sse > layer.sseThreshold;
+    node.sse = computeNodeSSE(context.camera, node);
+    return node.sse.sse > layer.sseThreshold;
 }

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -221,8 +221,6 @@ export function pre3dTilesUpdate(context, layer) {
     return [layer.root];
 }
 
-const cameraLocalPosition = new THREE.Vector3();
-const worldPosition = new THREE.Vector3();
 function computeNodeSSE(camera, node) {
     node.distance = 0;
     if (node.boundingVolume.region) {
@@ -242,11 +240,11 @@ function computeNodeSSE(camera, node) {
             ScreenSpaceError.MODE_3D);
     }
     if (node.boundingVolume.sphere) {
-        // TODO USE http://iquilezles.org/www/articles/sphereproj/sphereproj.htm
-        worldPosition.setFromMatrixPosition(node.matrixWorld);
-        cameraLocalPosition.copy(camera.camera3D.position).sub(worldPosition);
-        const distance = Math.max(0.0, node.boundingVolume.sphere.distanceToPoint(cameraLocalPosition));
-        return camera.preSSE * (node.geometricError / distance);
+        return ScreenSpaceError.computeFromSphere(
+            camera,
+            node.boundingVolume.sphere,
+            node.matrixWorld,
+            node.geometricError);
     } else {
         return Infinity;
     }

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -245,8 +245,6 @@ function computeNodeSSE(camera, node) {
             node.boundingVolume.sphere,
             node.matrixWorld,
             node.geometricError);
-    } else {
-        return Infinity;
     }
 }
 
@@ -331,5 +329,8 @@ export function $3dTilesSubdivisionControl(context, layer, node) {
         return false;
     }
     node.sse = computeNodeSSE(context.camera, node);
-    return node.sse.sse > layer.sseThreshold;
+    if (node.sse) {
+        const minSSE = Math.min.apply(Math, node.sse.sse);
+        return minSSE > layer.sseThreshold;
+    }
 }

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -228,16 +228,14 @@ function computeNodeSSE(camera, node) {
             camera,
             node.boundingVolume.region.box3D,
             node.boundingVolume.region.matrixWorld,
-            node.geometricError,
-            ScreenSpaceError.MODE_2D);
+            node.geometricError);
     }
     if (node.boundingVolume.box) {
         return ScreenSpaceError.computeFromBox3(
             camera,
             node.boundingVolume.box,
             node.matrixWorld,
-            node.geometricError,
-            ScreenSpaceError.MODE_3D);
+            node.geometricError);
     }
     if (node.boundingVolume.sphere) {
         return ScreenSpaceError.computeFromSphere(

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -102,7 +102,22 @@ export function globeSubdivisionControl(minLevel, maxLevel, maxDeltaElevationLev
             node.geometricError,
             ScreenSpaceError.MODE_2D);
         node.sse.offset = SIZE_TEXTURE_TILE;
-        return node.sse.sse > (SIZE_TEXTURE_TILE + layer.sseThreshold);
+
+        const cond1x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold));
+        const cond1y = (node.sse.sse[1] > (SIZE_TEXTURE_TILE + layer.sseThreshold));
+        const cond2x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold) * 0.85);
+        const cond2y = (node.sse.sse[1] > (SIZE_TEXTURE_TILE + layer.sseThreshold) * 0.85);
+
+        if (cond1x && cond1y) {
+            return true;
+        }
+        if (cond1x) {
+            return cond2y;
+        }
+        if (cond1y) {
+            return cond2x;
+        }
+        return false;
     };
 }
 

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -99,8 +99,7 @@ export function globeSubdivisionControl(minLevel, maxLevel, maxDeltaElevationLev
             context.camera,
             node.OBB().box3D,
             node.OBB().matrixWorld,
-            node.geometricError,
-            ScreenSpaceError.MODE_3D);
+            node.geometricError);
         node.sse.offset = SIZE_TEXTURE_TILE;
 
         let condition1 = 0;

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -103,19 +103,15 @@ export function globeSubdivisionControl(minLevel, maxLevel, maxDeltaElevationLev
             ScreenSpaceError.MODE_3D);
         node.sse.offset = SIZE_TEXTURE_TILE;
 
-        let condition1 = false;
-        let condition2 = true;
+        let condition1 = 0;
+        let condition2 = 0;
 
         for (let i = 0; i < 3; i++) {
-            condition1 |= node.sse.sse[i] > (SIZE_TEXTURE_TILE + layer.sseThreshold);
-            condition2 &= node.sse.sse[i] > 0.85 * (SIZE_TEXTURE_TILE + layer.sseThreshold);
-
-            if (!condition2) {
-                return false;
-            }
+            condition1 += node.sse.sse[i] > (SIZE_TEXTURE_TILE + layer.sseThreshold);
+            condition2 += node.sse.sse[i] > 0.85 * (SIZE_TEXTURE_TILE + layer.sseThreshold);
         }
 
-        return condition1 && condition2;
+        return condition1 >= 1 && condition2 >= 2;
     };
 }
 

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -100,24 +100,22 @@ export function globeSubdivisionControl(minLevel, maxLevel, maxDeltaElevationLev
             node.OBB().box3D,
             node.OBB().matrixWorld,
             node.geometricError,
-            ScreenSpaceError.MODE_2D);
+            ScreenSpaceError.MODE_3D);
         node.sse.offset = SIZE_TEXTURE_TILE;
 
-        const cond1x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold));
-        const cond1y = (node.sse.sse[1] > (SIZE_TEXTURE_TILE + layer.sseThreshold));
-        const cond2x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold) * 0.85);
-        const cond2y = (node.sse.sse[1] > (SIZE_TEXTURE_TILE + layer.sseThreshold) * 0.85);
+        let condition1 = false;
+        let condition2 = true;
 
-        if (cond1x && cond1y) {
-            return true;
+        for (let i = 0; i < 3; i++) {
+            condition1 |= node.sse.sse[i] > (SIZE_TEXTURE_TILE + layer.sseThreshold);
+            condition2 &= node.sse.sse[i] > 0.85 * (SIZE_TEXTURE_TILE + layer.sseThreshold);
+
+            if (!condition2) {
+                return false;
+            }
         }
-        if (cond1x) {
-            return cond2y;
-        }
-        if (cond1y) {
-            return cond2x;
-        }
-        return false;
+
+        return condition1 && condition2;
     };
 }
 

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -1,25 +1,12 @@
+import ScreenSpaceError from '../Core/ScreenSpaceError';
+import { SIZE_TEXTURE_TILE } from '../Core/Scheduler/Providers/OGCWebServiceHelper';
+
 function frustumCullingOBB(node, camera) {
     return camera.isBox3Visible(node.OBB().box3D, node.OBB().matrixWorld);
 }
 
 export function planarCulling(node, camera) {
     return !frustumCullingOBB(node, camera);
-}
-
-function _isTileBigOnScreen(camera, node) {
-    const onScreen = camera.box3SizeOnScreen(node.OBB().box3D, node.matrixWorld);
-
-    // onScreen.x/y/z are [-1, 1] so divide by 2
-    // (so x = 0.4 means the object width on screen is 40% of the total screen width)
-    const dim = {
-        x: 0.5 * (onScreen.max.x - onScreen.min.x),
-        y: 0.5 * (onScreen.max.y - onScreen.min.y),
-    };
-
-    // subdivide if on-screen width (and resp. height) is bigger than 30% of the screen width (resp. height)
-    // TODO: the 30% value is arbitrary and needs to be configurable by the user
-    // TODO: we might want to use texture resolution here as well
-    return (dim.x >= 0.3 && dim.y >= 0.3);
 }
 
 export function prePlanarUpdate(context, layer) {
@@ -48,7 +35,14 @@ export function planarSubdivisionControl(maxLevel, maxDeltaElevationLevel) {
             (node.level - currentElevationLevel) >= maxDeltaElevationLevel) {
             return false;
         }
-
-        return _isTileBigOnScreen(context.camera, node);
+        node.sse = ScreenSpaceError.computeFromBox3(
+            context.camera,
+            node.OBB().box3D,
+            node.OBB().matrixWorld,
+            node.geometricError,
+            ScreenSpaceError.MODE_2D);
+        node.sse.sse = Math.max(0, node.sse.sse - SIZE_TEXTURE_TILE);
+        node.sse.offset = SIZE_TEXTURE_TILE;
+        return node.sse.sse > layer.sseThreshold;
     };
 }

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -41,8 +41,22 @@ export function planarSubdivisionControl(maxLevel, maxDeltaElevationLevel) {
             node.OBB().matrixWorld,
             node.geometricError,
             ScreenSpaceError.MODE_2D);
-        node.sse.sse = Math.max(0, node.sse.sse - SIZE_TEXTURE_TILE);
         node.sse.offset = SIZE_TEXTURE_TILE;
-        return node.sse.sse > layer.sseThreshold;
+
+        const cond1x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold));
+        const cond1y = (node.sse.sse[1] > (SIZE_TEXTURE_TILE + layer.sseThreshold));
+        const cond2x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold) * 0.85);
+        const cond2y = (node.sse.sse[1] > (SIZE_TEXTURE_TILE + layer.sseThreshold) * 0.85);
+
+        if (cond1x && cond1y) {
+            return true;
+        }
+        if (cond1x) {
+            return cond2y;
+        }
+        if (cond1y) {
+            return cond2x;
+        }
+        return false;
     };
 }

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -1,5 +1,5 @@
 import ScreenSpaceError from '../Core/ScreenSpaceError';
-import { SIZE_TEXTURE_TILE } from '../Core/Scheduler/Providers/OGCWebServiceHelper';
+import { SIZE_TEXTURE_TILE } from '../Provider/OGCWebServiceHelper';
 
 function frustumCullingOBB(node, camera) {
     return camera.isBox3Visible(node.OBB().box3D, node.OBB().matrixWorld);

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -39,8 +39,7 @@ export function planarSubdivisionControl(maxLevel, maxDeltaElevationLevel) {
             context.camera,
             node.OBB().box3D,
             node.OBB().matrixWorld,
-            node.geometricError,
-            ScreenSpaceError.MODE_2D);
+            node.geometricError);
         node.sse.offset = SIZE_TEXTURE_TILE;
 
         const cond1x = (node.sse.sse[0] > (SIZE_TEXTURE_TILE + layer.sseThreshold));

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -70,7 +70,7 @@ function shouldDisplayNode(context, layer, elt) {
             // no point indicates shallow hierarchy, so we definitely want to load its children
             shouldBeLoaded = 1;
             elt.sse = {
-                sse: Infinity,
+                sse: [Infinity],
             };
         } else {
             elt.sse = ScreenSpaceError.computeFromBox3(context.camera,
@@ -78,7 +78,9 @@ function shouldDisplayNode(context, layer, elt) {
                     layer.object3d.matrixWorld,
                     elt.geometricError,
                     ScreenSpaceError.MODE_3D);
-            shouldBeLoaded = Math.min(1, elt.sse.sse / layer.sseThreshold);
+            shouldBeLoaded = Math.min(
+                1,
+                Math.min.apply(Math, elt.sse.sse) / layer.sseThreshold);
         }
         return shouldBeLoaded;
     }

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -76,8 +76,7 @@ function shouldDisplayNode(context, layer, elt) {
             elt.sse = ScreenSpaceError.computeFromBox3(context.camera,
                     cl,
                     layer.object3d.matrixWorld,
-                    elt.geometricError,
-                    ScreenSpaceError.MODE_3D);
+                    elt.geometricError);
             shouldBeLoaded = Math.min(
                 1,
                 Math.min.apply(Math, elt.sse.sse) / layer.sseThreshold);

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -96,6 +96,7 @@ export function processTiledGeometryNode(cullingTest, subdivisionTest) {
         if (!node.parent) {
             return ObjectRemovalHelper.removeChildrenAndCleanup(layer.id, node);
         }
+
         // early exit if parent' subdivision is in progress
         if (node.parent.pendingSubdivision) {
             node.visible = false;
@@ -132,6 +133,8 @@ export function processTiledGeometryNode(cullingTest, subdivisionTest) {
 
             // TODO: use Array.slice()
             return requestChildrenUpdate ? node.children.filter(n => n.layer == layer.id) : undefined;
+        } else {
+            node.sse = Infinity;
         }
 
         node.setDisplayed(false);

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -160,7 +160,7 @@ export default {
         layer.octreeDepthLimit = layer.octreeDepthLimit || -1;
         layer.pointBudget = layer.pointBudget || 15000000;
         layer.pointSize = layer.pointSize === 0 || !isNaN(layer.pointSize) ? layer.pointSize : 4;
-        layer.sseThreshold = layer.sseThreshold || 5;
+        layer.sseThreshold = layer.sseThreshold || 2;
         layer.type = 'geometry';
 
         // default update methods

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -83,7 +83,15 @@ function parseOctree(layer, hierarchyStepSize, root) {
                         const myname = childname.substr(root.name.length);
                         url = `${root.baseurl}/${myname}`;
                     }
-                    const item = { numPoints: n, childrenBitField: c, children: [], name: childname, baseurl: url, bbox: bounds };
+                    const item = {
+                        numPoints: n,
+                        childrenBitField: c,
+                        children: [],
+                        name: childname,
+                        baseurl: url,
+                        bbox: bounds,
+                        geometricError: layer.metadata.spacing / Math.pow(2, childname.length),
+                    };
                     snode.children.push(item);
                     stack.push(item);
                 }
@@ -152,7 +160,7 @@ export default {
         layer.octreeDepthLimit = layer.octreeDepthLimit || -1;
         layer.pointBudget = layer.pointBudget || 15000000;
         layer.pointSize = layer.pointSize === 0 || !isNaN(layer.pointSize) ? layer.pointSize : 4;
-        layer.overdraw = layer.overdraw || 2;
+        layer.sseThreshold = layer.sseThreshold || 5;
         layer.type = 'geometry';
 
         // default update methods
@@ -201,7 +209,12 @@ export default {
             return parseOctree(
                     layer,
                     layer.metadata.hierarchyStepSize,
-                    { baseurl: `${layer.url}/${cloud.octreeDir}/r`, name: '', bbox });
+                {
+                    baseurl: `${layer.url}/${cloud.octreeDir}/r`,
+                    name: '',
+                    bbox,
+                    geometricError: layer.metadata.spacing,
+                });
         }).then((root) => {
             // eslint-disable-next-line no-console
             console.log('LAYER metadata:', root);

--- a/src/Provider/TileProvider.js
+++ b/src/Provider/TileProvider.js
@@ -18,6 +18,7 @@ function preprocessDataLayer(layer, view, scheduler) {
 
     layer.level0Nodes = [];
     layer.onTileCreated = layer.onTileCreated || (() => {});
+    layer.sseThreshold = layer.sseThreshold || 5.0;
 
     const promises = [];
 

--- a/test/globe_test.js
+++ b/test/globe_test.js
@@ -24,8 +24,7 @@ function initialStateTest() {
 function afterSetRange() {
     // Our mock fetch() do not return proper elevation data, so to compute
     // the expected value the elevation layer needs to be disabled
-    assert.equal(itownsTesting.counters.displayed_at_level[12], 5);
-    assert.equal(itownsTesting.counters.displayed_at_level[13], 4);
+    assert.equal(itownsTesting.counters.displayed_at_level[12], 6);
 }
 
 var initialState = true;

--- a/test/planar_test.js
+++ b/test/planar_test.js
@@ -14,9 +14,8 @@ describe('Planar example', function () {
                 itownsTesting.countVisibleAndDisplayed(obj);
             }
 
-            assert.equal(itownsTesting.counters.displayed_at_level[2], 7);
-            assert.equal(itownsTesting.counters.displayed_at_level[3], 8);
-            assert.equal(itownsTesting.counters.displayed_at_level[4], 16);
+            assert.equal(itownsTesting.counters.displayed_at_level[2], 11);
+            assert.equal(itownsTesting.counters.displayed_at_level[3], 7);
 
             done();
         });

--- a/utils/debug/Main.js
+++ b/utils/debug/Main.js
@@ -3,3 +3,4 @@ export { default as PointCloudDebug } from './PointCloudDebug';
 export { default as createTileDebugUI } from './TileDebug';
 export { default as create3dTilesDebugUI } from './3dTilesDebug';
 export { default as GeometryDebug } from './GeometryDebug';
+export { default as ScreenSpaceErrorInspector } from './ScreenSpaceErrorInspector';

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -39,16 +39,15 @@ export default {
             .onChange(() => view.notifyChange(true));
         layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count')
             .onChange(() => view.notifyChange(true));
+        layer.debugUI.add(layer, 'sseThreshold', 1, 100).name('SSE threshold')
+            .onChange(() => view.notifyChange(true));
         layer.debugUI.add(layer.object3d.position, 'z', -50, 50).name('Z translation').onChange(() => {
             layer.object3d.updateMatrixWorld();
             view.notifyChange(true);
         });
-        const surf = layer.debugUI.addFolder('Surface Method params');
-        surf.add(layer, 'pointSize', 0, 15).name('Point Size')
+        layer.debugUI.add(layer, 'pointSize', 0, 15).name('Point Size')
             .onChange(() => view.notifyChange(true));
-        surf.add(layer, 'overdraw', 1, 5).name('Overdraw')
-            .onChange(() => view.notifyChange(true));
-        surf.add(layer, 'opacity', 0, 1).name('Opacity')
+        layer.debugUI.add(layer, 'opacity', 0, 1).name('Opacity')
             .onChange(() => view.notifyChange(true));
 
         // state

--- a/utils/debug/ScreenSpaceErrorInspector.js
+++ b/utils/debug/ScreenSpaceErrorInspector.js
@@ -1,0 +1,165 @@
+import * as THREE from 'three';
+
+function createDebugGeometry(view) {
+    const group = new THREE.Group();
+
+    for (let i = 0; i < 3; i++) {
+        const geom = new THREE.CircleGeometry(0.5, 30);
+        group.add(new THREE.Mesh(geom));
+    }
+
+    group.sseThreshold = group.children[0];
+    group.sseThreshold.material.color = new THREE.Color(0x00ff00);
+    group.sseThreshold.material.transparent = true;
+    group.sseThreshold.material.depthTest = false;
+    group.sseThreshold.material.opacity = 0.5;
+    group.sseThreshold.frustumCulled = false;
+    group.sseThreshold.renderOrder = 10;
+    group.sseValue = group.children[2];
+    group.sseValue.material.color = new THREE.Color(0xff0000);
+    group.sseValue.frustumCulled = false;
+    group.sseValue.material.depthTest = false;
+    group.sseValue.material.transparent = true;
+    group.sseValue.material.opacity = 0.5;
+    group.sseValue.renderOrder = 10;
+    group.sseShift = group.children[1];
+    group.sseShift.material.color = new THREE.Color(0xffff00);
+    group.sseShift.material.transparent = true;
+    group.sseShift.material.depthTest = false;
+    group.sseShift.material.opacity = 0.5;
+    group.sseShift.frustumCulled = false;
+    group.sseShift.renderOrder = 10;
+
+    group.frustumCulled = false;
+
+    view.scene.add(group);
+
+    return group;
+}
+
+
+function display(camera, sseResult, geometricError, sseThresholdPx, group, coords, scale) {
+    const m = new THREE.Matrix4().getInverse(
+        camera.camera3D.projectionMatrix);
+
+    const sseShift = sseResult.offset || 0;
+    // on scree
+    const ray = new THREE.Vector3(coords.x, coords.y, 0);
+    const ray2a = new THREE.Vector3(coords.x + (2 * (sseShift) / camera.width), coords.y, 0);
+    const ray2b = new THREE.Vector3(coords.x + (2 * (sseThresholdPx + sseShift) / camera.width), coords.y, 0);
+    const ray3 = new THREE.Vector3(coords.x + (2 * (sseResult.sse) / camera.width), coords.y, 0);
+    const rays = [ray, ray2a, ray2b, ray3];
+
+    for (const r of rays) {
+        // Transform in camera space
+        r.applyMatrix4(m);
+        // Scale back to desired z position
+        r.multiplyScalar(sseResult.distance / -r.z);
+        // Transform in world position
+        r.applyMatrix4(camera.camera3D.matrixWorld);
+    }
+
+    group.position.copy(ray);
+    group.rotation.copy(camera.camera3D.rotation);
+
+    const sseShiftWorld = ray2a.sub(ray).length();
+    const sseThresholdWorld = ray2b.sub(ray).length();
+    const sseValueWorld = ray3.sub(ray).length();
+
+    // draw a line to show sse threshold
+    group.sseShift.scale.set(sseShiftWorld * scale, sseShiftWorld * scale, 1);
+    group.sseThreshold.scale.set(sseThresholdWorld * scale, sseThresholdWorld * scale, 1);
+    // draw a line to show geometric error
+    // (both values are the same when using Math.max in ScreenSpaceError)
+    group.sseValue.scale.set(sseValueWorld * scale, sseValueWorld * scale, 1);
+
+    group.visible = true;
+    group.updateMatrixWorld(true);
+}
+
+function findValuesInParent(obj) {
+    if (obj.sse) {
+        return {
+            sse: obj.sse,
+            geometricError: obj.geometricError,
+        };
+    }
+    if (obj.parent) {
+        return findValuesInParent(obj.parent);
+    }
+}
+
+function onMouseMove(evt) {
+    const objects = this.view.pickObjectsAt(evt);
+    const v = this.group.visible;
+    this.group.visible = false;
+    if (objects.length > 0) {
+        if (objects[0].layer) {
+            const o = objects[0].object;
+            const layers = this.view.getLayers(l => l.id == objects[0].layer);
+            if (layers.length > 0) {
+                let sse = objects[0].object.sse;
+                let geometricError = o.geometricError;
+                if (!sse) {
+                    // Points ?
+                    if (o.owner) {
+                        sse = o.owner.sse;
+                        geometricError = o.owner.geometricError;
+                    } else {
+                        const c = findValuesInParent(o);
+                        sse = c.sse;
+                        geometricError = c.geometricError;
+                    }
+                }
+
+                if (sse) {
+                    const sseShift = sse.offset || 0;
+                    const percent = 100 * (sse.sse / (layers[0].sseThreshold + sseShift));
+                    this.sse = `${Math.round(Math.max(0, Math.min(100.0, percent)))} %`;
+                    display(
+                        this.view.camera,
+                        sse,
+                        geometricError,
+                        layers[0].sseThreshold,
+                        this.group,
+                        this.view.eventToNormalizedCoords(evt),
+                        this.scale);
+                    this.view.notifyChange(true);
+                }
+            }
+        }
+    }
+    if (v != this.group.visible) {
+        this.view.notifyChange(true);
+    }
+}
+
+
+export default {
+    create(datFolder, view) {
+        // add gui folder
+        const folder = datFolder.addFolder('Screen Space Error');
+
+        const state = {
+            enabled: false,
+            group: createDebugGeometry(view),
+            sse: '0',
+            view,
+            scale: 1,
+        };
+
+        const bound = onMouseMove.bind(state);
+        folder.add(state, 'enabled').onChange(() => {
+            if (state.enabled) {
+                view.mainLoop.gfxEngine.renderer.domElement.addEventListener(
+                    'mousemove', bound);
+            } else {
+                state.group.visible = false;
+                view.mainLoop.gfxEngine.renderer.domElement.removeEventListener(
+                    'mousemove', bound);
+            }
+        });
+        folder.add(state, 'sse', 0, 100).listen();
+        folder.add(state, 'scale', 1, 10);
+    },
+};

--- a/utils/debug/ScreenSpaceErrorInspector.js
+++ b/utils/debug/ScreenSpaceErrorInspector.js
@@ -47,7 +47,9 @@ function display(camera, sseResult, geometricError, sseThresholdPx, group, coord
     const ray = new THREE.Vector3(coords.x, coords.y, 0);
     const ray2a = new THREE.Vector3(coords.x + (2 * (sseShift) / camera.width), coords.y, 0);
     const ray2b = new THREE.Vector3(coords.x + (2 * (sseThresholdPx + sseShift) / camera.width), coords.y, 0);
-    const ray3 = new THREE.Vector3(coords.x + (2 * (sseResult.sse) / camera.width), coords.y, 0);
+    const ray3 = new THREE.Vector3(
+        coords.x + (2 * (sseResult.sse[0]) / camera.width),
+        coords.y + (2 * (sseResult.sse[1]) / camera.height), 0);
     const rays = [ray, ray2a, ray2b, ray3];
 
     for (const r of rays) {
@@ -64,14 +66,14 @@ function display(camera, sseResult, geometricError, sseThresholdPx, group, coord
 
     const sseShiftWorld = ray2a.sub(ray).length();
     const sseThresholdWorld = ray2b.sub(ray).length();
-    const sseValueWorld = ray3.sub(ray).length();
+    const sseValueWorld = ray3.sub(ray);
 
     // draw a line to show sse threshold
     group.sseShift.scale.set(sseShiftWorld * scale, sseShiftWorld * scale, 1);
     group.sseThreshold.scale.set(sseThresholdWorld * scale, sseThresholdWorld * scale, 1);
     // draw a line to show geometric error
     // (both values are the same when using Math.max in ScreenSpaceError)
-    group.sseValue.scale.set(sseValueWorld * scale, sseValueWorld * scale, 1);
+    group.sseValue.scale.set(sseValueWorld.x * scale, sseValueWorld.y * scale, 1);
 
     group.visible = true;
     group.updateMatrixWorld(true);

--- a/utils/debug/ScreenSpaceErrorInspector.js
+++ b/utils/debug/ScreenSpaceErrorInspector.js
@@ -147,7 +147,7 @@ function onMouseMove(evt) {
                                 Math.min(
                                     100,
                                     100 * (e / (layers[0].sseThreshold + sseShift))))));
-                    this.sse = percent.join('% ') + '%';
+                    this.sse = percent.join('% ');
                     display(
                         this.view.camera,
                         sse,


### PR DESCRIPTION
Until this PR each geometry type had its own SSE computation methods.
The goal of this PR is to provide a single method based on:
  - bounding-box (BB)
  - geometricError (in meters)
  - distance

The computation is simple:
  - transform camera in BB's basis
  - compute distance camera - BB
  - project geometricError on screen at distance

The last step produce a screen-space-error in pixels.

Geometric error values depend on the data type:
  - 3dtiles: the tileset defines a geometricError per node so we can use this value
  - pointcloud: PotreeConverter defines a spacing, which is the average distance
between points in each node. We use: geometricError = spacing / 2^depth
  - tiles: this PR adapted the existing formula to use consistent units

The second commit adds a SSE inspector debug tool:
![sse_inspector](https://user-images.githubusercontent.com/2198295/36847103-84733c3a-1d5d-11e8-961c-3136c82dc041.jpg)

red: computed SSE
yellow: texture resolution (only used for tile sse)
green: sse treshold

