### PR TITLE
Replace TextDecoder polyfill with static instance

### DIFF
--- a/src/Core/Scheduler/Providers/3dTiles_Provider.js
+++ b/src/Core/Scheduler/Providers/3dTiles_Provider.js
@@ -8,6 +8,7 @@ import { UNIT } from '../../Geographic/Coordinates';
 import Capabilities from '../../System/Capabilities';
 import PrecisionQualifier from '../../../Renderer/Shader/Chunk/PrecisionQualifier.glsl';
 import { init3dTilesLayer } from '../../../Process/3dTilesProcessing';
+import utf8Decoder from '../../../utils/Utf8Decoder';
 
 function $3dTilesIndex(tileset, baseURL) {
     let counter = 0;
@@ -143,10 +144,9 @@ export function patchMaterialForLogDepthSupport(material) {
 }
 
 let b3dmParser;
-let textDecoder;
 function b3dmToMesh(data, layer, url) {
     b3dmParser = b3dmParser || new B3dmParser();
-    return b3dmParser.parse(data, layer.asset.gltfUpAxis, url, textDecoder).then((result) => {
+    return b3dmParser.parse(data, layer.asset.gltfUpAxis, url).then((result) => {
         const init = function f_init(mesh) {
             mesh.frustumCulled = false;
             if (mesh.material) {
@@ -177,7 +177,7 @@ function b3dmToMesh(data, layer, url) {
 
 function pntsParse(data) {
     return new Promise((resolve) => {
-        resolve({ object3d: PntsParser.parse(data, textDecoder).point });
+        resolve({ object3d: PntsParser.parse(data).point });
     });
 }
 
@@ -210,7 +210,6 @@ function executeCommand(command) {
     const tile = new THREE.Object3D();
     configureTile(tile, layer, metadata, command.requester);
     const path = metadata.content ? metadata.content.url : undefined;
-    textDecoder = textDecoder || new TextDecoder('utf-8');
 
     const setLayer = (obj) => {
         obj.layers.set(layer.threejsLayer);
@@ -225,9 +224,9 @@ function executeCommand(command) {
         return Fetcher.arrayBuffer(url, layer.networkOptions).then((result) => {
             if (result !== undefined) {
                 let func;
-                const magic = textDecoder.decode(new Uint8Array(result, 0, 4));
+                const magic = utf8Decoder.decode(new Uint8Array(result, 0, 4));
                 if (magic[0] === '{') {
-                    result = JSON.parse(textDecoder.decode(new Uint8Array(result)));
+                    result = JSON.parse(utf8Decoder.decode(new Uint8Array(result)));
                     const newPrefix = url.slice(0, url.lastIndexOf('/') + 1);
                     layer.tileIndex.extendTileset(result, metadata.tileId, newPrefix);
                 } else if (magic == 'b3dm') {

--- a/src/Parser/BatchTable.js
+++ b/src/Parser/BatchTable.js
@@ -1,6 +1,8 @@
+import utf8Decoder from '../utils/Utf8Decoder';
+
 export default {
-    parse(buffer, textDecoder) {
-        const content = textDecoder.decode(new Uint8Array(buffer));
+    parse(buffer) {
+        const content = utf8Decoder.decode(new Uint8Array(buffer));
         const json = JSON.parse(content);
         return json;
     },

--- a/src/utils/Utf8Decoder.js
+++ b/src/utils/Utf8Decoder.js
@@ -1,7 +1,7 @@
 import {
   TextDecoder as TextDecoderPolyfill,
-  TextEncoder as TextEncoderPolyfill,
 } from 'text-encoding-utf-8';
 
 export const TextDecoder = typeof global.TextDecoder === 'function' ? global.TextDecoder : TextDecoderPolyfill;
-export const TextEncoder = typeof global.TextEncoder === 'function' ? global.TextEncoder : TextEncoderPolyfill;
+
+export default new TextDecoder('utf-8');

--- a/test/itowns-testing.js
+++ b/test/itowns-testing.js
@@ -16,8 +16,6 @@ const width = 800;
 const height = 600;
 
 
-global.TextDecoder = require('string_decoder').StringDecoder;
-
 // Mock missing globals
 global.fetch = function _fetch(url) {
     var res;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,11 +7,6 @@ var definePlugin = new webpack.DefinePlugin({
     __DEBUG__: JSON.stringify(process.env.NODE_ENV === 'development'),
 });
 
-var providePlugin = new webpack.ProvidePlugin({
-    TextDecoder: [path.resolve(__dirname, 'src/utils/polyfill'), 'TextDecoder'],
-    TextEncoder: [path.resolve(__dirname, 'src/utils/polyfill'), 'TextEncoder'],
-});
-
 module.exports = {
     entry: {
         itowns: ['babel-polyfill', 'url-polyfill', 'whatwg-fetch', path.resolve(__dirname, 'src/MainBundle.js')],
@@ -27,7 +22,6 @@ module.exports = {
     },
     plugins: [
         definePlugin,
-        providePlugin,
         new webpack.optimize.CommonsChunkPlugin({ name: 'itowns' }),
     ],
     module: {


### PR DESCRIPTION
## Description

This PR replaces #634 and depends on #696.

Replace TextDecoder polyfill with static utf8 decoder instance.

## Motivation and Context

Remove the need to pass TextDecoder in function parameters or to instantiate it at each use.
