### PR TITLE
refactor(core): change view.notifyChange semantics

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -80,7 +80,7 @@
             d.zoom = function() {
                 view.camera.camera3D.position.set(1215013.9, -4736315.5, 4081597.5);
                 view.camera.camera3D.quaternion.set(0.9108514448729665, 0.13456816437801225, 0.1107206134840362, 0.3741416847378546);
-                view.notifyChange(true);
+                view.notifyChange(view.camera.camera3D);
             }
             menuGlobe.gui.add(d, 'zoom').name('Go to point cloud');
 

--- a/examples/collada.html
+++ b/examples/collada.html
@@ -60,7 +60,7 @@
                 // loading manager
                 var loadingManager = new itowns.THREE.LoadingManager(function _addModel() {
                     globeView.scene.add(model);
-                    globeView.notifyChange(true);
+                    globeView.notifyChange();
                 });
                 // collada loader
                 var loader = new itowns.THREE.ColladaLoader(loadingManager);

--- a/examples/cubic_planar.html
+++ b/examples/cubic_planar.html
@@ -156,10 +156,10 @@
 
             controls = new itowns.THREE.OrbitControls(view.camera.camera3D, viewerDiv);
             controls.minDistance = 1;
-            controls.addEventListener('change', function _() { view.notifyChange(true); });
+            controls.addEventListener('change', function _() { view.notifyChange(view.camera.camera3D); });
 
             // Request redraw
-            view.notifyChange(true);
+            view.notifyChange();
         </script>
     </body>
 </html>

--- a/examples/globe.html
+++ b/examples/globe.html
@@ -78,7 +78,7 @@
                 // Update target miniview's camera
                 camera.position.copy(globeView.controls.moveTarget()).setLength(distance);
                 camera.lookAt(globeView.controls.moveTarget());
-                miniView.notifyChange(true);
+                miniView.notifyChange(camera);
             });
 
             // Add one imagery layer to the miniview

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -140,7 +140,7 @@
                 var i;
                 var mesh;
                 if (meshes.length) {
-                    globeView.notifyChange(true);
+                    globeView.notifyChange();
                 }
                 for (i = 0; i < meshes.length; i++) {
                     mesh = meshes[i];

--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -60,15 +60,15 @@ GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {
     var folder = this.colorGui.addFolder(layer.id);
     folder.add({ visible: layer.visible }, 'visible').onChange((function updateVisibility(value) {
         layer.visible = value;
-        this.view.notifyChange(true);
+        this.view.notifyChange();
     }).bind(this));
     folder.add({ opacity: layer.opacity }, 'opacity').min(0.0).max(1.0).onChange((function updateOpacity(value) {
         layer.opacity = value;
-        this.view.notifyChange(true);
+        this.view.notifyChange();
     }).bind(this));
     folder.add({ frozen: layer.frozen }, 'frozen').onChange((function updateFrozen(value) {
         layer.frozen = value;
-        this.view.notifyChange(true);
+        this.view.notifyChange();
     }).bind(this));
 };
 

--- a/examples/js/OrientedImageHelper.js
+++ b/examples/js/OrientedImageHelper.js
@@ -125,10 +125,10 @@ function setupPictureUI(menu, pictureInfos, plane, updateDistanceCallback, view,
     orientedImageGUI.add(pictureInfos, 'distance', min, max).name('Distance').onChange(function distanceChanged(value) {
         pictureInfos.distance = value;
         updateDistanceCallback();
-        view.notifyChange(true);
+        view.notifyChange();
     });
     orientedImageGUI.add(pictureInfos, 'opacity', 0, 1).name('Opacity').onChange(function opacityChanged(value) {
         plane.material.opacity = value;
-        view.notifyChange(true);
+        view.notifyChange();
     });
 }

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -86,7 +86,7 @@
 
                 if (t < 1) {
                     // animation is not finished, schedule a new view update
-                    globeView.notifyChange(true);
+                    globeView.notifyChange();
                 } else {
                     // animation is finished, remove the frame requester
                     globeView.removeFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
@@ -100,7 +100,7 @@
                     t = 0;
                     // schedule the animation
                     globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
-                    globeView.notifyChange(true);
+                    globeView.notifyChange();
                 }
             }
             viewerDiv.focus();
