### PR TITLE
puppeteer some small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See our [release page](https://github.com/iTowns/itowns/releases).
 
 - Imagery from WMTS/WMS/TMS
 - Elevation (DTM/DSM) from WMTS
-- 3D Tiles 
+- 3D Tiles
 - ...
 
 See the [feature list wiki page](https://github.com/iTowns/itowns/wiki/Supported-Features) for a complet list of features and data formats.
@@ -77,7 +77,14 @@ Then you can run the tests:
 ```bash
 npm run test-examples
 ```
+Supported environment variables:
 
+    * SCREENSHOT_FOLDER: take a screenshot at the end of each test and save it in this folder. Example: SCREENSHOT_FOLDER=/tmp/
+    * CHROME: path to Chrome executable. If unspecified itowns will use the one downloaded during puppeteer install.
+    * DEBUG: run Chrome in a window with the debug tools open.
+    * REMOTE_DEBUGGING: run Chrome in headless mode and set up remote debugging. Example: REMOTE_DEBUGGING=9222 will setup remote * debugging on port 9222. Then start another Chrome instance, browse to chrome://inspect/#devices and add localhost:9222 in Discover network targets.
+
+Note: Chrome in headless mode doesn't support the WebGL EXT_frag_depth extension. So rendering may differ and some bugs can only be present in headless mode.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ See the [feature list wiki page](https://github.com/iTowns/itowns/wiki/Supported
 
 If you want to run tests you'll need to install [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
+If you install pupperter behind proxy, use HTTP_PROXY, HTTPS_PROXY, NO_PROXY to defines HTTP proxy settings that are used to download and run Chromium.
+
 If puppeteer fails to download Chrome, you can try with the [documented environment variables](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#environment-variables).
 Or you can download it manually, and then:
 - install puppeteer without downloading Chrome: `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install puppeteer`
@@ -82,7 +84,7 @@ Supported environment variables:
     * SCREENSHOT_FOLDER: take a screenshot at the end of each test and save it in this folder. Example: SCREENSHOT_FOLDER=/tmp/
     * CHROME: path to Chrome executable. If unspecified itowns will use the one downloaded during puppeteer install.
     * DEBUG: run Chrome in a window with the debug tools open.
-    * REMOTE_DEBUGGING: run Chrome in headless mode and set up remote debugging. Example: REMOTE_DEBUGGING=9222 will setup remote * debugging on port 9222. Then start another Chrome instance, browse to chrome://inspect/#devices and add localhost:9222 in Discover network targets.
+    * REMOTE_DEBUGGING: run Chrome in headless mode and set up remote debugging. Example: REMOTE_DEBUGGING=9222 will setup remote debugging on port 9222. Then start another Chrome instance, browse to chrome://inspect/#devices and add localhost:9222 in Discover network targets.
 
 Note: Chrome in headless mode doesn't support the WebGL EXT_frag_depth extension. So rendering may differ and some bugs can only be present in headless mode.
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mocha": "^3.4.2",
     "node-fetch": "^1.7.0",
     "proj4": "^2.4.4",
+    "puppeteer": "^1.5.0",
     "raw-loader": "^0.5.1",
     "require-from-string": "^1.2.1",
     "three": "^0.89.0",

--- a/test/examples/bootstrap.js
+++ b/test/examples/bootstrap.js
@@ -140,19 +140,25 @@ before(async () => {
 
         return result;
     };
+    // For now the '--no-sandbox' flag is needed. Otherwise Chrome fails to start:
+    //
+    // FATAL:zygote_host_impl_linux.cc(124)] No usable sandbox! Update your kernel
+    // or see
+    // https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md
+    // for more information on developing with the SUID sandbox.
+    // If you want to live dangerously and need an immediate workaround, you can try
+    // using --no-sandbox.
+    const args = ['--no-sandbox'];
+
+    if (process.env.REMOTE_DEBUGGING) {
+        args.push(`--remote-debugging-port=${process.env.REMOTE_DEBUGGING}`);
+    }
+
     global.browser = await puppeteer.launch({
         executablePath: process.env.CHROME,
         headless: !process.env.DEBUG,
         devtools: !!process.env.DEBUG,
-        // For now the '--no-sandbox' flag is needed. Otherwise Chrome fails to start:
-        //
-        // FATAL:zygote_host_impl_linux.cc(124)] No usable sandbox! Update your kernel
-        // or see
-        // https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md
-        // for more information on developing with the SUID sandbox.
-        // If you want to live dangerously and need an immediate workaround, you can try
-        // using --no-sandbox.
-        args: ['--no-sandbox'] });
+        args });
 });
 
 // close browser and reset global variables

--- a/test/examples/positionGlobe.js
+++ b/test/examples/positionGlobe.js
@@ -37,8 +37,6 @@ describe('positionGlobe', () => {
                 globeView.notifyChange();
             }));
 
-        await page.screenshot({ path: '/tmp/b.png' });
-
         const value = await page.evaluate(() => {
             // bug was caused by the readDepthBuffer() returning an incorrect value
             // because it drew the cone in front of the cone


### PR DESCRIPTION
## Description
- add path to temp folder (cross-platform)
- add remote debugging option
- add puppeteer master in dev dependencies 

## Motivation and Context
- add remote debugging option, 
allows to debug different behaviors between headless and headfull  ( as EXT_frag_depth extension not supported in headless mode)
- As HTTP_PROXY, HTTPS_PROXY and NO_PROXY allow to install `puppeteer` behind proxy, we can add `puppeteer` in dev dependencies

## Screenshots (if appropriate)
Remote debugging in headless mode
![remote debug](https://user-images.githubusercontent.com/11291849/40839435-d7e69b04-65a2-11e8-91d4-7d0ff27b4faf.png)
