### PR TITLE
Two fixes

### DIFF
--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -21,7 +21,7 @@ export const MAIN_LOOP_EVENTS = {
     UPDATE_START: 'update_start',
     BEFORE_CAMERA_UPDATE: 'before_camera_update',
     AFTER_CAMERA_UPDATE: 'after_camera_update',
-    BEFORE_LAYER_UPDATE: 'before_camera_update',
+    BEFORE_LAYER_UPDATE: 'before_layer_update',
     AFTER_LAYER_UPDATE: 'after_layer_update',
     BEFORE_RENDER: 'before_render',
     AFTER_RENDER: 'after_render',

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -4,6 +4,8 @@ export default {
      * @param {Object3D} obj object to release
      */
     cleanup(obj) {
+        obj.layer = null;
+
         if (typeof obj.dispose === 'function') {
             obj.dispose();
         } else {


### PR DESCRIPTION
2 one-liners :
* fix(core): correct typo in event's name
* fix(core): unassign layer of deleted objects
    
    As soon as an object is deleted is doesn't belong to any layer,
    so let's remove its layer attribute value.
    
    Fixes one part of #727 (Uncaught TypeError: Cannot read property
    'findCommonAncestor' of null).