@@ -123,7 +123,7 @@
                     geo.setAltitude(geo.altitude() * 1.1);
                 }
                 globeView.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
-                globeView.notifyChange(true);
+                globeView.notifyChange();
             };
             viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);
             viewerDiv.addEventListener('mousewheel', onMouseWheel);

--- a/examples/orthographic.html
+++ b/examples/orthographic.html
@@ -71,7 +71,7 @@
             });
 
             // Request redraw
-            view.notifyChange(true);
+            view.notifyChange();
         </script>
     </body>
 </html>

--- a/examples/panorama.html
+++ b/examples/panorama.html
@@ -65,13 +65,14 @@
                     index ++;
                 }
                 view.camera.camera3D.far = 10000;
+                view.notifyChange();
 
                 // Setup debug menu
                 var gui = new dat.GUI();
                 var ddd = new debug.Debug(view, gui);
                 debug.createTileDebugUI(gui, view, view.baseLayer, ddd);
                 gui.add(view.baseLayer, 'quality').min(0.1).max(1.0).onChange(
-                    function () { view.notifyChange(true); });
+                    function () { view.notifyChange(); });
 
                 // Add controls
                 new itowns.FirstPersonControls(view, {
@@ -86,7 +87,7 @@
                     layers[activeIndex].visible = false;
                     activeIndex = (activeIndex + 1) % 5;
                     layers[activeIndex].visible = true;
-                    view.notifyChange(true);
+                    view.notifyChange();
                 });
                 window.view = view;
             }).catch(console.error);

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -97,7 +97,7 @@
             new itowns.PlanarControls(view, {});
 
             // Request redraw
-            view.notifyChange(true);
+            view.notifyChange();
 
             if (view.isDebugMode) {
                 var menuGlobe = new GuiTools('menuDiv', view);

--- a/examples/planar_vector.html
+++ b/examples/planar_vector.html
@@ -129,9 +129,6 @@
             // instanciate controls
             // eslint-disable-next-line no-new
             new itowns.PlanarControls(view, {});
-
-            // Request redraw
-            view.notifyChange(true);
         </script>
     </body>
 </html>

--- a/examples/pointcloud.html
+++ b/examples/pointcloud.html
@@ -201,7 +201,7 @@
                         controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
                         debugGui.add(controls.options, 'moveSpeed', 1, 100).name('Movement speed');
 
-                        view.notifyChange(true);
+                        view.notifyChange(view.camera.camera3D);
                     }
 
                     // add pointcloud to scene

--- a/examples/split.html
+++ b/examples/split.html
@@ -72,7 +72,7 @@
                 var s = (evt.clientX - xD) / splitSlider.parentElement.offsetWidth;
                 splitSlider.style.left = (100.0 * s) + '%';
                 splitPosition = s * window.innerWidth;
-                globeView.notifyChange(true);
+                globeView.notifyChange();
             }
 
             function mouseDown(evt) {

--- a/examples/stereo.html
+++ b/examples/stereo.html
@@ -87,7 +87,7 @@
 
                 if (!effect) return;
 
-                globeView.notifyChange(true);
+                globeView.notifyChange();
             }
 
             function disableEffect() {
@@ -98,7 +98,7 @@
                 effect = null;
                 globeView.render = null;
 
-                globeView.notifyChange(true);
+                globeView.notifyChange();
             }
 
             function enableEffect(_eff) {
@@ -119,7 +119,7 @@
                     effect.render(globeView.scene, globeView.camera.camera3D);
                 };
 
