### PR TITLE
fix (core): get max texture sampler unit with mesa/firefox

### DIFF
--- a/src/Core/System/Capabilities.js
+++ b/src/Core/System/Capabilities.js
@@ -1,11 +1,28 @@
+import SampleTestFS from '../../Renderer/Shader/SampleTestFS.glsl';
+import SampleTestVS from '../../Renderer/Shader/SampleTestVS.glsl';
+
 // default values
 let logDepthBufferSupported = false;
 let maxTexturesUnits = 8;
+
+function _WebGLShader(renderer, type, string) {
+    const gl = renderer.context;
+    const shader = gl.createShader(type);
+
+    gl.shaderSource(shader, string);
+    gl.compileShader(shader);
+    return shader;
+}
+
+function isFirefox() {
+    return navigator && navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+}
 
 export default {
     isLogDepthBufferSupported() {
         return logDepthBufferSupported;
     },
+    isFirefox,
     isInternetExplorer() {
         const internetExplorer = false || !!document.documentMode;
         return internetExplorer;
@@ -17,16 +34,39 @@ export default {
         const gl = renderer.context;
         maxTexturesUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
 
-        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
-        if (debugInfo !== null) {
-            const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
-            if (vendor.indexOf('mesa') > -1 || vendor.indexOf('Mesa') > -1) {
-                maxTexturesUnits = Math.min(16, maxTexturesUnits);
+        const program = gl.createProgram();
+        const glVertexShader = _WebGLShader(renderer, gl.VERTEX_SHADER, SampleTestVS);
+
+        let fragmentShader = `#define SAMPLE ${maxTexturesUnits}\n`;
+        fragmentShader += SampleTestFS;
+
+        const glFragmentShader = _WebGLShader(renderer, gl.FRAGMENT_SHADER, fragmentShader);
+
+        gl.attachShader(program, glVertexShader);
+        gl.attachShader(program, glFragmentShader);
+        gl.linkProgram(program);
+
+        if (gl.getProgramParameter(program, gl.LINK_STATUS) === false) {
+            if (maxTexturesUnits > 16) {
+                const info = gl.getProgramInfoLog(program);
+                // eslint-disable-next-line no-console
+                console.warn(`${info}: using a maximum of 16 texture units instead of the reported value (${maxTexturesUnits})`);
+                if (isFirefox()) {
+                    // eslint-disable-next-line no-console
+                    console.warn(`It can come from a Mesa/Firefox bug;
+                        the shader compiles to an error when using more than 16 sampler uniforms,
+                        see https://bugzilla.mozilla.org/show_bug.cgi?id=777028`);
+                }
+                maxTexturesUnits = 16;
+            } else {
+                throw (new Error(`The GPU capabilities could not be determined accurately.
+                    Impossible to link a shader with the Maximum texture units ${maxTexturesUnits}`));
             }
-        } else {
-            maxTexturesUnits = Math.min(16, maxTexturesUnits);
         }
 
+        gl.deleteProgram(program);
+        gl.deleteShader(glVertexShader);
+        gl.deleteShader(glFragmentShader);
         logDepthBufferSupported = renderer.capabilities.logarithmicDepthBuffer;
     },
 };

--- a/src/Renderer/Shader/SampleTestFS.glsl
+++ b/src/Renderer/Shader/SampleTestFS.glsl
@@ -1,0 +1,4 @@
+uniform sampler2D uni[SAMPLE];
+void main() {
+    gl_FragColor += texture2D(uni[SAMPLE-1], vec2(0));
+}

--- a/src/Renderer/Shader/SampleTestVS.glsl
+++ b/src/Renderer/Shader/SampleTestVS.glsl
@@ -1,0 +1,3 @@
+void main() {
+    gl_Position = vec4( 0.0, 0.0, 0.0, 1.0 );
+}


### PR DESCRIPTION
## Description

fix mesa/firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=777028) 