### PR TITLE
Fix(View): fix event vs mouse detection when picking

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -547,8 +547,7 @@ View.prototype.pickObjectsAt = function pickObjectsAt(mouseOrEvt, ...where) {
         this.getLayers(l => l.type == 'geometry') :
         [...where];
 
-    const mouse = (mouseOrEvt.x === undefined) ?
-        this.eventToViewCoords(mouseOrEvt) : mouseOrEvt;
+    const mouse = (mouseOrEvt instanceof Event) ? this.eventToViewCoords(mouseOrEvt) : mouseOrEvt;
 
     for (const source of sources) {
         if (source instanceof GeometryLayer ||


### PR DESCRIPTION
mouseEvent.x actually exists in Firefox and IE, see:
https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/x

This fixes picking in Firefox