### PR TITLE
fix(chore): tag eslint config as root

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+ root: true,
  'extends': [
    'eslint-config-airbnb-base',
    'eslint-config-airbnb-base/rules/strict',


### PR DESCRIPTION
From eslint doc: "By default, ESLint will look for configuration files in all
 parent folders up to the root directory." (see https://eslint.org/docs/user-guide/configuring)

So if one user cloned itowns in a folder with a .eslintrc.js, running npm run lint
in itowns folder would also use these rules.

This commit prevents this by adding a "root: true" attribute to our config.
