### PR TITLE
fix(provider): Allow WFS layer to have any format

### DIFF
--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -68,6 +68,7 @@ function acceptFeatureBus(properties) {
 }
 
 globeView.addLayer({
+    name: 'lyon_tcl_bus',
     type: 'geometry',
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
@@ -88,7 +89,7 @@ globeView.addLayer({
         south: 5138876.75,
         north: 5205890.19,
     },
-    format: 'application/geojson',
+    format: 'geojson',
 }, globeView.tileLayer);
 
 function colorBuildings(properties) {

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -59,6 +59,7 @@ function colorLine(properties) {
 }
 
 view.addLayer({
+    name: 'lyon_tcl_bus',
     update: itowns.FeatureProcessing.update,
     convert: itowns.Feature2Mesh.convert({
         color: colorLine }),
@@ -76,7 +77,7 @@ view.addLayer({
         south: 5138876.75,
         north: 5205890.19,
     },
-    format: 'application/geojson',
+    format: 'geojson',
 }, view.tileLayer);
 
 function colorBuildings(properties) {

--- a/src/Core/Scheduler/Providers/Fetcher.js
+++ b/src/Core/Scheduler/Providers/Fetcher.js
@@ -5,7 +5,7 @@ const textureLoader = new TextureLoader();
 function checkResponse(response) {
     if (!response.ok) {
         var error = new Error(`Error loading ${response.url}: status ${response.status}`);
-        error.status = response.status;
+        error.response = response;
         throw error;
     }
 }

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -85,7 +85,27 @@ function getFeatures(crs, tile, layer) {
 
     layer.convert = layer.convert ? layer.convert : Feature2Mesh.convert({});
 
-    return Fetcher.json(urld, layer.networkOptions).then(geojson => assignLayer(layer.convert(GeoJSON2Features.parse(crs, geojson, tile.extent, { filter: layer.filter })), layer));
+    return Fetcher.json(urld, layer.networkOptions).then(
+        geojson => assignLayer(layer.convert(GeoJSON2Features.parse(crs, geojson, tile.extent, { filter: layer.filter })), layer),
+        (err) => {
+            // special handling for 400 errors, as it probably means the config is wrong
+            if (err.response.status == 400) {
+                return err.response.text().then((text) => {
+                    const getCapUrl = `${layer.url}SERVICE=WFS&REQUEST=GetCapabilities&VERSION=${layer.version}`;
+                    const xml = new DOMParser().parseFromString(text, 'application/xml');
+                    const errorElem = xml.querySelector('Exception');
+                    const errorCode = errorElem.getAttribute('exceptionCode');
+                    const errorMessage = errorElem.querySelector('ExceptionText').textContent;
+                    // eslint-disable-next-line no-console
+                    console.error(`Layer ${layer.name}: bad request when fetching data. Server says: "${errorCode}: ${errorMessage}". \nReviewing ${getCapUrl} may help.`, err);
+                    throw err;
+                });
+            } else {
+                // eslint-disable-next-line no-console
+                console.error(`Layer ${layer.name}: ${err.response.status} error while trying to fetch WFS data. Url was ${urld}.`, err);
+                throw err;
+            }
+        });
 }
 
 export default {

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -12,9 +12,6 @@ import Feature2Mesh from '../../../Renderer/ThreeExtended/Feature2Mesh';
 
 const cache = CacheRessource();
 
-// TODO : support xml, gml2
-const supportedFormats = ['application/json', 'application/geojson'];
-
 function url(bbox, layer) {
     const box = bbox.as(layer.projection);
     const w = box.west();
@@ -34,9 +31,6 @@ function preprocessDataLayer(layer) {
     }
 
     layer.format = layer.format || 'application/json';
-    if (!supportedFormats.includes(layer.format)) {
-        throw new Error(`Layer ${layer.name}: unsupported layer.format '${layer.format}', must be one of '${supportedFormats.join('\', \'')}'`);
-    }
 
     layer.crs = layer.projection || 'EPSG:4326';
     layer.version = layer.version || '2.0.2';


### PR DESCRIPTION
Followup on #597 : it broke the wfs examples. 

Actually I was wrong for WFS: the spec allows any string in their format parameter. Therefore, I can't restrict layer.format to a mimetype. So I reverted the modification in the examples, and as a quick fix I removed the check on WFS layers. 

A more exact check could be implemented (properly catching the Fetcher.json results maybe?) to have better error messages.
