### PR TITLE
refactor(tilemesh): move getCoordsForLayer+getZoomForLayer to Providers

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -8,8 +8,7 @@ import * as THREE from 'three';
 import LayeredMaterial from '../Renderer/LayeredMaterial';
 import { l_ELEVATION } from '../Renderer/LayeredMaterialConstants';
 import RendererConstant from '../Renderer/RendererConstant';
-import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from '../Provider/OGCWebServiceHelper';
-import { is4326 } from './Geographic/Coordinates';
+import { SIZE_TEXTURE_TILE } from '../Provider/OGCWebServiceHelper';
 
 function TileMesh(geometry, params) {
     // Constructor
@@ -173,8 +172,7 @@ TileMesh.prototype.isElevationLayerLoaded = function isElevationLayerLoaded() {
 };
 
 TileMesh.prototype.isColorLayerDownscaled = function isColorLayerDownscaled(layer) {
-    const mat = this.material;
-    return mat.isColorLayerDownscaled(layer.id, this.getZoomForLayer(layer));
+    return this.material.isColorLayerDownscaled(layer.id, layer.getZoom(this));
 };
 
 TileMesh.prototype.OBB = function OBB() {
@@ -204,38 +202,13 @@ TileMesh.prototype.changeSequenceLayers = function changeSequenceLayers(sequence
 };
 
 TileMesh.prototype.getCoordsForLayer = function getCoordsForLayer(layer) {
-    if (layer.protocol.indexOf('wmts') == 0) {
-        OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, layer.options.tileMatrixSet);
-        return this.wmtsCoords[layer.options.tileMatrixSet];
-    } else if (layer.protocol == 'wms' && this.extent.crs() != layer.projection) {
-        if (layer.projection == 'EPSG:3857') {
-            const tilematrixset = 'PM';
-            OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, tilematrixset);
-            return this.wmtsCoords[tilematrixset];
-        } else {
-            throw new Error('unsupported projection wms for this viewer');
-        }
-    } else if (layer.protocol == 'tms' || layer.protocol == 'xyz') {
-        // Special globe case: use the P(seudo)M(ercator) coordinates
-        if (is4326(this.extent.crs()) &&
-                (layer.extent.crs() == 'EPSG:3857' || is4326(layer.extent.crs()))) {
-            OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, 'PM');
-            return this.wmtsCoords.PM;
-        } else {
-            return OGCWebServiceHelper.computeTMSCoordinates(this, layer.extent, layer.origin);
-        }
-    } else {
-        return [this.extent];
-    }
+    console.warn('tile.getCoordsForLayer(layer) is deprecated, use layer.getCoords(tile) instead.');
+    return layer.getCoords(this);
 };
 
 TileMesh.prototype.getZoomForLayer = function getZoomForLayer(layer) {
-    if (layer.protocol.indexOf('wmts') == 0) {
-        OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, layer.options.tileMatrixSet);
-        return this.wmtsCoords[layer.options.tileMatrixSet][0].zoom;
-    } else {
-        return this.level;
-    }
+    console.warn('tile.getZoomForLayer(layer) is deprecated, use layer.getZoom(tile) instead.');
+    return layer.getZoom(this);
 };
 
 /**

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -141,6 +141,9 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
         };
     }
 
+    layer.getCoords = layer.getCoords || (node => [node.extent]);
+    layer.getZoom = layer.getZoom || (node => node.level);
+
     if (provider) {
         if (provider.tileInsideLimit) {
             layer.tileInsideLimit = provider.tileInsideLimit.bind(provider);

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -11,7 +11,7 @@ const MAX_RETRY = 4;
 
 function initNodeImageryTexturesFromParent(node, parent, layer) {
     if (parent.material && parent.material.getColorLayerLevelById(layer.id) > EMPTY_TEXTURE_ZOOM) {
-        const coords = node.getCoordsForLayer(layer);
+        const coords = layer.getCoords(node);
         const offsetTextures = node.material.getLayerTextureOffset(layer.id);
 
         let textureIndex = offsetTextures;
@@ -44,7 +44,7 @@ function initNodeElevationTextureFromParent(node, parent, layer) {
     // multiple elevation layers (thus multiple calls to initNodeElevationTextureFromParent) but a given
     // node can only use 1 elevation texture
     if (parent.material && parent.material.getElevationLayerLevel() > node.material.getElevationLayerLevel()) {
-        const coords = node.getCoordsForLayer(layer);
+        const coords = layer.getCoords(node);
 
         const texture = parent.material.textures[l_ELEVATION][0];
         const pitch = coords[0].offsetToParent(parent.material.textures[l_ELEVATION][0].coords);
@@ -84,7 +84,7 @@ function getIndiceWithPitch(i, pitch, w) {
 
 function insertSignificantValuesFromParent(texture, node, parent, layer) {
     if (parent.material && parent.material.getElevationLayerLevel() > EMPTY_TEXTURE_ZOOM) {
-        const coords = node.getCoordsForLayer(layer);
+        const coords = layer.getCoords(node);
         const textureParent = parent.material.textures[l_ELEVATION][0];
         const pitch = coords[0].offsetToParent(parent.material.textures[l_ELEVATION][0].coords);
         const tData = texture.image.data;
@@ -169,10 +169,10 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
 
         if (material.indexOfColorLayer(layer.id) === -1) {
             const texturesCount =
-                node.getCoordsForLayer(layer).length;
+                layer.getCoords(node).length;
 
             const paramMaterial = {
-                tileMT: layer.options.tileMatrixSet || node.getCoordsForLayer(layer)[0].crs(),
+                tileMT: layer.options.tileMatrixSet || layer.getCoords(node)[0].crs(),
                 texturesCount,
                 visible: layer.visible,
                 opacity: layer.opacity,
@@ -240,7 +240,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
 
     const failureParams = node.layerUpdateState[layer.id].failureParams;
     const currentLevel = node.material.getColorLayerLevelById(layer.id);
-    const nodeLevel = node.getCoordsForLayer(layer)[0].zoom || node.level;
+    const nodeLevel = layer.getCoords(node)[0].zoom || node.level;
     const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, nodeLevel, currentLevel, layer, failureParams);
     if (targetLevel <= currentLevel) {
         return;
@@ -348,7 +348,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
         }
     }
 
-    const c = node.getCoordsForLayer(layer)[0];
+    const c = layer.getCoords(node)[0];
     const zoom = c.zoom || node.level;
     const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, zoom, currentElevation, layer);
 

--- a/test/layeredmaterialnodeprocessing_unit_test.js
+++ b/test/layeredmaterialnodeprocessing_unit_test.js
@@ -39,6 +39,8 @@ describe('updateLayeredMaterialNodeImagery', function () {
         layer.tileInsideLimit = () => true;
         layer.visible = true;
         layer.updateStrategy = STRATEGY_MIN_NETWORK_TRAFFIC;
+        layer.getCoords = tile => [tile.extent];
+        layer.getZoom = tile => tile.level;
         layer.options = {
             zoom: {
                 min: 0,


### PR DESCRIPTION
## Description
This refactor moves the `getCoordsForLayer` and `getZoomForLayer` from `TileMesh` to new methods in layers (`getCoords` and `getZoom`) that are configured in the Providers.

## Motivation and Context
IMHO, code in Core should not depend explicitly (via `import`) or `implicitly` (via switching on properties defined outside the core, such as the layer `protocol` here). This will help untangle the dependencies and improve the modularity of the code. 

## Screenshots (if appropriate)
not relevant (no functionnal change)

## Note
This is the first commit of a series (cf see https://github.com/iTowns/itowns/compare/master...mbredif:refactor_coords to see where I am heading)