### PR TITLE
feat(core): view.addLayer(url) support (#697)

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -92,7 +92,7 @@
 
             var menuGlobe = new GuiTools('menuDiv', view, 300);
 
-            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return view.addLayer(result) });
+            view.addLayer('layers/JSONLayers/Ortho.json');
 
             // function use :
             // For preupdate Layer geomtry :

--- a/examples/collada.js
+++ b/examples/collada.js
@@ -16,27 +16,23 @@ var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
 var menuGlobe = new GuiTools('menuDiv');
 
-var promiseElevation = [];
-
 menuGlobe.view = globeView;
 
 function addLayerCb(layer) {
-    return globeView.addLayer(layer).then(function addGui(la) {
-        if (la.type === 'color') {
-            menuGlobe.addImageryLayerGUI(la);
-        } else if (la.type === 'elevation') {
-            menuGlobe.addElevationLayerGUI(la);
-        }
-    });
+    if (layer.type === 'color') {
+        menuGlobe.addImageryLayerGUI(layer);
+    } else if (layer.type === 'elevation') {
+        menuGlobe.addElevationLayerGUI(layer);
+    }
 }
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
+globeView.addLayer('./layers/JSONLayers/Ortho.json').then(addLayerCb);
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promiseElevation.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promiseElevation.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb);
+globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/externalscene.js
+++ b/examples/externalscene.js
@@ -11,12 +11,8 @@ setupLoadingScreen(viewerDiv, globeView);
 
 globeView.mainLoop.name = 'external-ML';
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
-
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
+globeView.addLayer('./layers/JSONLayers/Ortho.json');
+globeView.addLayer('./layers/JSONLayers/IGN_MNT.json');
 
 exports.globeView = globeView;
 exports.scene = scene;

--- a/examples/globe.js
+++ b/examples/globe.js
@@ -15,9 +15,6 @@ var miniDiv = document.getElementById('miniDiv');
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 setupLoadingScreen(viewerDiv, globeView);
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 
 // Dont' instance mini viewer if it's Test env
 if (!renderer) {
@@ -49,17 +46,17 @@ if (!renderer) {
     });
 
     // Add one imagery layer to the miniview
