### PR TITLE
refactor: align Feature2Mesh and Feature2Texture

### DIFF
--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -94,9 +94,10 @@
                 name: 'lyon_tcl_bus',
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
+                style: {
                     color: colorLine,
-                    altitude: altitudeLine }),
+                    altitude: altitudeLine,
+                },
                 linewidth: 5,
                 filter: acceptFeatureBus,
                 url: 'https://download.data.grandlyon.com/wfs/rdata?',
@@ -157,10 +158,11 @@
             globeView.addLayer({
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
+                style: {
                     color: colorBuildings,
                     altitude: altitudeBuildings,
-                    extrude: extrudeBuildings }),
+                    extrude: extrudeBuildings
+                },
                 onMeshCreated: function scaleZ(mesh) {
                     mesh.scale.z = 0.01;
                     meshes.push(mesh);
@@ -212,9 +214,10 @@
             globeView.addLayer({
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
+                style: {
                     altitude: altitudePoint,
-                    color: colorPoint }),
+                    color: colorPoint
+                },
                 size: 5,
                 onMeshCreated: configPointMaterial,
                 filter: selectRoad,

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -95,8 +95,8 @@
             view.addLayer({
                 name: 'lyon_tcl_bus',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
-                    color: colorLine }),
+                type: 'geometry',
+                style: { color: colorLine },
                 onMeshCreated: setMaterialLineWidth,
                 url: 'https://download.data.grandlyon.com/wfs/rdata?',
                 protocol: 'wfs',
@@ -147,9 +147,10 @@
             view.addLayer({
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
+                style: {
                     color: colorBuildings,
-                    extrude: extrudeBuildings }),
+                    extrude: extrudeBuildings
+                },
                 onMeshCreated: function scaleZ(mesh) {
                     mesh.scale.z = 0.01;
                     meshes.push(mesh);
@@ -193,9 +194,10 @@
             view.addLayer({
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
+                style: {
                     altitude: 0,
-                    color: colorPoint }),
+                    color: colorPoint
+                },
                 onMeshCreated: configPointMaterial,
                 url: 'http://wxs.ign.fr/72hpsel8j8nhb5qgdh07gcyp/geoportail/wfs?',
                 networkOptions: { crossOrigin: 'anonymous' },

--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -23,10 +23,12 @@
             "src/Provider/URLBuilder.js",
 
             "src/Renderer/ColorLayersOrdering.js",
-            "src/Renderer/ThreeExtended/Feature2Mesh.js",
             "src/Renderer/ThreeExtended/GlobeControls.js",
             "src/Renderer/ThreeExtended/PlanarControls.js",
-            "src/Renderer/ThreeExtended/FirstPersonControls.js"
+            "src/Renderer/ThreeExtended/FirstPersonControls.js",
+
+            "src/Transform/feature2Mesh.js",
+            "src/Transform/feature2Texture.js"
         ]
     }
 }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -8,6 +8,8 @@ import { GeometryLayer, Layer, defineLayerProperty } from './Layer/Layer';
 import Scheduler from './Scheduler/Scheduler';
 import Picking from './Picking';
 import { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } from '../Process/LayeredMaterialNodeProcessing';
