### PR TITLE
WIP: refacto(examples): stop hiding our config objects and document them

### DIFF
--- a/examples/globe.js
+++ b/examples/globe.js
@@ -1,5 +1,5 @@
 /* global itowns, document, renderer, setupLoadingScreen */
-// # Simple Globe viewer
+// Simple Globe viewer
 
 // Define initial camera position
 var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
@@ -19,7 +19,7 @@ function addLayerCb(layer) {
     return globeView.addLayer(layer);
 }
 
-// Dont' instance mini viewer if it's Test env
+// Don't instance mini viewer if it's Test env
 if (!renderer) {
     miniView = new itowns.GlobeView(miniDiv, positionOnGlobe, {
         // `limit globe' subdivision level:
@@ -55,7 +55,166 @@ if (!renderer) {
 // Add one imagery layer to the scene
 // This layer is defined in a json file but it could be defined as a plain js
 // object. See Layer* for more info.
-promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
+var orthoLayerOptions = {
+    // Choose here a unique id for your layer
+    "id":         "Ortho",
+    // we'll display this layer as color texture on our globe
+    "type": "color",
+    // protocol and url defines the datasource
+    "protocol":   "wmts",
+    // The api key 'va5orxd0pgzvq3jxutqfuy0b' is for testing purpose, and only usable in localhost.
+    // When you'll host your application based on iTowns, you'll have to request a new api key if you want to use IGN datasources.
+    "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
+    // this is the name of the layer to use in the above endpoint
+    // (cf http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts?service=wmts&version=1.0.0&request=GetCapabilities)
+    "name": "ORTHOIMAGERY.ORTHOPHOTOS",
+    // this option will be passed to the loaders that'll do the individual fetching
+    // see Fetcher.js
+    "networkOptions": {
+        "crossOrigin": "anonymous"
+    },
+    //
+    "updateStrategy": {
+        "type": itowns.STRATEGY_MIN_NETWORK_TRAFFIC,
+        "options": {}
+    },
+    // what format to use, among the supported format of this layer
+    "format": "image/jpeg",
+
+    "options": {
+        // store there your attributions for your datasource
+        "attribution" : {
+            "name":"IGN",
+            "url":"http://www.ign.fr/"
+        },
+        // This defines the tilematrixset of our WMTS layer. Supported types are currently PM and WGS84G.
+        // More to be supported in the futur.
+        "tileMatrixSet": "PM",
+    }
+};
+
+// now we need to set the WMTS limits. This should be compatible from what GetCapabilities returns.
+// (cf http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts?service=wmts&version=1.0.0&request=GetCapabilities)
+orthoLayerOptions.options.tileMatrixSetLimits = {
+    "2": {
+        "minTileRow": 0,
+        "maxTileRow": 4,
+        "minTileCol": 0,
+        "maxTileCol": 4
+    },
+    "3": {
+        "minTileRow": 0,
+        "maxTileRow": 8,
+        "minTileCol": 0,
+        "maxTileCol": 8
+    },
+    "4": {
+        "minTileRow": 0,
+        "maxTileRow": 16,
+        "minTileCol": 0,
+        "maxTileCol": 16
+    },
+    "5": {
+        "minTileRow": 0,
+        "maxTileRow": 32,
+        "minTileCol": 0,
+        "maxTileCol": 32
+    },
+    "6": {
+        "minTileRow": 1,
+        "maxTileRow": 64,
+        "minTileCol": 0,
+        "maxTileCol": 64
+    },
+    "7": {
+        "minTileRow": 3,
+        "maxTileRow": 128,
+        "minTileCol": 0,
+        "maxTileCol": 128
+    },
+    "8": {
+        "minTileRow": 7,
+        "maxTileRow": 256,
+        "minTileCol": 0,
+        "maxTileCol": 256
+    },
+    "9": {
+        "minTileRow": 15,
+        "maxTileRow": 512,
+        "minTileCol": 0,
+        "maxTileCol": 512
+    },
+    "10": {
+        "minTileRow": 31,
+        "maxTileRow": 1024,
+        "minTileCol": 0,
+        "maxTileCol": 1024
+    },
+    "11": {
+        "minTileRow": 62,
+        "maxTileRow": 2048,
+        "minTileCol": 0,
+        "maxTileCol": 2048
+    },
+    "12": {
+        "minTileRow": 125,
+        "maxTileRow": 4096,
+        "minTileCol": 0,
+        "maxTileCol": 4096
+    },
+    "13": {
+        "minTileRow": 2739,
+        "maxTileRow": 4628,
+        "minTileCol": 41,
+        "maxTileCol": 7917
+    },
+    "14": {
+        "minTileRow": 5478,
+        "maxTileRow": 9256,
+        "minTileCol": 82,
+        "maxTileCol": 15835
+    },
+    "15": {
+        "minTileRow": 10956,
+        "maxTileRow": 18513,
+        "minTileCol": 165,
+        "maxTileCol": 31670
+    },
+    "16": {
+        "minTileRow": 21912,
+        "maxTileRow": 37026,
+        "minTileCol": 330,
+        "maxTileCol": 63341
+    },
+    "17": {
+        "minTileRow": 43825,
+        "maxTileRow": 74052,
+        "minTileCol": 660,
+        "maxTileCol": 126683
+    },
+    "18": {
+        "minTileRow": 87651,
+        "maxTileRow": 148105,
+        "minTileCol": 1320,
+        "maxTileCol": 253366
+    },
+    "19": {
+        "minTileRow": 175302,
+        "maxTileRow": 294060,
+        "minTileCol": 170159,
+        "maxTileCol": 343473
+    },
+    "20": {
+        "minTileRow": 376733,
+        "maxTileRow": 384679,
+        "minTileCol": 530773,
+        "maxTileCol": 540914
+    }
+};
+
+// then we are finally ready to add our layer
+globeView.addLayer(orthoLayerOptions);
+
 // Add two elevation layers.
 // These will deform iTowns globe geometry to represent terrain elevation.
 promises.push(itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb));

--- a/src/Provider/WMTSProvider.js
+++ b/src/Provider/WMTSProvider.js
@@ -28,16 +28,16 @@ function preprocessDataLayer(layer) {
     }
 
     if (layer.protocol === 'wmts') {
+        layer.version = layer.version || '1.0.0';
+        layer.projection = layer.projection || 'EPSG:3857';
         const options = layer.options;
-        options.version = options.version || '1.0.0';
         options.tileMatrixSet = options.tileMatrixSet || 'WGS84';
         options.style = options.style || 'normal';
-        options.projection = options.projection || 'EPSG:3857';
         let newBaseUrl = `${layer.url}` +
-            `?LAYER=${options.name}` +
+            `?LAYER=${layer.name}` +
             `&FORMAT=${layer.format}` +
             '&SERVICE=WMTS' +
-            `&VERSION=${options.version}` +
+            `&VERSION=${layer.version}` +
             '&REQUEST=GetTile' +
             `&STYLE=${options.style}` +
             `&TILEMATRIXSET=${options.tileMatrixSet}`;


### PR DESCRIPTION
Followup on the discussion on #714:

## Description

Creating a config object to add a layer is an essential piece to understand when you want to use iTowns and plug your own data in.

Hiding them in json files far away from the code had 2 very bad consequences:
- they weren't documented
- some mistakes and discrepancies between protocols have been forgotten, see the changes in WMTS_Provider

This PR is a proof-of-concept of putting our config back in examples. They are now documented.

To further my idea, we can then autogenerate this kind of webpages from our examples (based on the work @peppsac did on docco): http://37.187.164.233/itowns-docs2/docs/globe.html


