### PR TITLE
Improve panorama support

### DIFF
--- a/examples/panorama.html
+++ b/examples/panorama.html
@@ -75,6 +75,9 @@
                         protocol: 'static',
                         id: _id,
                         projection: 'EPSG:4326',
+                        updateStrategy: {
+                            type: itowns.STRATEGY_DICHOTOMY,
+                        }
                     }).then(() => {
                         view.notifyChange(false);
                     });

--- a/src/Core/Layer/LayerUpdateStrategy.js
+++ b/src/Core/Layer/LayerUpdateStrategy.js
@@ -37,9 +37,9 @@ function _progressive(nodeLevel, currentLevel, options) {
 // Load textures at mid-point between current level and node's level.
 // This produces smoother transitions and a single fetch updates multiple
 // tiles thanks to caching.
-function _dichotomy(nodeLevel, currentLevel, options) {
+function _dichotomy(nodeLevel, currentLevel, options = {}) {
     if (currentLevel == EMPTY_TEXTURE_ZOOM) {
-        return options.zoom.min;
+        return options.zoom ? options.zoom.min : 0;
     }
     return Math.min(
         nodeLevel,

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -10,6 +10,7 @@ import { panoramaCulling, panoramaSubdivisionControl } from '../../Process/Panor
 import PanoramaTileBuilder from './Panorama/PanoramaTileBuilder';
 import SubdivisionControl from '../../Process/SubdivisionControl';
 import ProjectionType from './Panorama/Constants';
+import Picking from '../Picking';
 
 export function createPanoramaLayer(id, coordinates, type, options = {}) {
     const tileLayer = new GeometryLayer(id, options.object3d || new THREE.Group());
@@ -167,6 +168,9 @@ export function createPanoramaLayer(id, coordinates, type, options = {}) {
         enable: false,
         position: { x: -0.5, y: 0.0, z: 1.0 },
     };
+    // provide custom pick function
+    tileLayer.pickObjectsAt = (_view, mouse) => Picking.pickTilesAt(_view, mouse, tileLayer);
+
 
     return tileLayer;
 }

--- a/src/Process/PanoramaTileProcessing.js
+++ b/src/Process/PanoramaTileProcessing.js
@@ -30,6 +30,10 @@ function _isTileBiggerThanTexture(camera, textureSize, quality, node) {
 
 export function panoramaSubdivisionControl(maxLevel, textureSize) {
     return function _panoramaSubdivisionControl(context, layer, node) {
+        if (node.level < 1) {
+            return true;
+        }
+
         if (maxLevel <= node.level) {
             return false;
         }


### PR DESCRIPTION
PR with small fixes and addition, to improve panorama support in iTowns.

3 commits content:
```
feat(protocols): implement targetLevel for StaticProvider
fix(panorama): improve default settings for Panorama
fix(core): assume min level is 0 if not provided for dichotomy strategy
```