### PR TITLE
feat(pointcloud): use 'changeSource' mechanism to avoid useless work

### DIFF
--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -94,6 +94,19 @@ function parseOctree(layer, hierarchyStepSize, root) {
     });
 }
 
+function findChildrenByName(node, name) {
+    if (node.name === name) {
+        return node;
+    }
+    const charIndex = node.name.length;
+    for (let i = 0; i < node.children.length; i++) {
+        if (node.children[i].name[charIndex] == name[charIndex]) {
+            return findChildrenByName(node.children[i], name);
+        }
+    }
+    throw new Error(`Cannot find node with name '${name}'`);
+}
+
 let nextuuid = 1;
 function addPickingAttribute(points) {
     // generate unique id for picking
@@ -206,6 +219,8 @@ export default {
             // eslint-disable-next-line no-console
             console.log('LAYER metadata:', root);
             layer.root = root;
+            root.findChildrenByName = findChildrenByName.bind(root, root);
+
             return layer;
         });
     },

--- a/test/pointcloudprocessing_unit_test.js
+++ b/test/pointcloudprocessing_unit_test.js
@@ -1,0 +1,54 @@
+import PointCloudProcessing from '../src/Process/PointCloudProcessing';
+/* global describe, it */
+
+const assert = require('assert');
+
+describe('preUpdate', function () {
+    it('should return root if no change source', () => {
+        const layer = { root: {} };
+        const sources = new Set();
+        assert.equal(
+            layer.root,
+            PointCloudProcessing.preUpdate(null, layer, sources)[0]);
+    });
+
+    it('should return root if no common ancestors', () => {
+        const layer = { root: {}, id: 'a' };
+        const elt1 = { name: '12', obj: { layer: 'a', isPoints: true } };
+        const elt2 = { name: '345', obj: { layer: 'a', isPoints: true } };
+        const sources = new Set();
+        sources.add(elt1);
+        sources.add(elt2);
+        assert.equal(
+            layer.root,
+            PointCloudProcessing.preUpdate(null, layer, sources)[0]);
+    });
+
+    it('should return common ancestor', () => {
+        const layer = { root: {}, id: 'a' };
+        const elt1 = { name: '123', obj: { layer: 'a', isPoints: true } };
+        const elt2 = { name: '12567', obj: { layer: 'a', isPoints: true } };
+        const elt3 = { name: '122', obj: { layer: 'a', isPoints: true } };
+        const sources = new Set();
+        sources.add(elt1);
+        sources.add(elt2);
+        sources.add(elt3);
+        layer.root.findChildrenByName = (name) => {
+            assert.equal('12', name);
+        };
+        PointCloudProcessing.preUpdate(null, layer, sources);
+    });
+
+    it('should not search ancestors if layer are different root if no common ancestors', () => {
+        const layer = { root: {}, id: 'a' };
+        const elt1 = { name: '12', obj: { layer: 'a', isPoints: true } };
+        const elt2 = { name: '13', obj: { layer: 'b', isPoints: true } };
+        const sources = new Set();
+        sources.add(elt1);
+        sources.add(elt2);
+        layer.root.findChildrenByName = (name) => {
+            assert.equal('12', name);
+        };
+        PointCloudProcessing.preUpdate(null, layer, sources);
+    });
+});


### PR DESCRIPTION
Implements a simple logic to avoid updating the full layer if we
already know that the result won't change.

This feature is already implemented for tile based layers
(see 3f340b9ed610009f197f0d43982faf01e899d3ad).