-                globeView.notifyChange(true);
+                globeView.notifyChange();
             }
 
             /**

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -77,7 +77,7 @@
             new itowns.PlanarControls(view, {});
 
             // Request redraw
-            view.notifyChange(true);
+            view.notifyChange();
 
             function setMaterialLineWidth(result) {
                 result.traverse(function _setLineWidth(mesh) {
@@ -132,7 +132,7 @@
                 var i;
                 var mesh;
                 if (meshes.length) {
-                    view.notifyChange(true);
+                    view.notifyChange();
                 }
                 for (i = 0; i < meshes.length; i++) {
                     mesh = meshes[i];

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -109,12 +109,12 @@ GeometryLayer.prototype.detach = function detach(layer) {
  * // Change layer's visibilty
  * const layerToChange = view.getLayers(layer => layer.id == 'idLayerToChange')[0];
  * layerToChange.visible = false;
- * view.notifyChange(true); // update viewer
+ * view.notifyChange(); // update viewer
  *
  * // Change layer's opacity
  * const layerToChange = view.getLayers(layer => layer.id == 'idLayerToChange')[0];
  * layerToChange.opacity = 0.5;
- * view.notifyChange(true); // update viewer
+ * view.notifyChange(); // update viewer
  *
  * // Listen properties
  * const layerToListen = view.getLayers(layer => layer.id == 'idLayerToListen')[0];

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -101,9 +101,7 @@ export function createGlobeLayer(id, options) {
         }
 
         preGlobeUpdate(context, layer);
-        if (changeSources.has(undefined) || changeSources.size == 0) {
-            return layer.level0Nodes;
-        }
+
         let commonAncestor;
         for (const source of changeSources.values()) {
             if (source.isCamera) {
@@ -276,7 +274,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
 
     this.addEventListener(VIEW_EVENTS.LAYERS_INITIALIZED, fn);
 
-    this.notifyChange(true);
+    this.notifyChange(this.wgs84TileLayer);
 }
 
 GlobeView.prototype = Object.create(View.prototype);
@@ -330,7 +328,7 @@ GlobeView.prototype.removeLayer = function removeImageryLayer(layerId) {
             }
         }
 
-        this.notifyChange(true);
+        this.notifyChange(this.wgs84TileLayer);
         this.dispatchEvent({
             type: GLOBE_VIEW_EVENTS.LAYER_REMOVED,
             layerId,
@@ -360,7 +358,7 @@ GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
         });
     }
 
-    this.notifyChange(true);
+    this.notifyChange();
 };
 
 GlobeView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, height) {
@@ -448,14 +446,14 @@ GlobeView.prototype.setRealisticLightingOn = function setRealisticLightingOn(val
 
     this.updateMaterialUniform('lightingEnabled', value);
     this.updateMaterialUniform('lightPosition', coSun);
-    this.notifyChange(true);
+    this.notifyChange(this.wgs84TileLayer);
 };
 
 GlobeView.prototype.setLightingPos = function setLightingPos(pos) {
     const lightingPos = pos || CoordStars.getSunPositionInScene(this.ellipsoid, new Date().getTime(), 48.85, 2.35);
 
     this.updateMaterialUniform('lightPosition', lightingPos.clone().normalize());
-    this.notifyChange(true);
+    this.notifyChange(this.wgs84TileLayer);
 };
 
 GlobeView.prototype.updateMaterialUniform = function updateMaterialUniform(uniformName, value) {

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -169,7 +169,7 @@ PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
         });
     }
 
-    this.notifyChange(true);
+    this.notifyChange();
 };
 
 

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -154,7 +154,7 @@ Scheduler.prototype.runCommand = function runCommand(command, queue, executingCo
 
     queue.execute(command, provider, executingCounterUpToDate).then(() => {
         // notify view that one command ended.
-        command.view.notifyChange('redraw' in command ? command.redraw : true, command.requester);
+        command.view.notifyChange(command.requester, command.redraw);
 
         // try to execute next command
         if (queue.counters.executing < this.maxCommandsPerHost) {

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -185,7 +185,7 @@ export default {
      * itowns.GpxParser.parse(file, { crs: viewer.referenceCrs }).then((gpx) => {
      *      if (gpx) {
      *         viewer.scene.add(gpx);
-     *         viewer.notifyChange(true);
+     *         viewer.notifyChange();
      *      }
      * });
      *

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -50,7 +50,7 @@ function _subdivideNodeAdditive(context, layer, node, cullingTest) {
         child.promise = requestNewTile(context.view, context.scheduler, layer, child, node, true).then((tile) => {
             node.add(tile);
             tile.updateMatrixWorld();
-            context.view.notifyChange(true);
+            context.view.notifyChange(child);
             child.loaded = true;
             delete child.promise;
         });
@@ -73,14 +73,14 @@ function _subdivideNodeSubstractive(context, layer, node) {
                     node.add(tile);
                     tile.updateMatrixWorld();
                     if (node.additiveRefinement) {
-                        context.view.notifyChange(true);
+                        context.view.notifyChange(node);
                     }
                     layer.tileIndex.index[tile.tileId].loaded = true;
                 }));
         }
         Promise.all(promises).then(() => {
             node.pendingSubdivision = false;
-            context.view.notifyChange(true);
+            context.view.notifyChange(node);
         });
     }
 }

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -125,7 +125,7 @@ export default {
                 node.layerUpdateState[layer.id].failure(Date.now());
                 setTimeout(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
                     () => {
-                        context.view.notifyChange(false);
+                        context.view.notifyChange(layer, false);
                     });
             }
         });

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -196,7 +196,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
         // Indeed in the second pass, their state (not visible or not displayed) can block them to fetch
         const minLevel = layer.options.zoom ? layer.options.zoom.min : 0;
         if (node.material.getColorLayerLevelById(layer.id) >= minLevel) {
-            context.view.notifyChange(false, node);
+            context.view.notifyChange(node, false);
             return;
         }
     }
@@ -296,7 +296,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
                 node.layerUpdateState[layer.id].failure(Date.now(), definitiveError, { targetLevel });
                 if (!definitiveError) {
                     window.setTimeout(() => {
-                        context.view.notifyChange(false, node);
+                        context.view.notifyChange(node, false);
                     }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
                 }
             }
@@ -324,7 +324,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
         currentElevation = material.getElevationLayerLevel();
         const minLevel = layer.options.zoom ? layer.options.zoom.min : 0;
         if (currentElevation >= minLevel) {
-            context.view.notifyChange(false, node);
+            context.view.notifyChange(node, false);
             return;
         }
     }
@@ -417,7 +417,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
                 node.layerUpdateState[layer.id].failure(Date.now(), definitiveError);
                 if (!definitiveError) {
                     window.setTimeout(() => {
-                        context.view.notifyChange(false, node);
+                        context.view.notifyChange(node, false);
                     }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
                 }
             }

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -99,15 +99,10 @@ export default {
             context.camera.height /
                 (2 * Math.tan(THREE.Math.degToRad(context.camera.camera3D.fov) * 0.5));
 
-
-        if (changeSources.has(undefined) || changeSources.size == 0) {
-            return [layer.root];
-        }
-
         // lookup lowest common ancestor of changeSources
         let commonAncestorName;
         for (const source of changeSources.values()) {
-            if (source.isCamera) {
+            if (source.isCamera || source == layer) {
                 // if the change is caused by a camera move, no need to bother
                 // to find common ancestor: we need to update the whole tree:
                 // some invisible tiles may now be visible

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -81,7 +81,7 @@ function subdivideNode(context, layer, node) {
             }
             */
             node.pendingSubdivision = false;
