### PR TITLE
feat(protocols): add spatial hashing to StaticProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,6 +2986,11 @@
         "write": "0.2.1"
       }
     },
+    "flatbush": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-1.2.0.tgz",
+      "integrity": "sha512-aqajjXSxILewVRHufGsY2eyzIxxXuGQlhGHwsV2tut+SjjP1D5XmmicY0BgVccO+uSK2V3VnQQ8tgWh/HFK/Ew=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.20.0",
     "earcut": "^2.1.1",
+    "flatbush": "^1.2.0",
     "js-priority-queue": "^0.1.5",
     "jszip": "^3.1.3",
     "monotone-convex-hull-2d": "^1.0.1",

--- a/src/Core/Scheduler/Providers/StaticProvider.js
+++ b/src/Core/Scheduler/Providers/StaticProvider.js
@@ -13,9 +13,9 @@ function _selectImagesFromSpatialIndex(index, images, extent) {
 
 // select the smallest image entirely covering the tile
 function selectBestImageForExtent(layer, extent) {
-    const candidates = (layer.extent.crs() == extent.crs()) ?
-        _selectImagesFromSpatialIndex(layer._spatialIndex, layer.images, extent) :
-        layer.images;
+    const candidates =
+        _selectImagesFromSpatialIndex(
+            layer._spatialIndex, layer.images, extent.as(layer.extent.crs()));
 
     let selection;
     for (const entry of candidates) {
@@ -148,17 +148,8 @@ export default {
             return false;
         }
 
-        if (tile.extent.crs() == layer.extent.crs()) {
-            return _selectImagesFromSpatialIndex(
-                layer._spatialIndex, layer.images, tile.extent).length > 0;
-        } else {
-            for (const entry of layer.images) {
-                if (tile.extent.isInside(entry.extent)) {
-                    return true;
-                }
-            }
-            return false;
-        }
+        return _selectImagesFromSpatialIndex(
+            layer._spatialIndex, layer.images, tile.extent.as(layer.extent.crs())).length > 0;
     },
 
     canTileTextureBeImproved(layer, tile) {


### PR DESCRIPTION
Using https://github.com/mourner/flatbush speeds up the look up by a factor of 10.

For instance, on my computer and the panorama demo:
  - before the PR selectBestImageForExtent used to take 0.5ms to 3ms
  - after the PR: <= 0.1ms
