### PR TITLE
example: fix positionGlobe camera moves and altitude

### DIFF
--- a/examples/positionGlobe.js
+++ b/examples/positionGlobe.js
@@ -44,12 +44,15 @@ function addMeshToScene() {
     var geometry = new THREE.CylinderGeometry(0, 10, 60, 8);
     var material = new THREE.MeshBasicMaterial({ color: 0xff0000 });
     var mesh = new THREE.Mesh(geometry, material);
+    var cameraTargetPosition;
+    var meshCoord;
 
     // get the position on the globe, from the camera
-    var cameraTargetPosition = globeView.controls.getCameraTargetGeoPosition();
+    globeView.controls.updateCameraTransformation();
+    cameraTargetPosition = globeView.controls.getCameraTargetGeoPosition();
 
     // position of the mesh
-    var meshCoord = cameraTargetPosition;
+    meshCoord = cameraTargetPosition;
     meshCoord.setAltitude(cameraTargetPosition.altitude() + 30);
 
     // position and orientation of the mesh

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -366,7 +366,9 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
 GlobeView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
     const g = this.mainLoop.gfxEngine;
     const restore = this.wgs84TileLayer.level0Nodes.map(n => n.pushRenderState(RendererConstant.DEPTH));
-    const buffer = g.renderViewToBuffer(this, { x, y, width, height });
+    const buffer = g.renderViewToBuffer(
+        { camera: this.camera, scene: this.wgs84TileLayer.object3d },
+        { x, y, width, height });
     restore.forEach(r => r());
 
     return buffer;

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -176,7 +176,9 @@ PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
 PlanarView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
     const g = this.mainLoop.gfxEngine;
     const restoreState = this.tileLayer.level0Nodes[0].pushRenderState(RendererConstant.DEPTH);
-    const buffer = g.renderViewToBuffer(this, { x, y, width, height });
+    const buffer = g.renderViewToBuffer(
+        { camera: this.camera, scene: this.tileLayer.object3d },
+        { x, y, width, height });
     restoreState();
     return buffer;
 };


### PR DESCRIPTION
Two fixes:
  - make sure we only render the globe (or plane) objects when querying the depthbuffer
  - update globecontrols before using getCameraTargetGeoPosition to avoid inconsistent
results.