-            context.view.notifyChange(false, node);
+            context.view.notifyChange(node, false);
         }, (err) => {
             node.pendingSubdivision = false;
             if (!(err instanceof CancelledCommandException)) {

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -83,7 +83,15 @@ function parseOctree(layer, hierarchyStepSize, root) {
                         const myname = childname.substr(root.name.length);
                         url = `${root.baseurl}/${myname}`;
                     }
-                    const item = { numPoints: n, childrenBitField: c, children: [], name: childname, baseurl: url, bbox: bounds };
+                    const item = {
+                        numPoints: n,
+                        childrenBitField: c,
+                        children: [],
+                        name: childname,
+                        baseurl: url,
+                        bbox: bounds,
+                        layer,
+                    };
                     snode.children.push(item);
                     stack.push(item);
                 }
@@ -233,7 +241,7 @@ export default {
 
         // Query HRC if we don't have children metadata yet.
         if (node.childrenBitField && node.children.length === 0) {
-            parseOctree(layer, layer.metadata.hierarchyStepSize, node).then(() => command.view.notifyChange(false));
+            parseOctree(layer, layer.metadata.hierarchyStepSize, node).then(() => command.view.notifyChange(layer, false));
         }
 
         const extension = layer.metadata.customBinFormat ? 'cin' : 'bin';

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -166,7 +166,7 @@ Camera.prototype.adjustAltitudeToAvoidCollisionWithLayer = function adjustAltitu
             if (difElevation < 0) {
                 camLocation.setAltitude(elevationUnderCamera.z + minDistanceCollision);
                 view.camera.camera3D.position.copy(camLocation.as(view.referenceCrs).xyz());
-                view.notifyChange(true);
+                view.notifyChange(this.camera3D);
             }
         }
     }

