### PR TITLE
refacto(3dtiles): adapt PntsParser to return a Geometry

### DIFF
--- a/src/Parser/PntsParser.js
+++ b/src/Parser/PntsParser.js
@@ -68,7 +68,6 @@ export default {
 function parseFeatureBinary(array, byteOffset, FTJSONLength) {
     // Init geometry
     const geometry = new THREE.BufferGeometry();
-    const material = new THREE.PointsMaterial({ size: 0.05, vertexColors: THREE.VertexColors, sizeAttenuation: true });
 
     // init Array feature binary
     const subArrayJson = utf8Decoder.decode(new Uint8Array(array, byteOffset, FTJSONLength));
@@ -105,14 +104,13 @@ function parseFeatureBinary(array, byteOffset, FTJSONLength) {
     if (parseJSON.BATCH_ID) {
         throw new Error('For pnts loader, BATCH_ID: not yet managed');
     }
-    // creation points with geometry and material
-    const points = new THREE.Points(geometry, material);
-    points.realPointCount = lengthFeature;
 
     // Add RTC feature
-    if (parseJSON.RTC_CENTER) {
-        points.position.fromArray(parseJSON.RTC_CENTER);
-    }
+    const offset = parseJSON.RTC_CENTER ?
+        new THREE.Vector3().fromArray(parseJSON.RTC_CENTER) : undefined;
 
-    return points;
+    return {
+        geometry,
+        offset,
+    };
 }

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -131,8 +131,21 @@ function b3dmToMesh(data, layer, url) {
     });
 }
 
-function pntsParse(data) {
-    return PntsParser.parse(data).then(result => ({ object3d: result.point }));
+function pntsParse(data, layer) {
+    return PntsParser.parse(data).then((result) => {
+        const material = layer.material ?
+            layer.material.clone() :
+            new THREE.PointsMaterial({ size: 0.05, vertexColors: THREE.VertexColors });
+
+        // creation points with geometry and material
+        const points = new THREE.Points(result.point.geometry, material);
+
+        if (result.point.offset) {
+            points.position.copy(result.point.offset);
+        }
+
+        return { object3d: points };
+    });
 }
 
 export function configureTile(tile, layer, metadata, parent) {

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
-  rules: {
-      'func-names': 'off',
-      'prefer-arrow-callback': 'off',
-  }
+    rules: {
+        'func-names': 'off',
+        'prefer-arrow-callback': 'off',
+    },
+    env: {
+        mocha: true,
+    }
 }

--- a/test/pnts_parser_unit_test.js
+++ b/test/pnts_parser_unit_test.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import PntsParser from '../src/Parser/PntsParser';
+
+function bufferFromString(pnts, size) {
+    const buffer = new ArrayBuffer(size);
+    const typed = new Uint8Array(buffer);
+    let next = 0;
+    for (const word of pnts.split(/\s+/)) {
+        if (word.length == 2) {
+            typed[next++] = parseInt(word, 16);
+        }
+    }
+    assert.equal(next, size);
+    return buffer;
+}
+
+describe('pnts parser', function () {
+    const pnts = `
+        70 6e 74 73 01 00 00 00  82 00 00 00 48 00 00 00
+        1e 00 00 00 00 00 00 00  00 00 00 00 7b 22 50 4f
+        49 4e 54 53 5f 4c 45 4e  47 54 48 22 3a 32 2c 22
+        50 4f 53 49 54 49 4f 4e  22 3a 7b 22 62 79 74 65
+        4f 66 66 73 65 74 22 3a  30 7d 2c 22 52 47 42 22
+        3a 7b 22 62 79 74 65 4f  66 66 73 65 74 22 3a 32
+        34 7d 7d 20 f1 34 09 42  90 a9 56 42 9c 15 24 41
+        58 9b 0d 42 90 a9 56 42  9c 15 24 41 e0 9b 85 b7
+        8f 89`;
+    it('should return the correct points', function (done) {
+        const buffer = bufferFromString(pnts, 16 * 8 + 2);
+
+        PntsParser.parse(buffer).then((result) => {
+            // 2 points of 3 components in the geometry
+            assert.equal(
+                result.point.geometry.attributes.position.array.length,
+                2 * 3);
+            // 'Red': 224, 'Green': 155, 'Blue': 133
+            assert.equal(
+                result.point.geometry.attributes.color.array[1],
+                155);
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
This PR applies the idea from PR #764 and adapt it for 3dtiles pointclouds.

So now the PntsParser returns a BufferGeometry and the Provider create
a renderable object out of it.
