### PR TITLE
feat(parsers) Parser registry

### DIFF
--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -39,8 +39,8 @@
             globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
                 itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx').then(xml => itowns.GpxParser.parse(xml, { crs: globeView.referenceCrs })).then(function (gpx) {
-                    if (gpx) {
-                        globeView.scene.add(gpx);
+                    if (gpx && gpx.object3d) {
+                        globeView.scene.add(gpx.object3d);
                         globeView.controls.setTilt(45, true);
                     }
                 });

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -116,16 +116,11 @@ Scheduler.prototype.initDefaultProviders = function initDefaultProviders() {
 Scheduler.prototype.initDefaultParsers = function initDefaultParsers() {
     // Register all parsers
     this.addFormatParser('gpx', GpxParser);
-    // this.addFormatParser('xbil', XbilParser);
     this.addFormatParser('application/json', GeoJsonParser);
     this.addFormatParser('geojson', GeoJsonParser);
     this.addFormatParser('json', GeoJsonParser);
-    // this.addFormatParser('pnts', PntsParser);
-    // this.addFormatParser('b3dm', B3dmParser);
     this.addFormatParser('bin', PotreeBinParser);
     this.addFormatParser('cin', PotreeCinParser);
-    // this.addFormatParser('gltf', GLTFLoader);
-    // this.addFormatParser('gltf-legacy', LegacyGLTFLoader);
 };
 
 Scheduler.prototype.runCommand = function runCommand(command, queue, executingCounterUpToDate) {

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -18,14 +18,9 @@ import RasterProvider from '../../Provider/RasterProvider';
 import StaticProvider from '../../Provider/StaticProvider';
 
 import GpxParser from '../../Parser/GpxParser';
-import XbilParser from '../../Parser/XbilParser';
 import GeoJsonParser from '../../Parser/GeoJsonParser';
-import PntsParser from '../../Parser/PntsParser';
-import B3dmParser from '../../Parser/B3dmParser';
 import PotreeBinParser from '../../Parser/PotreeBinParser';
 import PotreeCinParser from '../../Parser/PotreeCinParser';
-// import GLTFLoader from '../../Parser/GLTFLoader';
-// import LegacyGLTFLoader from '../../Parser/LegacyGLTFLoader';
 
 var instanceScheduler = null;
 
@@ -121,11 +116,12 @@ Scheduler.prototype.initDefaultProviders = function initDefaultProviders() {
 Scheduler.prototype.initDefaultParsers = function initDefaultParsers() {
     // Register all parsers
     this.addFormatParser('gpx', GpxParser);
-    this.addFormatParser('xbil', XbilParser);
+    // this.addFormatParser('xbil', XbilParser);
     this.addFormatParser('application/json', GeoJsonParser);
     this.addFormatParser('geojson', GeoJsonParser);
-    this.addFormatParser('pnts', PntsParser);
-    this.addFormatParser('b3dm', B3dmParser);
+    this.addFormatParser('json', GeoJsonParser);
+    // this.addFormatParser('pnts', PntsParser);
+    // this.addFormatParser('b3dm', B3dmParser);
     this.addFormatParser('bin', PotreeBinParser);
     this.addFormatParser('cin', PotreeCinParser);
     // this.addFormatParser('gltf', GLTFLoader);

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -256,9 +256,9 @@ export default {
 
     /**
      * Parse a GeoJSON file content and return a Feature or an array of Features.
-     * @param {string} json - The GeoJSON file content to parse.
+     * @param {object|string} json - The GeoJSON file content to parse.
      * @param {object} options - options controlling the parsing
-     * @param {string} options.crsOut - The CRS to convert the input coordinates to.
+     * @param {string} options.crs - The CRS to convert the input coordinates to.
      * @param {string} options.crsIn - override the data crs
      * @param {Extent=} options.filteringExtent - Optional filter to reject features
      * outside of this extent.
@@ -268,19 +268,23 @@ export default {
      * @returns {Promise} - a promise resolving with a Feature or an array of Features
      */
     parse(json, options = {}) {
-        const crsOut = options.crsOut;
         const filteringExtent = options.filteringExtent;
         if (typeof (json) === 'string') {
             json = JSON.parse(json);
         }
-        options.crsIn = options.crsIn || readCRS(json);
+        const crsIn = options.crsIn || readCRS(json);
+        const crsOut = options.crs;
         switch (json.type.toLowerCase()) {
             case 'featurecollection':
-                return Promise.resolve(readFeatureCollection(options.crsIn, crsOut, json, filteringExtent, options));
+                return Promise.resolve(readFeatureCollection(crsIn, crsOut, json, filteringExtent, options));
             case 'feature':
-                return Promise.resolve(readFeature(options.crsIn, crsOut, json, filteringExtent, options));
+                return Promise.resolve(readFeature(crsIn, crsOut, json, filteringExtent, options));
             default:
                 throw new Error(`Unsupported GeoJSON type: '${json.type}`);
         }
     },
+    format: 'geojson',
+    extensions: ['json', 'geojson'],
+    mimetypes: ['application/json', 'application/geojson'],
+    fetchtype: 'json',
 };

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -166,7 +166,7 @@ function _gpxToMesh(gpxXML, options = {}) {
     // gpxMesh is static data, it doens't need matrix update
     gpxMesh.matrixAutoUpdate = false;
 
-    return gpxMesh;
+    return { object3d: gpxMesh };
 }
 
 export default {

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -173,7 +173,7 @@ export default {
     /** @module GpxParser */
     /** Parse gpx file and convert to THREE.Mesh
      * @function parse
-     * @param {string} xml - the gpx file or xml.
+     * @param {string | XMLDocument} xml - the gpx file or xml.
      * @param {Object=} options - additional properties.
      * @param {string} options.crs - the default CRS of Three.js coordinates. Should be a cartesian CRS.
      * @param {boolean=} [options.enablePin=true] - draw pin for way points.
@@ -196,4 +196,8 @@ export default {
         }
         return Promise.resolve(_gpxToMesh(xml, options));
     },
+    format: 'gpx',
+    extensions: ['gpx', 'xml'],
+    mimetypes: ['application/gpx+xml', 'application/gpx'],
+    fetchtype: 'xml',
 };

--- a/src/Parser/PntsParser.js
+++ b/src/Parser/PntsParser.js
@@ -63,6 +63,10 @@ export default {
             throw new Error('Invalid pnts file.');
         }
     },
+    format: '3d-tiles/pnts',
+    extensions: ['pnts'],
+    mimetypes: ['application/octet-stream'],
+    fetchtype: 'arrayBuffer',
 };
 
 function parseFeatureBinary(array, byteOffset, FTJSONLength) {

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -7,7 +7,7 @@ export default {
     /** Parse .bin PotreeConverter format and convert to THREE.Points
      * @function parse
      * @param {ArrayBuffer} buffer - the bin buffer.
-     * @return {Promise} a promise that resolves with a THREE.Points.
+     * @return {Promise} a promise that resolves as { object3d: <THREE.Points> }.
      *
      */
     parse: function parse(buffer) {
@@ -57,6 +57,6 @@ export default {
         points.realPointCount = numPoints;
         points.tightbbox = tightbbox;
 
-        return Promise.resolve(points);
+        return Promise.resolve({ object3d: points });
     },
 };

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -59,4 +59,8 @@ export default {
 
         return Promise.resolve({ object3d: points });
     },
+    format: 'potree/bin',
+    extensions: ['bin'],
+    mimetypes: ['binary/octet-stream'],
+    fetchtype: 'arrayBuffer',
 };

--- a/src/Parser/PotreeCinParser.js
+++ b/src/Parser/PotreeCinParser.js
@@ -39,4 +39,8 @@ export default {
 
         return Promise.resolve({ object3d: points });
     },
+    format: 'potree/cin',
+    extensions: ['cin'],
+    mimetypes: ['binary/octet-stream'],
+    fetchtype: 'arrayBuffer',
 };

--- a/src/Parser/PotreeCinParser.js
+++ b/src/Parser/PotreeCinParser.js
@@ -6,7 +6,7 @@ export default {
     /** Parse .cin PotreeConverter format (see {@link https://github.com/peppsac/PotreeConverter/tree/custom_bin}) and convert to THREE.Points
      * @function parse
      * @param {ArrayBuffer} buffer - the cin buffer.
-     * @return {Promise} - a promise that resolves with a THREE.Points.
+     * @return {Promise} - a promise that resolves as { object3d: <THREE.Points> }.
      *
      */
     parse: function parse(buffer) {
@@ -37,6 +37,6 @@ export default {
         points.realPointCount = numPoints;
         points.tightbbox = tightbbox;
 
-        return Promise.resolve(points);
+        return Promise.resolve({ object3d: points });
     },
 };

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -135,8 +135,7 @@ function addPickingAttribute(points) {
 }
 
 function loadPointFile(layer, url) {
-    return fetch(url, layer.fetchOptions)
-        .then(dat => dat.arrayBuffer())
+    return layer.fetcher(url, layer.fetchOptions)
         .then(buf => layer.parser.parse(buf))
         .then(obj => addPickingAttribute(obj.object3d));
 }
@@ -186,7 +185,6 @@ export default {
             if (layer.metadata.scale != undefined) {
                 // PotreeConverter format
                 layer.format = layer.format || (layer.metadata.pointAttributes === 'CIN' ? 'cin' : 'bin');
-                layer.parser = scheduler.getFormatParser(layer.format);
                 bbox = new THREE.Box3(
                     new THREE.Vector3(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz),
                     new THREE.Vector3(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz));
@@ -208,7 +206,8 @@ export default {
                    new THREE.Vector3(cloud[idx].bbox.xmin, cloud[idx].bbox.ymin, cloud[idx].bbox.zmin),
                    new THREE.Vector3(cloud[idx].bbox.xmax, cloud[idx].bbox.ymax, cloud[idx].bbox.zmax));
             }
-
+            layer.parser = scheduler.getFormatParser(layer.format);
+            layer.fetcher = Fetcher[layer.parser.fetchtype];
 
             return parseOctree(
                     layer,

--- a/src/Provider/RasterProvider.js
+++ b/src/Provider/RasterProvider.js
@@ -105,7 +105,7 @@ export default {
                 const options = {
                     buildExtent: true,
                     crsIn: layer.projection,
-                    crsOut: parentCrs,
+                    crs: parentCrs,
                     filteringExtent: layer.extent,
                 };
 

--- a/test/feature2mesh_unit_test.js
+++ b/test/feature2mesh_unit_test.js
@@ -11,7 +11,7 @@ proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 function parse() {
-    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true });
+    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crs: 'EPSG:3946', buildExtent: true });
 }
 
 function computeAreaOfMesh(mesh) {

--- a/test/featureUtils_unit_test.js
+++ b/test/featureUtils_unit_test.js
@@ -6,7 +6,7 @@ import Coordinates from '../src/Core/Geographic/Coordinates';
 const assert = require('assert');
 const geojson = require('./data/geojson/simple.geojson.json');
 
-const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true });
+const promise = GeoJsonParser.parse(geojson, { crs: 'EPSG:4326', buildExtent: true });
 
 describe('FeaturesUtils', function () {
     it('should correctly parse geojson', () =>


### PR DESCRIPTION
## Description
This PR introduces a registry of format parsers in the scheduler, similar to the protocol registry that is already there.

## Motivation and Context
The goal is to decouple format parsing from the providers, so that protocols, formats and styling may be mixed and matched (instead of current providers that hardcode formats).

(extracted from #705)