--- a/src/Renderer/ColorLayersOrdering.js
+++ b/src/Renderer/ColorLayersOrdering.js
@@ -35,7 +35,7 @@ export const ColorLayersOrdering = {
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
             });
-            view.notifyChange(true);
+            view.notifyChange(view.wgs84TileLayer);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }
@@ -59,7 +59,7 @@ export const ColorLayersOrdering = {
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
             });
-            view.notifyChange(true);
+            view.notifyChange(view.wgs84TileLayer);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }
@@ -84,7 +84,7 @@ export const ColorLayersOrdering = {
                 previous: { sequence: previousSequence },
                 new: { sequence: ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers) },
             });
-            view.notifyChange(true);
+            view.notifyChange(view.wgs84TileLayer);
         } else {
             throw new Error(`${layerId} isn't color layer`);
         }

--- a/src/Renderer/ThreeExtended/FirstPersonControls.js
+++ b/src/Renderer/ThreeExtended/FirstPersonControls.js
@@ -19,7 +19,7 @@ function applyRotation(view, camera3D, state) {
     camera3D.rotateY(state.rotateY);
     camera3D.rotateX(state.rotateX);
 
-    view.notifyChange(true, camera3D);
+    view.notifyChange(view.camera.camera3D);
 }
 
 const MOVEMENTS = {
@@ -156,8 +156,8 @@ class FirstPersonControls extends THREE.EventDispatcher {
             applyRotation(this.view, this.camera, this._state);
         }
 
-        if (this.moves.size || this._isMouseDown) {
-            this.view.notifyChange(true);
+        if (this.moves.size) {
+            this.view.notifyChange(this.view.camera.camera3D);
         }
     }
 
@@ -228,7 +228,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
         const move = MOVEMENTS[e.keyCode];
         if (move) {
             this.moves.delete(move);
-            this.view.notifyChange(true);
+            this.view.notifyChange(undefined, false);
             e.preventDefault();
         }
     }
@@ -237,7 +237,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
         const move = MOVEMENTS[e.keyCode];
         if (move) {
             this.moves.add(move);
-            this.view.notifyChange(false);
+            this.view.notifyChange(undefined, false);
             e.preventDefault();
         }
     }

--- a/src/Renderer/ThreeExtended/FlyControls.js
+++ b/src/Renderer/ThreeExtended/FlyControls.js
@@ -42,7 +42,7 @@ function onPointerMove(event) {
         this._camera3D.rotateX((coords.y - this._onMouseDownMouseY) * pxToAngleRatio);
         this._onMouseDownMouseX = coords.x;
         this._onMouseDownMouseY = coords.y;
-        this.view.notifyChange(false, this._camera3D);
+        this.view.notifyChange(this._camera3D, false);
     }
 }
 
@@ -62,7 +62,7 @@ function onKeyDown(e) {
     const move = MOVEMENTS[e.keyCode];
     if (move) {
         this.moves.add(move);
-        this.view.notifyChange(false, this);
+        this.view.notifyChange(this._camera3D, false);
         e.preventDefault();
     }
 }
