### PR TITLE
fix(core): stop to add layer if there's a error

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -280,6 +280,9 @@ GlobeView.prototype = Object.create(View.prototype);
 GlobeView.prototype.constructor = GlobeView;
 
 GlobeView.prototype.addLayer = function addLayer(layer) {
+    if (!layer) {
+        return new Promise((resolve, reject) => reject(new Error('layer is undefined')));
+    }
     if (layer.type == 'color') {
         const colorLayerCount = this.getLayers(l => l.type === 'color').length;
         layer.sequence = colorLayerCount;

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -188,6 +188,9 @@ PanoramaView.prototype = Object.create(View.prototype);
 PanoramaView.prototype.constructor = PanoramaView;
 
 PanoramaView.prototype.addLayer = function addLayer(layer) {
+    if (!layer) {
+        return new Promise((resolve, reject) => reject(new Error('layer is undefined')));
+    }
     if (layer.type != 'color') {
         throw new Error(`Unsupported layer type ${layer.type} (PanoramaView only support 'color' layers)`);
     }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -319,9 +319,14 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         layer.update = layer.update || updateLayeredMaterialNodeElevation;
     }
     return new Promise((resolve, reject) => {
+        if (!layer) {
+            reject(new Error('layer is undefined'));
+            return;
+        }
         const duplicate = this.getLayers((l => l.id == layer.id));
         if (duplicate.length > 0) {
             reject(new Error(`Invalid id '${layer.id}': id already used`));
+            return;
         }
 
         if (parentLayer && !layer.extent) {
@@ -331,6 +336,7 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         const provider = this.mainLoop.scheduler.getProtocolProvider(layer.protocol);
         if (layer.protocol && !provider) {
             reject(new Error(`${layer.protocol} is not a recognized protocol name.`));
+            return;
         }
         layer = _preprocessLayer(this, layer, provider, parentLayer);
         if (parentLayer) {
@@ -338,9 +344,11 @@ View.prototype.addLayer = function addLayer(layer, parentLayer) {
         } else {
             if (typeof (layer.update) !== 'function') {
                 reject(new Error('Cant add GeometryLayer: missing a update function'));
+                return;
             }
             if (typeof (layer.preUpdate) !== 'function') {
                 reject(new Error('Cant add GeometryLayer: missing a preUpdate function'));
+                return;
             }
 
             this._layers.push(layer);


### PR DESCRIPTION
## Description
Stop to add layer if there's a function error

## Motivation and Context
The layers work is disrupted
By example, if a layer is added with the same id, it's still add.
if we delete a layer then both are deleted