### PR TITLE
fix(renderer): extruded polygon in Feature2Mesh

### DIFF
--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -96,24 +96,27 @@ function addExtrudedPolygonSideFaces(indices, length, ring, isClockWise) {
     // add indices to make two triangle, that make the side face
     const mod = ring.offset + ring.count + length;
     for (let i = ring.offset; i < ring.offset + ring.count; ++i) {
+        const i1 = Math.max((i + 1) % mod, ring.offset);
+        const i2 = Math.max((i + length) % mod, ring.offset);
+        const i3 = Math.max((i + length + 1) % mod, ring.offset);
         if (isClockWise) {
             // first triangle indices
             indices.push(i);
-            indices.push((i + length) % mod);
-            indices.push((i + 1) % mod);
+            indices.push(i2);
+            indices.push(i1);
             // second triangle indices
-            indices.push((i + 1) % mod);
-            indices.push((i + length) % mod);
-            indices.push((i + length + 1) % mod);
+            indices.push(i1);
+            indices.push(i2);
+            indices.push(i3);
         } else {
             // first triangle indices
-            indices.push((i + length) % mod);
+            indices.push(i2);
             indices.push(i);
-            indices.push((i + length + 1) % mod);
+            indices.push(i3);
             // second triangle indices
-            indices.push((i + length + 1) % mod);
+            indices.push(i3);
             indices.push(i);
-            indices.push((i + 1) % mod);
+            indices.push(i1);
         }
     }
 }

--- a/test/feature2mesh_unit_test.js
+++ b/test/feature2mesh_unit_test.js
@@ -55,4 +55,20 @@ describe('Feature2Mesh', function () {
                 noHoleArea - holeArea,
                 meshWithHoleArea);
         }));
+
+    it('square polygon should have double the vertices for being extruded', () =>
+        parse().then((feature) => {
+            const noExtrude = Feature2Mesh.convert()(feature[0]);
+            const extrude = Feature2Mesh.convert({
+                extrude: 2,
+            })(feature[0]);
+
+            assert.equal(noExtrude.geometry.attributes.position.count, 4);
+            assert.equal(extrude.geometry.attributes.position.count, 8);
+
+            // 2 triangles -> 6 indexes
+            assert.equal(noExtrude.geometry.index.count, 6);
+            // 2 triangles * 6 faces - bottom -> 30 indexes
+            assert.equal(extrude.geometry.index.count, 30);
+        }));
 });


### PR DESCRIPTION
Simple polygons in Feature2Mesh were not extruded properly. This has
been resolved, and in the same time the two very similar part of the
code related to this have been merged.

(moved out of #756)