### PR TITLE
feat(core): move url function outside providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
-    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js src/Core/MainLoop.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
+    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js src/Core/MainLoop.js src/Core/Scheduler/Providers/URLBuilder.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",

--- a/src/Core/Scheduler/Providers/TMS_Provider.js
+++ b/src/Core/Scheduler/Providers/TMS_Provider.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
+import URLBuilder from './URLBuilder';
 import Extent from '../../Geographic/Extent';
 
 function preprocessDataLayer(layer) {
@@ -24,14 +25,6 @@ function preprocessDataLayer(layer) {
     }
 }
 
-function url(coTMS, layer) {
-    /* eslint-disable no-template-curly-in-string */
-    return layer.url.replace('${z}', coTMS.zoom)
-        .replace('${y}', coTMS.row)
-        .replace('${x}', coTMS.col);
-    /* eslint-enable no-template-curly-in-string */
-}
-
 function executeCommand(command) {
     const layer = command.layer;
     const tile = command.requester;
@@ -42,7 +35,7 @@ function executeCommand(command) {
             OGCWebServiceHelper.WMTS_WGS84Parent(coordTMS, command.targetLevel) :
             undefined;
 
-        const urld = url(coordTMSParent || coordTMS, layer);
+        const urld = URLBuilder.xyz(coordTMSParent || coordTMS, layer);
 
         promises.push(OGCWebServiceHelper.getColorTextureByUrl(urld, layer.networkOptions).then((texture) => {
             const result = {};

--- a/src/Core/Scheduler/Providers/URLBuilder.js
+++ b/src/Core/Scheduler/Providers/URLBuilder.js
@@ -1,0 +1,88 @@
+/**
+ * @module URLBuilder
+ */
+export default {
+    /**
+     * Builds an URL knowing the coordinates and the layer to query.
+     * <br><br>
+     * The layer object needs to have an url property, which should have some
+     * specific strings that will be replaced by coordinates.
+     * <ul>
+     * <li><code>${x}</code> or <code>%COL</code> will be replaced by
+     * <code>coords.col</code></li>
+     * <li><code>${y}</code> or <code>%ROW</code> will be replaced by
+     * <code>coords.row</code></li>
+     * <li><code>${z}</code> or <code>%TILEMATRIX</code> will be replaced by
+     * <code>coords.zoom</code></li>
+     * </ul>
+     *
+     * @example
+     * coords = new Coordinates('WMTS:WGS84', 12, 1410, 2072);
+     * layer.url = 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=%TILEMATRIX&TILEROW=%ROW&TILECOL=%COL';
+     * url = URLBuilder.xyz(coords, layer);
+     *
+     * // The resulting url is:
+     * // http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=12&TILEROW=1410&TILECOL=2072;
+     *
+     * @example
+     * coords = new Extent('TMS', 15, 2142, 3412);
+     * layer.url = 'http://server.geo/tms/${z}/${y}/${x}.jpg';
+     * url = URLBuilder.xyz(coords, layer);
+     *
+     * // The resulting url is:
+     * // http://server.geo/tms/15/2142/3412.jpg;
+     *
+     * @param {Extent} coords - the coordinates
+     * @param {Layer} layer
+     *
+     * @return {string} the formed url
+     */
+    xyz: function xyz(coords, layer) {
+        return layer.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
+            .replace(/(\$\{y\}|%ROW)/, coords.row)
+            .replace(/(\$\{x\}|%COL)/, coords.col);
+    },
+
+    /**
+     * Builds an URL knowing the bounding box and the layer to query.
+     * <br><br>
+     * The layer object needs to have an url property, which should have the
+     * string <code>%bbox</code> in it. This string will be replaced by the four
+     * cardinal points composing the bounding box.
+     * <br><br>
+     * Order of the points can be specified in the <code>axisOrder</code>
+     * property in layer, using the letters <code>w, s, e, n</code> respectively
+     * for <code>WEST, SOUTH, EAST, NORTH</code>. The default order is
+     * <code>wsen</code>.
+     *
+     * @example
+     * extent = new Extent('EPSG:4326', 12, 14, 35, 46);
+     * layer.projection = 'EPSG:4326';
+     * layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
+     * url = URLBuilder.bbox(extent, layer);
+     *
+     * // The resulting url is:
+     * // http://server.geo/wms/BBOX=12,35,14,46&FORMAT=jpg&SERVICE=WMS
+     *
+     * @param {Extent} bbox - the bounding box
+     * @param {Layer} layer
+     *
+     * @return {string} the formed url
+     */
+    bbox: function bbox(bbox, layer) {
+        const box = bbox.as(layer.projection);
+        const w = box.west();
+        const s = box.south();
+        const e = box.east();
+        const n = box.north();
+
+        let bboxInUnit = layer.axisOrder || 'wsen';
+        bboxInUnit = bboxInUnit.replace('w', `${w},`)
+            .replace('s', `${s},`)
+            .replace('e', `${e},`)
+            .replace('n', `${n},`)
+            .slice(0, -1);
+
+        return layer.url.replace('%bbox', bboxInUnit);
+    },
+};

--- a/src/Core/Scheduler/Providers/WFS_Provider.js
+++ b/src/Core/Scheduler/Providers/WFS_Provider.js
@@ -5,25 +5,13 @@
  */
 
 import Extent from '../../Geographic/Extent';
+import URLBuilder from './URLBuilder';
 import Fetcher from './Fetcher';
 import CacheRessource from './CacheRessource';
 import GeoJSON2Features from '../../../Renderer/ThreeExtended/GeoJSON2Features';
 import Feature2Mesh from '../../../Renderer/ThreeExtended/Feature2Mesh';
 
 const cache = CacheRessource();
-
-function url(bbox, layer) {
-    const box = bbox.as(layer.projection);
-    const w = box.west();
-    const s = box.south();
-    const e = box.east();
-    const n = box.north();
-
-    // TODO: use getPointOrder
-    const bboxInUnit = `${w},${s},${e},${n}`;
-
-    return layer.customUrl.replace('%bbox', bboxInUnit);
-}
 
 function preprocessDataLayer(layer) {
     if (!layer.typeName) {
@@ -39,7 +27,7 @@ function preprocessDataLayer(layer) {
     if (!(layer.extent instanceof Extent)) {
         layer.extent = new Extent(layer.projection, layer.extent);
     }
-    layer.customUrl = `${layer.url
+    layer.url = `${layer.url
                       }SERVICE=WFS&REQUEST=GetFeature&typeName=${layer.typeName
                       }&VERSION=${layer.version
                       }&SRSNAME=${layer.crs
@@ -74,10 +62,10 @@ function getFeatures(crs, tile, layer) {
         return Promise.resolve();
     }
 
-    const urld = url(tile.extent.as(layer.crs), layer);
+    const urld = URLBuilder.bbox(tile.extent.as(layer.crs), layer);
     const result = {};
 
-    result.feature = cache.getRessource(url);
+    result.feature = cache.getRessource(urld);
 
     if (result.feature !== undefined) {
         return Promise.resolve(result);

--- a/src/Core/Scheduler/Providers/WMS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMS_Provider.js
@@ -7,22 +7,9 @@
 import * as THREE from 'three';
 import Extent from '../../Geographic/Extent';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
+import URLBuilder from './URLBuilder';
 
 const supportedFormats = ['image/png', 'image/jpg', 'image/jpeg'];
-
-function url(bbox, layer) {
-    const box = bbox.as(layer.projection);
-    const w = box.west();
-    const s = box.south();
-    const e = box.east();
-    const n = box.north();
-
-    const bboxInUnit = layer.axisOrder === 'swne' ?
-        `${s},${w},${n},${e}` :
-        `${w},${s},${e},${n}`;
-
-    return layer.customUrl.replace('%bbox', bboxInUnit);
-}
 
 function tileTextureCount(tile, layer) {
     return tile.extent.crs() == layer.projection ? 1 : tile.getCoordsForLayer(layer).length;
@@ -73,7 +60,7 @@ function preprocessDataLayer(layer) {
         crsPropName = 'CRS';
     }
 
-    layer.customUrl = `${layer.url
+    layer.url = `${layer.url
                   }?SERVICE=WMS&REQUEST=GetMap&LAYERS=${layer.name
                   }&VERSION=${layer.version
                   }&STYLES=${layer.style
@@ -116,7 +103,7 @@ function getColorTexture(tile, layer, targetLevel, tileCoords) {
     }
 
     const coords = extent.as(layer.projection);
-    const urld = url(coords, layer);
+    const urld = URLBuilder.bbox(coords, layer);
     const pitch = tileCoords ? new THREE.Vector4(0, 0, 1, 1) : tile.extent.offsetToParent(extent);
     const result = { pitch };
 

--- a/src/Core/Scheduler/Providers/WMTS_Provider.js
+++ b/src/Core/Scheduler/Providers/WMTS_Provider.js
@@ -6,6 +6,7 @@
 
 import * as THREE from 'three';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
+import URLBuilder from './URLBuilder';
 import Extent from '../../Geographic/Extent';
 
 const coordTile = new Extent('WMTS:WGS84', 0, 0, 0);
@@ -16,15 +17,6 @@ const supportedFormats = new Map([
     ['image/jpeg', getColorTextures],
     ['image/x-bil;bits=32', getXbilTexture],
 ]);
-
-
-function customUrl(layer, url, tilematrix, row, col) {
-    let urld = url.replace('%TILEMATRIX', tilematrix.toString());
-    urld = urld.replace('%ROW', row.toString());
-    urld = urld.replace('%COL', col.toString());
-
-    return urld;
-}
 
 function preprocessDataLayer(layer) {
     layer.fx = layer.fx || 0.0;
@@ -63,19 +55,9 @@ function preprocessDataLayer(layer) {
                 max: maxZoom,
             };
         }
-        layer.customUrl = newBaseUrl;
+        layer.url = newBaseUrl;
     }
     layer.options.zoom = layer.options.zoom || { min: 2, max: 20 };
-}
-
-/**
- * Return url wmts orthophoto
- * @param {{zoom:number,row:number,col:number}} coWMTS
- * @param {Layer} layer
- * @returns {string}
- */
-function url(coWMTS, layer) {
-    return customUrl(layer, layer.customUrl, coWMTS.zoom, coWMTS.row, coWMTS.col);
 }
 
 /**
@@ -93,7 +75,7 @@ function getXbilTexture(tile, layer, targetZoom) {
         coordWMTS = OGCWebServiceHelper.WMTS_WGS84Parent(coordWMTS, targetZoom, pitch);
     }
 
-    const urld = url(coordWMTS, layer);
+    const urld = URLBuilder.xyz(coordWMTS, layer);
 
     return OGCWebServiceHelper.getXBilTextureByUrl(urld, layer.networkOptions).then((texture) => {
         texture.coords = coordWMTS;
@@ -114,7 +96,7 @@ function getXbilTexture(tile, layer, targetZoom) {
  * @returns {Promise<Texture>}
  */
 function getColorTexture(coordWMTS, layer) {
-    const urld = url(coordWMTS, layer);
+    const urld = URLBuilder.xyz(coordWMTS, layer);
     return OGCWebServiceHelper.getColorTextureByUrl(urld, layer.networkOptions).then((texture) => {
         const result = {};
         result.texture = texture;

--- a/test/provider_url_unit_test.js
+++ b/test/provider_url_unit_test.js
@@ -1,0 +1,40 @@
+/* global describe, it */
+/* eslint-disable no-template-curly-in-string */
+import assert from 'assert';
+import URLBuilder from '../src/Core/Scheduler/Providers/URLBuilder';
+import Extent from '../src/Core/Geographic/Extent';
+
+const layer = {};
+
+describe('URL creations', function () {
+    it('should correctly replace ${x}, ${y} and ${z} to 359, 512 and 10', function () {
+        var coords = new Extent('TMS', 10, 512, 359);
+        layer.url = 'http://server.geo/tms/${z}/${y}/${x}.jpg';
+        var result = URLBuilder.xyz(coords, layer);
+        assert.equal(result, 'http://server.geo/tms/10/512/359.jpg');
+    });
+
+    it('should correctly replace %COL, %ROW, %TILEMATRIX to 2072, 1410 and 12', function () {
+        var coords = new Extent('WMTS:WGS84', 12, 1410, 2072);
+        layer.url = 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=%TILEMATRIX&TILEROW=%ROW&TILECOL=%COL';
+        var result = URLBuilder.xyz(coords, layer);
+        assert.equal(result, 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=12&TILEROW=1410&TILECOL=2072');
+    });
+
+    it('should correctly replace %bbox to 12,35,14,46', function () {
+        var extent = new Extent('EPSG:4326', 12, 14, 35, 46);
+        layer.projection = 'EPSG:4326';
+        layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
+        var result = URLBuilder.bbox(extent, layer);
+        assert.equal(result, 'http://server.geo/wms/BBOX=12,35,14,46&FORMAT=jpg&SERVICE=WMS');
+    });
+
+    it('should correctly replace %bbox to 12,14,35,46', function () {
+        var extent = new Extent('EPSG:4326', 12, 14, 35, 46);
+        layer.projection = 'EPSG:4326';
+        layer.axisOrder = 'wesn';
+        layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
+        var result = URLBuilder.bbox(extent, layer);
+        assert.equal(result, 'http://server.geo/wms/BBOX=12,14,35,46&FORMAT=jpg&SERVICE=WMS');
+    });
+});


### PR DESCRIPTION
## Description
url functions in some provider (tms, wfs, wms and wmts) share quite the same content. Following the work in #182, these functions can be put outside the providers without problem.

Full documentation has been added, for easier usage outside the core, and unit testing as well.

## Motivation and Context
This comes in the work of #182, part of rewriting the Providers/Loader/etc system.
