### PR TITLE
Points shader optimization

### DIFF
--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -164,8 +164,10 @@ export default {
         if (elt.numPoints > 0) {
             if (elt.obj) {
                 elt.obj.material.visible = true;
-                elt.obj.material.uniforms.size.value = layer.pointSize;
-
+                elt.obj.material.size = layer.pointSize;
+                if (elt.obj.material.updateUniforms) {
+                    elt.obj.material.updateUniforms();
+                }
                 if (__DEBUG__) {
                     if (layer.bboxes.visible) {
                         if (!elt.obj.boxHelper) {

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -1,4 +1,4 @@
-import { Color, Uniform, Vector2, NoBlending, NormalBlending, RawShaderMaterial } from 'three';
+import { Vector4, Uniform, NoBlending, NormalBlending, RawShaderMaterial } from 'three';
 import PointsVS from './Shader/PointsVS.glsl';
 import PointsFS from './Shader/PointsFS.glsl';
 import Capabilities from '../Core/System/Capabilities';
@@ -8,13 +8,13 @@ class PointsMaterial extends RawShaderMaterial {
         super();
         this.vertexShader = PointsVS;
         this.fragmentShader = PointsFS;
+        this.size = size || 0;
+        this.scale = 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
 
-        this.uniforms.size = new Uniform(size);
-        this.uniforms.resolution = new Uniform(new Vector2(window.innerWidth, window.innerHeight));
+        this.uniforms.size = new Uniform(this.size);
         this.uniforms.pickingMode = new Uniform(false);
         this.uniforms.opacity = new Uniform(1.0);
-        this.uniforms.useCustomColor = new Uniform(false);
-        this.uniforms.customColor = new Uniform(new Color());
+        this.uniforms.overlayColor = new Uniform(new Vector4(0, 0, 0, 0));
 
         if (Capabilities.isLogDepthBufferSupported()) {
             this.defines = {
@@ -26,12 +26,19 @@ class PointsMaterial extends RawShaderMaterial {
         if (__DEBUG__) {
             this.defines.DEBUG = 1;
         }
+
+        this.updateUniforms();
     }
 
-    enablePicking(v) {
+    enablePicking(pickingMode) {
         // we don't want pixels to blend over already drawn pixels
-        this.blending = v ? NoBlending : NormalBlending;
-        this.uniforms.pickingMode.value = v;
+        this.blending = pickingMode ? NoBlending : NormalBlending;
+        this.uniforms.pickingMode.value = pickingMode;
+    }
+
+    updateUniforms() {
+        // if size is null, switch to autosizing using the canvas height
+        this.uniforms.size.value = (this.size > 0) ? this.size : -this.scale * window.innerHeight;
     }
 }
 

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -4,30 +4,14 @@ precision highp int;
 #include <logdepthbuf_pars_fragment>
 
 varying vec4 vColor;
-uniform bool pickingMode;
-uniform float opacity;
-
-uniform bool useCustomColor;
-uniform vec3 customColor;
 
 void main() {
     // circular point rendering
-    float u = 2.0 * gl_PointCoord.x - 1.0;
-    float v = 2.0 * gl_PointCoord.y - 1.0;
-    float cc = u*u + v*v;
-    if(cc > 1.0){
+    if(length(gl_PointCoord - 0.5) > 0.5){
         discard;
     }
 
-    if (useCustomColor && !pickingMode) {
-        gl_FragColor = mix(vColor, vec4(customColor, 1.0), 0.5);
-    } else {
-        gl_FragColor = vColor;
-    }
-
-    if (!pickingMode) {
-        gl_FragColor.a = opacity;
-    }
+    gl_FragColor = vColor;
 
     #include <logdepthbuf_fragment>
 }

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -4,16 +4,16 @@ precision highp int;
 #include <logdepthbuf_pars_vertex>
 #define EPSILON 1e-6
 
-uniform float size;
-uniform float scale;
+attribute vec3 position;
 uniform mat4 projectionMatrix;
 uniform mat4 modelViewMatrix;
-uniform vec2 resolution;
-uniform bool pickingMode;
+uniform float size;
 
-attribute vec4 unique_id;
+uniform bool pickingMode;
+uniform float opacity;
+uniform vec4 overlayColor;
 attribute vec3 color;
-attribute vec3 position;
+attribute vec4 unique_id;
 
 varying vec4 vColor;
 
@@ -21,21 +21,15 @@ void main() {
     if (pickingMode) {
         vColor = unique_id;
     } else {
-        vColor = vec4(color, 1.0);
+        vColor = vec4(mix(color, overlayColor.rgb, overlayColor.a), opacity);
     }
-    vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-    mat4 projModelViewMatrix = projectionMatrix * modelViewMatrix;
-    gl_Position = projModelViewMatrix* vec4( position, 1.0);
 
-    if (size > 0.01) {
+    gl_Position = projectionMatrix * (modelViewMatrix * vec4( position, 1.0 ));
+
+    if (size > 0.) {
         gl_PointSize = size;
     } else {
-        float pointSize = 1.0;
-        float slope = tan(1.0 / 2.0);
-        float projFactor =  -0.5 * resolution.y / (slope * mvPosition.z);
-
-        float z = min(0.5 * -gl_Position.z / gl_Position.w, 1.0);
-        gl_PointSize = max(3.0, min(10.0, 0.05 * projFactor));
+        gl_PointSize = clamp(-size / gl_Position.w, 3.0, 10.0);
     }
 
     #include <logdepthbuf_vertex>


### PR DESCRIPTION
## Description
This PR simplifies and tentatively optimizes Points shader code.

## Motivation and Context
this PR:
- prevents an [unnecessary mat4 * mat4 multiplication in the VS](https://github.com/iTowns/itowns/compare/points_shader?expand=1#diff-a6598601c3959d96f711a02a6c151364L27)
- [change the 0.01 magic number for automatic size selection to 0](https://github.com/iTowns/itowns/compare/points_shader?expand=1#diff-a6598601c3959d96f711a02a6c151364R35) (but does not look into the automatic size selection itself)
- simplifies to the minimum the FS, moving all color computation to the VS. (to optimize and simplify further, one could remove the bool uniforms and use instead the a pair of attribute and uniform vec4 colors)

## Screenshots (if appropriate)
apart for the 0.01->0 autosize threshold, the output should be unchanged.