### PR TITLE
refactor(parser) : move Materials from potree parsers to potree provider (+custom layer material option)

### DIFF
--- a/examples/pointcloud.html
+++ b/examples/pointcloud.html
@@ -152,6 +152,7 @@
             <script src="js/loading_screen.js"></script>
             <script src="../dist/debug.js"></script>
             <script type="text/javascript">
+                var searchParams = new URL(window.location.href).searchParams;
                 function showPointcloud(serverUrl, fileName, lopocsTable) {
                     var pointcloud;
                     var oldPostUpdate;
@@ -182,6 +183,14 @@
                     pointcloud.protocol = 'potreeconverter';
                     pointcloud.url = serverUrl;
                     pointcloud.table = lopocsTable;
+                    if (searchParams.get('material') === 'three') {
+                        pointcloud.material = new itowns.THREE.PointsMaterial({
+                            color: 0xff8888,
+                            sizeAttenuation: false,
+                            size: 1,
+                            vertexColors: itowns.THREE.VertexColors
+                        });
+                    }
 
                     // point selection on double-click
                     function dblClickHandler(event) {
@@ -236,8 +245,7 @@
                     view.addLayer(pointcloud).then(onLayerReady);
                 }
 
-
-                if (new URL(window.location.href).searchParams.get('selector')) {
+                if (searchParams.get('selector')) {
                     document.getElementsByClassName('centered')[0].style.display = 'block';
                     document.getElementById('submit').addEventListener('click', onConnectClicked);
                 } else {

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -1,13 +1,11 @@
 import * as THREE from 'three';
-import PointsMaterial from '../Renderer/PointsMaterial';
 
-// Parse .bin PotreeConverter format
 export default {
     /** @module PotreeBinParser */
-    /** Parse .bin PotreeConverter format and convert to THREE.Points
+    /** Parse .bin PotreeConverter format and convert to a THREE.BufferGeometry
      * @function parse
      * @param {ArrayBuffer} buffer - the bin buffer.
-     * @return {Promise} a promise that resolves with a THREE.Points.
+     * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      *
      */
     parse: function parse(buffer) {
@@ -22,9 +20,9 @@ export default {
         const positions = new Float32Array(3 * numPoints);
         const colors = new Uint8Array(4 * numPoints);
 
-        const tightbbox = new THREE.Box3();
-        tightbbox.min.set(Infinity, Infinity, Infinity);
-        tightbbox.max.set(-Infinity, -Infinity, -Infinity);
+        const box = new THREE.Box3();
+        box.min.set(Infinity, Infinity, Infinity);
+        box.max.set(-Infinity, -Infinity, -Infinity);
         const tmp = new THREE.Vector3();
 
         let offset = 0;
@@ -34,8 +32,8 @@ export default {
             positions[3 * i + 2] = view.getUint32(offset + 8, true);
 
             tmp.fromArray(positions, 3 * i);
-            tightbbox.min.min(tmp);
-            tightbbox.max.max(tmp);
+            box.min.min(tmp);
+            box.max.max(tmp);
 
             colors[4 * i] = view.getUint8(offset + 12);
             colors[4 * i + 1] = view.getUint8(offset + 13);
@@ -48,15 +46,8 @@ export default {
         const geometry = new THREE.BufferGeometry();
         geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
         geometry.addAttribute('color', new THREE.BufferAttribute(colors, 4, true));
+        geometry.boundingBox = box;
 
-        const material = new PointsMaterial();
-        const points = new THREE.Points(geometry, material);
-
-        points.frustumCulled = false;
-        points.matrixAutoUpdate = false;
-        points.realPointCount = numPoints;
-        points.tightbbox = tightbbox;
-
-        return Promise.resolve(points);
+        return Promise.resolve(geometry);
     },
 };

--- a/src/Parser/PotreeCinParser.js
+++ b/src/Parser/PotreeCinParser.js
@@ -1,12 +1,11 @@
 import * as THREE from 'three';
-import PointsMaterial from '../Renderer/PointsMaterial';
 
 export default {
     /** @module PotreeCinParser */
-    /** Parse .cin PotreeConverter format (see {@link https://github.com/peppsac/PotreeConverter/tree/custom_bin}) and convert to THREE.Points
+    /** Parse .cin PotreeConverter format (see {@link https://github.com/peppsac/PotreeConverter/tree/custom_bin}) and convert to a THREE.BufferGeometry
      * @function parse
      * @param {ArrayBuffer} buffer - the cin buffer.
-     * @return {Promise} - a promise that resolves with a THREE.Points.
+     * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      *
      */
     parse: function parse(buffer) {
@@ -18,7 +17,7 @@ export default {
         const view = new DataView(buffer, 0, 6 * 4);
         const min = new THREE.Vector3(view.getFloat32(0, true), view.getFloat32(4, true), view.getFloat32(8, true));
         const max = new THREE.Vector3(view.getFloat32(12, true), view.getFloat32(16, true), view.getFloat32(20, true));
-        const tightbbox = new THREE.Box3(min, max);
+        const box = new THREE.Box3(min, max);
 
         const numPoints = Math.floor((buffer.byteLength - 24) / 16);
 
@@ -28,15 +27,8 @@ export default {
         const geometry = new THREE.BufferGeometry();
         geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
         geometry.addAttribute('color', new THREE.BufferAttribute(colors, 4, true));
+        geometry.boundingBox = box;
 
-        const material = new PointsMaterial();
-        const points = new THREE.Points(geometry, material);
-
-        points.frustumCulled = false;
-        points.matrixAutoUpdate = false;
-        points.realPointCount = numPoints;
-        points.tightbbox = tightbbox;
-
-        return Promise.resolve(points);
+        return Promise.resolve(geometry);
     },
 };

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -99,6 +99,12 @@ export default {
             context.camera.height /
                 (2 * Math.tan(THREE.Math.degToRad(context.camera.camera3D.fov) * 0.5));
 
+        if (layer.material) {
+            layer.material.opacity = layer.opacity;
+            layer.material.transparent = layer.opacity < 1;
+            layer.material.size = layer.pointSize;
+        }
+
         // lookup lowest common ancestor of changeSources
         let commonAncestorName;
         for (const source of changeSources.values()) {
@@ -158,11 +164,7 @@ export default {
         // only load geometry if this elements has points
         if (elt.numPoints > 0) {
             if (elt.obj) {
-                elt.obj.material.visible = true;
-                elt.obj.material.size = layer.pointSize;
-                if (elt.obj.material.updateUniforms) {
-                    elt.obj.material.updateUniforms();
-                }
+                elt.obj.material.copy(layer.material);
                 if (__DEBUG__) {
                     if (layer.bboxes.visible) {
                         if (!elt.obj.boxHelper) {

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -4,17 +4,19 @@ import PointsFS from './Shader/PointsFS.glsl';
 import Capabilities from '../Core/System/Capabilities';
 
 class PointsMaterial extends RawShaderMaterial {
-    constructor(size = 0) {
-        super();
+    constructor(options = {}) {
+        super(options);
         this.vertexShader = PointsVS;
         this.fragmentShader = PointsFS;
-        this.size = size || 0;
-        this.scale = 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
+
+        this.size = options.size || 0;
+        this.scale = options.scale || 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
+        this.overlayColor = options.overlayColor || new Vector4(0, 0, 0, 0);
 
         this.uniforms.size = new Uniform(this.size);
         this.uniforms.pickingMode = new Uniform(false);
-        this.uniforms.opacity = new Uniform(1.0);
-        this.uniforms.overlayColor = new Uniform(new Vector4(0, 0, 0, 0));
+        this.uniforms.opacity = new Uniform(this.opacity);
+        this.uniforms.overlayColor = new Uniform(this.overlayColor);
 
         if (Capabilities.isLogDepthBufferSupported()) {
             this.defines = {
@@ -26,19 +28,31 @@ class PointsMaterial extends RawShaderMaterial {
         if (__DEBUG__) {
             this.defines.DEBUG = 1;
         }
-
         this.updateUniforms();
     }
 
     enablePicking(pickingMode) {
         // we don't want pixels to blend over already drawn pixels
-        this.blending = pickingMode ? NoBlending : NormalBlending;
         this.uniforms.pickingMode.value = pickingMode;
+        this.blending = pickingMode ? NoBlending : NormalBlending;
     }
 
     updateUniforms() {
         // if size is null, switch to autosizing using the canvas height
         this.uniforms.size.value = (this.size > 0) ? this.size : -this.scale * window.innerHeight;
+        this.uniforms.opacity.value = this.opacity;
+        this.uniforms.overlayColor.value = this.overlayColor;
+    }
+
+    copy(source) {
+        this.visible = source.visible;
+        this.opacity = source.opacity;
+        this.transparent = source.transparent;
+        this.size = source.size;
+        this.scale = source.scale;
+        this.overlayColor.copy(source.overlayColor);
+        this.updateUniforms();
+        return this;
     }
 }
 

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -10,22 +10,17 @@ function isInHierarchy(elt, hierarchyNode) {
 
 export default {
     initTools(view, layer, datUi) {
+        const update = () => view.notifyChange(layer);
         layer.debugUI = datUi.addFolder(`${layer.id}`);
 
-        layer.debugUI.add(layer, 'sseThreshold').name('SSE threshold')
-            .onChange(() => view.notifyChange(layer));
-        layer.debugUI.add(layer, 'octreeDepthLimit', -1, 20).name('Depth limit')
-            .onChange(() => view.notifyChange(layer));
-        layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count')
-            .onChange(() => view.notifyChange(layer));
+        layer.debugUI.add(layer.material, 'visible').name('Visible').onChange(update);
+        layer.debugUI.add(layer, 'sseThreshold').name('SSE threshold').onChange(update);
+        layer.debugUI.add(layer, 'octreeDepthLimit', -1, 20).name('Depth limit').onChange(update);
+        layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count').onChange(update);
         layer.debugUI.add(layer.object3d.position, 'z', -50, 50).name('Z translation').onChange(() => {
             layer.object3d.updateMatrixWorld();
             view.notifyChange(layer);
         });
-        layer.debugUI.add(layer, 'pointSize', 0, 15).name('Point Size')
-            .onChange(() => view.notifyChange(layer));
-        layer.debugUI.add(layer, 'opacity', 0, 1).name('Opacity')
-            .onChange(() => view.notifyChange(layer));
 
         layer.dbgEnableStickyNode = false;
         layer.dbgStickyNode = '';
@@ -33,16 +28,18 @@ export default {
         layer.dbgDisplayParents = true;
         layer.dbgDisplaybbox = false;
 
+        var styleUI = layer.debugUI.addFolder('Styling');
+        styleUI.add(layer, 'opacity', 0, 1).name('Layer Opacity').onChange(update);
+        styleUI.add(layer, 'pointSize', 0, 15).name('Point Size').onChange(update);
+        styleUI.add(layer, 'dbgDisplaybbox').name('Display Bounding Boxes').onChange(update);
+
         // UI
-        const update = () => view.notifyChange(layer);
         const sticky = layer.debugUI.addFolder('Sticky');
         sticky.add(layer, 'dbgEnableStickyNode').name('Enable sticky node').onChange(update);
         sticky.add(layer, 'dbgStickyNode').name('Sticky node name').onChange(update);
         sticky.add(layer, 'dbgDisplayChildren').name('Display children of sticky node').onChange(update);
         sticky.add(layer, 'dbgDisplayParents').name('Display parents of sticky node').onChange(update);
 
-        // bbox
-        layer.debugUI.add(layer, 'dbgDisplaybbox').name('Display bounding boxes').onChange(update);
 
         view.addFrameRequester('after_layer_update', () => {
             if (layer.bboxes) {


### PR DESCRIPTION
## Description
Potree parsers used a hardcoded itowns.PointsMaterial  material
This PR tackles some part of #695 to decouple the parsing and the styling of potree pointclouds.

## Change
- Potree parsers now output a THREE.BufferGeometry, rather than a THREE.Points.
- The potree PointCloudProvider (to be renamed more explicitly as well as the pointcloud examples by the way :) ) is now responsible for creating the THREE.Points and adding the layer material (which defaults to itowns.PointsMaterial : Potree Parser now have no knowledge of materials and rendering logic.
- customBinFormat is now a local variable (private implementation detail)
- realPointCount is removed as it was not used apparently (if needed, it can be accessed using the size of the position attribute)
- the pointcloud.html example shows a sample usage of potree layer with a custom material : [a simple upstream THREE.PointsMaterial](https://github.com/iTowns/itowns/compare/potree_custom_material?expand=1#diff-d619f5f9635467ba864c74d37cfcda7fR185).

## Screenshots
- http://localhost:8080/examples/pointcloud.html : No visible change
- http://localhost:8080/examples/pointcloud.html?material=three
![image](https://user-images.githubusercontent.com/7373521/40424460-f1adfa82-5e95-11e8-829b-c413898b11a5.png)
(note the red diffuse color and the square sprites)

## Note
This PR is a slight rework of the first commit of #760. The second commit that allows sharing the material with no cloning will be reworked in its own PR.