@@ -81,7 +81,7 @@ function onDocumentMouseWheel(event) {
         this.moves.add(MOVEMENTS.wheeldown);
     }
 
-    this.view.notifyChange(false, this);
+    this.view.notifyChange(this._camera3D, false);
 }
 
 /**
@@ -156,7 +156,7 @@ class FlyControls extends THREE.EventDispatcher {
         }
 
         if (this.moves.size > 0 || this._isMouseDown) {
-            this.view.notifyChange(true, this._camera3D);
+            this.view.notifyChange(this._camera3D);
 
             for (const move of this.moves) {
                 if (move.oneshot) {

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -581,7 +581,7 @@ function GlobeControls(view, target, radius, options = {}) {
         } else if (this.camera instanceof THREE.OrthographicCamera) {
             this.camera.zoom = Math.max(this.minZoom, Math.min(this.maxZoom, this.camera.zoom * dollyScale));
             this.camera.updateProjectionMatrix();
-            this._view.notifyChange(true, this.camera);
+            this._view.notifyChange(this.camera);
         } else {
 
             // console.warn('WARNING: GlobeControls.js encountered an unknown camera type - dolly/zoom disabled.');
@@ -599,7 +599,7 @@ function GlobeControls(view, target, radius, options = {}) {
         } else if (this.camera instanceof THREE.OrthographicCamera) {
             this.camera.zoom = Math.max(this.minZoom, Math.min(this.maxZoom, this.camera.zoom / dollyScale));
             this.camera.updateProjectionMatrix();
-            this._view.notifyChange(true, this.camera);
+            this._view.notifyChange(this.camera);
         } else {
 
             // console.warn('WARNING: GlobeControls.js encountered an unknown camera type - dolly/zoom disabled.');
@@ -763,7 +763,7 @@ function GlobeControls(view, target, radius, options = {}) {
         // using small-angle approximation cos(x/2) = 1 - x^2 / 8
 
         if (lastPosition.distanceToSquared(this.camera.position) > EPS || 8 * (1 - lastQuaternion.dot(this.camera.quaternion)) > EPS) {
-            this._view.notifyChange(true, this.camera);
+            this._view.notifyChange(this.camera);
 
             lastPosition.copy(this.camera.position);
             lastQuaternion.copy(this.camera.quaternion);
@@ -856,14 +856,14 @@ function GlobeControls(view, target, radius, options = {}) {
         state = this.states.NONE;
         lastRotation = [];
         if (enableTargetHelper) {
-            this._view.notifyChange(true, cameraTargetOnGlobe);
+            this._view.notifyChange(this.camera);
         }
     };
 
     // Update helper
     var updateHelper = enableTargetHelper ? function updateHelper(position, helper) {
         positionObject(position, helper);
-        this._view.notifyChange(true, cameraTargetOnGlobe);
+        this._view.notifyChange(this.camera);
     } : function empty() {};
 
     this.getPickingPositionOnSphere = function getPickingPositionOnSphere() {
@@ -1942,7 +1942,7 @@ GlobeControls.prototype.reset = function reset() {
     this.camera.zoom = initialZoom;
 
     this.camera.updateProjectionMatrix();
-    this._view.notifyChange(true);
+    this._view.notifyChange();
 
     this.updateCameraTransformation();
 };

--- a/src/Renderer/ThreeExtended/PlanarControls.js
+++ b/src/Renderer/ThreeExtended/PlanarControls.js
@@ -218,7 +218,7 @@ function PlanarControls(view, options = {}) {
         }
         if (this.state === STATE.TRAVEL) {
             this.handleTravel(dt);
-            this.view.notifyChange(true);
+            this.view.notifyChange(this.camera);
         }
         if (this.state === STATE.DRAG) {
             this.handleDragMovement();
@@ -495,7 +495,7 @@ function PlanarControls(view, options = {}) {
      */
     this.initiateTravel = function initiateTravel(targetPos, travelTime, targetOrientation, useSmooth) {
         this.state = STATE.TRAVEL;
-        this.view.notifyChange(true);
+        this.view.notifyChange(this.camera);
         // the progress of the travel (animation alpha)
         travelAlpha = 0;
         // update cursor
@@ -812,7 +812,7 @@ function onMouseMove(event) {
 
     // notify change if moving
     if (this.state !== STATE.NONE) {
-        this.view.notifyChange(true);
+        this.view.notifyChange();
     }
 }
 

--- a/test/examples/3dtiles.js
+++ b/test/examples/3dtiles.js
@@ -55,7 +55,7 @@ describe('3dtiles', () => {
                             '3d-tiles-request-volume').length);
                     }
                 });
