### PR TITLE
fix(gis): initialize Extent from Coordinates correctly

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -38,11 +38,10 @@ function Extent(crs, ...values) {
         values[0] instanceof Coordinates &&
         values[1] instanceof Coordinates) {
         this._values = new Float64Array(4);
-        for (let i = 0; i < values.length; i++) {
-            for (let j = 0; j < 2; j++) {
-                this._values[2 * i + j] = values[i]._values[j];
-            }
-        }
+        this._values[CARDINAL.WEST] = values[0]._values[0];
+        this._values[CARDINAL.EAST] = values[1]._values[0];
+        this._values[CARDINAL.SOUTH] = values[0]._values[1];
+        this._values[CARDINAL.NORTH] = values[1]._values[1];
     } else if (values.length == 1 && values[0].west != undefined) {
         this._values = new Float64Array(4);
         this._values[CARDINAL.WEST] = values[0].west;

--- a/test/extent_unit_test.js
+++ b/test/extent_unit_test.js
@@ -1,0 +1,46 @@
+/* global describe, it */
+import assert from 'assert';
+import Coordinates from '../src/Core/Geographic/Coordinates';
+import Extent from '../src/Core/Geographic/Extent';
+
+describe('Extent constructors', function () {
+    const minX = 0;
+    const maxX = 10;
+    const minY = -1;
+    const maxY = 3;
+
+    it('should build the expected extent using Coordinates', function () {
+        const withCoords = new Extent('EPSG:4326',
+            new Coordinates('EPSG:4326', minX, minY),
+            new Coordinates('EPSG:4326', maxX, maxY));
+        assert.equal(minX, withCoords.west());
+        assert.equal(maxX, withCoords.east());
+        assert.equal(minY, withCoords.south());
+        assert.equal(maxY, withCoords.north());
+    });
+
+    it('should build the expected extent using keywords', function () {
+        const withKeywords = new Extent('EPSG:4326', {
+            south: minY,
+            east: maxX,
+            north: maxY,
+            west: minX,
+        });
+        assert.equal(minX, withKeywords.west());
+        assert.equal(maxX, withKeywords.east());
+        assert.equal(minY, withKeywords.south());
+        assert.equal(maxY, withKeywords.north());
+    });
+
+    it('should build the expected extent using values', function () {
+        const withValues = new Extent('EPSG:4326',
+            minX,
+            maxX,
+            minY,
+            maxY);
+        assert.equal(minX, withValues.west());
+        assert.equal(maxX, withValues.east());
+        assert.equal(minY, withValues.south());
+        assert.equal(maxY, withValues.north());
+    });
+});


### PR DESCRIPTION
This commits fixes the initialization of an Extent from 2 Coordinates and adds a unit test to validate this change.