### PR TITLE
feat(core): store Layer instead of layer's id

### DIFF
--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -90,12 +90,12 @@ function traversePickingCircle(radius, callback) {
     }
 }
 
-function findLayerIdInParent(obj) {
+function findLayerInParent(obj) {
     if (obj.layer) {
         return obj.layer;
     }
     if (obj.parent) {
-        return findLayerIdInParent(obj.parent);
+        return findLayerInParent(obj.parent);
     }
 }
 
@@ -123,7 +123,7 @@ export default {
             if (_ids.indexOf(node.id) >= 0 && node instanceof TileMesh) {
                 results.push({
                     object: node,
-                    layer: layer.id,
+                    layer,
                 });
             }
         };
@@ -192,7 +192,7 @@ export default {
                         result.push({
                             object: o,
                             index: candidates[i].index,
-                            layer: layer.id,
+                            layer,
                         });
                     }
                 }
@@ -255,7 +255,7 @@ export default {
 
             const intersects = raycaster.intersectObject(object, true);
             for (const inter of intersects) {
-                inter.layer = findLayerIdInParent(inter.object);
+                inter.layer = findLayerInParent(inter.object);
                 target.push(inter);
             }
 

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -58,7 +58,7 @@ function _subdivideNodeAdditive(context, layer, node, cullingTest) {
 }
 
 function _subdivideNodeSubstractive(context, layer, node) {
-    if (!node.pendingSubdivision && node.children.filter(n => n.layer == layer.id).length == 0) {
+    if (!node.pendingSubdivision && node.children.filter(n => n.layer == layer).length == 0) {
         const childrenTiles = layer.tileIndex.index[node.tileId].children;
         if (childrenTiles === undefined || childrenTiles.length === 0) {
             return;
@@ -294,11 +294,11 @@ export function process3dTilesNode(cullingTest, subdivisionTest) {
                 subdivideNode(context, layer, node, cullingTest);
                 // display iff children aren't ready
                 setDisplayed(node, node.pendingSubdivision || node.additiveRefinement);
-                returnValue = node.children.filter(n => n.layer == layer.id);
+                returnValue = node.children.filter(n => n.layer == layer);
             } else {
                 setDisplayed(node, true);
 
-                for (const n of node.children.filter(n => n.layer == layer.id)) {
+                for (const n of node.children.filter(n => n.layer == layer)) {
                     n.visible = false;
                     markForDeletion(layer, n);
                 }

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -43,7 +43,7 @@ export default {
             return;
         }
 
-        const features = node.children.filter(n => n.layer == layer.id);
+        const features = node.children.filter(n => n.layer == layer);
         for (const feat of features) {
             feat.traverse((o) => {
                 if (o.material) {
@@ -109,7 +109,7 @@ export default {
                 if (result.minAltitude) {
                     result.position.z = result.minAltitude;
                 }
-                result.layer = layer.id;
+                result.layer = layer;
                 node.add(result);
                 node.updateMatrixWorld();
             } else {

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -21,29 +21,29 @@ export default {
     },
 
     /**
-     * Remove obj's children belonging to layerId layer.
+     * Remove obj's children belonging to a layer.
      * Neither obj nor its children will be disposed!
-     * @param {String} layerId The id of the layer that objects must belong to. Other object are ignored
+     * @param {Layer} layer The layer that objects must belong to. Other object are ignored
      * @param {Object3D} obj The Object3D we want to clean
      * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
      */
-    removeChildren(layerId, obj) {
-        const toRemove = obj.children.filter(c => c.layer === layerId);
+    removeChildren(layer, obj) {
+        const toRemove = obj.children.filter(c => c.layer === layer);
         obj.remove(...toRemove);
         return toRemove;
     },
 
     /**
-     * Remove obj's children belonging to layerId layer and cleanup objexts.
+     * Remove obj's children belonging to a layer and cleanup objexts.
      * obj will be disposed but its children **won't**!
-     * @param {String} layerId The id of the layer that objects must belong to. Other object are ignored
+     * @param {Layer} layer The layer that objects must belong to. Other object are ignored
      * @param {Object3D} obj The Object3D we want to clean
      * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
      */
-    removeChildrenAndCleanup(layerId, obj) {
-        const toRemove = obj.children.filter(c => c.layer === layerId);
+    removeChildrenAndCleanup(layer, obj) {
+        const toRemove = obj.children.filter(c => c.layer === layer);
 
-        if (obj.layer === layerId) {
+        if (obj.layer === layer) {
             this.cleanup(obj);
         }
 
@@ -52,18 +52,18 @@ export default {
     },
 
     /**
-     * Recursively remove obj's children belonging to layerId layer.
+     * Recursively remove obj's children belonging to a layer.
      * All removed obj will have their geometry/material disposed.
-     * @param {String} layerId The id of the layer that objects must belong to. Other object are ignored
+     * @param {Layer} layer The layer that objects must belong to. Other object are ignored
      * @param {Object3D} obj The Object3D we want to clean
      * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
      */
-    removeChildrenAndCleanupRecursively(layerId, obj) {
-        const toRemove = obj.children.filter(c => c.layer === layerId);
+    removeChildrenAndCleanupRecursively(layer, obj) {
+        const toRemove = obj.children.filter(c => c.layer === layer);
         for (const c of toRemove) {
-            this.removeChildrenAndCleanupRecursively(layerId, c);
+            this.removeChildrenAndCleanupRecursively(layer, c);
         }
-        if (obj.layer === layerId) {
+        if (obj.layer === layer) {
             this.cleanup(obj);
         }
         obj.remove(...toRemove);

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -117,7 +117,7 @@ export default {
                 continue;
             }
             // filter sources that belong to our layer
-            if (source.obj.isPoints && source.obj.layer == layer.id) {
+            if (source.obj.isPoints && source.obj.layer == layer) {
                 if (!commonAncestorName) {
                     commonAncestorName = source.name;
                 } else {

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -46,7 +46,7 @@ export function requestNewTile(view, scheduler, geometryLayer, extent, parent, l
 }
 
 function subdivideNode(context, layer, node) {
-    if (!node.pendingSubdivision && !node.children.some(n => n.layer == layer.id)) {
+    if (!node.pendingSubdivision && !node.children.some(n => n.layer == layer)) {
         const extents = subdivisionExtents(node.extent);
         // TODO: pendingSubdivision mechanism is fragile, get rid of it
         node.pendingSubdivision = true;
@@ -94,7 +94,7 @@ function subdivideNode(context, layer, node) {
 export function processTiledGeometryNode(cullingTest, subdivisionTest) {
     return function _processTiledGeometryNode(context, layer, node) {
         if (!node.parent) {
-            return ObjectRemovalHelper.removeChildrenAndCleanup(layer.id, node);
+            return ObjectRemovalHelper.removeChildrenAndCleanup(layer, node);
         }
         // early exit if parent' subdivision is in progress
         if (node.parent.pendingSubdivision) {
@@ -126,15 +126,15 @@ export function processTiledGeometryNode(cullingTest, subdivisionTest) {
                 }
 
                 if (!requestChildrenUpdate) {
-                    return ObjectRemovalHelper.removeChildren(layer.id, node);
+                    return ObjectRemovalHelper.removeChildren(layer, node);
                 }
             }
 
             // TODO: use Array.slice()
-            return requestChildrenUpdate ? node.children.filter(n => n.layer == layer.id) : undefined;
+            return requestChildrenUpdate ? node.children.filter(n => n.layer == layer) : undefined;
         }
 
         node.setDisplayed(false);
-        return ObjectRemovalHelper.removeChildren(layer.id, node);
+        return ObjectRemovalHelper.removeChildren(layer, node);
     };
 }

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -136,7 +136,7 @@ function pntsParse(data) {
 
 function configureTile(tile, layer, metadata, parent) {
     tile.frustumCulled = false;
-    tile.layer = layer.id;
+    tile.layer = layer;
 
     // parse metadata
     if (metadata.transform) {

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -258,7 +258,7 @@ export default {
             points.material.uniforms.opacity.value = layer.opacity;
             points.updateMatrix();
             points.layers.set(layer.threejsLayer);
-            points.layer = layer.id;
+            points.layer = layer;
             return points;
         });
     },

--- a/src/Provider/TileProvider.js
+++ b/src/Provider/TileProvider.js
@@ -75,7 +75,6 @@ function executeCommand(command) {
 
     // build tile
     const params = {
-        layerId: layer.id,
         extent,
         level,
         materialOptions: layer.materialOptions,
@@ -83,7 +82,7 @@ function executeCommand(command) {
 
     geometry._count++;
     const tile = new TileMesh(geometry, params);
-    tile.layer = layer.id;
+    tile.layer = layer;
     tile.layers.set(command.threejsLayer);
 
     if (parent && parent instanceof TileMesh) {

--- a/test/examples/3dtiles.js
+++ b/test/examples/3dtiles.js
@@ -26,7 +26,7 @@ describe('3dtiles', () => {
         await exampleCanRenderTest(page, this.test.fullTitle());
 
         const layers = await page.evaluate(
-            () => view.pickObjectsAt({ x: 195, y: 146 }).map(p => p.layer));
+            () => view.pickObjectsAt({ x: 195, y: 146 }).map(p => p.layer.id));
 
         assert.ok(layers.indexOf('globe') >= 0);
         assert.ok(layers.indexOf('3d-tiles-discrete-lod') >= 0);

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -18,7 +18,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
         if (!enabled) {
             return;
         }
-        var obbChildren = node.children.filter(n => n.layer == obb_layer_id);
+        var obbChildren = node.children.filter(n => n.layer == layer);
 
         if (node.visible && node.boundingVolume) {
             // 3dTiles case
@@ -30,7 +30,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
                     helper.position.copy(node.boundingVolume.region.position);
                     helper.rotation.copy(node.boundingVolume.region.rotation);
                     node.add(helper);
-                    helper.layer = obb_layer_id;
+                    helper.layer = layer;
                     // add the ability to hide all the debug obj for one layer at once
                     const l = context.view.getLayers(l => l.id === obb_layer_id)[0];
                     const l3js = l.threejsLayer;
@@ -46,7 +46,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
                     helper = new THREE.Mesh(g, material);
                     node.boundingVolume.box.getCenter(helper.position);
                     node.add(helper);
-                    helper.layer = obb_layer_id;
+                    helper.layer = layer;
                     // add the ability to hide all the debug obj for one layer at once
                     const l = context.view.getLayers(l => l.id === obb_layer_id)[0];
                     const l3js = l.threejsLayer;
@@ -60,7 +60,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
                     helper = new THREE.Mesh(geometry, material);
                     helper.position.copy(node.boundingVolume.sphere.center);
                     node.add(helper);
-                    helper.layer = obb_layer_id;
+                    helper.layer = layer;
                     // add the ability to hide all the debug obj for one layer at once
                     const l = context.view.getLayers(l => l.id === obb_layer_id)[0];
                     const l3js = l.threejsLayer;
@@ -72,7 +72,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
             }
             if (helper) {
                 helper.visible = true;
-                for (const child of node.children.filter(n => n.layer == obb_layer_id)) {
+                for (const child of node.children.filter(n => n.layer == layer)) {
                     if (typeof child.setMaterialVisibility === 'function') {
                         child.setMaterialVisibility(true);
                     }
@@ -81,7 +81,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
             }
         } else {
             // hide obb children
-            for (const child of node.children.filter(n => n.layer == obb_layer_id)) {
+            for (const child of node.children.filter(n => n.layer == layer)) {
                 if (typeof child.setMaterialVisibility === 'function') {
                     child.setMaterialVisibility(false);
                 }

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -6,9 +6,9 @@ import View from '../../src/Core/View';
 import ObjectRemovalHelper from '../../src/Process/ObjectRemovalHelper';
 import GeometryDebug from './GeometryDebug';
 
-function applyToNodeFirstMaterial(view, root, layerId, cb) {
+function applyToNodeFirstMaterial(view, root, layer, cb) {
     root.traverse((object) => {
-        if (object.material && object.layer === layerId) {
+        if (object.material && object.layer === layer) {
             cb(object.material);
         }
     });
@@ -37,7 +37,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
     gui.add(layer, 'showOutline').name('Show tiles outline').onChange((newValue) => {
         layer.showOutline = newValue;
 
-        applyToNodeFirstMaterial(view, layer.object3d, layer.id, (material) => {
+        applyToNodeFirstMaterial(view, layer.object3d, layer, (material) => {
             if (material.uniforms) {
                 material.uniforms.showOutline = { value: newValue };
                 material.needsUpdate = true;
@@ -49,7 +49,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
     gui.add(layer, 'wireframe').name('Wireframe').onChange((newValue) => {
         layer.wireframe = newValue;
 
-        applyToNodeFirstMaterial(view, layer.object3d, layer.id, (material) => {
+        applyToNodeFirstMaterial(view, layer.object3d, layer, (material) => {
             material.wireframe = newValue;
         });
     });
@@ -92,7 +92,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
         if (!enabled) {
             return;
         }
-        const helpers = node.children.filter(n => n.layer == layer.id);
+        const helpers = node.children.filter(n => n.layer == layer);
 
         if (node.material && node.material.visible) {
             let helper;
@@ -113,7 +113,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
                 }
 
                 helper.layers.set(l3js);
-                helper.layer = layer.id;
+                helper.layer = layer;
                 node.add(helper);
                 helper.updateMatrixWorld(true);
 


### PR DESCRIPTION
It's more convenient (no need to use `View.getLayers()` to retrieve the real layer) and won't be costlier than storing strings.

(I have another PR coming that depends on this)