+import feature2Mesh from '../Transform/feature2Mesh';
+import feature2Texture from '../Transform/feature2Texture';
 
 export const VIEW_EVENTS = {
     /**
@@ -181,6 +183,8 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
         defineLayerProperty(layer, 'visible', true);
         defineLayerProperty(layer, 'opacity', 1.0);
         defineLayerProperty(layer, 'sequence', 0);
+
+        layer.transform = feature2Texture;
     } else if (layer.type == 'elevation') {
         defineLayerProperty(layer, 'frozen', false);
     } else if (layer.type == 'geometry' || layer.type == 'debug') {
@@ -215,6 +219,8 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
                 });
             }
         });
+
+        layer.transform = feature2Mesh;
     }
     return layer;
 }

--- a/src/Main.js
+++ b/src/Main.js
@@ -19,7 +19,6 @@ export { processTiledGeometryNode, initTiledGeometryLayer } from './Process/Tile
 export { ColorLayersOrdering } from './Renderer/ColorLayersOrdering';
 export { default as PointsMaterial } from './Renderer/PointsMaterial';
 export { default as PointCloudProcessing } from './Process/PointCloudProcessing';
-export { default as Feature2Mesh } from './Renderer/ThreeExtended/Feature2Mesh';
 export { default as FlyControls } from './Renderer/ThreeExtended/FlyControls';
 export { default as FirstPersonControls } from './Renderer/ThreeExtended/FirstPersonControls';
 export { default as PlanarControls } from './Renderer/ThreeExtended/PlanarControls';

--- a/src/Provider/RasterProvider.js
+++ b/src/Provider/RasterProvider.js
@@ -7,7 +7,7 @@
 import * as THREE from 'three';
 import togeojson from 'togeojson';
 import Extent from '../Core/Geographic/Extent';
-import Feature2Texture from '../Renderer/ThreeExtended/Feature2Texture';
+import feature2Texture from '../Transform/feature2Texture';
 import GeoJsonParser from '../Parser/GeoJsonParser';
 import Fetcher from './Fetcher';
 
@@ -31,7 +31,11 @@ function createTextureFromVector(tile, layer) {
     if (layer.type == 'color') {
         const coords = tile.extent;
         const result = { pitch: new THREE.Vector4(0, 0, 1, 1) };
-        result.texture = Feature2Texture.createTextureFromFeature(layer.feature, tile.extent, 256, layer.style);
+        result.texture = feature2Texture(layer.feature, {
+            extent: tile.extent,
+            size: 256,
+            style: layer.style,
+        });
         result.texture.extent = tile.extent;
         result.texture.coords = coords;
         result.texture.coords.zoom = tile.level;

--- a/src/Provider/WFSProvider.js
+++ b/src/Provider/WFSProvider.js
@@ -9,7 +9,7 @@ import URLBuilder from './URLBuilder';
 import Fetcher from './Fetcher';
 import Cache from '../Core/Scheduler/Cache';
 import GeoJsonParser from '../Parser/GeoJsonParser';
-import Feature2Mesh from '../Renderer/ThreeExtended/Feature2Mesh';
+import feature2Mesh from '../Transform/feature2Mesh';
 
 function preprocessDataLayer(layer) {
     if (!layer.typeName) {
@@ -62,7 +62,7 @@ function getFeatures(crs, tile, layer) {
 
     const urld = URLBuilder.bbox(tile.extent.as(layer.crs), layer);
 
-    layer.convert = layer.convert ? layer.convert : Feature2Mesh.convert({});
+    layer.transform = layer.transform ? layer.transform : feature2Mesh;
 
     return (Cache.get(urld) || Cache.set(urld, Fetcher.json(urld, layer.networkOptions)))
         .then(
@@ -84,7 +84,7 @@ function getFeatures(crs, tile, layer) {
                     throw err;
                 }
             })
-        .then(feature => assignLayer(layer.convert(feature), layer));
+        .then(feature => assignLayer(layer.transform(feature, layer.style), layer));
 }
 
 export default {

--- a/src/Transform/feature2Mesh.js
+++ b/src/Transform/feature2Mesh.js
@@ -258,16 +258,9 @@ function featureToExtrudedPolygon(feature, properties, options) {
     return new THREE.Mesh(geom);
 }
 
-/**
- * Convert a [Feature]{@link Feature#geometry}'s geometry to a Mesh
- *
- * @param {Object} feature - a Feature's geometry
- * @param {Object} options - options controlling the conversion
- * @param {number|function} options.altitude - define the base altitude of the mesh
- * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
- * @param {object|function} options.color - define per feature color
- * @return {THREE.Mesh} mesh
- */
+// Convert a Feature geometry to a three.js Mesh
+// Supported attributes (as constant or functions) in options are: altitude,
+// extrude and color. See the module exportation below for more details.
 function featureToMesh(feature, options) {
     if (!feature.vertices) {
         return;
@@ -333,24 +326,29 @@ function featuresToThree(features, options) {
 }
 
 /**
- * @module Feature2Mesh
+ * Converts [Features]{@link module:GeoJsonParser} to [THREE.Mesh]{@link
+ * https://threejs.org/docs/#api/objects/Mesh}.Feature collection will be
+ * converted to a a [THREE.Group]{@link
+ * https://threejs.org/docs/#api/objects/Group}.
+ *
+ * @function feature2Mesh
+ *
+ * @param {module:GeoJsonParser~FeatureCollection} collection - a Feature or an
+ * array of Feature.
+ * @param {Object} [options] - Options controlling the conversion.
+ * @param {number|function} options.altitude - Define the base altitude of
+ * the mesh.
+ * @param {number|function} options.extrude - If defined, polygons will be
+ * extruded by the specified amount.
+ * @param {Object|function} options.color - Define per feature color.
+ *
+ * @return {THREE.Mesh|THREE.Group} Returns a [THREE.Mesh]{@link
+ * https://threejs.org/docs/#api/objects/Mesh}. If an array of Feature is
+ * specified, it will be converted to a [THREE.Group]{@link
+ * https://threejs.org/docs/#api/objects/Group}.
  */
-export default {
-    /**
-     * Return a function that converts [Features]{@link module:GeoJsonParser} to Meshes. Feature collection will be converted to a
-     * a THREE.Group.
-     *
-     * @param {Object} options - options controlling the conversion
-     * @param {number|function} options.altitude - define the base altitude of the mesh
-     * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
-     * @param {object|function} options.color - define per feature color
-     * @return {function}
-     */
-    convert(options = {}) {
-        return function _convert(collection) {
-            if (!collection) return;
+export default function (collection, options = {}) {
+    if (!collection) return;
 
-            return featuresToThree(collection.features, options);
-        };
-    },
-};
+    return featuresToThree(collection.features, options);
+}

--- a/src/Transform/feature2Texture.js
+++ b/src/Transform/feature2Texture.js
@@ -63,6 +63,12 @@ function drawPoint(ctx, vertice, origin, scale, style = {}) {
 function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
     const properties = feature.properties;
 
+    if (typeof style === 'function') {
+        style = style(properties, feature);
+    }
+
+    ctx.globalCompositeOperation = style.globalCompositeOperation || 'source-over';
+
     for (const geometry of feature.geometry) {
         if (feature.type === 'point') {
             drawPoint(ctx, feature.vertices[0], origin, scale, style);
@@ -72,33 +78,51 @@ function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
     }
 }
 
-export default {
-    createTextureFromFeature(collection, extent, sizeTexture, style) {
-        // A texture is instancied drawn canvas
-        // origin and dimension are used to transform the feature's coordinates to canvas's space
-        const origin = new THREE.Vector2(extent.west(), extent.south());
-        const dimension = extent.dimensions();
-        const c = document.createElement('canvas');
+/**
+ * Converts [Feature]{@link module:GeoJsonParser~Feature} to
+ * [THREE.Texture]{@link https://threejs.org/docs/#api/textures/Texture}.
+ *
+ * @function feature2Texture
+ *
+ * @param {module:GeoJsonParser~FeatureCollection} collection - a Feature or an
+ * array of Feature.
+ * @param {Object} [options] - Options controlling the conversion.
+ * @param {Extent} options.extent - The extent containing the feature.
+ * @param {number} options.size - The size of the texture, in pixels. The
+ * resulting texture will be a square, and it is highly recommended to use a
+ * power of 2 for GPU optimization purpose.
+ * @param {Object|function} options.style - The style to apply to the
+ * feature before rendering the texture. If it is a function, the two
+ * arguments are the <code>properties</code> of the current processed
+ * feature, and the <code>feature</code> itself.
+ *
+ * @return {function} Returns a [THREE.Texture]{@link
+ * https://threejs.org/docs/#api/textures/Texture}.
+ */
+export default function (collection, options = {}) {
+    // A texture is instancied drawn canvas
+    // origin and dimension are used to transform the feature's coordinates to canvas's space
+    const origin = new THREE.Vector2(options.extent.west(), options.extent.south());
+    const dimension = options.extent.dimensions();
+    const c = document.createElement('canvas');
+    c.width = options.size;
+    c.height = options.size;
 
-        c.width = sizeTexture;
-        c.height = sizeTexture;
-        const ctx = c.getContext('2d');
-        ctx.globalCompositeOperation = style.globalCompositeOperation || 'source-over';
+    const ctx = c.getContext('2d');
 
-        const scale = new THREE.Vector2(ctx.canvas.width / dimension.x, ctx.canvas.width / dimension.y);
+    const scale = new THREE.Vector2(ctx.canvas.width / dimension.x, ctx.canvas.width / dimension.y);
 
-        // Draw the canvas
-        for (const feature of collection.features) {
-            drawFeature(ctx, feature, origin, scale, extent, style);
-        }
+    // Draw the canvas
+    for (const feature of collection.features) {
+        drawFeature(ctx, feature, origin, scale, options.extent, options.style);
+    }
 
-        const texture = new THREE.Texture(c);
-        texture.flipY = false;
-        texture.generateMipmaps = false;
-        texture.magFilter = THREE.LinearFilter;
-        texture.minFilter = THREE.LinearFilter;
-        texture.needsUpdate = true;
-        return texture;
-    },
-};
+    const texture = new THREE.Texture(c);
+    texture.flipY = false;
+    texture.generateMipmaps = false;
+    texture.magFilter = THREE.LinearFilter;
+    texture.minFilter = THREE.LinearFilter;
+    texture.needsUpdate = true;
+    return texture;
+}
 

--- a/test/examples/globe_vector.js
+++ b/test/examples/globe_vector.js
@@ -14,4 +14,27 @@ describe('globe_vector', () => {
         assert.ok(result);
         await page.close();
     });
+
+    it('should return the correct element', async function _() {
+        const page = await browser.newPage();
+
+        await page.setViewport({ width: 400, height: 300 });
+        await page.goto(`http://localhost:${itownsPort}/examples/globe_vector.html`);
+        await page.waitFor('#viewerDiv > canvas');
+
+        await exampleCanRenderTest(page, this.test.fullTitle());
+
+        const ariege = await page.evaluate(() => {
+            const layer = globeView.getLayers(l => l.name === 'ariege');
+            const position = globeView.controls.pickGeoPosition({ x: 118, y: 215 });
+            const result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(position,
+                layer[0].feature);
+
+            return result[0].feature.properties.code;
+        });
+
+        assert.equal('09', ariege);
+        page.close();
+        await page.close();
+    });
 });

--- a/test/feature2mesh_unit_test.js
+++ b/test/feature2mesh_unit_test.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import proj4 from 'proj4';
 import GeoJsonParser from '../src/Parser/GeoJsonParser';
-import Feature2Mesh from '../src/Renderer/ThreeExtended/Feature2Mesh';
+import feature2Mesh from '../src/Transform/feature2Mesh';
 /* global describe, it */
 
 const assert = require('assert');
@@ -30,11 +30,11 @@ function computeAreaOfMesh(mesh) {
     return area;
 }
 
-describe('Feature2Mesh', function () {
+describe('feature2Mesh', function () {
     it('rect mesh area should match geometry extent', () =>
-        parse().then((features) => {
-            const mesh = Feature2Mesh.convert()(features);
-            const extentSize = features.extent.dimensions();
+        parse().then((collection) => {
+            const mesh = feature2Mesh(collection);
+            const extentSize = collection.extent.dimensions();
 
             assert.equal(
                 extentSize.x * extentSize.y,
@@ -42,8 +42,8 @@ describe('Feature2Mesh', function () {
         }));
 
     it('square mesh area should match geometry extent minus holes', () =>
-        parse().then((feature) => {
-            const mesh = Feature2Mesh.convert()(feature);
+        parse().then((collection) => {
+            const mesh = feature2Mesh(collection);
 
             const noHoleArea = computeAreaOfMesh(mesh.children[0]);
             const holeArea = computeAreaOfMesh(mesh.children[1]);


### PR DESCRIPTION
## Description

The two modules are very similar: they take a feature or an array of feature as arguments, and return either a mesh or a texture. It makes sense to regroup them under the same scheme.

The documentation was completed in the same time.

No breaking change as the old function has been marked as deprecated.

## Question

I'm not quite happy with the name of the common method (`convert`), and I wish to find a better name. In the same vein, I would like to take the opportunity to move those two module in `src/Core/newFolder` to start the gathering of all "stylizing/symbolizing" modules (as in #695 maybe). Any suggestion ?