### PR TITLE
chore(parser): remove unneeded gpx/geojson parser options

### DIFF
--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -38,7 +38,7 @@
             // Listen for globe full initialisation event
             globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
-                itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx').then(xml => itowns.GpxParser.parse(xml, { xml: true, crs: globeView.referenceCrs })).then(function (gpx) {
+                itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx').then(xml => itowns.GpxParser.parse(xml, { crs: globeView.referenceCrs })).then(function (gpx) {
                     if (gpx) {
                         globeView.scene.add(gpx);
                         globeView.controls.setTilt(45, true);

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -255,10 +255,9 @@ export default {
     */
 
     /**
-     * Parse a GeoJSON file and return a Feature or an array of Features.
-     * @param {string} file - The GeoJSON file to parse.
+     * Parse a GeoJSON file content and return a Feature or an array of Features.
+     * @param {string} json - The GeoJSON file content to parse.
      * @param {object} options - options controlling the parsing
-     * @param {boolean} [options.json=false] - set to true if file is actually a parsed json.
      * @param {string} options.crsOut - The CRS to convert the input coordinates to.
      * @param {string} options.crsIn - override the data crs
      * @param {Extent=} options.filteringExtent - Optional filter to reject features
@@ -268,21 +267,20 @@ export default {
      * @param {function=} options.filter - Filter function to remove features
      * @returns {Promise} - a promise resolving with a Feature or an array of Features
      */
-    parse(file, options = {}) {
+    parse(json, options = {}) {
         const crsOut = options.crsOut;
         const filteringExtent = options.filteringExtent;
-        let json = file;
-        if (!options.json) {
-            json = file.json();
+        if (typeof (json) === 'string') {
+            json = JSON.parse(json);
         }
-        options.crsIn = options.crsIn || readCRS(file);
-        switch (file.type.toLowerCase()) {
+        options.crsIn = options.crsIn || readCRS(json);
+        switch (json.type.toLowerCase()) {
             case 'featurecollection':
                 return Promise.resolve(readFeatureCollection(options.crsIn, crsOut, json, filteringExtent, options));
             case 'feature':
                 return Promise.resolve(readFeature(options.crsIn, crsOut, json, filteringExtent, options));
             default:
-                throw new Error(`Unsupported GeoJSON type: '${file.type}`);
+                throw new Error(`Unsupported GeoJSON type: '${json.type}`);
         }
     },
 };

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -173,9 +173,8 @@ export default {
     /** @module GpxParser */
     /** Parse gpx file and convert to THREE.Mesh
      * @function parse
-     * @param {string} file - the gpx file or xml.
+     * @param {string} xml - the gpx file or xml.
      * @param {Object=} options - additional properties.
-     * @param {boolean} options.xml - set to true if file is actually a parsed xml.
      * @param {string} options.crs - the default CRS of Three.js coordinates. Should be a cartesian CRS.
      * @param {boolean=} [options.enablePin=true] - draw pin for way points.
      * @param {NetworkOptions=} options.networkOptions - options for fetching resources over network.
@@ -191,9 +190,8 @@ export default {
      * });
      *
      */
-    parse(file, options = {}) {
-        let xml = file;
-        if (!options.xml) {
+    parse(xml, options = {}) {
+        if (!(xml instanceof XMLDocument)) {
             xml = new window.DOMParser().parseFromString(xml, 'text/xml');
         }
         return Promise.resolve(_gpxToMesh(xml, options));

--- a/src/Provider/RasterProvider.js
+++ b/src/Provider/RasterProvider.js
@@ -107,7 +107,6 @@ export default {
                     crsIn: layer.projection,
                     crsOut: parentCrs,
                     filteringExtent: layer.extent,
-                    json: true,
                 };
 
                 return GeoJsonParser.parse(geojson, options);

--- a/src/Provider/WFSProvider.js
+++ b/src/Provider/WFSProvider.js
@@ -71,7 +71,7 @@ function getFeatures(crs, tile, layer) {
 
     return Fetcher.json(urld, layer.networkOptions)
         .then(
-            geojson => GeoJsonParser.parse(geojson, { crsOut: crs, filteringExtent: tile.extent, filter: layer.filter, json: true }),
+            geojson => GeoJsonParser.parse(geojson, { crsOut: crs, filteringExtent: tile.extent, filter: layer.filter }),
             (err) => {
                 // special handling for 400 errors, as it probably means the config is wrong
                 if (err.response.status == 400) {

--- a/test/feature2mesh_unit_test.js
+++ b/test/feature2mesh_unit_test.js
@@ -11,7 +11,7 @@ proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 function parse() {
-    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, json: true });
+    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true });
 }
 
 function computeAreaOfMesh(mesh) {

--- a/test/featureUtils_unit_test.js
+++ b/test/featureUtils_unit_test.js
@@ -6,7 +6,7 @@ import Coordinates from '../src/Core/Geographic/Coordinates';
 const assert = require('assert');
 const geojson = require('./data/geojson/simple.geojson.json');
 
-const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true, json: true });
+const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true });
 
 describe('FeaturesUtils', function () {
     it('should correctly parse geojson', () =>


### PR DESCRIPTION
Since we can detect if a given object has already been parsed or not,
there's no need to require the user to specify this fact using an option.
