### PR TITLE
refactor(core): remove unused condition in Scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
-    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Parser/GpxParser.js src/Core/MainLoop.js src/Provider/URLBuilder.js src/Renderer/ThreeExtended/Feature2Mesh.js src/Parser/GeoJsonParser.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
+    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Parser/GpxParser.js src/Core/MainLoop.js src/Provider/URLBuilder.js src/Renderer/ThreeExtended/Feature2Mesh.js src/Parser/GeoJsonParser.js src/Core/Scheduler/Scheduler.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -62,6 +62,14 @@ function _instanciateQueue() {
     };
 }
 
+/**
+ * The Scheduler is in charge of managing the [Providers]{@link Provider} that
+ * are used to gather resources needed to display the layers on a {@link View}.
+ * There is only one instance of a Scheduler per webview, and it is instanciated
+ * with the creation of the first view.
+ *
+ * @constructor
+ */
 function Scheduler() {
     // Constructor
     if (instanceScheduler !== null) {
@@ -156,6 +164,76 @@ Scheduler.prototype.execute = function execute(command) {
     return command.promise;
 };
 
+/**
+ * A Provider has the responsability to handle protocols and datablobs. Given a
+ * data request (see {@link Provider#executeCommand} for details about this
+ * request), it fetches serialized datasets, file content or even file chunks.
+ *
+ * @interface Provider
+ */
+
+/**
+ * When adding a layer to a view, some preprocessing can be done on it, before
+ * fetching or creating resources attached to it. For example, in the WMTS and
+ * WFS providers (included in iTowns), default options to the layer are added if
+ * some are missing.
+ *
+ * @function
+ * @name Provider#preprocessDataLayer
+ *
+ * @param {Layer} layer
+ * @param {View} [view]
+ * @param {Scheduler} [scheduler]
+ * @param {Layer} [parentLayer]
+ */
+
+/**
+ * In the {@link Scheduler} loop, this function is called every time the layer
+ * needs new information about itself. For tiled layers, it gets the necessary
+ * tiles, given the current position of the camera on the map. For simple layers
+ * like a GPX trace, it gets the data once.
+ * <br><br>
+ * It passes a <code>command</code> object as a parameter, with the
+ * <code>view</code> and the <code>layer</code> always present. The other
+ * parameters are optional.
+ *
+ * @function
+ * @name Provider#executeCommand
+ *
+ * @param {Object} command
+ * @param {View} command.view
+ * @param {Layer} command.layer
+ * @param {TileMesh} [command.requester] - Every layer is attached to a tile.
+ * @param {number} [command.targetLevel] - The target level is used when there
+ * is a tiled layer, such as WMTS or TMS, but not in case like a GPX layer.
+ *
+ * @return {Promise} The {@link Scheduler} always expect a Promise as a result,
+ * resolving to an object containing sufficient information for the associated
+ * processing to the current layer. For example, see the
+ * [LayeredMaterialNodeProcessing#updateLayeredMaterialNodeElevation]{@link
+ * https://github.com/iTowns/itowns/blob/master/src/Process/LayeredMaterialNodeProcessing.js}
+ * class or other processing class.
+ */
+
+/**
+ * Adds a provider for a specified protocol. The provider will be used when
+ * executing the queue to provide resources. See {@link Provider} for more
+ * informations.
+ * By default, some protocols are already set in iTowns: WMTS, WMS, WFS, TMS,
+ * XYZ, PotreeConverter, Rasterizer, 3D-Tiles and Static.
+ * <br><br>
+ * Warning: if the specified protocol has already a provider attached to it, the
+ * current provider will be overwritten by the given provider.
+ *
+ * @param {string} protocol - The name of the protocol to add. This is the
+ * <code>protocol</code> parameter put inside the configuration when adding a
+ * layer. The capitalization of the name is not taken into account here.
+ * @param {Provider} provider - The provider to link to the protocol, that must
+ * respect the {@link Provider} interface description.
+ *
+ * @throws {Error} an error if any method of the {@link Provider} is not present
+ * in the provider.
+ */
 Scheduler.prototype.addProtocolProvider = function addProtocolProvider(protocol, provider) {
     if (typeof (provider.executeCommand) !== 'function') {
         throw new Error(`Can't add provider for ${protocol}: missing a executeCommand function.`);
@@ -167,6 +245,13 @@ Scheduler.prototype.addProtocolProvider = function addProtocolProvider(protocol,
     this.providers[protocol] = provider;
 };
 
+/**
+ * Get a specific {@link Provider} given a particular protocol.
+ *
+ * @param {string} protocol
+ *
+ * @return {Provider}
+ */
 Scheduler.prototype.getProtocolProvider = function getProtocolProvider(protocol) {
     return this.providers[protocol];
 };

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -45,11 +45,7 @@ function _instanciateQueue() {
                 this.counters.executing++;
             }
 
-            // If the provider returns a Promise, use it to handle counters
-            // Otherwise use a resolved Promise.
-            var p = provider.executeCommand(cmd) || Promise.resolve();
-
-            return p.then((result) => {
+            return provider.executeCommand(cmd).then((result) => {
                 this.counters.executing--;
                 cmd.resolve(result);
                 // only count successul commands
@@ -200,10 +196,6 @@ Scheduler.prototype.resetCommandsCount = function resetCommandsCount(type) {
         q[1].counters[type] = 0;
     }
     return sum;
-};
-
-Scheduler.prototype.getProviders = function getProviders() {
-    return this.providers.slice();
 };
 
 Scheduler.prototype.deQueue = function deQueue(queue) {


### PR DESCRIPTION
I gave a test in all examples we have, everything is working, and providers seem to be ok too, so we can drop this `|| Promise.resolve`. A provider with a `executeCommand` returning a Promise should be mandatory I think.