### PR TITLE
fix(panorama): change flatbush version and import line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2987,9 +2987,9 @@
       }
     },
     "flatbush": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-1.2.0.tgz",
-      "integrity": "sha512-aqajjXSxILewVRHufGsY2eyzIxxXuGQlhGHwsV2tut+SjjP1D5XmmicY0BgVccO+uSK2V3VnQQ8tgWh/HFK/Ew=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-1.3.0.tgz",
+      "integrity": "sha512-bbkYUka6M8uOW1Mjh9X0ADsIPcGoe6Gd1fYUoIbnZBDQpRj1t0i24gPxM1D5+bCTtLhUIpQiacv3ETvCDxPfsA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.20.0",
     "earcut": "^2.1.1",
-    "flatbush": "^1.2.0",
+    "flatbush": "^1.3.0",
     "js-priority-queue": "^0.1.5",
     "jszip": "^3.1.3",
     "monotone-convex-hull-2d": "^1.0.1",

--- a/src/Core/Scheduler/Providers/StaticProvider.js
+++ b/src/Core/Scheduler/Providers/StaticProvider.js
@@ -1,4 +1,4 @@
-import * as FlatBush from 'flatbush';
+import flatbush from 'flatbush';
 import { Vector4 } from 'three';
 import Extent from '../../Geographic/Extent';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
@@ -121,7 +121,7 @@ export default {
                     extent,
                 });
             }
-            layer._spatialIndex = FlatBush(layer.images.length);
+            layer._spatialIndex = flatbush(layer.images.length);
             for (const image of layer.images) {
                 layer._spatialIndex.add(
                     image.extent.west(),


### PR DESCRIPTION
flatbush applied a [breaking change](https://github.com/mourner/flatbush/commit/7cc362a3e4d26293a559353dbe7e92f53fd47f62) in a minor version.
So this commits forces upgrade to the new version and adapts the import line.

