### PR TITLE
feat(controls): make event listeners opt-out for FirstPersonControls

### DIFF
--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -24,7 +24,8 @@
             "src/Renderer/ColorLayersOrdering.js",
             "src/Renderer/ThreeExtended/Feature2Mesh.js",
             "src/Renderer/ThreeExtended/GlobeControls.js",
-            "src/Renderer/ThreeExtended/PlanarControls.js"
+            "src/Renderer/ThreeExtended/PlanarControls.js",
+            "src/Renderer/ThreeExtended/FirstPersonControls.js"
         ]
     }
 }


### PR DESCRIPTION
Allows the user to control precisely when FirstPersonControls reacts to user input.
e.g: if a user might want to have multiple controls in parallel, and switch from one to another based on the context.

This commits allows to easily forward the events to only one of them, depending of the application state.
