### PR TITLE
chore(examples): no need to pass a parent layer

### DIFF
--- a/examples/globe_wfs_extruded.js
+++ b/examples/globe_wfs_extruded.js
@@ -91,7 +91,7 @@ globeView.addLayer({
         north: 5205890.19,
     },
     format: 'geojson',
-}, globeView.tileLayer);
+});
 
 function colorBuildings(properties) {
     if (properties.id.indexOf('bati_remarquable') === 0) {
@@ -154,7 +154,7 @@ globeView.addLayer({
     projection: 'EPSG:4326',
     ipr: 'IGN',
     format: 'application/json',
-}, globeView.tileLayer);
+});
 
 function configPointMaterial(result) {
     var i = 0;
@@ -206,7 +206,7 @@ globeView.addLayer({
     projection: 'EPSG:2154',
     ipr: 'IGN',
     format: 'application/json',
-}, globeView.tileLayer);
+});
 
 exports.view = globeView;
 exports.initialPosition = positionOnGlobe;

--- a/examples/wfs.js
+++ b/examples/wfs.js
@@ -83,7 +83,7 @@ view.addLayer({
         north: 5205890.19,
     },
     format: 'geojson',
-}, view.tileLayer);
+});
 
 function colorBuildings(properties) {
     if (properties.id.indexOf('bati_remarquable') === 0) {
@@ -141,7 +141,7 @@ view.addLayer({
     },
     ipr: 'IGN',
     format: 'application/json',
-}, view.tileLayer);
+});
 
 function configPointMaterial(result) {
     var i = 0;


### PR DESCRIPTION
## Description

When adding a "geometry" layer using view.addLayer there's no need to pass a parent layer.

And in the case of a globe view (globe_wfs_extruded.js) view.tileLayer is undefined anyway, the "tile layer" being view.wgs84TileLayer not view.tileLayer.

## Motivation and Context

Make the examples simpler when possible.