### PR TITLE
[bug] [do not merge] single material bug in point clouds

### DIFF
--- a/examples/pointcloud.html
+++ b/examples/pointcloud.html
@@ -204,6 +204,13 @@
                         view.notifyChange(true);
                     }
 
+                    var material = new itowns.THREE.PointsMaterial({
+                        color: 0xff8888,
+                        sizeAttenuation: false,
+                        size: 1,
+                        vertexColors: itowns.THREE.VertexColors
+                    });
+
                     // add pointcloud to scene
                     function onLayerReady() {
                         var ratio;
@@ -221,6 +228,10 @@
                         lookAt.z = pointcloud.root.bbox.min.z;
                         placeCamera(position, lookAt);
                         controls.moveSpeed = pointcloud.root.bbox.getSize().length() / 3;
+
+                        pointcloud.onPointsCreated = (pointcloud, pts) => {
+                            pts.material = material;
+                        };
 
                         // update stats window
                         oldPostUpdate = pointcloud.postUpdate;

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -164,7 +164,9 @@ export default {
         if (elt.numPoints > 0) {
             if (elt.obj) {
                 elt.obj.material.visible = true;
-                elt.obj.material.uniforms.size.value = layer.pointSize;
+                if (elt.obj.material.uniforms && elt.obj.material.uniforms.size) {
+                    elt.obj.material.uniforms.size.value = layer.pointSize;
+                }
 
                 if (__DEBUG__) {
                     if (layer.bboxes.visible) {


### PR DESCRIPTION
## Description
@peppsac suggested in [comment](https://github.com/iTowns/itowns/pull/760#issuecomment-390911368) that a shared custom material may be assigned to the potree tiles as follows :

```
layer.onPointsCreated = (layer, pts) => {
   pts.material = mymaterial;
};
```

This PR (DO NOT MERGE!) shows that it does not work (at least not the way I understand the comment).

## Motivation and Context
due to the coupling of the parsers/provider/process for potree tiles, it does not work : 
- the custom material may not have a `uniforms` property (this PR provides a [workaround](https://github.com/iTowns/itowns/pull/761/files#diff-6b60bae2240ab556c955b4eb0a07a12eL167) for this)
- the process sets the visibility of the tile material instead of the visibility of the tile itself, so that the visibility status is then shared by all tiles (either all or none are displayed, depending on the last process update)

## Fix
#760 works towards fixing this bug.