### PR TITLE
Add support for other data types in potree pointclouds

### DIFF
--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -55,11 +55,10 @@ for (const potreeName of Object.keys(POINT_ATTTRIBUTES)) {
     attr.byteSize = attr.numElements * attr.numByte;
     attr.normalized = attr.normalized || false;
     // chrome is known to perform badly when we call a method without respecting its arity
-    // also, not using ternary because I measured a 25% perf hit on firefox doing so...
     const fnName = `getUint${attr.numByte * 8}`;
-    attr.value = attr.numByte === 1 ?
-        function value(view, offset) { return view[fnName](offset); } :
-        function value(view, offset) { return view[fnName](offset, true); };
+    attr.getValue = attr.numByte === 1 ?
+        function getValue(view, offset) { return view[fnName](offset); } :
+        function getValue(view, offset) { return view[fnName](offset, true); };
 }
 
 export default {
@@ -93,7 +92,7 @@ export default {
             const array = new attr.arrayType(arrayLength);
             for (let arrayOffset = 0; arrayOffset < arrayLength; arrayOffset += attr.numElements) {
                 for (let elemIdx = 0; elemIdx < attr.numElements; elemIdx++) {
-                    array[arrayOffset + elemIdx] = attr.value(view, attrOffset + elemIdx * attr.numByte);
+                    array[arrayOffset + elemIdx] = attr.getValue(view, attrOffset + elemIdx * attr.numByte);
                 }
                 attrOffset += pointByteSize;
             }

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -1,52 +1,118 @@
 import * as THREE from 'three';
 
+// See the different constants holding ordinal, name, numElements, byteSize in PointAttributes.cpp in PotreeConverter
+// elementByteSize is byteSize / numElements
+const POINT_ATTTRIBUTES = {
+    POSITION_CARTESIAN: {
+        numElements: 3,
+        arrayType: Float32Array,
+        attributeName: 'position',
+    },
+    COLOR_PACKED: {
+        numElements: 4,
+        arrayType: Uint8Array,
+        attributeName: 'color',
+        normalized: true,
+    },
+    INTENSITY: {
+        numElements: 1,
+        numByte: 2,
+        // using Float32Array because Float16Array doesn't exist
+        arrayType: Float32Array,
+        attributeName: 'intensity',
+        normalized: true,
+    },
+    CLASSIFICATION: {
+        numElements: 1,
+        arrayType: Uint8Array,
+        attributeName: 'classification',
+    },
+    // Note: at the time of writing, PotreeConverter will only generate normals in Oct16 format
+    // see PotreeConverter.cpp:121
+    // we keep all the historical value to still supports old conversion
+    NORMAL_SPHEREMAPPED: {
+        numElements: 2,
+        arrayType: Uint8Array,
+        attributeName: 'sphereMappedNormal',
+    },
+    // see https://web.archive.org/web/20150303053317/http://lgdv.cs.fau.de/get/1602
+    NORMAL_OCT16: {
+        numElements: 2,
+        arrayType: Uint8Array,
+        attributeName: 'oct16Normal',
+    },
+    NORMAL: {
+        numElements: 3,
+        arrayType: Float32Array,
+        attributeName: 'normal',
+    },
+};
+
 export default {
     /** @module PotreeBinParser */
     /** Parse .bin PotreeConverter format and convert to a THREE.BufferGeometry
      * @function parse
      * @param {ArrayBuffer} buffer - the bin buffer.
+     * @param {Object} pointAttributes - the point attributes information contained in layer.metadata coming from cloud.js
      * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      *
      */
-    parse: function parse(buffer) {
+    parse: function parse(buffer, pointAttributes) {
         if (!buffer) {
             throw new Error('No array buffer provided.');
         }
 
         const view = new DataView(buffer);
         // Format: X1,Y1,Z1,R1,G1,B1,A1,[...],XN,YN,ZN,RN,GN,BN,AN
-        const numPoints = Math.floor(buffer.byteLength / 16);
+        let pointByteSize = 0;
+        for (const potreeName of pointAttributes) {
+            const attr = POINT_ATTTRIBUTES[potreeName];
+            pointByteSize += attr.numElements * (attr.numByte || attr.arrayType.BYTES_PER_ELEMENT);
+        }
+        const numPoints = Math.floor(buffer.byteLength / pointByteSize);
 
-        const positions = new Float32Array(3 * numPoints);
-        const colors = new Uint8Array(4 * numPoints);
-
-        const box = new THREE.Box3();
-        box.min.set(Infinity, Infinity, Infinity);
-        box.max.set(-Infinity, -Infinity, -Infinity);
-        const tmp = new THREE.Vector3();
+        const attrs = [];
+        // get the variable attributes
+        for (const potreeName of pointAttributes) {
+            const attr = POINT_ATTTRIBUTES[potreeName];
+            const numByte = attr.numByte || attr.arrayType.BYTES_PER_ELEMENT;
+            attrs.push({
+                potreeName,
+                numElements: attr.numElements,
+                attributeName: attr.attributeName,
+                normalized: attr.normalized,
+                array: new attr.arrayType(attr.numElements * numPoints),
+                numByte,
+                // Potree stores everything as int, and uses scale + offset
+                fnName: `getUint${numByte * 8}`,
+            });
+        }
 
         let offset = 0;
-        for (let i = 0; i < numPoints; i++) {
-            positions[3 * i] = view.getUint32(offset + 0, true);
-            positions[3 * i + 1] = view.getUint32(offset + 4, true);
-            positions[3 * i + 2] = view.getUint32(offset + 8, true);
+        for (let pntIdx = 0; pntIdx < numPoints; pntIdx++) {
+            for (const attr of attrs) {
+                for (let elemIdx = 0; elemIdx < attr.numElements; elemIdx++) {
+                    // chrome is known to perform badly when we call a method without respecting its arity
+                    // also, not using ternary because I measured a 25% perf hit on firefox doing so...
+                    let value;
+                    if (attr.numByte === 1) {
+                        value = view[attr.fnName](offset);
+                    } else {
+                        value = view[attr.fnName](offset, true);
+                    }
+                    attr.array[pntIdx * attr.numElements + elemIdx] = value;
 
-            tmp.fromArray(positions, 3 * i);
-            box.min.min(tmp);
-            box.max.max(tmp);
-
-            colors[4 * i] = view.getUint8(offset + 12);
-            colors[4 * i + 1] = view.getUint8(offset + 13);
-            colors[4 * i + 2] = view.getUint8(offset + 14);
-            colors[4 * i + 3] = 255;
-
-            offset += 16;
+                    offset += attr.numByte;
+                }
+            }
         }
 
         const geometry = new THREE.BufferGeometry();
-        geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
-        geometry.addAttribute('color', new THREE.BufferAttribute(colors, 4, true));
-        geometry.boundingBox = box;
+        for (const attr of attrs) {
+            geometry.addAttribute(attr.attributeName, new THREE.BufferAttribute(attr.array, attr.numElements, attr.normalized));
+        }
+
+        geometry.computeBoundingBox();
 
         return Promise.resolve(geometry);
     },

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -104,7 +104,6 @@ export default {
             layer.material.opacity = layer.opacity;
             layer.material.transparent = layer.opacity < 1;
             layer.material.size = layer.pointSize;
-            layer.material.mode = layer.mode;
         }
 
         // lookup lowest common ancestor of changeSources

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -104,6 +104,7 @@ export default {
             layer.material.opacity = layer.opacity;
             layer.material.transparent = layer.opacity < 1;
             layer.material.size = layer.pointSize;
+            layer.material.mode = layer.mode;
         }
 
         // lookup lowest common ancestor of changeSources

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher';
 import PointCloudProcessing from '../Process/PointCloudProcessing';
 import PotreeBinParser from '../Parser/PotreeBinParser';
 import PotreeCinParser from '../Parser/PotreeCinParser';
-import PointsMaterial from '../Renderer/PointsMaterial';
+import PointsMaterial, { MODE } from '../Renderer/PointsMaterial';
 import Picking from '../Core/Picking';
 import Extent from '../Core/Geographic/Extent';
 
@@ -169,6 +169,7 @@ export default {
         layer.type = 'geometry';
         layer.material = layer.material || {};
         layer.material = layer.material.isMaterial ? layer.material : new PointsMaterial(layer.material);
+        layer.mode = MODE.COLOR;
 
         // default update methods
         layer.preUpdate = PointCloudProcessing.preUpdate;
@@ -194,6 +195,13 @@ export default {
                 bbox = new THREE.Box3(
                     new THREE.Vector3(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz),
                     new THREE.Vector3(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz));
+
+                // do we have normal information
+                const normal = Array.isArray(layer.metadata.pointAttributes) &&
+                    layer.metadata.pointAttributes.find(elem => elem.startsWith('NORMAL'));
+                if (normal) {
+                    layer.material.defines[normal] = 1;
+                }
             } else {
                 // Lopocs
                 layer.metadata.scale = 1;
@@ -247,7 +255,7 @@ export default {
         // when we request .hrc files)
         const url = `${node.baseurl}/r${node.name}.${layer.extension}?isleaf=${command.isLeaf ? 1 : 0}`;
 
-        return Fetcher.arrayBuffer(url, layer.fetchOptions).then(layer.parse).then((geometry) => {
+        return Fetcher.arrayBuffer(url, layer.fetchOptions).then(buffer => layer.parse(buffer, layer.metadata.pointAttributes)).then((geometry) => {
             const points = new THREE.Points(geometry, layer.material.clone());
             addPickingAttribute(points);
             points.frustumCulled = false;

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -169,6 +169,7 @@ export default {
         layer.type = 'geometry';
         layer.material = layer.material || {};
         layer.material = layer.material.isMaterial ? layer.material : new PointsMaterial(layer.material);
+        layer.material.defines = layer.material.defines || {};
         layer.mode = MODE.COLOR;
 
         // default update methods

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -164,7 +164,7 @@ function computeBbox(layer) {
     return bbox;
 }
 
-function setLayerMetadata(metadata, layer) {
+function parseMetadata(metadata, layer) {
     layer.metadata = metadata;
 
     var customBinFormat = true;
@@ -236,7 +236,7 @@ export default {
 
         return Fetcher.json(`${layer.url}/${layer.file}`, layer.fetchOptions)
             .then((metadata) => {
-                setLayerMetadata(metadata, layer);
+                parseMetadata(metadata, layer);
                 const bbox = computeBbox(layer);
                 return parseOctree(layer, layer.metadata.hierarchyStepSize, { baseurl: `${layer.url}/${layer.metadata.octreeDir}/r`, name: '', bbox });
             })
@@ -284,6 +284,5 @@ export default {
 };
 
 export const _testing = {
-    setLayerMetadata,
-    computeBbox,
+    parseMetadata,
 };

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -3,6 +3,14 @@ import PointsVS from './Shader/PointsVS.glsl';
 import PointsFS from './Shader/PointsFS.glsl';
 import Capabilities from '../Core/System/Capabilities';
 
+export const MODE = {
+    COLOR: 0,
+    PICKING: 1,
+    INTENSITY: 2,
+    CLASSIFICATION: 3,
+    NORMAL: 4,
+};
+
 class PointsMaterial extends RawShaderMaterial {
     constructor(options = {}) {
         super(options);
@@ -12,17 +20,24 @@ class PointsMaterial extends RawShaderMaterial {
         this.size = options.size || 0;
         this.scale = options.scale || 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
         this.overlayColor = options.overlayColor || new Vector4(0, 0, 0, 0);
+        this.mode = options.mode || MODE.COLOR;
+        this.oldMode = null;
+
+        for (const key in MODE) {
+            if (Object.prototype.hasOwnProperty.call(MODE, key)) {
+                this.defines[`MODE_${key}`] = MODE[key];
+            }
+        }
 
         this.uniforms.size = new Uniform(this.size);
+        this.uniforms.mode = new Uniform(this.mode);
         this.uniforms.pickingMode = new Uniform(false);
         this.uniforms.opacity = new Uniform(this.opacity);
         this.uniforms.overlayColor = new Uniform(this.overlayColor);
 
         if (Capabilities.isLogDepthBufferSupported()) {
-            this.defines = {
-                USE_LOGDEPTHBUF: 1,
-                USE_LOGDEPTHBUF_EXT: 1,
-            };
+            this.defines.USE_LOGDEPTHBUF = 1;
+            this.defines.USE_LOGDEPTHBUF_EXT = 1;
         }
 
         if (__DEBUG__) {
@@ -33,13 +48,22 @@ class PointsMaterial extends RawShaderMaterial {
 
     enablePicking(pickingMode) {
         // we don't want pixels to blend over already drawn pixels
-        this.uniforms.pickingMode.value = pickingMode;
         this.blending = pickingMode ? NoBlending : NormalBlending;
+        if (pickingMode) {
+            if (this.uniforms.mode.value !== MODE.PICKING) {
+                this.oldMode = this.uniforms.mode.value;
+                this.uniforms.mode.value = MODE.PICKING;
+            }
+        } else {
+            this.uniforms.mode.value = this.oldMode || this.uniforms.mode.value;
+            this.oldMode = null;
+        }
     }
 
     updateUniforms() {
         // if size is null, switch to autosizing using the canvas height
         this.uniforms.size.value = (this.size > 0) ? this.size : -this.scale * window.innerHeight;
+        this.uniforms.mode.value = this.mode || MODE.COLOR;
         this.uniforms.opacity.value = this.opacity;
         this.uniforms.overlayColor.value = this.overlayColor;
     }
@@ -49,9 +73,11 @@ class PointsMaterial extends RawShaderMaterial {
         this.opacity = source.opacity;
         this.transparent = source.transparent;
         this.size = source.size;
+        this.mode = source.mode;
         this.scale = source.scale;
         this.overlayColor.copy(source.overlayColor);
         this.updateUniforms();
+        Object.assign(this.defines, source.defines);
         return this;
     }
 }

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -58,21 +58,24 @@ vec3 decodeSphereMappedNormal(vec2 encodedNormal) {
 #endif
 
 void main() {
+
+#if defined(NORMAL_OCT16)
+    vec3  normal = decodeOct16Normal(oct16Normal);
+#elif defined(NORMAL_SPHEREMAPPED)
+    vec3 normal = decodeSphereMappedNormal(sphereMappedNormal);
+#elif defined(NORMAL)
+    // nothing to do
+#else
+    // default to color
+    vec3 normal = color;
+#endif
+
     if (pickingMode) {
         vColor = unique_id;
     } else if (mode == MODE_INTENSITY) {
         vColor = vec4(intensity, intensity, intensity, opacity);
     } else if (mode == MODE_NORMAL) {
-#if defined(NORMAL_OCT16)
-        vColor = vec4(abs(decodeOct16Normal(oct16Normal)), opacity);
-#elif defined(NORMAL_SPHEREMAPPED)
-        vColor = vec4(abs(decodeSphereMappedNormal(sphereMappedNormal)), opacity);
-#elif defined(NORMAL)
         vColor = vec4(abs(normal), opacity);
-#else
-        // default to color
-        vColor = vec4(mix(color, overlayColor.rgb, overlayColor.a), opacity);
-#endif
     } else {
         // default to color mode
         vColor = vec4(mix(color, overlayColor.rgb, overlayColor.a), opacity);

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -9,18 +9,71 @@ uniform mat4 projectionMatrix;
 uniform mat4 modelViewMatrix;
 uniform float size;
 
-uniform bool pickingMode;
+uniform int mode;
 uniform float opacity;
 uniform vec4 overlayColor;
 attribute vec3 color;
 attribute vec4 unique_id;
+attribute float intensity;
+
+#if defined(NORMAL_OCT16)
+attribute vec2 oct16Normal;
+#elif defined(NORMAL_SPHEREMAPPED)
+attribute vec2 sphereMappedNormal;
+#else
+attribute vec3 normal;
+#endif
 
 varying vec4 vColor;
 
-void main() {
-    if (pickingMode) {
-        vColor = unique_id;
+// see https://web.archive.org/web/20150303053317/http://lgdv.cs.fau.de/get/1602
+// and implementation in PotreeConverter (BINPointReader.cpp) and potree (BinaryDecoderWorker.js)
+#if defined(NORMAL_OCT16)
+vec3 decodeOct16Normal(vec2 encodedNormal) {
+    vec2 nNorm = 2. * (encodedNormal / 255.) - 1.;
+    vec3 n;
+    n.z = 1. - abs(nNorm.x) - abs(nNorm.y);
+    if (n.z >= 0.) {
+        n.x = nNorm.x;
+        n.y = nNorm.y;
     } else {
+        n.x = sign(nNorm.x) - sign(nNorm.x) * sign(nNorm.y) * nNorm.y;
+        n.y = sign(nNorm.y) - sign(nNorm.y) * sign(nNorm.x) * nNorm.x;
+    }
+    return normalize(n);
+}
+#elif defined(NORMAL_SPHEREMAPPED)
+// see http://aras-p.info/texts/CompactNormalStorage.html method #4
+// or see potree's implementation in BINPointReader.cpp
+vec3 decodeSphereMappedNormal(vec2 encodedNormal) {
+    vec2 fenc = 2. * encodedNormal / 255. - 1.;
+    float f = dot(fenc,fenc);
+    float g = 2. * sqrt(1. - f);
+    vec3 n;
+    n.xy = fenc * g;
+    n.z = 1. - 2. * f;
+    return n;
+}
+#endif
+
+void main() {
+    if (mode == MODE_PICKING) {
+        vColor = unique_id;
+    } else if (mode == MODE_INTENSITY) {
+        vColor = vec4(intensity, intensity, intensity, opacity);
+    } else if (mode == MODE_NORMAL) {
+#if defined(NORMAL_OCT16)
+        vColor = vec4(abs(decodeOct16Normal(oct16Normal)), opacity);
+#elif defined(NORMAL_SPHEREMAPPED)
+        vColor = vec4(abs(decodeSphereMappedNormal(sphereMappedNormal)), opacity);
+#elif defined(NORMAL)
+        vColor = vec4(abs(normal), opacity);
+#else
+        // default to color
+        vColor = vec4(mix(color, overlayColor.rgb, overlayColor.a), opacity);
+#endif
+    } else {
+        // default to color mode
         vColor = vec4(mix(color, overlayColor.rgb, overlayColor.a), opacity);
     }
 

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -9,6 +9,7 @@ uniform mat4 projectionMatrix;
 uniform mat4 modelViewMatrix;
 uniform float size;
 
+uniform bool pickingMode;
 uniform int mode;
 uniform float opacity;
 uniform vec4 overlayColor;
@@ -57,7 +58,7 @@ vec3 decodeSphereMappedNormal(vec2 encodedNormal) {
 #endif
 
 void main() {
-    if (mode == MODE_PICKING) {
+    if (pickingMode) {
         vColor = unique_id;
     } else if (mode == MODE_INTENSITY) {
         vColor = vec4(intensity, intensity, intensity, opacity);

--- a/test/PotreeBinParser_unit_test.js
+++ b/test/PotreeBinParser_unit_test.js
@@ -1,0 +1,72 @@
+/* global describe, it */
+import PotreeBinParser from '../src/Parser/PotreeBinParser';
+
+const assert = require('assert');
+
+
+describe('PotreeBinParser', function () {
+    it('should correctly parse position buffer', function () {
+        const buffer = new ArrayBuffer(12 * 4);
+        const dv = new DataView(buffer);
+        for (let i = 0; i < 12; i++) {
+            dv.setInt32(i * 4, i * 2, true);
+        }
+        return PotreeBinParser.parse(buffer, ['POSITION_CARTESIAN']).then((geom) => {
+            const posAttr = geom.getAttribute('position');
+            assert.equal(posAttr.itemSize, 3);
+            assert.ok(posAttr.array instanceof Float32Array);
+            assert.equal(posAttr.array.length, 12);
+            assert.equal(posAttr.array[0], 0);
+            assert.equal(posAttr.array[11], 22);
+        });
+    });
+
+    it('should correctly parse a complex buffer (positions, intensity, rgb and classification)', function () {
+        // generate 12 points: positions, intensity, rgba, classification
+        const numbyte = 3 * 4 + 2 + 4 * 1 + 1;
+        const numPoints = 5;
+        const buffer = new ArrayBuffer(numPoints * numbyte);
+        const dv = new DataView(buffer);
+        for (let i = 0; i < numPoints; i++) {
+            // position
+            dv.setInt32(i * numbyte + 0, 3 * i, true);
+            dv.setInt32(i * numbyte + 4, 3 * i + 1, true);
+            dv.setInt32(i * numbyte + 8, 3 * i + 2, true);
+            // intensity
+            dv.setInt16(i * numbyte + 12, 100 + i, true);
+            // color
+            dv.setUint8(i * numbyte + 14, 200 + 4 * i, true);
+            dv.setUint8(i * numbyte + 15, 201 + 4 * i, true);
+            dv.setUint8(i * numbyte + 16, 202 + 4 * i, true);
+            dv.setUint8(i * numbyte + 17, 203 + 4 * i, true);
+
+            // classification
+            dv.setUint8(i * numbyte + 18, i * 3);
+        }
+
+        return PotreeBinParser.parse(buffer, ['POSITION_CARTESIAN', 'INTENSITY', 'COLOR_PACKED', 'CLASSIFICATION']).then(function (geom) {
+            const posAttr = geom.getAttribute('position');
+            const intensityAttr = geom.getAttribute('intensity');
+            const colorAttr = geom.getAttribute('color');
+            const classificationAttr = geom.getAttribute('classification');
+
+            // check position buffer
+            assert.equal(posAttr.itemSize, 3);
+            assert.deepStrictEqual(posAttr.array, Float32Array.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14));
+            // check intensity
+            assert.equal(intensityAttr.itemSize, 1);
+            assert.deepStrictEqual(intensityAttr.array, Float32Array.of(100, 101, 102, 103, 104));
+            // check colors
+            assert.equal(colorAttr.itemSize, 4);
+            assert.deepStrictEqual(colorAttr.array, Uint8Array.of(
+                        200, 201, 202, 203,
+                        204, 205, 206, 207,
+                        208, 209, 210, 211,
+                        212, 213, 214, 215,
+                        216, 217, 218, 219));
+            // check classif
+            assert.equal(classificationAttr.itemSize, 1);
+            assert.deepStrictEqual(classificationAttr.array, Uint8Array.of(0, 3, 6, 9, 12));
+        });
+    });
+});

--- a/test/pointcloudprovider_unit_test.js
+++ b/test/pointcloudprovider_unit_test.js
@@ -21,14 +21,14 @@ describe('PointCloudProvider', function () {
             pointAttributes: ['POSITION', 'RGB'],
         };
 
-        _testing.parseMetadata(layer, metadata);
+        _testing.setLayerMetadata(metadata, layer);
         const normalDefined = layer.material.defines.NORMAL || layer.material.defines.NORMAL_SPHEREMAPPED || layer.material.defines.NORMAL_OCT16;
         assert.ok(!normalDefined);
 
         // normals as vector
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'NORMAL', 'CLASSIFICATION'];
-        _testing.parseMetadata(layer, metadata);
+        _testing.setLayerMetadata(metadata, layer);
         assert.ok(layer.material.defines.NORMAL);
         assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
         assert.ok(!layer.material.defines.NORMAL_OCT16);
@@ -36,7 +36,7 @@ describe('PointCloudProvider', function () {
         // spheremapped normals
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'];
-        _testing.parseMetadata(layer, metadata);
+        _testing.setLayerMetadata(metadata, layer);
         assert.ok(!layer.material.defines.NORMAL);
         assert.ok(layer.material.defines.NORMAL_SPHEREMAPPED);
         assert.ok(!layer.material.defines.NORMAL_OCT16);
@@ -44,7 +44,7 @@ describe('PointCloudProvider', function () {
         // oct16 normals
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'];
-        _testing.parseMetadata(layer, metadata);
+        _testing.setLayerMetadata(metadata, layer);
         assert.ok(!layer.material.defines.NORMAL);
         assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
         assert.ok(layer.material.defines.NORMAL_OCT16);

--- a/test/pointcloudprovider_unit_test.js
+++ b/test/pointcloudprovider_unit_test.js
@@ -21,14 +21,14 @@ describe('PointCloudProvider', function () {
             pointAttributes: ['POSITION', 'RGB'],
         };
 
-        _testing.setLayerMetadata(metadata, layer);
+        _testing.parseMetadata(metadata, layer);
         const normalDefined = layer.material.defines.NORMAL || layer.material.defines.NORMAL_SPHEREMAPPED || layer.material.defines.NORMAL_OCT16;
         assert.ok(!normalDefined);
 
         // normals as vector
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'NORMAL', 'CLASSIFICATION'];
-        _testing.setLayerMetadata(metadata, layer);
+        _testing.parseMetadata(metadata, layer);
         assert.ok(layer.material.defines.NORMAL);
         assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
         assert.ok(!layer.material.defines.NORMAL_OCT16);
@@ -36,7 +36,7 @@ describe('PointCloudProvider', function () {
         // spheremapped normals
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'];
-        _testing.setLayerMetadata(metadata, layer);
+        _testing.parseMetadata(metadata, layer);
         assert.ok(!layer.material.defines.NORMAL);
         assert.ok(layer.material.defines.NORMAL_SPHEREMAPPED);
         assert.ok(!layer.material.defines.NORMAL_OCT16);
@@ -44,7 +44,7 @@ describe('PointCloudProvider', function () {
         // oct16 normals
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'];
-        _testing.setLayerMetadata(metadata, layer);
+        _testing.parseMetadata(metadata, layer);
         assert.ok(!layer.material.defines.NORMAL);
         assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
         assert.ok(layer.material.defines.NORMAL_OCT16);

--- a/test/pointcloudprovider_unit_test.js
+++ b/test/pointcloudprovider_unit_test.js
@@ -1,0 +1,53 @@
+/* global describe, it */
+import assert from 'assert';
+import { _testing } from '../src/Provider/PointCloudProvider';
+
+
+describe('PointCloudProvider', function () {
+    it('should correctly parse normal information in metadata', function () {
+        const layer = {
+            material: { defines: {} }
+        };
+
+        // no normals
+        const metadata = {
+            boundingBox: {
+                lx: 0,
+                ly: 1,
+                ux: 2,
+                uy: 3,
+            },
+            scale: 1.0,
+            pointAttributes: ['POSITION', 'RGB'],
+        };
+
+        let result = _testing.parseMetadata(layer, metadata);
+        const normalDefined = layer.material.defines['NORMAL'] || layer.material.defines['NORMAL_SPHEREMAPPED'] || layer.material.defines['NORMAL_OCT16'];
+        assert.ok(!normalDefined);
+
+        // normals as vector
+        layer.material = { defines: {} };
+        metadata.pointAttributes = ['POSITION', 'NORMAL', 'CLASSIFICATION'];
+        result = _testing.parseMetadata(layer, metadata);
+        assert.ok(layer.material.defines['NORMAL']);
+        assert.ok(!layer.material.defines['NORMAL_SPHEREMAPPED']);
+        assert.ok(!layer.material.defines['NORMAL_OCT16']);
+
+        // spheremapped normals
+        layer.material = { defines: {} };
+        metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'];
+        result = _testing.parseMetadata(layer, metadata);
+        assert.ok(!layer.material.defines['NORMAL']);
+        assert.ok(layer.material.defines['NORMAL_SPHEREMAPPED']);
+        assert.ok(!layer.material.defines['NORMAL_OCT16']);
+
+        // oct16 normals
+        layer.material = { defines: {} };
+        metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'];
+        result = _testing.parseMetadata(layer, metadata);
+        assert.ok(!layer.material.defines['NORMAL']);
+        assert.ok(!layer.material.defines['NORMAL_SPHEREMAPPED']);
+        assert.ok(layer.material.defines['NORMAL_OCT16']);
+    });
+});
+

--- a/test/pointcloudprovider_unit_test.js
+++ b/test/pointcloudprovider_unit_test.js
@@ -6,7 +6,7 @@ import { _testing } from '../src/Provider/PointCloudProvider';
 describe('PointCloudProvider', function () {
     it('should correctly parse normal information in metadata', function () {
         const layer = {
-            material: { defines: {} }
+            material: { defines: {} },
         };
 
         // no normals
@@ -21,33 +21,33 @@ describe('PointCloudProvider', function () {
             pointAttributes: ['POSITION', 'RGB'],
         };
 
-        let result = _testing.parseMetadata(layer, metadata);
-        const normalDefined = layer.material.defines['NORMAL'] || layer.material.defines['NORMAL_SPHEREMAPPED'] || layer.material.defines['NORMAL_OCT16'];
+        _testing.parseMetadata(layer, metadata);
+        const normalDefined = layer.material.defines.NORMAL || layer.material.defines.NORMAL_SPHEREMAPPED || layer.material.defines.NORMAL_OCT16;
         assert.ok(!normalDefined);
 
         // normals as vector
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'NORMAL', 'CLASSIFICATION'];
-        result = _testing.parseMetadata(layer, metadata);
-        assert.ok(layer.material.defines['NORMAL']);
-        assert.ok(!layer.material.defines['NORMAL_SPHEREMAPPED']);
-        assert.ok(!layer.material.defines['NORMAL_OCT16']);
+        _testing.parseMetadata(layer, metadata);
+        assert.ok(layer.material.defines.NORMAL);
+        assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
+        assert.ok(!layer.material.defines.NORMAL_OCT16);
 
         // spheremapped normals
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'];
-        result = _testing.parseMetadata(layer, metadata);
-        assert.ok(!layer.material.defines['NORMAL']);
-        assert.ok(layer.material.defines['NORMAL_SPHEREMAPPED']);
-        assert.ok(!layer.material.defines['NORMAL_OCT16']);
+        _testing.parseMetadata(layer, metadata);
+        assert.ok(!layer.material.defines.NORMAL);
+        assert.ok(layer.material.defines.NORMAL_SPHEREMAPPED);
+        assert.ok(!layer.material.defines.NORMAL_OCT16);
 
         // oct16 normals
         layer.material = { defines: {} };
         metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'];
-        result = _testing.parseMetadata(layer, metadata);
-        assert.ok(!layer.material.defines['NORMAL']);
-        assert.ok(!layer.material.defines['NORMAL_SPHEREMAPPED']);
-        assert.ok(layer.material.defines['NORMAL_OCT16']);
+        _testing.parseMetadata(layer, metadata);
+        assert.ok(!layer.material.defines.NORMAL);
+        assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
+        assert.ok(layer.material.defines.NORMAL_OCT16);
     });
 });
 

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -1,3 +1,5 @@
+import { MODE } from '../../src/Renderer/PointsMaterial';
+
 function isInHierarchy(elt, hierarchyNode) {
     if (elt.name.length > hierarchyNode.length) {
         return elt.name.startsWith(hierarchyNode);
@@ -29,6 +31,7 @@ export default {
         layer.dbgDisplaybbox = false;
 
         var styleUI = layer.debugUI.addFolder('Styling');
+        styleUI.add(layer, 'mode', MODE).name('Display mode').onChange(update);
         styleUI.add(layer, 'opacity', 0, 1).name('Layer Opacity').onChange(update);
         styleUI.add(layer, 'pointSize', 0, 15).name('Point Size').onChange(update);
         styleUI.add(layer, 'dbgDisplaybbox').name('Display Bounding Boxes').onChange(update);

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -31,10 +31,15 @@ export default {
         layer.dbgDisplaybbox = false;
 
         var styleUI = layer.debugUI.addFolder('Styling');
-        styleUI.add(layer, 'mode', MODE).name('Display mode').onChange(update);
+        if (layer.material.mode != undefined) {
+            styleUI.add(layer.material, 'mode', MODE).name('Display mode').onChange(update);
+        }
         styleUI.add(layer, 'opacity', 0, 1).name('Layer Opacity').onChange(update);
         styleUI.add(layer, 'pointSize', 0, 15).name('Point Size').onChange(update);
         styleUI.add(layer, 'dbgDisplaybbox').name('Display Bounding Boxes').onChange(update);
+        if (layer.material.picking != undefined) {
+            styleUI.add(layer.material, 'picking').name('Display picking id').onChange(update);
+        }
 
         // UI
         const sticky = layer.debugUI.addFolder('Sticky');


### PR DESCRIPTION
## Description

We were only supporting position and rgb informations from potree converted pointclouds. This PR aims at supporting all of them. At least I wanted to have them parsed in attributes, but I also added some default rendering to check that it is working correctly. 

Some remarks:
- I didn't test the oct16 normals, because I don't have any las with normal information or already converted pointclouds with oct16 format for normals. If some of you have one, I'd be very interested :-)
- what to do with classification remains to be decided. I could add some default rendering, but I'm not sure which type :-)