-    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(layer) { miniView.addLayer(layer); });
+    miniView.addLayer('./layers/JSONLayers/Ortho.json');
 }
 
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json'));
+promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe_fly.js
+++ b/examples/globe_fly.js
@@ -18,14 +18,11 @@ setupLoadingScreen(viewerDiv, globeView);
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-function addLayer(layer) {
-    return globeView.addLayer(layer);
-}
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayer));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayer));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayer));
+promises.push(globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json'));
+promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/globe_vector.js
+++ b/examples/globe_vector.js
@@ -11,18 +11,15 @@ var viewerDiv = document.getElementById('viewerDiv');
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 setupLoadingScreen(viewerDiv, globeView);
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json'));
+promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
 promises.push(globeView.addLayer({
     type: 'color',

--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -14,9 +14,6 @@ var viewerDiv = document.getElementById('viewerDiv');
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 setupLoadingScreen(viewerDiv, globeView);
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 itowns.proj4.defs('EPSG:3946',
@@ -27,12 +24,12 @@ itowns.proj4.defs('EPSG:2154',
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
 
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json'));
+promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
 function altitudeLine(properties, contour) {
     var altitudes = [];

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -10,20 +10,15 @@ var viewerDiv = document.getElementById('viewerDiv');
 // Instanciate iTowns GlobeView*
 var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { renderer: renderer });
 
-var promises = [];
-
 setupLoadingScreen(viewerDiv, globeView);
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+globeView.addLayer('./layers/JSONLayers/Ortho.json');
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json');
+globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json');
 
 exports.view = globeView;

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -42,14 +42,10 @@
             setupLoadingScreen(viewerDiv, globeView);
             menuGlobe.view = globeView;
 
-            function addLayerCb(layer) {
-                return globeView.addLayer(layer);
-            }
-
             var promises = [];
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb));
+            promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
+            promises.push(globeView.addLayer('./layers/JSONLayers/Region.json'));
+            promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT.json'));
 
             function removeDups(a) {
                 var temp = {};

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -64,10 +64,7 @@
             setupLoadingScreen(viewerDiv, globeView);
             layers.push(globeView.wgs84TileLayer);
 
-            function addLayerCb(layer) {
-                return globeView.addLayer(layer);
-            }
-            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
+            globeView.addLayer('./layers/JSONLayers/Ortho.json');
 
             // create a second smaller globe
             const globe2 = itowns.createGlobeLayer('globe2', { object3d: ref[1] });

--- a/examples/pointcloud_globe.js
+++ b/examples/pointcloud_globe.js
@@ -20,9 +20,6 @@ function showPointcloud(serverUrl, fileName) {
     setupLoadingScreen(viewerDiv, view);
 
     view.controls.minDistance = 0;
-    function addLayerCb(layer) {
-        return view.addLayer(layer);
-    }
 
     // Configure Point Cloud layer
     pointcloud = new itowns.GeometryLayer('pointcloud', view.scene);
@@ -59,6 +56,6 @@ function showPointcloud(serverUrl, fileName) {
 
     itowns.View.prototype.addLayer.call(view, pointcloud).then(onLayerReady);
 
-    itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
-    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
+    view.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json');
+    view.addLayer('./layers/JSONLayers/Ortho.json');
 }

--- a/examples/positionGlobe.js
+++ b/examples/positionGlobe.js
@@ -24,17 +24,14 @@ menuGlobe.view = globeView;
 
 setupLoadingScreen(viewerDiv, globeView);
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json'));
+promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/postprocessing.js
+++ b/examples/postprocessing.js
@@ -49,12 +49,8 @@ globeView.render = function render() {
         cam);
 };
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
-
-itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
+globeView.addLayer('./layers/JSONLayers/Ortho.json');
+globeView.addLayer('./layers/JSONLayers/IGN_MNT.json');
 
 exports.globeView = globeView;
 exports.postprocessScene = postprocessScene;

--- a/examples/split.js
+++ b/examples/split.js
@@ -20,19 +20,16 @@ var xD;
 
 setupLoadingScreen(viewerDiv, globeView);
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb).then(function _(l) { orthoLayer = l; }));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(addLayerCb).then(function _(l) { osmLayer = l; }));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json').then(function _(l) { orthoLayer = l; }));
+promises.push(globeView.addLayer('./layers/JSONLayers/OPENSM.json').then(function _(l) { osmLayer = l; }));
 
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb);
-itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
+globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json');
+globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json');
 
 // Slide handling
 splitPosition = 0.5 * window.innerWidth;

--- a/examples/stereo.js
+++ b/examples/stereo.js
@@ -29,18 +29,14 @@ itowns.THREE.StereoCamera.prototype.update = function _update(camera) {
     fnUpdateStereoCamera.bind(this)(camera);
 };
 
-function addLayerCb(layer) {
-    return globeView.addLayer(layer);
-}
-
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/Ortho.json'));
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+promises.push(globeView.addLayer('./layers/JSONLayers/WORLD_DTM.json'));
+promises.push(globeView.addLayer('./layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
 /* eslint-disable no-unused-vars */
 function updateEyeSep(value) {

--- a/index.html
+++ b/index.html
@@ -43,25 +43,20 @@ and open the template in the editor.
             var menuGlobe = new GuiTools('menuDiv', globeView);
             menuGlobe.view = globeView;
 
-
-            function addLayerCb(layer) {
-                return globeView.addLayer(layer);
-            }
-
             var promises = []
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Ortho.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/OrthosCRS.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/ScanEX.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Region.json').then(addLayerCb));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Ortho.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/OrthosCRS.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/ScanEX.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Region.json'));
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Cada.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Administrative.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Transport.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Railways.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/Denomination.json').then(addLayerCb));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Cada.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Administrative.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Transport.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Railways.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/Denomination.json'));
 
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));
-            promises.push(itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/WORLD_DTM.json'));
+            promises.push(globeView.addLayer('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json'));
 
             menuGlobe.addGUI('RealisticLighting', false,
                 function(newValue) { globeView.setRealisticLightingOn(newValue); });

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -6,6 +6,7 @@ import { COLOR_LAYERS_ORDER_CHANGED } from '../../Renderer/ColorLayersOrdering';
 import RendererConstant from '../../Renderer/RendererConstant';
 import GlobeControls from '../../Renderer/ThreeExtended/GlobeControls';
 
+import Fetcher from '../../Provider/Fetcher';
 import { GeometryLayer } from '../Layer/Layer';
 
 import Atmosphere from './Globe/Atmosphere';
@@ -302,6 +303,14 @@ GlobeView.prototype = Object.create(View.prototype);
 GlobeView.prototype.constructor = GlobeView;
 
 GlobeView.prototype.addLayer = function addLayer(layer) {
+    if (typeof layer === 'string') {
+        if (!layer.endsWith('json')) {
+            throw new Error('Only JSON file can be read to load a layer.');
+        }
+
+        return Fetcher.json(layer).then(file => this.addLayer(file));
+    }
+
     if (layer.type == 'color') {
         const colorLayerCount = this.getLayers(l => l.type === 'color').length;
         layer.sequence = colorLayerCount;

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import View from '../View';
 
 import { GeometryLayer } from '../Layer/Layer';
+import Fetcher from '../../Provider/Fetcher';
 import Extent from '../Geographic/Extent';
 import { processTiledGeometryNode } from '../../Process/TiledNodeProcessing';
 import { updateLayeredMaterialNodeImagery } from '../../Process/LayeredMaterialNodeProcessing';
@@ -208,6 +209,14 @@ PanoramaView.prototype = Object.create(View.prototype);
 PanoramaView.prototype.constructor = PanoramaView;
 
 PanoramaView.prototype.addLayer = function addLayer(layer) {
+    if (typeof layer === 'string') {
+        if (!layer.endsWith('json')) {
+            throw new Error('Only JSON file can be read to load a layer.');
+        }
+
+        return Fetcher.json(layer).then(file => this.addLayer(file));
+    }
+
     if (layer.type == 'color') {
         layer.update = updateLayeredMaterialNodeImagery;
     } else {

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -4,6 +4,7 @@ import View from '../View';
 import { RENDERING_PAUSED, MAIN_LOOP_EVENTS } from '../MainLoop';
 import RendererConstant from '../../Renderer/RendererConstant';
 
+import Fetcher from '../../Provider/Fetcher';
 import { GeometryLayer } from '../Layer/Layer';
 
 import { processTiledGeometryNode } from '../../Process/TiledNodeProcessing';
@@ -162,6 +163,14 @@ PlanarView.prototype = Object.create(View.prototype);
 PlanarView.prototype.constructor = PlanarView;
 
 PlanarView.prototype.addLayer = function addLayer(layer) {
+    if (typeof layer === 'string') {
+        if (!layer.endsWith('json')) {
+            throw new Error('Only JSON file can be read to load a layer.');
+        }
+
+        return Fetcher.json(layer).then(file => this.addLayer(file));
+    }
+
     if (layer.type == 'color') {
         layer.update = updateLayeredMaterialNodeImagery;
     } else if (layer.type == 'elevation') {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -293,7 +293,11 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
  * // One can also attach a callback to the same promise with a layer instance.
  * layer.whenReady.then(() => { ... });
  *
- * @param {LayerOptions|Layer|GeometryLayer} layer
+ * // The layer can also being added by passing directly the url leading to the
+ * // configuration of the layer.
+ * view.addLayer('http://geo.server/layers/Ortho.json');
+ *
+ * @param {LayerOptions|Layer|GeometryLayer|string} layer
  * @param {Layer=} parentLayer
  * @return {Promise} a promise resolved with the new layer object when it is fully initialized
  */


### PR DESCRIPTION
Layers can be added simplier by adding the string, representing the url leading to the configuration of the layer. For example:

```js
view.addLayer('http://geo.server/layers/ortho.json');
```

This resolves #697 