### PR TITLE
refactor: change the return value of Fetcher.texture

### DIFF
--- a/src/Provider/Fetcher.js
+++ b/src/Provider/Fetcher.js
@@ -58,19 +58,14 @@ export default {
     },
 
     /**
-     * @typedef {Object} TexturePromise
-     * @property {Promise} promise - a promise that resolves when the texture is loaded
-     * @property {Object} texture - the loading texture
-     */
-    /**
-     * Wrapper around TextureLoader
+     * Wrapper around TextureLoader.
      *
      * @param {string} url
      * @param {Object} options - options to pass to TextureLoader. Note that
      * THREE.js docs mention withCredentials, but it is not actually used in TextureLoader.js.
      * @param {string} options.crossOrigin - passed directly to html elements supporting it
      *
-     * @return {TexturePromise}
+     * @return {Promise}
      */
     texture(url, options = {}) {
         let res;
@@ -83,8 +78,8 @@ export default {
             rej = reject;
         });
 
-        const texture = textureLoader.load(url, res, () => {}, rej);
-        return { texture, promise };
+        textureLoader.load(url, res, () => {}, rej);
+        return promise;
     },
 
     /**

--- a/src/Provider/OGCWebServiceHelper.js
+++ b/src/Provider/OGCWebServiceHelper.js
@@ -27,22 +27,22 @@ export default {
             return Promise.resolve(cache.get(url));
         }
 
-        const { texture, promise } = (pending.has(url)) ?
+        const promise = (pending.has(url)) ?
             pending.get(url) :
             Fetcher.texture(url, networkOptions);
 
-        texture.generateMipmaps = false;
-        texture.magFilter = THREE.LinearFilter;
-        texture.minFilter = THREE.LinearFilter;
-        texture.anisotropy = 16;
+        pending.set(url, promise);
 
+        return promise.then((texture) => {
+            texture.generateMipmaps = false;
+            texture.magFilter = THREE.LinearFilter;
+            texture.minFilter = THREE.LinearFilter;
+            texture.anisotropy = 16;
 
-        pending.set(url, { texture, promise });
-
-        return promise.then(() => {
             if (!cache.has(url)) {
                 cache.set(url, texture);
             }
+
             pending.delete(url);
             return texture;
         });


### PR DESCRIPTION
To harmonize all `Fetcher` methods, I removed the object returned when calling `Fetcher.texture` to a simple promise. If it does impact someone outside of the iTowns core, I'll be happy to discuss it, as we are several to feel that the `Fetcher` module shouldn't be available in the public API.

BREAKING CHANGE: the signature of `Fetcher.texture` has changed, and only return a promise now, instead of an object containing the texture and the promise.
