### PR TITLE
chore: change the JSDOC configuration

### DIFF
--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -6,5 +6,25 @@
                 "paths": ["static_jsdoc"]
             }
         }
+    },
+    "source": {
+        "include": [
+            "src/Core/MainLoop.js",
+            "src/Core/View.js",
+            "src/Core/Geographic/Coordinates.js",
+            "src/Core/Layer/Layer.js",
+            "src/Core/Prefab/GlobeView.js",
+            "src/Core/Scheduler/Scheduler.js",
+
+            "src/Parser/GeoJsonParser.js",
+            "src/Parser/GpxParser.js",
+
+            "src/Provider/URLBuilder.js",
+
+            "src/Renderer/ColorLayersOrdering.js",
+            "src/Renderer/ThreeExtended/Feature2Mesh.js",
+            "src/Renderer/ThreeExtended/GlobeControls.js",
+            "src/Renderer/ThreeExtended/PlanarControls.js"
+        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Main.js",
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\"",
-    "doc": "jsdoc src/Core/View.js src/Core/Prefab/GlobeView.js src/Core/Layer/Layer.js src/Renderer/ColorLayersOrdering.js src/Renderer/ThreeExtended/GlobeControls.js src/Core/Geographic/Coordinates.js src/Parser/GpxParser.js src/Core/MainLoop.js src/Provider/URLBuilder.js src/Renderer/ThreeExtended/Feature2Mesh.js src/Parser/GeoJsonParser.js src/Core/Scheduler/Scheduler.js src/Renderer/ThreeExtended/PlanarControls.js -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
+    "doc": "jsdoc -t node_modules/docdash --readme JSDOC.md -c jsdoc-config.json",
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-examples && npm run test-unit",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --compilers js:babel-core/register test/*unit_test.js",


### PR DESCRIPTION
I'm getting tired of editing the `package.json` each time I want to add documentation, so I moved the list of files to jsdoc-config.json.