### PR TITLE
fix(core): sphere argument needed for box3D.getBoundingSphere

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -29,7 +29,8 @@ function TileMesh(geometry, params) {
 
     this.obb = this.geometry.OBB.clone();
 
-    this.boundingSphere = this.OBB().box3D.getBoundingSphere();
+    this.boundingSphere = new THREE.Sphere();
+    this.OBB().box3D.getBoundingSphere(this.boundingSphere);
 
     this.material = new LayeredMaterial(params.materialOptions);
 


### PR DESCRIPTION
## Description
THREE now outputs a [deprecation warning](https://github.com/mrdoob/three.js/blob/master/src/math/Box3.js#L524-L529) if `getBoundingSphere` is called with no sphere argument.

## Motivation and Context
 `getBoundingSphere` is now called with a preexisting sphere `target`.