### PR TITLE
refactor(vector): rework feature support

### DIFF
--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -175,8 +175,14 @@ function selectRoad(properties) {
 }
 
 function altitudePoint(properties, contour) {
+    var result;
+    var z = 0;
     if (contour.length && contour.length > 0) {
-        return itowns.DEMUtils.getElevationValueAt(globeView.wgs84TileLayer, contour[0]).z + 5;
+        result = itowns.DEMUtils.getElevationValueAt(globeView.wgs84TileLayer, contour[0]);
+        if (result) {
+            z = result.z;
+        }
+        return z + 5;
     }
     return 0;
 }

--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -37,11 +37,11 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                 layer = layers[i];
                 result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(
                     geoCoord, layer.feature, precision);
-                result.sort(function compare(a, b) { return b.type !== 'point'; });
+                result.sort(function compare(a, b) { return b.feature.geometry.type !== 'point'; });
                 for (p = 0; p < result.length; p++) {
                     visible = true;
-                    if (result[p].type === 'polygon') {
-                        polygon = result[p];
+                    if (result[p].feature.geometry.type === 'polygon') {
+                        polygon = result[p].feature;
                         color = polygon.properties.fill || layer.style.fill;
                         stroke = polygon.properties.stroke || layer.style.stroke;
                         name = 'polygon' + id;
@@ -50,13 +50,13 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                         document.getElementById(name).style['-webkit-text-stroke'] = '1.25px ' + stroke;
                         document.getElementById(name).style.color = color;
                         ++id;
-                    } else if (result[p].type === 'linestring') {
-                        line = result[p];
+                    } else if (result[p].feature.geometry.type === 'linestring') {
+                        line = result[p].feature;
                         color = line.properties.stroke || layer.style.stroke;
                         symb = '<span style=color:' + color + ';>&#9473</span>';
                         tooltip.innerHTML += symb + ' ' + (line.name || layer.name) + '<br />';
-                    } else if (result[p].type === 'point') {
-                        point = result[p];
+                    } else if (result[p].feature.geometry.type === 'point') {
+                        point = result[p].feature;
                         color = 'white';
                         name = 'point' + id;
                         symb = '<span id=' + name + ' style=color:' + color + ';>&#9679</span>';

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -51,7 +51,11 @@ new itowns.PlanarControls(view, {});
 view.notifyChange(true);
 
 function setMaterialLineWidth(result) {
-    result.children[0].material.linewidth = 5;
+    result.traverse(function _setLineWidth(mesh) {
+        if (mesh.material) {
+            mesh.material.linewidth = 5;
+        }
+    });
 }
 
 function colorLine(properties) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
-    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js src/Core/MainLoop.js src/Core/Scheduler/Providers/URLBuilder.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
+    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Core/Scheduler/Providers/GpxUtils.js src/Core/MainLoop.js src/Core/Scheduler/Providers/URLBuilder.js src/Renderer/ThreeExtended/Feature2Mesh.js src/Renderer/ThreeExtended/GeoJSON2Features.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",

--- a/src/Core/Scheduler/Providers/Raster_Provider.js
+++ b/src/Core/Scheduler/Providers/Raster_Provider.js
@@ -104,7 +104,11 @@ export default {
             }
 
             if (geojson) {
-                layer.feature = GeoJSON2Features.parse(parentCrs, geojson, layer.extent, options);
+                return GeoJSON2Features.parse(parentCrs, geojson, layer.extent, options);
+            }
+        }).then((feature) => {
+            if (feature) {
+                layer.feature = feature;
                 layer.extent = layer.feature.extent || layer.feature.geometry.extent;
             }
         });

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -50,6 +50,7 @@ export default {
                     o.material.transparent = layer.opacity < 1.0;
                     o.material.opacity = layer.opacity;
                     o.material.wireframe = layer.wireframe;
+
                     if (layer.size) {
                         o.material.size = layer.size;
                     }

--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -40,7 +40,7 @@ function getColor(options, properties) {
     return randomColor();
 }
 
-function fillColorArray(colors, offset, length, r, g, b) {
+function fillColorArray(colors, length, r, g, b, offset) {
     const len = offset + length;
     for (let i = offset; i < len; ++i) {
         colors[3 * i] = r;
@@ -57,263 +57,334 @@ function fillColorArray(colors, offset, length, r, g, b) {
  * @return {Vector3[]} vertices
  */
 const vec = new THREE.Vector3();
-function coordinatesToVertices(contour, altitude, target, offset) {
-    let i = 0;
+function coordinatesToVertices(contour, altitude, target, offset = 0, extrude = undefined) {
     // loop over contour coodinates
-    for (const coordinate of contour) {
+    for (let i = 0; i < contour.length; i++) {
+        const coordinate = contour[i];
         // convert coordinate to position
         coordinate.xyz(vec);
-        // get the normal vector.
-        const normal = coordinate.geodesicNormal;
-        // get altitude from array or constant
-        const alti = Array.isArray(altitude) ? altitude[i++] : altitude;
         // move the vertex following the normal, to put the point on the good altitude
-        vec.addScaledVector(normal, alti);
+        vec.addScaledVector(coordinate.geodesicNormal,
+            Array.isArray(altitude) ? altitude[i] : altitude);
+        if (extrude) {
+            vec.addScaledVector(coordinate.geodesicNormal,
+                Array.isArray(extrude) ? extrude[i] : extrude);
+        }
         // fill the vertices array at the offset position
         vec.toArray(target, offset);
-        // increment the offset
         offset += 3;
     }
-}
-
-const vecTop = new THREE.Vector3();
-const vecBottom = new THREE.Vector3();
-function coordinatesToExtrudedVertices(contour, top, bottom, target, offset) {
-    // loop over contour coodinates
-    const slgt = contour.length * 3;
-    for (const coordinate of contour) {
-        // convert coordinate to position
-        coordinate.xyz(vecTop);
-        vecBottom.copy(vecTop);
-        // move the vertex following the normal, to put the point on the good altitude
-        vecTop.addScaledVector(coordinate.geodesicNormal, top);
-        vecBottom.addScaledVector(coordinate.geodesicNormal, bottom);
-        // fill the vertices array at the offset position
-        vecTop.toArray(target, offset);
-        vecBottom.toArray(target, slgt + offset);
-        // increment the offset
-        offset += 3;
-    }
-}
-
-
-/*
- * Helper function to extract, for a given feature id, the feature contour coordinates, and its properties.
- *
- * param  {structure with coordinate[] and featureVertices[]} coordinates - representation of the features
- * param  {properties[]} properties - properties of the features
- * param  {number} id - id of the feature
- * return {Coordinate[], propertie[] } {contour, properties}
- */
-function extractFeature(coordinates, properties, id) {
-    const featureVertices = coordinates.featureVertices[id];
-    const contour = coordinates.coordinates.slice(featureVertices.offset, featureVertices.offset + featureVertices.count);
-    const property = properties[id].properties;
-    return { contour, property };
 }
 
 /*
  * Add indices for the side faces.
  * We loop over the contour and create a side face made of two triangles.
  *
- * For a contour made of (n) coordinates, there are (n*2) vertices.
+ * For a ring made of (n) coordinates, there are (n*2) vertices.
  * The (n) first vertices are on the roof, the (n) other vertices are on the floor.
  *
  * If index (i) is on the roof, index (i+length) is on the floor.
  *
  * @param {number[]} indices - Indices of vertices
- * @param {number} length - length of the contour of the feature
- * @param {number} offset - index of the first vertice of this feature
+ * @param {number} length - total vertices count in the geom (excluding the extrusion ones)
+ * @param {object} ring - ring needing side faces
+ * @param {number} ring.offset - beginning of the ring
+ * @param {number} ring.count - vertices count in the ring
  */
-function addFaces(indices, length, offset) {
+function addExtrudedPolygonSideFaces(indices, length, ring, isClockWise) {
     // loop over contour length, and for each point of the contour,
     // add indices to make two triangle, that make the side face
-    for (let i = offset; i < offset + length - 1; ++i) {
-        // first triangle indices
-        indices.push(i);
-        indices.push(i + length);
-        indices.push(i + 1);
-        // second triangle indices
-        indices.push(i + 1);
-        indices.push(i + length);
-        indices.push(i + length + 1);
-    }
-}
-
-function coordinateToPoints(coordinates, properties, options) {
-    const vertices = new Float32Array(3 * coordinates.coordinates.length);
-    const colors = new Uint8Array(3 * coordinates.coordinates.length);
-    const geometry = new THREE.BufferGeometry();
-    let offset = 0;
-
-    /* eslint-disable guard-for-in */
-    for (const id in coordinates.featureVertices) {
-        const { contour, property } = extractFeature(coordinates, properties, id);
-        // get altitude from properties
-        const altitude = getAltitude(options, property, contour);
-        coordinatesToVertices(contour, altitude, vertices, offset * 3);
-
-        // assign color to each point
-        const color = getColor(options, property);
-        fillColorArray(colors, offset, contour.length, color.r * 255, color.g * 255, color.b * 255);
-
-        // increment offset
-        offset += contour.length;
-    }
-    geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
-    geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
-    return new THREE.Points(geometry);
-}
-
-function coordinateToLines(coordinates, properties, options) {
-    const indices = [];
-    const vertices = new Float32Array(3 * coordinates.coordinates.length);
-    const colors = new Uint8Array(3 * coordinates.coordinates.length);
-    const geometry = new THREE.BufferGeometry();
-    let offset = 0;
-
-    /* eslint-disable-next-line */
-    for (const id in coordinates.featureVertices) {
-        const { contour, property } = extractFeature(coordinates, properties, id);
-        // get altitude from properties
-        const altitude = getAltitude(options, property, contour);
-        coordinatesToVertices(contour, altitude, vertices, offset * 3);
-
-        // set indices
-        const line = coordinates.featureVertices[id];
-        // TODO optimize indices lines
-        // is the same array each time
-        for (let i = line.offset; i < line.offset + line.count - 1; ++i) {
+    for (let i = ring.offset; i < ring.offset + ring.count - 1; ++i) {
+        if (isClockWise) {
+            // first triangle indices
+            indices.push(i);
+            indices.push(i + length);
+            indices.push(i + 1);
+            // second triangle indices
+            indices.push(i + 1);
+            indices.push(i + length);
+            indices.push(i + length + 1);
+        } else {
+            // first triangle indices
+            indices.push(i + length);
+            indices.push(i);
+            indices.push(i + length + 1);
+            // second triangle indices
+            indices.push(i + length + 1);
             indices.push(i);
             indices.push(i + 1);
         }
-
-        // assign color to each point
-        const color = getColor(options, property);
-        fillColorArray(colors, offset, contour.length, color.r * 255, color.g * 255, color.b * 255);
-
-        // increment offset
-        offset += contour.length;
     }
-
-    geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
-    geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
-    geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(indices), 1));
-    return new THREE.LineSegments(geometry);
 }
 
-function coordinateToPolygon(coordinates, properties, options) {
-    const indices = [];
-    const vertices = new Float32Array(3 * coordinates.coordinates.length);
-    const colors = new Uint8Array(3 * coordinates.coordinates.length);
-    const geometry = new THREE.BufferGeometry();
-    let offset = 0;
-    let minAltitude = Infinity;
-    /* eslint-disable-next-line */
-    for (const id in coordinates.featureVertices) {
-        // extract contour coodinates and properties of one feature
-        const { contour, property } = extractFeature(coordinates, properties, id);
-        // get altitude and extrude amount from properties
-        const altitudeBottom = getAltitude(options, property, contour);
-        minAltitude = Math.min(minAltitude, altitudeBottom);
-        const altitudeTopFace = altitudeBottom;
-        // add vertices of the top face
-        coordinatesToVertices(contour, altitudeTopFace, vertices, offset * 3);
-        const verticesTopFace = vertices.slice(offset * 3, offset * 3 + contour.length * 3);
-        // triangulate the top face
-        const triangles = Earcut(verticesTopFace, null, 3);
-        for (const indice of triangles) {
-            indices.push(offset + indice);
+function prepareBufferGeometry(vert, color, altitude, extrude) {
+    const multiplyVerticesCount = (extrude == undefined) ? 1 : 2;
+
+    const vertices = new Float32Array(3 * vert.length * multiplyVerticesCount);
+    const colors = new Uint8Array(3 * vert.length * multiplyVerticesCount);
+
+    if (multiplyVerticesCount == 1) {
+        coordinatesToVertices(vert, altitude, vertices);
+        fillColorArray(colors, vert.length, color.r * 255, color.g * 255, color.b * 255, 0);
+    } else {
+        coordinatesToVertices(vert, altitude, vertices, 0);
+        fillColorArray(colors, vert.length, color[0].r * 255, color[0].g * 255, color[0].b * 255, 0);
+
+        coordinatesToVertices(vert, altitude, vertices, 3 * vert.length, extrude);
+        fillColorArray(colors, vert.length, color[1].r * 255, color[1].g * 255, color[1].b * 255, vert.length);
+    }
+
+    const geom = new THREE.BufferGeometry();
+    geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
+    geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+    return geom;
+}
+
+
+function geometryToPoint(geometry, properties, options, multiGeomAttributes) {
+    const vertices = multiGeomAttributes ? multiGeomAttributes.vertices : geometry.vertices;
+
+    // get altitude / color from properties
+    const altitude = getAltitude(options, properties, vertices);
+    const color = getColor(options, properties);
+
+    const geom = prepareBufferGeometry(
+        vertices,
+        color,
+        altitude);
+
+    return new THREE.Points(geom);
+}
+
+function geometryToLine(geometry, properties, options, multiGeomAttributes) {
+    const vertices = multiGeomAttributes ? multiGeomAttributes.vertices : geometry.vertices;
+
+    // get altitude / color from properties
+    const altitude = getAltitude(options, properties, vertices);
+    const color = getColor(options, properties);
+
+    const geom = prepareBufferGeometry(
+        vertices,
+        color,
+        altitude);
+
+    if (multiGeomAttributes) {
+        const indices = [];
+        // Multi line case
+        for (let i = 0; i < geometry.length; i++) {
+            const start = multiGeomAttributes.elements[i].offset;
+            const end = multiGeomAttributes.elements[i].offset + multiGeomAttributes.elements[i].count;
+            for (let j = start; j < end; j++) {
+                indices.push(j);
+                indices.push(j + 1);
+            }
         }
-        // assign color to each point
-        const color = getColor(options, property);
-        fillColorArray(colors, offset, contour.length, color.r * 255, color.g * 255, color.b * 255);
-        // increment offset
-        offset += contour.length;
+        geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
+        return new THREE.LineSegments(geom);
+    } else {
+        return new THREE.Line(geom);
     }
-
-    geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
-    geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
-    geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
-    return new THREE.Mesh(geometry);
 }
 
-function coordinateToPolygonExtruded(coordinates, properties, options) {
+function geometryToPolygon(geometry, properties, options, multiGeomAttributes) {
+    const vertices = multiGeomAttributes ? multiGeomAttributes.vertices : geometry.vertices;
+
+    // get altitude / color from properties
+    const altitude = getAltitude(options, properties, vertices);
+    const color = getColor(options, properties);
+
+    const geom = prepareBufferGeometry(
+        vertices,
+        color,
+        altitude);
+
     const indices = [];
-    const vertices = new Float32Array(2 * 3 * coordinates.coordinates.length);
-    const colors = new Uint8Array(3 * 2 * coordinates.coordinates.length);
-    const geometry = new THREE.BufferGeometry();
-    let offset = 0;
-    let offset2 = 0;
-    let nbVertices = 0;
-    let minAltitude = Infinity;
-    /* eslint-disable-next-line */
-    for (const id in coordinates.featureVertices) {
-        // extract contour coodinates and properties of one feature
-        const { contour, property } = extractFeature(coordinates, properties, id);
-        // get altitude and extrude amount from properties
-        const altitudeBottom = getAltitude(options, property, contour);
-        minAltitude = Math.min(minAltitude, altitudeBottom);
-        const extrudeAmount = getExtrude(options, property);
-        // altitudeTopFace is the altitude of the visible top face.
-        const altitudeTopFace = altitudeBottom + extrudeAmount;
-        // add vertices of the top face
-        coordinatesToExtrudedVertices(contour, altitudeTopFace, altitudeBottom, vertices, offset2);
-        // triangulate the top face
-        nbVertices = contour.length * 3;
-        const verticesTopFace = vertices.slice(offset2, offset2 + nbVertices);
-        const triangles = Earcut(verticesTopFace, null, 3);
-        for (const indice of triangles) {
-            indices.push(offset + indice);
+    // Build indices
+    if (multiGeomAttributes) {
+        // Multi polygon case
+        for (let i = 0; i < geometry.length; i++) {
+            const holesOffsets = geometry[i].holes.map(h => h.offset);
+            const start = multiGeomAttributes.elements[i].offset + geometry[i].contour.offset;
+            const end = multiGeomAttributes.elements[i].offset + multiGeomAttributes.elements[i].count;
+            const triangles = Earcut(geom.attributes.position.array.slice(start * 3, end * 3),
+                holesOffsets,
+                3);
+            for (const indice of triangles) {
+                indices.push(start + indice);
+            }
         }
-        offset2 += nbVertices * 2;
-        addFaces(indices, contour.length, offset);
-        // assign color to each point
-        const color = getColor(options, property);
-        fillColorArray(colors, offset, contour.length, color.r * 255, color.g * 255, color.b * 255);
-        offset += contour.length;
-        fillColorArray(colors, offset, contour.length, color.r * 155, color.g * 155, color.b * 155);
-        offset += contour.length;
+    } else {
+        // Single polygon case
+        const holesOffsets = geometry.holes.map(h => h.offset);
+        const triangles = Earcut(geom.attributes.position.array, holesOffsets, 3);
+        for (const indice of triangles) {
+            indices.push(indice);
+        }
     }
-    geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
-    geometry.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
-    geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
-    const result = new THREE.Mesh(geometry);
-    result.minAltitude = minAltitude;
-    return result;
+
+    geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
+    return new THREE.Mesh(geom);
 }
 
-/*
- * Convert all feature coordinates in one mesh.
+
+function geometryToExtrudedPolygon(geometry, properties, options, multiGeomAttributes) {
+    const vertices = multiGeomAttributes ? multiGeomAttributes.vertices : geometry.vertices;
+
+    // get altitude / color from properties
+    const altitude = getAltitude(options, properties, vertices);
+    const extrude = getExtrude(options, properties);
+
+    const colors = [
+        getColor(options, properties)];
+    colors.push(colors[0].clone());
+    colors[0].multiplyScalar(155 / 255);
+
+    const geom = prepareBufferGeometry(
+        vertices,
+        colors,
+        altitude,
+        extrude);
+
+    const indices = [];
+    // Build indices
+    if (multiGeomAttributes) {
+        // Multi polygon case
+        const isClockWise = THREE.ShapeUtils.isClockWise(
+            vertices.slice(
+                multiGeomAttributes.elements[0].offset + geometry[0].contour.offset,
+                multiGeomAttributes.elements[0].offset +
+                geometry[0].contour.offset +
+                geometry[0].contour.count).map(c => c.xyz()));
+
+        for (let i = 0; i < geometry.length; i++) {
+            const holesOffsets = geometry[i].holes.map(h => h.offset);
+            // triangulate the top face
+            const start = vertices.length + multiGeomAttributes.elements[i].offset + geometry[i].contour.offset;
+            const end = vertices.length + multiGeomAttributes.elements[i].offset + multiGeomAttributes.elements[i].count;
+            const triangles = Earcut(geom.attributes.position.array.slice(start * 3, end * 3),
+                holesOffsets,
+                3);
+            for (const indice of triangles) {
+                indices.push(start + indice);
+            }
+            addExtrudedPolygonSideFaces(
+                indices,
+                vertices.length,
+                {
+                    count: geometry[i].contour.count,
+                    offset: multiGeomAttributes.elements[i].offset + geometry[i].contour.offset,
+                },
+                isClockWise);
+            if (holesOffsets.length > 0) {
+                for (let j = 0; j < geometry[i].holes.length; j++) {
+                    addExtrudedPolygonSideFaces(
+                        indices,
+                        vertices.length,
+                        {
+                            count: geometry[i].holes[j].count,
+                            offset: multiGeomAttributes.elements[i].offset + geometry[i].holes[j].offset,
+                        },
+                        isClockWise);
+                }
+            }
+        }
+    } else {
+        // Single polygon case
+        const isClockWise = THREE.ShapeUtils.isClockWise(
+            vertices.slice(geometry.contour.offset,
+                geometry.contour.offset +
+                geometry.contour.count).map(c => c.xyz()));
+
+        const holesOffsets = geometry.holes.map(h => h.offset);
+        const triangles = Earcut(geom.attributes.position.array.slice(
+            vertices.length * 3), holesOffsets, 3);
+        for (const indice of triangles) {
+            indices.push(indice);
+        }
+        addExtrudedPolygonSideFaces(
+            indices,
+            vertices.length,
+            geometry.contour,
+            isClockWise);
+        if (holesOffsets.length > 0) {
+            for (let j = 0; j < geometry.holes.length; j++) {
+                addExtrudedPolygonSideFaces(
+                    indices,
+                    vertices.length,
+                    geometry.holes[j],
+                    isClockWise);
+            }
+        }
+    }
+
+    geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
+    return new THREE.Mesh(geom);
+}
+
+/**
+ * Convert a [Feature]{@link Feature#geometry}'s geometry to a Mesh
  *
- * Read the altitude of each feature in the properties of the feature, using the function given in the param style : style.altitude(properties).
- * For polygon, read extrude amout using the function given in the param style.extrude(properties).
- *
- * param  {structure with coordinate[] and featureVertices[]} coordinates - representation of all the features
- * param  {properties[]} properties - properties of all the features
- * param  {callbacks} callbacks defines functions to read altitude and extrude amout from feature properties
- * return {THREE.Mesh} mesh
+ * @param {Object} geometry - a Feature's geometry
+ * @param {properties[]} properties - Feature's properties
+ * @param {Object} options - options controlling the conversion
+ * @param {number|function} options.altitude - define the base altitude of the mesh
+ * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
+ * @param {object|function} options.color - define per feature color
+ * @return {THREE.Mesh} mesh
  */
-function coordinatesToMesh(coordinates, properties, options) {
-    if (!coordinates) {
+function geometryToMesh(geometry, properties, options) {
+    if (!geometry) {
         return;
     }
+
+    // concat vertices of multigeometries in one big array
+    let multiGeometries;
+    if (geometry.type.indexOf('multi') == 0) {
+        // vertices count
+        let vertices = [];
+        multiGeometries = {
+            elements: [],
+        };
+        let offset = 0;
+        for (let i = 0; i < geometry.length; i++) {
+            vertices = vertices.concat(geometry[i].vertices);
+            multiGeometries.elements.push({
+                offset,
+                count: geometry[i].vertices.length,
+            });
+            offset += geometry[i].vertices.length;
+        }
+        multiGeometries.vertices = vertices;
+    }
+
+
     var mesh;
-    switch (coordinates.type) {
-        case 'point': {
-            mesh = coordinateToPoints(coordinates, properties, options);
+    switch (geometry.type) {
+        case 'point':
+        case 'multipoint': {
+            mesh = geometryToPoint(geometry, properties, options, multiGeometries);
             break;
         }
-        case 'linestring': {
-            mesh = coordinateToLines(coordinates, properties, options);
+        case 'linestring':
+        case 'multilinestring': {
+            mesh = geometryToLine(geometry, properties, options, multiGeometries);
             break;
         }
-        case 'polygon': {
+        case 'polygon':
+        case 'multipolygon': {
             if (options.extrude) {
-                mesh = coordinateToPolygonExtruded(coordinates, properties, options);
+                mesh = geometryToExtrudedPolygon(
+                    geometry,
+                    properties,
+                    options,
+                    multiGeometries);
             }
             else {
-                mesh = coordinateToPolygon(coordinates, properties, options);
+                mesh = geometryToPolygon(
+                    geometry,
+                    properties,
+                    options,
+                    multiGeometries);
             }
             break;
         }
@@ -327,7 +398,7 @@ function coordinatesToMesh(coordinates, properties, options) {
 }
 
 function featureToThree(feature, options) {
-    const mesh = coordinatesToMesh(feature.geometry, feature.properties, options);
+    const mesh = geometryToMesh(feature.geometry, feature.properties, options);
     mesh.properties = feature.properties;
     return mesh;
 }
@@ -335,22 +406,33 @@ function featureToThree(feature, options) {
 function featureCollectionToThree(featureCollection, options) {
     const group = new THREE.Group();
     group.minAltitude = Infinity;
-    for (const geometry of featureCollection.geometries) {
-        const properties = featureCollection.features;
-        const mesh = coordinatesToMesh(geometry, properties, options);
+    for (const feature of featureCollection) {
+        const mesh = featureToThree(feature, options);
         group.add(mesh);
         group.minAltitude = Math.min(mesh.minAltitude, group.minAltitude);
     }
-    group.features = featureCollection.features;
     return group;
 }
 
+/**
+ * @module Feature2Mesh
+ */
 export default {
-
+    /**
+     * Return a function that converts [Feature]s{@link module:GeoJSON2Features} to Meshes. Feature collection will be converted to a
+     * a THREE.Group.
+     *
+     * @param {Object} options - options controlling the conversion
+     * @param {number|function} options.altitude - define the base altitude of the mesh
+     * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
+     * @param {object|function} options.color - define per feature color
+     * @return {function}
+     */
     convert(options = {}) {
         return function _convert(feature) {
             if (!feature) return;
-            if (feature.geometries) {
+
+            if (Array.isArray(feature)) {
                 return featureCollectionToThree(feature, options);
             } else {
                 return featureToThree(feature, options);

--- a/test/data/geojson/holes.geojson.json
+++ b/test/data/geojson/holes.geojson.json
@@ -1,0 +1,101 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              0,
+              0
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              2,
+              1
+            ],
+            [
+              2,
+              0
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              0.2,
+              0.3
+            ],
+            [
+              0.2,
+              0.7
+            ],
+            [
+              1.4,
+              0.7
+            ],
+            [
+              1.4,
+              0.3
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              0,
+              0
+            ],
+            [
+              0,
+              1
+            ],
+            [
+              2,
+              1
+            ],
+            [
+              2,
+              0
+            ]
+          ],
+          [
+            [
+              0.2,
+              0.3
+            ],
+            [
+              0.2,
+              0.7
+            ],
+            [
+              1.4,
+              0.7
+            ],
+            [
+              1.4,
+              0.3
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/test/data/geojson/simple.geojson.json
+++ b/test/data/geojson/simple.geojson.json
@@ -60,7 +60,9 @@
           ]
         ]
       },
-      "properties": {}
+      "properties": {
+        "my_prop": 14
+      }
     }
   ]
 }

--- a/test/feature2mesh_unit_test.js
+++ b/test/feature2mesh_unit_test.js
@@ -1,0 +1,60 @@
+import * as THREE from 'three';
+import proj4 from 'proj4';
+import GeoJSON2Features from '../src/Renderer/ThreeExtended/GeoJSON2Features';
+import Feature2Mesh from '../src/Renderer/ThreeExtended/Feature2Mesh';
+/* global describe, it */
+
+const assert = require('assert');
+const geojson = require('./data/geojson/holes.geojson.json');
+
+proj4.defs('EPSG:3946',
+    '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
+function parse() {
+    return GeoJSON2Features.parse(
+    'EPSG:3946', geojson, undefined,
+    { buildExtent: true, crsIn: 'EPSG:3946' });
+}
+
+function computeAreaOfMesh(mesh) {
+    // Sum each triangle area
+    let area = 0;
+    for (let i = 0; i < mesh.geometry.index.array.length; i += 3) {
+        const contour = [];
+        for (let j = 0; j < 3; j++) {
+            const index = mesh.geometry.index.array[i + j];
+            contour.push(
+                new THREE.Vector3().fromArray(
+                    mesh.geometry.attributes.position.array, 3 * index));
+        }
+        area += THREE.ShapeUtils.area(contour);
+    }
+    return area;
+}
+
+describe('FeaturesUtils', function () {
+    it('rect mesh area should match geometry extent', () =>
+        parse().then((feature) => {
+            const mesh = Feature2Mesh.convert()(feature[0]);
+            const extentSize = feature[0].geometry.extent.dimensions();
+
+            assert.equal(
+                extentSize.x * extentSize.y,
+                computeAreaOfMesh(mesh));
+        }));
+
+    it('square mesh area should match geometry extent minus holes', () =>
+        parse().then((feature) => {
+            const noHole = Feature2Mesh.convert()(feature[0]);
+            const hole = Feature2Mesh.convert()(feature[1]);
+            const meshWithHole = Feature2Mesh.convert()(feature[2]);
+
+            const noHoleArea = computeAreaOfMesh(noHole);
+            const holeArea = computeAreaOfMesh(hole);
+            const meshWithHoleArea = computeAreaOfMesh(meshWithHole);
+
+            assert.equal(
+                noHoleArea - holeArea,
+                meshWithHoleArea);
+        }));
+});

--- a/test/featureUtils_unit_test.js
+++ b/test/featureUtils_unit_test.js
@@ -4,36 +4,45 @@ import Coordinates from '../src/Core/Geographic/Coordinates';
 /* global describe, it */
 
 const assert = require('assert');
-const geojson = require('../examples/geojson/simple.geojson.json');
+const geojson = require('./data/geojson/simple.geojson.json');
 
-const feature = GeoJSON2Features.parse('EPSG:4326', geojson, undefined, { buildExtent: true });
+const promise = GeoJSON2Features.parse('EPSG:4326', geojson, undefined, { buildExtent: true });
 
 describe('FeaturesUtils', function () {
-    it('should correctly parse geojson', () => {
-        assert.equal(feature.geometries.length, 3);
-    });
-    it('should correctly compute extent geojson', () => {
-        assert.equal(feature.extent.west(), 0.30798339284956455);
-        assert.equal(feature.extent.east(), 2.4722900334745646);
-        assert.equal(feature.extent.south(), 42.91620643817353);
-        assert.equal(feature.extent.north(), 43.72744458647463);
-    });
-    it('should correctly filter point', () => {
-        const coordinates = new Coordinates('EPSG:4326', 1.26, 42.9);
-        const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
-        assert.equal(filter.length, 1.0);
-        assert.equal(filter[0].type == 'point', 1.0);
-    });
-    it('should correctly filter polygon', () => {
-        const coordinates = new Coordinates('EPSG:4326', 0.62, 43.52);
-        const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
-        assert.equal(filter.length, 1.0);
-        assert.equal(filter[0].type == 'polygon', 1.0);
-    });
-    it('should correctly filter line', () => {
-        const coordinates = new Coordinates('EPSG:4326', 2.23, 43.39);
-        const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
-        assert.equal(filter.length, 1.0);
-        assert.equal(filter[0].type == 'linestring', 1.0);
-    });
+    it('should correctly parse geojson', () =>
+        promise.then((feature) => {
+            assert.equal(feature.length, 3);
+        }));
+    it('should correctly compute extent geojson', () =>
+        promise.then((feature) => {
+            assert.equal(feature.extent.west(), 0.30798339284956455);
+            assert.equal(feature.extent.east(), 2.4722900334745646);
+            assert.equal(feature.extent.south(), 42.91620643817353);
+            assert.equal(feature.extent.north(), 43.72744458647463);
+        }));
+    it('should correctly filter point', () =>
+        promise.then((feature) => {
+            const coordinates = new Coordinates('EPSG:4326', 1.26, 42.9);
+            const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
+            assert.equal(filter.length, 1.0);
+            assert.equal(filter[0].feature.geometry.type == 'point', 1.0);
+        }));
+    it('should correctly filter polygon', () =>
+        promise.then((feature) => {
+            const coordinates = new Coordinates('EPSG:4326', 0.62, 43.52);
+            const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
+            assert.equal(filter.length, 1.0);
+            assert.equal(filter[0].feature.geometry.type == 'polygon', 1.0);
+        }));
+    it('should correctly filter line', () =>
+        promise.then((feature) => {
+            const coordinates = new Coordinates('EPSG:4326', 2.23, 43.39);
+            const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
+            assert.equal(filter.length, 1.0);
+            assert.equal(filter[0].feature.geometry.type == 'linestring', 1.0);
+        }));
+    it('should remember individual feature properties', () =>
+        promise.then((feature) => {
+            assert.equal(feature[2].properties.my_prop, 14);
+        }));
 });


### PR DESCRIPTION
This commits refactors Feature related code.

It introduces a documented Feature object.
GeoJSON2Feature returns either a Feature or an array of Feature (when parsing
a FeatureCollection object).

Geometry merges now only happens for multi-* geometries to simplify user
handling of individual features.

Geometry holes are now supported:
![capture d ecran de 2018-03-13 13-52-32](https://user-images.githubusercontent.com/2198295/37342758-cf84d4ba-26c5-11e8-928a-9faa8882f8df.png)


And last but not least this commit fixes the geometry merge bug from issue 688.

Fixes #688. This is a screenshot of the example geojson, displayed both as a texture (in yellow) and as a mesh (blue wireframe):

![capture d ecran de 2018-03-13 13-54-23](https://user-images.githubusercontent.com/2198295/37342841-130b88aa-26c6-11e8-9745-2210a6656ac0.png)


BREAKING CHANGE: feature collection are not merged anymore
BREAKING CHANGE: GeoJSON2Feature now returns a Promise
