### PR TITLE
refactor(pointsmaterial) : shared potree material among point tiles (no cloning)

### DIFF
--- a/examples/pointcloud.html
+++ b/examples/pointcloud.html
@@ -234,11 +234,14 @@
                         // update stats window
                         oldPostUpdate = pointcloud.postUpdate;
                         pointcloud.postUpdate = function postUpdate() {
-                            var info = document.getElementById('info');
                             oldPostUpdate.apply(pointcloud, arguments);
+                            pointcloud.statsUpdate();
+                        };
+                        pointcloud.statsUpdate = function statsUpdate() {
+                            var info = document.getElementById('info');
                             info.textContent = 'Nb points: ' +
                                 pointcloud.displayedCount.toLocaleString();
-                        };
+                        }
                     }
                     window.view = view;
 

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -246,7 +246,7 @@ export default {
         const url = `${node.baseurl}/r${node.name}.${layer.extension}?isleaf=${command.isLeaf ? 1 : 0}`;
 
         return Fetcher.arrayBuffer(url, layer.fetchOptions).then(layer.parse).then((geometry) => {
-            const points = new THREE.Points(geometry, layer.material.clone());
+            const points = new THREE.Points(geometry, layer.material);
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -49,30 +49,30 @@ export default {
                 layer.displayedCount = 0;
                 const stickies = layer.dbgStickyNode.split(',');
                 for (const pts of layer.group.children) {
-                    pts.material.visible = false;
+                    pts.visible = false;
                     for (const name of stickies) {
                         if (pts.owner.name == name) {
-                            pts.material.visible = true;
+                            pts.visible = true;
                         } else if (!isInHierarchy(pts.owner, name)) {
                             continue;
                         } else if (pts.owner.name.length < name.length) {
-                            pts.material.visible = layer.dbgDisplayParents;
+                            pts.visible = layer.dbgDisplayParents;
                             break;
                         } else {
-                            pts.material.visible = layer.dbgDisplayChildren;
+                            pts.visible = layer.dbgDisplayChildren;
                         }
-                        if (pts.material.visible) {
+                        if (pts.visible) {
                             break;
                         }
                     }
-                    if (pts.material.visible) {
+                    if (pts.visible) {
                         layer.displayedCount += pts.geometry.attributes.position.count;
                     }
                 }
             }
             for (const pts of layer.group.children) {
                 if (pts.boxHelper) {
-                    pts.boxHelper.material.visible = layer.dbgDisplaybbox
+                    pts.boxHelper.visible = layer.dbgDisplaybbox
                         && pts.visible && pts.material.visible;
                 }
             }


### PR DESCRIPTION
## Description
Potree parsers used a hardcoded itowns.PointsMaterial  material
This PR tackles some part of #695 to decouple the parsing and the styling of potree pointclouds.

## Change
- Potree parsers now output a THREE.BufferGeometry, rather than a THREE.Points.
- The potree PointCloudProvider (to be renamed more explicitly as well as the pointcloud examples by the way :) ) is now responsible for creating the THREE.Points and adding the layer material (which defaults to itowns.PointsMaterial.
- customBinFormat is now a local variable (private implementation detail)
- realPointCount is removed as it was not used apparently (if needed, it can be accessed using the size of the position attribute)

## Screenshots
No visible change

## Question
I am not sure I understand why I need to [clone](https://github.com/iTowns/itowns/compare/points_material#diff-4033c2db9cc0d018b29c8a27df1bf722R240) the material. Ideally, I would like to use the same material for all pointcloud tiles.
@peppsac : any clue ?

