### PR TITLE
refactor geojson parsing

### DIFF
--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -37,10 +37,10 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                 layer = layers[i];
                 result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(
                     geoCoord, layer.feature, precision);
-                result.sort(function compare(a, b) { return b.feature.geometry.type !== 'point'; });
+                result.sort(function compare(a, b) { return b.feature.type !== 'point'; });
                 for (p = 0; p < result.length; p++) {
                     visible = true;
-                    if (result[p].feature.geometry.type === 'polygon') {
+                    if (result[p].feature.type === 'polygon') {
                         polygon = result[p].feature;
                         color = polygon.properties.fill || layer.style.fill;
                         stroke = polygon.properties.stroke || layer.style.stroke;
@@ -50,12 +50,12 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                         document.getElementById(name).style['-webkit-text-stroke'] = '1.25px ' + stroke;
                         document.getElementById(name).style.color = color;
                         ++id;
-                    } else if (result[p].feature.geometry.type === 'linestring') {
+                    } else if (result[p].feature.type === 'linestring') {
                         line = result[p].feature;
                         color = line.properties.stroke || layer.style.stroke;
                         symb = '<span style=color:' + color + ';>&#9473</span>';
                         tooltip.innerHTML += symb + ' ' + (line.name || layer.name) + '<br />';
-                    } else if (result[p].feature.geometry.type === 'point') {
+                    } else if (result[p].feature.type === 'point') {
                         point = result[p].feature;
                         color = 'white';
                         name = 'point' + id;

--- a/src/Provider/RasterProvider.js
+++ b/src/Provider/RasterProvider.js
@@ -114,7 +114,7 @@ export default {
         }).then((feature) => {
             if (feature) {
                 layer.feature = feature;
-                layer.extent = layer.feature.extent || layer.feature.geometry.extent;
+                layer.extent = feature.extent;
             }
         });
     },

--- a/src/Renderer/ThreeExtended/Feature2Texture.js
+++ b/src/Renderer/ThreeExtended/Feature2Texture.js
@@ -16,36 +16,20 @@ function _lineTo(ctx, coord, scale, origin) {
     ctx.lineTo(pt.x, pt.y);
 }
 
-function drawPolygon(ctx, vertices, contour, holes, origin, scale, properties, style = {}) {
+function drawPolygon(ctx, vertices, indices, origin, scale, properties, style = {}) {
     if (vertices.length === 0) {
         return;
     }
     // build contour
     ctx.beginPath();
-    if (contour) {
-        _moveTo(ctx, vertices[contour.offset], scale, origin);
-        for (let i = 1; i < contour.count; i++) {
-            _lineTo(ctx, vertices[contour.offset + i], scale, origin);
-        }
-    } else {
-        // linestring
-        _moveTo(ctx, vertices[0], scale, origin);
-        for (let i = 1; i < vertices.length; i++) {
-            _lineTo(ctx, vertices[i], scale, origin);
+    for (const indice of indices) {
+        _moveTo(ctx, vertices[indice.offset], scale, origin);
+        for (let j = 1; j < indice.count; j++) {
+            _lineTo(ctx, vertices[indice.offset + j], scale, origin);
         }
     }
+    ctx.closePath();
 
-    // holes
-    if (contour && holes) {
-        for (const hole of holes) {
-            // ctx.beginPath();
-            _moveTo(ctx, vertices[hole.offset], scale, origin);
-            for (let i = 1; i < hole.count; i++) {
-                _lineTo(ctx, vertices[hole.offset + i], scale, origin);
-            }
-            ctx.closePath();
-        }
-    }
     // draw line polygon
     if (style.stroke || properties.stroke) {
         ctx.strokeStyle = style.stroke || properties.stroke;
@@ -55,7 +39,7 @@ function drawPolygon(ctx, vertices, contour, holes, origin, scale, properties, s
     }
 
     // fill polygon
-    if (contour && (style.fill || properties.fill)) {
+    if (indices && (style.fill || properties.fill)) {
         ctx.fillStyle = style.fill || properties.fill;
         ctx.globalAlpha = style.fillOpacity || properties['fill-opacity'] || 1.0;
         ctx.fill();
@@ -76,27 +60,20 @@ function drawPoint(ctx, vertice, origin, scale, style = {}) {
     ctx.stroke();
 }
 
-function _drawFeatureGeometry(ctx, feature, geometry, origin, scale, extent, style) {
-    const properties = feature.properties;
-    if (geometry.type === 'point') {
-        drawPoint(ctx, geometry.vertices[0], origin, scale, style);
-    } else if (geometry.extent.intersectsExtent(extent)) {
-        drawPolygon(ctx, geometry.vertices, geometry.contour, geometry.holes, origin, scale, properties, style);
-    }
-}
-
 function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
-    if (Array.isArray(feature.geometry)) {
-        for (let i = 0; i < feature.geometry.length; i++) {
-            _drawFeatureGeometry(ctx, feature, feature.geometry[i], origin, scale, extent, style);
+    const properties = feature.properties;
+
+    for (const geometry of feature.geometry) {
+        if (feature.type === 'point') {
+            drawPoint(ctx, feature.vertices[0], origin, scale, style);
+        } else if (geometry.extent.intersectsExtent(extent)) {
+            drawPolygon(ctx, feature.vertices, geometry.indices, origin, scale, properties, style);
         }
-    } else {
-        _drawFeatureGeometry(ctx, feature, feature.geometry, origin, scale, extent, style);
     }
 }
 
 export default {
-    createTextureFromFeature(features, extent, sizeTexture, style) {
+    createTextureFromFeature(collection, extent, sizeTexture, style) {
         // A texture is instancied drawn canvas
         // origin and dimension are used to transform the feature's coordinates to canvas's space
         const origin = new THREE.Vector2(extent.west(), extent.south());
@@ -111,12 +88,8 @@ export default {
         const scale = new THREE.Vector2(ctx.canvas.width / dimension.x, ctx.canvas.width / dimension.y);
 
         // Draw the canvas
-        if (Array.isArray(features)) {
-            for (let i = 0; i < features.length; i++) {
-                drawFeature(ctx, features[i], origin, scale, extent, style);
-            }
-        } else {
-            drawFeature(ctx, features, origin, scale, extent, style);
+        for (const feature of collection.features) {
+            drawFeature(ctx, feature, origin, scale, extent, style);
         }
 
         const texture = new THREE.Texture(c);

--- a/test/feature2mesh_unit_test.js
+++ b/test/feature2mesh_unit_test.js
@@ -32,24 +32,22 @@ function computeAreaOfMesh(mesh) {
 
 describe('Feature2Mesh', function () {
     it('rect mesh area should match geometry extent', () =>
-        parse().then((feature) => {
-            const mesh = Feature2Mesh.convert()(feature[0]);
-            const extentSize = feature[0].geometry.extent.dimensions();
+        parse().then((features) => {
+            const mesh = Feature2Mesh.convert()(features);
+            const extentSize = features.extent.dimensions();
 
             assert.equal(
                 extentSize.x * extentSize.y,
-                computeAreaOfMesh(mesh));
+                computeAreaOfMesh(mesh.children[0]));
         }));
 
     it('square mesh area should match geometry extent minus holes', () =>
         parse().then((feature) => {
-            const noHole = Feature2Mesh.convert()(feature[0]);
-            const hole = Feature2Mesh.convert()(feature[1]);
-            const meshWithHole = Feature2Mesh.convert()(feature[2]);
+            const mesh = Feature2Mesh.convert()(feature);
 
-            const noHoleArea = computeAreaOfMesh(noHole);
-            const holeArea = computeAreaOfMesh(hole);
-            const meshWithHoleArea = computeAreaOfMesh(meshWithHole);
+            const noHoleArea = computeAreaOfMesh(mesh.children[0]);
+            const holeArea = computeAreaOfMesh(mesh.children[1]);
+            const meshWithHoleArea = computeAreaOfMesh(mesh.children[2]);
 
             assert.equal(
                 noHoleArea - holeArea,

--- a/test/featureUtils_unit_test.js
+++ b/test/featureUtils_unit_test.js
@@ -10,39 +10,39 @@ const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent:
 
 describe('FeaturesUtils', function () {
     it('should correctly parse geojson', () =>
-        promise.then((feature) => {
-            assert.equal(feature.length, 3);
+        promise.then((collection) => {
+            assert.equal(collection.features.length, 3);
         }));
     it('should correctly compute extent geojson', () =>
-        promise.then((feature) => {
-            assert.equal(feature.extent.west(), 0.30798339284956455);
-            assert.equal(feature.extent.east(), 2.4722900334745646);
-            assert.equal(feature.extent.south(), 42.91620643817353);
-            assert.equal(feature.extent.north(), 43.72744458647463);
+        promise.then((collection) => {
+            assert.equal(collection.extent.west(), 0.30798339284956455);
+            assert.equal(collection.extent.east(), 2.4722900334745646);
+            assert.equal(collection.extent.south(), 42.91620643817353);
+            assert.equal(collection.extent.north(), 43.72744458647463);
         }));
     it('should correctly filter point', () =>
-        promise.then((feature) => {
+        promise.then((collection) => {
             const coordinates = new Coordinates('EPSG:4326', 1.26, 42.9);
-            const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
+            const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, collection, 0.1);
             assert.equal(filter.length, 1.0);
-            assert.equal(filter[0].feature.geometry.type == 'point', 1.0);
+            assert.equal(filter[0].feature.type == 'point', 1.0);
         }));
     it('should correctly filter polygon', () =>
         promise.then((feature) => {
             const coordinates = new Coordinates('EPSG:4326', 0.62, 43.52);
             const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
             assert.equal(filter.length, 1.0);
-            assert.equal(filter[0].feature.geometry.type == 'polygon', 1.0);
+            assert.equal(filter[0].feature.type == 'polygon', 1.0);
         }));
     it('should correctly filter line', () =>
         promise.then((feature) => {
             const coordinates = new Coordinates('EPSG:4326', 2.23, 43.39);
             const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
             assert.equal(filter.length, 1.0);
-            assert.equal(filter[0].feature.geometry.type == 'linestring', 1.0);
+            assert.equal(filter[0].feature.type == 'linestring', 1.0);
         }));
     it('should remember individual feature properties', () =>
         promise.then((feature) => {
-            assert.equal(feature[2].properties.my_prop, 14);
+            assert.equal(feature.features[2].properties.my_prop, 14);
         }));
 });

--- a/test/geojson_unit_test.js
+++ b/test/geojson_unit_test.js
@@ -15,12 +15,12 @@ function parse(geojson) {
 
 describe('GeoJsonParser', function () {
     it('should set all z coordinates to 1', () =>
-        parse(holes).then((feature) => {
-            assert.ok(feature[0].geometry.vertices.every(v => v.z() == 1));
+        parse(holes).then((collection) => {
+            assert.ok(collection.features[0].vertices.every(v => v.z() == 1));
         }));
 
     it('should respect all z coordinates', () =>
-        parse(gpx).then((feature) => {
-            assert.ok(feature[0].geometry.vertices.every(v => v.z() != 1));
+        parse(gpx).then((collection) => {
+            assert.ok(collection.features[0].vertices.every(v => v.z() != 1));
         }));
 });


### PR DESCRIPTION
When parsing a multi polygon, line or point, the result was a modified `Array` with custom properties, not respecting the original object. It has been replaced by an `Object` containig the `Array` in question, under the name elements.

Also, when a multi polygon, line or point, is composed of only one element, we simplify the result by returning directly a polygon, line or point.

I would like to wait #753 and #757 to be merged before merging this one.