### PR TITLE
fix(examples): fix mouse move event doesn't work under menu, in 3dtiles examples

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -44,16 +44,13 @@
                     display: none;
                 }
             }
-            #menuDiv {
-                margin : auto auto;
-                width: 100%;
-                padding: 0;
-                height: 100%;
 
+            #menuDiv {
                 position: absolute;
                 top:0px;
                 margin-left: 0px;
             }
+
             @media (max-width: 600px) {
                 #menuDiv {
                     display: none;


### PR DESCRIPTION
## Motivation and Context
Renderer.domElement's **mousemove** doesn't work under menu, in 3dtiles examples