### PR TITLE
Tiny fixes

### DIFF
--- a/examples/layers/JSONLayers/Administrative.json
+++ b/examples/layers/JSONLayers/Administrative.json
@@ -9,7 +9,7 @@
   "transparent": true,
   "format": "image/png",
   "updateStrategy": {
-    "type": "0",
+    "type": 0,
     "options": {}
   },
   "networkOptions": {

--- a/examples/layers/JSONLayers/Cada.json
+++ b/examples/layers/JSONLayers/Cada.json
@@ -8,7 +8,7 @@
   "opacity": 1,
   "transparent": true,
   "updateStrategy": {
-    "type": "0",
+    "type": 0,
     "options": {}
   },
   "networkOptions": {

--- a/examples/layers/JSONLayers/Denomination.json
+++ b/examples/layers/JSONLayers/Denomination.json
@@ -9,7 +9,7 @@
   "transparent": true,
   "format": "image/png",
   "updateStrategy": {
-    "type": "0",
+    "type": 0,
     "options": {}
   },
   "networkOptions": {

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -7,7 +7,7 @@
         "crossOrigin": "anonymous"
     },
     "updateStrategy": {
-        "type": "0",
+        "type": 0,
         "options": {}
     },
     "format": "image/jpeg",

--- a/examples/layers/JSONLayers/Railways.json
+++ b/examples/layers/JSONLayers/Railways.json
@@ -9,7 +9,7 @@
   "transparent": true,
   "format": "image/png",
   "updateStrategy": {
-    "type": "0",
+    "type": 0,
     "options": {}
   },
   "networkOptions": {

--- a/examples/layers/JSONLayers/Transport.json
+++ b/examples/layers/JSONLayers/Transport.json
@@ -9,7 +9,7 @@
   "transparent": true,
   "format": "image/png",
   "updateStrategy": {
-    "type": "0",
+    "type": 0,
     "options": {}
   },
   "networkOptions": {

--- a/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
+++ b/src/Core/Scheduler/Providers/OGCWebServiceHelper.js
@@ -147,6 +147,7 @@ export default {
             pitch.x = cWMTS.col * invDiff - c;
             pitch.y = cWMTS.row * invDiff - r;
             pitch.z = invDiff;
+            pitch.w = invDiff;
         }
 
         return target.set(levelParent, r, c);


### PR DESCRIPTION
3 small commits fixing minor issues:
  - the first & last one allow to use `STRATEGY_DICHOTOMY` for WMTS color layers (I believed it was already supported...)
  - the 2nd fixes a typo in json examples layers