### PR TITLE
chore: change the no-console property of eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
     'brace-style': 'off',
     'new-cap': 'off',
     'no-continue': 'off',
+    'no-console': [ 'warn', { allow: ['warn', 'error'] } ],
   },
   "globals": {
     "__DEBUG__": false

--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -162,7 +162,6 @@ function b3dmToMesh(data, layer, url) {
                             && mesh.material.isRawShaderMaterial
                             && !layer.doNotPatchMaterial) {
                     patchMaterialForLogDepthSupport(mesh.material);
-                    // eslint-disable-next-line no-console
                     console.warn('b3dm shader has been patched to add log depth buffer support');
                 }
                 mesh.material.transparent = layer.opacity < 1.0;

--- a/src/Core/Scheduler/Providers/GpxUtils.js
+++ b/src/Core/Scheduler/Providers/GpxUtils.js
@@ -118,7 +118,6 @@ function _gpxToWTrackPointsMesh(gpxXML, options) {
                 if (Capabilities.isLogDepthBufferSupported()) {
                     material.fragmentShader = material.fragmentShader.replace(/.*/, '').substr(1);
                     patchMaterialForLogDepthSupport(material);
-                    // eslint-disable-next-line no-console
                     console.warn('MeshLineMaterial shader has been patched to add log depth buffer support');
                 }
 

--- a/src/Core/Scheduler/Providers/PointCloudProvider.js
+++ b/src/Core/Scheduler/Providers/PointCloudProvider.js
@@ -102,7 +102,6 @@ function addPickingAttribute(points) {
     const baseId = nextuuid++;
     if (numPoints > 0xffff || baseId > 0xffff) {
         // TODO: fixme
-        // eslint-disable-next-line no-console
         console.warn('Currently picking is limited to Points with less than 65535 elements and less than 65535 Points instances');
         return points;
     }

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -96,12 +96,10 @@ function getFeatures(crs, tile, layer) {
                     const errorElem = xml.querySelector('Exception');
                     const errorCode = errorElem.getAttribute('exceptionCode');
                     const errorMessage = errorElem.querySelector('ExceptionText').textContent;
-                    // eslint-disable-next-line no-console
                     console.error(`Layer ${layer.name}: bad request when fetching data. Server says: "${errorCode}: ${errorMessage}". \nReviewing ${getCapUrl} may help.`, err);
                     throw err;
                 });
             } else {
-                // eslint-disable-next-line no-console
                 console.error(`Layer ${layer.name}: ${err.response.status} error while trying to fetch WFS data. Url was ${urld}.`, err);
                 throw err;
             }

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -59,7 +59,6 @@ function _instanciateQueue() {
                 cmd.reject(err);
                 this.counters.failed++;
                 if (__DEBUG__ && this.counters.failed < 3) {
-                    // eslint-disable-next-line no-console
                     console.error(err);
                 }
             });

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -113,7 +113,6 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
     layer.options = layer.options || {};
     // TODO remove this warning and fallback after the release following v2.3.0
     if (!layer.format && layer.options.mimetype) {
-        // eslint-disable-next-line no-console
         console.warn('layer.options.mimetype is deprecated, please use layer.format');
         layer.format = layer.options.mimetype;
     }

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -28,9 +28,7 @@ function initNodeImageryTexturesFromParent(node, parent, layer) {
 
         if (__DEBUG__) {
             if ((textureIndex - offsetTextures) != coords.length) {
-                /* eslint-disable */
                 console.error(`non-coherent result ${textureIndex} ${offsetTextures} vs ${coords.length}. ${coords}`);
-                /* eslint-enable */
             }
         }
         const index = node.material.indexOfColorLayer(layer.id);
@@ -282,7 +280,6 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
                 node.layerUpdateState[layer.id].success();
             } else {
                 if (__DEBUG__) {
-                    // eslint-disable-next-line no-console
                     console.warn(`Imagery texture update error for ${node}: ${err}`);
                 }
                 const definitiveError = node.layerUpdateState[layer.id].errorCount > MAX_RETRY;
@@ -404,7 +401,6 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
                 node.layerUpdateState[layer.id].success();
             } else {
                 if (__DEBUG__) {
-                    // eslint-disable-next-line no-console
                     console.warn(`Elevation texture update error for ${node}: ${err}`);
                 }
                 const definitiveError = node.layerUpdateState[layer.id].errorCount > MAX_RETRY;

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1115,7 +1115,6 @@ function GlobeControls(view, target, radius, options = {}) {
         if (this.enabled === false) return;
 
         if (!this.isAnimationEnabled()) {
-             // eslint-disable-next-line no-console
             console.warn('double click without animation is disabled, waiting fix in future refactoring');
             return;
         }

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -58,7 +58,6 @@ function c3DEngine(rendererOrDiv, options = {}) {
             logarithmicDepthBuffer: options.logarithmicDepthBuffer,
         });
     } catch (ex) {
-        // eslint-disable-next-line no-console
         console.error('Failed to create WebGLRenderer', ex);
         this.renderer = null;
     }
@@ -186,7 +185,6 @@ c3DEngine.prototype.getUniqueThreejsLayer = function getUniqueThreejsLayer() {
     // one to each new geometry layer.
     // Warning: only 32 ([0, 31]) different layers can exist.
     if (this._nextThreejsLayer > 31) {
-        // eslint-disable-next-line no-console
         console.warn('Too much three.js layers. Starting from now all of them will use layerMask = 31');
         this._nextThreejsLayer = 31;
     }


### PR DESCRIPTION
Change the no-console property to a more permissive one, allowing
console.error and console.warn statement, and removing the annotation in
some file about already present statement.