-                view.notifyChange(false);
+                view.notifyChange(undefined, false);
             }));
         assert.ok(pickingCount > 0);
         await page.close();

--- a/test/examples/bootstrap.js
+++ b/test/examples/bootstrap.js
@@ -101,7 +101,7 @@ before(async () => {
                     resolve();
                 }
                 v.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, resolveWhenDrawn);
-                v.notifyChange(true);
+                v.notifyChange();
             });
         }));
 

--- a/test/examples/positionGlobe.js
+++ b/test/examples/positionGlobe.js
@@ -31,10 +31,10 @@ describe('positionGlobe', () => {
                     if (globeView.mesh) {
                         resolve();
                     } else {
-                        globeView.notifyChange(true);
+                        globeView.notifyChange();
                     }
                 });
-                globeView.notifyChange(true);
+                globeView.notifyChange();
             }));
 
         await page.screenshot({ path: '/tmp/b.png' });

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -98,12 +98,12 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
             visible: false,
         }, layer).then((l) => {
             gui.add(l, 'visible').name('Bounding boxes').onChange(() => {
-                view.notifyChange(true);
+                view.notifyChange();
             });
         });
 
     // The sse Threshold for each tile
     gui.add(layer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
-        view.notifyChange(true);
+        view.notifyChange();
     });
 }

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -63,12 +63,12 @@ function Debug(view, datDebugTool, chartDivContainer) {
         } else {
             view.removeFrameRequester(MAIN_LOOP_EVENTS.AFTER_RENDER, renderCameraDebug);
         }
