### PR TITLE
feat(core): add a Cache system with expiration policy

### DIFF
--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -14,6 +14,7 @@
             "src/Core/Geographic/Coordinates.js",
             "src/Core/Layer/Layer.js",
             "src/Core/Prefab/GlobeView.js",
+            "src/Core/Scheduler/Cache.js",
             "src/Core/Scheduler/Scheduler.js",
 
             "src/Parser/GeoJsonParser.js",

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -1,5 +1,6 @@
 import { EventDispatcher } from 'three';
 import { GeometryLayer, Layer } from './Layer/Layer';
+import Cache from '../Core/Scheduler/Cache';
 
 export const RENDERING_PAUSED = 0;
 export const RENDERING_SCHEDULED = 1;
@@ -184,6 +185,9 @@ MainLoop.prototype._step = function _step(view, timestamp) {
     }
 
     view.camera.camera3D.matrixAutoUpdate = oldAutoUpdate;
+
+    // Clear the cache of expired resources
+    Cache.flush();
 
     view.execFrameRequesters(MAIN_LOOP_EVENTS.UPDATE_END, dt, this._updateLoopRestarted);
 };

--- a/src/Core/Scheduler/Cache.js
+++ b/src/Core/Scheduler/Cache.js
@@ -1,0 +1,157 @@
+const data = new Map();
+const stats = new Map();
+
+/**
+ * This is a copy of the Map object, except that it also store a value for last
+ * time used. This value is used for cache expiration mechanism.
+ * <br><br>
+ * This module can be imported anywhere, its data will be shared, as it is a
+ * single instance.
+ *
+ * @module Cache
+ *
+ * @example
+ * import Cache from './Cache';
+ *
+ * Cache.set('foo', { bar: 1 }, Cache.POLICIES.TEXTURE);
+ * Cache.set('acme', { bar: 32 });
+ *
+ * Cache.get('foo');
+ *
+ * Cache.delete('foo');
+ *
+ * Cache.clear();
+ */
+const Cache = {
+    /**
+     * Cache policies for flushing. Those policies can be used when something is
+     * [set]{@link Cache.set} into the Cache, as the lifetime property.
+     *
+     * @name module:Cache
+     * @typedef {Object} module:Cache.POLICIES
+     *
+     * @property INFINITE - The entry is never flushed, except when the
+     * <code>all</code> flag is set to <code>true</code> when calling {@link
+     * Cache.flush}.
+     * @property TEXTURE - Shortcut for texture resources. Time is 15 minutes.
+     * @property ELEVATION - Shortcut for elevation resources. Time is 15
+     * minutes.
+     */
+    POLICIES: {
+        INFINITE: Infinity,
+        TEXTURE: 900000,
+        ELEVATION: 900000,
+    },
+
+    /**
+     * Returns the entry related to the specified key from the cache. The last
+     * time used property of the entry is updated to extend the longevity of the
+     * entry.
+     *
+     * @name module:Cache.get
+     * @function
+     *
+     * @param {string} key
+     *
+     * @return {Object}
+     */
+    get: (key) => {
+        const entry = data.get(key);
+        const stat = stats.get(key) || stats.set(key, { hit: 0, miss: 0 });
+
+        if (entry) {
+            stat.hit++;
+            entry.lastTimeUsed = Date.now();
+            return entry.value;
+        }
+
+        stat.miss++;
+    },
+
+    /**
+     * Adds or updates an entry with a specified key. A lifetime can be added,
+     * by specifying a numerical value or using the {@link Cache.POLICIES}
+     * values. By default an entry has an infinite lifetime.
+     *
+     * @name module:Cache.set
+     * @function
+     *
+     * @param {string} key
+     * @param {Object} value
+     * @param {number} [lifetime]
+     *
+     * @return {Object} the added value
+     */
+    set: (key, value, lifetime = Infinity) => {
+        const entry = {
+            value,
+            lastTimeUsed: Date.now(),
+            lifetime,
+        };
+        data.set(key, entry);
+
+        return value;
+    },
+
+    /**
+     * Deletes the specified entry from the cache.
+     *
+     * @name module:Cache.delete
+     * @function
+     *
+     * @param {string} key
+     *
+     * @return {boolean} - Confirmation that the entry has been deleted.
+     */
+    delete: key => data.delete(key),
+
+    /**
+     * Removes all entries of the cache.
+     *
+     * @name module:Cache.clear
+     * @function
+     */
+    clear: data.clear(),
+
+    /**
+     * Flush the cache: entries that have been present for too long since the
+     * last time they were used, are removed from the cache. By default, the
+     * time is the current time, but the interval can be reduced by doing
+     * something like <code>Cache.flush(Date.now() - reductionTime)</code>. If
+     * you want to clear the whole cache, use {@link Cache.clear} instead.
+     *
+     * @name module:Cache.flush
+     * @function
+     *
+     * @param {number} [time]
+     *
+     * @return {Object} Statistics about the flush: <code>before</code>
+     * gives the number of entries before flushing, <code>after</code> the
+     * number after flushing, <code>hit</code> the number of total successful
+     * hit on resources in the cache, and </code>miss</code> the number of
+     * failed hit. The hit and miss are based since the last flush, and are
+     * reset on every flush.
+     */
+    flush: (time = Date.now()) => {
+        const before = data.size;
+
+        data.forEach((entry, key) => {
+            if (entry.lifetime < time - entry.lastTimeUsed) {
+                data.delete(key);
+            }
+        });
+
+        let hit = 0;
+        let miss = 0;
+        stats.forEach((stat) => {
+            hit += stat.hit;
+            miss += stat.miss;
+        });
+        stats.clear();
+
+        return { before, after: data.size, hit, miss };
+    },
+};
+
+Object.freeze(Cache);
+export default Cache;

