### PR TITLE
fix(protocols): fix wrong orientation in panorama

### DIFF
--- a/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
+++ b/src/Core/Prefab/Panorama/PanoramaTileBuilder.js
@@ -80,7 +80,7 @@ PanoramaTileBuilder.prototype.VertexNormal = function VertexNormal() {
 // coord u tile to projected
 PanoramaTileBuilder.prototype.uProjecte = function uProjecte(u, params) {
     // both (theta, phi) and (y, z) are swapped in setFromSpherical
-    params.projected.theta = Math.PI - THREE.Math.lerp(
+    params.projected.theta = Math.PI * 0.5 - THREE.Math.lerp(
         params.extent.east(UNIT.RADIAN),
         params.extent.west(UNIT.RADIAN),
         1 - u);

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -174,16 +174,18 @@ function PanoramaView(viewerDiv, coordinates, ratio, options = {}) {
     View.call(this, coordinates.crs, viewerDiv, options);
 
     // Configure camera
-    coordinates.xyz(this.camera.camera3D.position);
-    this.camera.camera3D.fov = 45;
+    const camera = this.camera.camera3D;
+    coordinates.xyz(camera.position);
 
-    this.camera.camera3D.near = 0.1;
-    this.camera.camera3D.far = 1000;
-    this.camera.camera3D.up = coordinates.geodesicNormal;
-    this.camera.camera3D.quaternion.setFromUnitVectors(
-        new THREE.Vector3(0, 1, 0), coordinates.geodesicNormal);
-    this.camera.camera3D.updateProjectionMatrix();
-    this.camera.camera3D.updateMatrixWorld();
+    camera.fov = 45;
+    camera.near = 0.1;
+    camera.far = 1000;
+    camera.up = coordinates.geodesicNormal;
+    // look at to the north
+    camera.lookAt(new THREE.Vector3(0, 1, 0).add(camera.position));
+
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld();
 
     const tileLayer = createPanoramaLayer('panorama', coordinates, ratio, options);
 


### PR DESCRIPTION
## Description
panorama's Y axis (north) look at the image pano's center
and by default pano's camera look at the same north