-        view.notifyChange(true);
+        view.notifyChange();
     });
 
     gui.add(state, 'freeze').name('freeze update').onChange((newValue) => {
         tileLayer.frozen = newValue;
-        view.notifyChange(true);
+        view.notifyChange();
     });
 
     gui.add(state, 'eventsDebug').name('Debug event').onChange((() => {

--- a/utils/debug/GeometryDebug.js
+++ b/utils/debug/GeometryDebug.js
@@ -2,23 +2,23 @@ export default {
 
     addWireFrameCheckbox(gui, view, layer) {
         layer.wireframe = layer.wireframe || false;
-        gui.add(layer, 'wireframe').name('Wireframe').onChange(() => view.notifyChange(true));
+        gui.add(layer, 'wireframe').name('Wireframe').onChange(() => view.notifyChange());
     },
 
     addMaterialSize(gui, view, layer, begin, end) {
         layer.size = layer.size || 1;
-        gui.add(layer, 'size', begin, end).name('Size').onChange(() => view.notifyChange(true));
+        gui.add(layer, 'size', begin, end).name('Size').onChange(() => view.notifyChange());
     },
 
     addMaterialLineWidth(gui, view, layer, begin, end) {
         layer.linewidth = layer.linewidth || 1;
-        gui.add(layer, 'linewidth', begin, end).name('Line Width').onChange(() => view.notifyChange(true));
+        gui.add(layer, 'linewidth', begin, end).name('Line Width').onChange(() => view.notifyChange());
     },
 
     createGeometryDebugUI(datDebugTool, view, layer) {
         const gui = datDebugTool.addFolder(`Layer ${layer.id}`);
-        gui.add(layer, 'visible').name('Visible').onChange(() => view.notifyChange(true));
-        gui.add(layer, 'opacity', 0, 1).name('Opacity').onChange(() => view.notifyChange(true));
+        gui.add(layer, 'visible').name('Visible').onChange(() => view.notifyChange());
+        gui.add(layer, 'opacity', 0, 1).name('Opacity').onChange(() => view.notifyChange());
         return gui;
     },
 };

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -13,19 +13,19 @@ export default {
         layer.debugUI = datUi.addFolder(`${layer.id}`);
 
         layer.debugUI.add(layer, 'sseThreshold').name('SSE threshold')
-            .onChange(() => view.notifyChange(true));
+            .onChange(() => view.notifyChange(layer));
         layer.debugUI.add(layer, 'octreeDepthLimit', -1, 20).name('Depth limit')
-            .onChange(() => view.notifyChange(true));
+            .onChange(() => view.notifyChange(layer));
         layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count')
-            .onChange(() => view.notifyChange(true));
+            .onChange(() => view.notifyChange(layer));
         layer.debugUI.add(layer.object3d.position, 'z', -50, 50).name('Z translation').onChange(() => {
             layer.object3d.updateMatrixWorld();
-            view.notifyChange(true);
+            view.notifyChange(layer);
         });
         layer.debugUI.add(layer, 'pointSize', 0, 15).name('Point Size')
-            .onChange(() => view.notifyChange(true));
+            .onChange(() => view.notifyChange(layer));
         layer.debugUI.add(layer, 'opacity', 0, 1).name('Opacity')
-            .onChange(() => view.notifyChange(true));
+            .onChange(() => view.notifyChange(layer));
 
         layer.dbgEnableStickyNode = false;
         layer.dbgStickyNode = '';
@@ -34,7 +34,7 @@ export default {
         layer.dbgDisplaybbox = false;
 
         // UI
-        const update = () => view.notifyChange(true);
+        const update = () => view.notifyChange(layer);
         const sticky = layer.debugUI.addFolder('Sticky');
         sticky.add(layer, 'dbgEnableStickyNode').name('Enable sticky node').onChange(update);
         sticky.add(layer, 'dbgStickyNode').name('Sticky node name').onChange(update);

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -12,7 +12,7 @@ function applyToNodeFirstMaterial(view, root, layer, cb) {
             cb(object.material);
         }
     });
-    view.notifyChange(true);
+    view.notifyChange();
 }
 
 export default function createTileDebugUI(datDebugTool, view, layer, debugInstance) {
@@ -167,7 +167,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
             visible: false,
         }, layer).then((l) => {
             gui.add(l, 'visible').name('Bounding boxes').onChange(() => {
-                view.notifyChange(true);
+                view.notifyChange();
             });
         });
     View.prototype.addLayer.call(view,
@@ -178,7 +178,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
             visible: false,
         }, layer).then((l) => {
             gui.add(l, 'visible').name('Bounding Spheres').onChange(() => {
-                view.notifyChange(true);
+                view.notifyChange();
             });
         });
 }


### PR DESCRIPTION
This commit changes the semantics of view.notifyChange function to something more
useful: `changeSource` now drives layer update.

This implies that no `changeSource` -> no update.

`changeSource` can be either a layer, an object from a layer or the camera.

The signature also changed slightly:
```js
   notifyChange(needsRedraw = false, changeSource = undefined)
```
becomes:
```js
   notifyChange(changeSource = undefined, needsRedraw = true)
```

Some examples usage:
  - `notifyChange()`: the scene will be redraw, but no update will be performed. This
is useful if a user adds some objetcs to the scene and wants to request a redraw but
do no need a full update of all layer (eg: a measure tool drawn with threejs lines)
  - `notifyChange(XXX)`: only the layer XXX (or the layer to which XXX belongs) will
be updated. So if you have 100 layers, and layer #4 has a new texture, it will not
cause a full update of other layers.
  - `notifyChange(camera)`: this is equivalent to the previous notifyChange(true): all
layers will be updated.

MainLoop also handles `changeSource` filtering and could later even handle ancestor
lookup (if we build a common ancestor lookup interface).
