### PR TITLE
refacto(core): add or use optional target to getPickingPositionFromDepth

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -375,10 +375,19 @@ GlobeView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, heig
 
 const matrix = new THREE.Matrix4();
 const screen = new THREE.Vector2();
-const pickWorldPosition = new THREE.Vector3();
 const ray = new THREE.Ray();
 const direction = new THREE.Vector3();
-GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse) {
+
+/**
+ * Returns the world position (view's crs: referenceCrs) under view coordinates.
+ * This position is computed with depth buffer.
+ *
+ * @param      {THREE.Vector2}  mouse  position in view coordinates (in pixel), if it's null so it's view's center.
+ * @param      {THREE.Vector3}  [target=THREE.Vector3()] target the result will be copied into this Vector3. If not present a new one will be created.
+ * @return     {THREE.Vector3}  the world position in view's crs: referenceCrs.
+ */
+
+GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse, target = new THREE.Vector3()) {
     const l = this.mainLoop;
     const viewPaused = l.scheduler.commandsWaitingExecutionCount() == 0 && l.renderingState == RENDERING_PAUSED;
     const g = l.gfxEngine;
@@ -423,14 +432,14 @@ GlobeView.prototype.getPickingPositionFromDepth = function getPickingPositionFro
     const orthoZ = g.depthBufferRGBAValueToOrthoZ(buffer, camera);
     const length = orthoZ / Math.cos(angle);
 
-    pickWorldPosition.addVectors(camera.position, ray.direction.setLength(length));
+    target.addVectors(camera.position, ray.direction.setLength(length));
 
     camera.layers.mask = prev;
 
-    if (pickWorldPosition.length() > 10000000)
+    if (target.length() > 10000000)
         { return undefined; }
 
-    return pickWorldPosition;
+    return target;
 };
 
 GlobeView.prototype.setRealisticLightingOn = function setRealisticLightingOn(value) {

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -178,10 +178,19 @@ PlanarView.prototype.readDepthBuffer = function readDepthBuffer(x, y, width, hei
 
 const matrix = new THREE.Matrix4();
 const screen = new THREE.Vector2();
-const pickWorldPosition = new THREE.Vector3();
 const ray = new THREE.Ray();
 const direction = new THREE.Vector3();
-PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse) {
+
+/**
+ * Returns the world position (view's crs: referenceCrs) under view coordinates.
+ * This position is computed with depth buffer.
+ *
+ * @param      {THREE.Vector2}  mouse  position in view coordinates (in pixel), if it's null so it's view's center.
+ * @param      {THREE.Vector3}  [target=THREE.Vector3()] target. the result will be copied into this Vector3. If not present a new one will be created.
+ * @return     {THREE.Vector3}  the world position in view's crs: referenceCrs.
+ */
+
+PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFromDepth(mouse, target = new THREE.Vector3()) {
     const l = this.mainLoop;
     const viewPaused = l.scheduler.commandsWaitingExecutionCount() == 0 && l.renderingState == RENDERING_PAUSED;
     const g = l.gfxEngine;
@@ -227,14 +236,14 @@ PlanarView.prototype.getPickingPositionFromDepth = function getPickingPositionFr
     const orthoZ = g.depthBufferRGBAValueToOrthoZ(buffer, camera);
     const length = orthoZ / Math.cos(angle);
 
-    pickWorldPosition.addVectors(camera.position, ray.direction.setLength(length));
+    target.addVectors(camera.position, ray.direction.setLength(length));
 
     camera.layers.mask = prev;
 
-    if (pickWorldPosition.length() > 10000000)
+    if (target.length() > 10000000)
         { return undefined; }
 
-    return pickWorldPosition;
+    return target;
 };
 
 export default PlanarView;

--- a/src/Renderer/ThreeExtended/PlanarControls.js
+++ b/src/Renderer/ThreeExtended/PlanarControls.js
@@ -438,16 +438,7 @@ function PlanarControls(view, options = {}) {
      * @ignore
      */
     this.initiateSmartZoom = function initiateSmartZoom() {
-        // point under mouse cursor
-        const pointUnderCursor = new THREE.Vector3();
-
-        // check if there is valid geometry under cursor
-        if (typeof this.view.getPickingPositionFromDepth(mousePosition) !== 'undefined') {
-            pointUnderCursor.copy(this.view.getPickingPositionFromDepth(mousePosition));
-        }
-        else {
-            return;
-        }
+        const pointUnderCursor = this.getWorldPointAtScreenXY(mousePosition);
 
         // direction of the movement, projected on xy plane and normalized
         const dir = new THREE.Vector3();
@@ -665,6 +656,8 @@ function PlanarControls(view, options = {}) {
         };
     })();
 
+    // point under mouse cursor
+    const pointUnderCursor = new THREE.Vector3();
     /**
      * Returns the world point (xyz) under the posXY screen point. If geometry
      * is under the cursor, the point in obtained with
@@ -677,7 +670,7 @@ function PlanarControls(view, options = {}) {
      * @ignore
      */
     this.getWorldPointAtScreenXY = function getWorldPointAtScreenXY(posXY) {
-        const pointUnderCursor = this.view.getPickingPositionFromDepth(posXY);
+        this.view.getPickingPositionFromDepth(posXY, pointUnderCursor);
         // check if there is valid geometry under cursor
         if (pointUnderCursor) {
             return pointUnderCursor;

--- a/test/examples/planar.js
+++ b/test/examples/planar.js
@@ -11,4 +11,40 @@ describe('planar', () => {
         assert.ok(result);
         await page.close();
     });
+    it('should get picking position from depth', async function _() {
+        const page = await browser.newPage();
+
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/planar.html`,
+            this.test.fullTitle());
+
+        const length = 1500;
+
+        // get range with depth buffer and altitude
+        await page.evaluate((l) => {
+            const lookat = extent.center().xyz();
+
+            view.camera.camera3D.position.copy(lookat);
+            view.camera.camera3D.position.z = l;
+            view.camera.camera3D.lookAt(lookat);
+            view.notifyChange(view.camera.camera3D, true);
+        }, length);
+
+        await waitUntilItownsIsIdle(page, this.test.fullTitle());
+
+        const result = await page.evaluate(() => {
+            const depthMethod = view
+                .getPickingPositionFromDepth().distanceTo(view.camera.camera3D.position);
+
+            const altitude = itowns.DEMUtils
+                .getElevationValueAt(view.tileLayer, extent.center().clone()).z;
+
+            return { depthMethod, altitude };
+        });
+        // threorical range between ground and camera
+        const theoricalRange = length - result.altitude;
+        const diffRange = Math.abs(theoricalRange - result.depthMethod);
+        assert.ok(diffRange < 2);
+        await page.close();
+    });
 });


### PR DESCRIPTION
## Description
add or use optional target to getPickingPositionFromDepth

## Motivation and Context
 - Avoid excessive memory allocations that cause GC work.
If target is defined then use this to write the result instead of
allocating an objet
- it's also to avoid the returned result being modified by a new function call