--- a/src/Provider/TileProvider.js
+++ b/src/Provider/TileProvider.js
@@ -7,9 +7,8 @@ import * as THREE from 'three';
 import TileGeometry from '../Core/TileGeometry';
 import TileMesh from '../Core/TileMesh';
 import CancelledCommandException from '../Core/Scheduler/CancelledCommandException';
+import Cache from '../Core/Scheduler/Cache';
 import { requestNewTile } from '../Process/TiledNodeProcessing';
-
-const cacheGeometry = new Map();
 
 function preprocessDataLayer(layer, view, scheduler) {
     if (!layer.schemeTile) {
@@ -50,7 +49,7 @@ function executeCommand(command) {
     const segment = layer.segments || 16;
     const key = `${builder.type}_${layer.disableSkirt ? 0 : 1}_${segment}_${level}_${south}`;
 
-    let geometry = cacheGeometry.get(key);
+    let geometry = Cache.get(key);
     // build geometry if doesn't exist
     if (!geometry) {
         const paramsGeometry = {
@@ -61,14 +60,14 @@ function executeCommand(command) {
         };
 
         geometry = new TileGeometry(paramsGeometry, builder);
-        cacheGeometry.set(key, geometry);
+        Cache.set(key, geometry);
 
         geometry._count = 0;
         geometry.dispose = () => {
             geometry._count--;
             if (geometry._count == 0) {
                 THREE.BufferGeometry.prototype.dispose.call(geometry);
-                cacheGeometry.delete(key);
+                Cache.delete(key);
             }
         };
     }


### PR DESCRIPTION
As explained in #741, the CacheResource was removed in #687, but the cache was locked inside
module like OGCWebServiceHelper. In order to remove the cache outside of this module later, a new Cache has been added, introducing a flush system based on a cache expiration mechanism.

The cache expiration mechanism is simple: when setting something into the cache, a lifetime value is specified, which is then read when the `Cache.flush` method is being called. If the lifetime is too old, the entry is flushed from the cache.
We could also used something more complete like a LFRU ([see common cache replacement policies here](https://en.wikipedia.org/wiki/Cache_replacement_policies)), but I'm not sure how we can determine the size of the cache here.

Note: this is a proposition to #741