### PR TITLE
feat(core): allow layer to specify which elements should be updatable

### DIFF
--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -80,6 +80,21 @@ function GeometryLayer(id, object3d) {
     // Setup default picking method
     this.pickObjectsAt = (view, mouse, radius) => Picking.pickObjectsAt(view, mouse, radius, this.object3d);
 
+    // Attached layers expect to receive the visual representation of a layer (= THREE object with a material).
+    // So if a layer's update function don't process this kind of object, the layer must provide
+    // a getObjectToUpdateForAttachedLayers function that returns the correct object to update for attached
+    // layer.
+    // See 3dtilesProvider or PointCloudProvider for examples.
+    // eslint-disable-next-line arrow-body-style
+    this.getObjectToUpdateForAttachedLayers = (obj) => {
+        if (obj.parent && obj.material) {
+            return {
+                element: obj,
+                parent: obj.parent,
+            };
+        }
+    };
+
     this.postUpdate = () => {};
 }
 

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -65,10 +65,37 @@ function updateElements(context, geometryLayer, elements) {
         // and then update Debug.js:addGeometryLayerDebugFeatures
         const newElementsToUpdate = geometryLayer.update(context, geometryLayer, element);
 
-        // update attached layers
-        for (const attachedLayer of geometryLayer._attachedLayers) {
-            if (attachedLayer.ready) {
-                attachedLayer.update(context, attachedLayer, element);
+        const sub = geometryLayer.getObjectToUpdateForAttachedLayers(element);
+
+        if (sub) {
+            if (sub.element) {
+                if (__DEBUG__) {
+                    if (!(sub.element.isObject3D)) {
+                        throw new Error(`
+                            Invalid object for attached layer to update.
+                            Must be a THREE.Object and have a THREE.Material`);
+                    }
+                }
+                // update attached layers
+                for (const attachedLayer of geometryLayer._attachedLayers) {
+                    if (attachedLayer.ready) {
+                        attachedLayer.update(context, attachedLayer, sub.element, sub.parent);
+                    }
+                }
+            } else if (sub.elements) {
+                for (let i = 0; i < sub.elements.length; i++) {
+                    if (!(sub.elements[i].isObject3D)) {
+                        throw new Error(`
+                            Invalid object for attached layer to update.
+                            Must be a THREE.Object and have a THREE.Material`);
+                    }
+                    // update attached layers
+                    for (const attachedLayer of geometryLayer._attachedLayers) {
+                        if (attachedLayer.ready) {
+                            attachedLayer.update(context, attachedLayer, sub.elements[i], sub.parent);
+                        }
+                    }
+                }
             }
         }
         updateElements(context, geometryLayer, newElementsToUpdate);

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -140,11 +140,7 @@ function checkNodeElevationTextureValidity(texture, noDataValue) {
            tData[l - Math.sqrt(l)] > noDataValue;
 }
 
-export function updateLayeredMaterialNodeImagery(context, layer, node) {
-    if (!node.parent) {
-        return;
-    }
-
+export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     const material = node.material;
 
     // Initialisation
@@ -156,10 +152,10 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
             // because even if this tile is outside of the layer, it could inherit it's
             // parent texture
             if (!layer.noTextureParentOutsideLimit &&
-                node.parent &&
-                node.parent.material &&
-                node.parent.getIndexLayerColor &&
-                node.parent.getIndexLayerColor(layer.id) >= 0) {
+                parent &&
+                parent.material &&
+                parent.getIndexLayerColor &&
+                parent.getIndexLayerColor(layer.id) >= 0) {
                 // ok, we're going to inherit our parent's texture
             } else {
                 node.layerUpdateState[layer.id].noMoreUpdatePossible();
@@ -185,7 +181,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
             const sequence = ImageryLayers.getColorLayersIdOrderedBySequence(imageryLayers);
             material.setSequence(sequence);
 
-            initNodeImageryTexturesFromParent(node, node.parent, layer);
+            initNodeImageryTexturesFromParent(node, parent, layer);
         }
 
         // Proposed new process, two separate processes:
@@ -303,10 +299,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node) {
         });
 }
 
-export function updateLayeredMaterialNodeElevation(context, layer, node) {
-    if (!node.parent) {
-        return;
-    }
+export function updateLayeredMaterialNodeElevation(context, layer, node, parent) {
     // TODO: we need either
     //  - compound or exclusive layers
     //  - support for multiple elevation layers
@@ -320,7 +313,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
     // Init elevation layer, and inherit from parent if possible
     if (node.layerUpdateState[layer.id] === undefined) {
         node.layerUpdateState[layer.id] = new LayerUpdateState();
-        initNodeElevationTextureFromParent(node, node.parent, layer);
+        initNodeElevationTextureFromParent(node, parent, layer);
         currentElevation = material.getElevationLayerLevel();
         const minLevel = layer.options.zoom ? layer.options.zoom.min : 0;
         if (currentElevation >= minLevel) {
@@ -401,7 +394,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node) {
                 // Quick check to avoid using elevation texture with no data value
                 // If we have no data values, we use value from the parent tile
                 // We should later implement multi elevation layer to choose the one to use at each level
-                insertSignificantValuesFromParent(terrain.texture, node, node.parent, layer);
+                insertSignificantValuesFromParent(terrain.texture, node, parent, layer);
             }
 
             node.setTextureElevation(terrain);

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -206,7 +206,6 @@ export default {
                     layer.group.add(elt.obj);
                     elt.obj.updateMatrixWorld(true);
 
-                    elt.obj.owner = elt;
                     elt.promise = null;
                 }, (err) => {
                     if (err instanceof CancelledCommandException) {
@@ -265,7 +264,7 @@ export default {
                 // This format doesn't require points to be evenly distributed, so
                 // we're going to sort the nodes by "importance" (= on screen size)
                 // and display only the first N nodes
-                layer.group.children.sort((p1, p2) => p2.owner.sse - p1.owner.sse);
+                layer.group.children.sort((p1, p2) => p2.userData.metadata.sse - p1.userData.metadata.sse);
 
                 let limitHit = false;
                 layer.displayedCount = 0;
@@ -284,7 +283,7 @@ export default {
         const now = Date.now();
         for (let i = layer.group.children.length - 1; i >= 0; i--) {
             const obj = layer.group.children[i];
-            if (!obj.material.visible && (now - obj.owner.notVisibleSince) > 10000) {
+            if (!obj.material.visible && (now - obj.userData.metadata.notVisibleSince) > 10000) {
                 // remove from group
                 layer.group.children.splice(i, 1);
 
@@ -292,7 +291,7 @@ export default {
                 obj.geometry.dispose();
                 obj.material = null;
                 obj.geometry = null;
-                obj.owner.obj = null;
+                obj.userData.metadata.obj = null;
 
                 if (__DEBUG__) {
                     if (obj.boxHelper) {

--- a/test/3dtiles_unit_test.js
+++ b/test/3dtiles_unit_test.js
@@ -65,7 +65,7 @@ describe('Distance computation using boundingVolume.region', function () {
         const tileset = tilesetWithRegion();
         const tileIndex = new $3dTilesIndex(tileset, '');
         const tile = new Object3D();
-        configureTile(tile, { }, tileIndex.index['0']);
+        configureTile(tile, { }, tileIndex.index['1']);
 
         computeNodeSSE(camera, tile);
 
@@ -78,7 +78,7 @@ describe('Distance computation using boundingVolume.region', function () {
         const tileset = tilesetWithRegion(m);
         const tileIndex = new $3dTilesIndex(tileset, '');
         const tile = new Object3D();
-        configureTile(tile, { }, tileIndex.index['0']);
+        configureTile(tile, { }, tileIndex.index['1']);
 
         computeNodeSSE(camera, tile);
 
@@ -99,7 +99,7 @@ describe('Distance computation using boundingVolume.box', function () {
         const tileIndex = new $3dTilesIndex(tileset, '');
 
         const tile = new Object3D();
-        configureTile(tile, { }, tileIndex.index['0']);
+        configureTile(tile, { }, tileIndex.index['1']);
 
         computeNodeSSE(camera, tile);
 
@@ -114,7 +114,7 @@ describe('Distance computation using boundingVolume.box', function () {
         const tileIndex = new $3dTilesIndex(tileset, '');
 
         const tile = new Object3D();
-        configureTile(tile, { }, tileIndex.index['0']);
+        configureTile(tile, { }, tileIndex.index['1']);
 
         tile.updateMatrixWorld(true);
 
@@ -137,7 +137,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
         const tileIndex = new $3dTilesIndex(tileset, '');
 
         const tile = new Object3D();
-        configureTile(tile, { }, tileIndex.index['0']);
+        configureTile(tile, { }, tileIndex.index['1']);
 
         computeNodeSSE(camera, tile);
 
@@ -152,7 +152,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
         const tileIndex = new $3dTilesIndex(tileset, '');
 
         const tile = new Object3D();
-        configureTile(tile, { }, tileIndex.index['0']);
+        configureTile(tile, { }, tileIndex.index['1']);
 
         tile.updateMatrixWorld(true);
 

--- a/test/3dtilesprovider_unit_test.js
+++ b/test/3dtilesprovider_unit_test.js
@@ -1,0 +1,24 @@
+/* global describe, it */
+import assert from 'assert';
+import { Group, Mesh } from 'three';
+import { getObjectToUpdateForAttachedLayers } from '../src/Provider/3dTilesProvider';
+
+describe('getObjectToUpdateForAttachedLayers', function () {
+    it('should correctly return all children', function () {
+        const layer = { };
+        const tile = {
+            content: new Group(),
+            layer,
+        };
+
+        for (let i = 0; i < 3; i++) {
+            const mesh = new Mesh();
+            mesh.layer = layer;
+            tile.content.add(mesh);
+        }
+
+        const result = getObjectToUpdateForAttachedLayers(tile);
+        assert.ok(Array.isArray(result.elements));
+        assert.ok(result.elements.length, 3);
+    });
+});

--- a/test/pointcloudprovider_unit_test.js
+++ b/test/pointcloudprovider_unit_test.js
@@ -1,7 +1,5 @@
-/* global describe, it */
 import assert from 'assert';
-import { _testing } from '../src/Provider/PointCloudProvider';
-
+import { getObjectToUpdateForAttachedLayers, _testing } from '../src/Provider/PointCloudProvider';
 
 describe('PointCloudProvider', function () {
     it('should correctly parse normal information in metadata', function () {
@@ -51,3 +49,23 @@ describe('PointCloudProvider', function () {
     });
 });
 
+
+describe('getObjectToUpdateForAttachedLayers', function () {
+    it('should correctly no-parent for the root', function () {
+        const meta = {
+            obj: 'a',
+        };
+        assert.equal(getObjectToUpdateForAttachedLayers(meta).element, 'a');
+    });
+    it('should correctly return the element and its parent', function () {
+        const meta = {
+            obj: 'a',
+            parent: {
+                obj: 'b',
+            },
+        };
+        const result = getObjectToUpdateForAttachedLayers(meta);
+        assert.equal(result.element, 'a');
+        assert.equal(result.parent, 'b');
+    });
+});

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -3,14 +3,20 @@ import OBBHelper from './OBBHelper';
 import View from '../../src/Core/View';
 import GeometryDebug from './GeometryDebug';
 
-export default function create3dTilesDebugUI(datDebugTool, view, layer) {
-    const gui = GeometryDebug.createGeometryDebugUI(datDebugTool, view, layer);
+const invMatrixChangeUpVectorZtoY = new THREE.Matrix4().getInverse(new THREE.Matrix4().makeRotationX(Math.PI / 2));
+const invMatrixChangeUpVectorZtoX = new THREE.Matrix4().getInverse(new THREE.Matrix4().makeRotationZ(-Math.PI / 2));
+
+export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) {
+    const gui = GeometryDebug.createGeometryDebugUI(datDebugTool, view, _3dTileslayer);
+
+    const regionBoundingBoxParent = new THREE.Group();
+    view.scene.add(regionBoundingBoxParent);
 
     // add wireframe
-    GeometryDebug.addWireFrameCheckbox(gui, view, layer);
+    GeometryDebug.addWireFrameCheckbox(gui, view, _3dTileslayer);
 
     // Bounding box control
-    const obb_layer_id = `${layer.id}_obb_debug`;
+    const obb_layer_id = `${_3dTileslayer.id}_obb_debug`;
 
     const debugIdUpdate = function debugIdUpdate(context, layer, node) {
         const enabled = context.camera.camera3D.layers.test({ mask: 1 << layer.threejsLayer });
@@ -18,74 +24,74 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
         if (!enabled) {
             return;
         }
-        var obbChildren = node.children.filter(n => n.layer == layer);
+        const metadata = node.userData.metadata;
 
-        if (node.visible && node.boundingVolume) {
-            // 3dTiles case
-            let helper;
-            if (obbChildren.length == 0) {
+        let helper = node.userData.obb;
+
+        if (node.visible && metadata.boundingVolume) {
+            if (!helper) {
                 // 3dtiles with region
-                if (node.boundingVolume.region) {
-                    helper = new OBBHelper(node.boundingVolume.region, `id:${node.id}`);
-                    helper.position.copy(node.boundingVolume.region.position);
-                    helper.rotation.copy(node.boundingVolume.region.rotation);
-                    node.add(helper);
-                    helper.layer = layer;
-                    // add the ability to hide all the debug obj for one layer at once
-                    const l = context.view.getLayers(l => l.id === obb_layer_id)[0];
-                    const l3js = l.threejsLayer;
-                    helper.layers.set(l3js);
-                    helper.children[0].layers.set(l3js);
-                    helper.updateMatrixWorld();
+                if (metadata.boundingVolume.region) {
+                    helper = new OBBHelper(metadata.boundingVolume.region, `id:${node.id}`);
+                    helper.position.copy(metadata.boundingVolume.region.position);
+                    helper.rotation.copy(metadata.boundingVolume.region.rotation);
+                    regionBoundingBoxParent.add(helper);
                 }
                 // 3dtiles with box
-                if (node.boundingVolume.box) {
-                    const size = node.boundingVolume.box.getSize();
+                if (metadata.boundingVolume.box) {
+                    const size = metadata.boundingVolume.box.getSize();
                     const g = new THREE.BoxGeometry(size.x, size.y, size.z);
                     const material = new THREE.MeshBasicMaterial({ wireframe: true });
                     helper = new THREE.Mesh(g, material);
-                    node.boundingVolume.box.getCenter(helper.position);
-                    node.add(helper);
-                    helper.layer = layer;
-                    // add the ability to hide all the debug obj for one layer at once
-                    const l = context.view.getLayers(l => l.id === obb_layer_id)[0];
-                    const l3js = l.threejsLayer;
-                    helper.layers.set(l3js);
-                    helper.updateMatrixWorld();
+                    metadata.boundingVolume.box.getCenter(helper.position);
                 }
                 // 3dtiles with Sphere
-                if (node.boundingVolume.sphere) {
-                    const geometry = new THREE.SphereGeometry(node.boundingVolume.sphere.radius, 32, 32);
+                if (metadata.boundingVolume.sphere) {
+                    const geometry = new THREE.SphereGeometry(metadata.boundingVolume.sphere.radius, 32, 32);
                     const material = new THREE.MeshBasicMaterial({ wireframe: true });
                     helper = new THREE.Mesh(geometry, material);
-                    helper.position.copy(node.boundingVolume.sphere.center);
-                    node.add(helper);
+                    helper.position.copy(metadata.boundingVolume.sphere.center);
+                }
+
+                if (helper) {
                     helper.layer = layer;
                     // add the ability to hide all the debug obj for one layer at once
-                    const l = context.view.getLayers(l => l.id === obb_layer_id)[0];
-                    const l3js = l.threejsLayer;
+                    const l3js = layer.threejsLayer;
                     helper.layers.set(l3js);
+                    if (helper.children.length) {
+                        helper.children[0].layers.set(l3js);
+                    }
+                    node.userData.obb = helper;
+                    helper.updateMatrixWorld();
+                }
+
+                if (helper && !metadata.boundingVolume.region) {
+                    // compensate B3dm orientation correction
+                    const gltfUpAxis = _3dTileslayer.asset.gltfUpAxis;
+                    helper.updateMatrix();
+                    if (gltfUpAxis === undefined || gltfUpAxis === 'Y') {
+                        helper.matrix.premultiply(invMatrixChangeUpVectorZtoY);
+                    } else if (gltfUpAxis === 'X') {
+                        helper.matrix.premultiply(invMatrixChangeUpVectorZtoX);
+                    }
+                    helper.applyMatrix(new THREE.Matrix4());
+
+                    node.add(helper);
                     helper.updateMatrixWorld();
                 }
             } else {
-                helper = obbChildren[0];
+                helper = node.userData.obb;
             }
             if (helper) {
                 helper.visible = true;
-                for (const child of node.children.filter(n => n.layer == layer)) {
-                    if (typeof child.setMaterialVisibility === 'function') {
-                        child.setMaterialVisibility(true);
-                    }
-                    child.visible = true;
+                if (typeof helper.setMaterialVisibility === 'function') {
+                    helper.setMaterialVisibility(true);
                 }
             }
-        } else {
-            // hide obb children
-            for (const child of node.children.filter(n => n.layer == layer)) {
-                if (typeof child.setMaterialVisibility === 'function') {
-                    child.setMaterialVisibility(false);
-                }
-                child.visible = false;
+        } else if (helper) {
+            helper.visible = false;
+            if (typeof helper.setMaterialVisibility === 'function') {
+                helper.setMaterialVisibility(false);
             }
         }
     };
@@ -96,14 +102,14 @@ export default function create3dTilesDebugUI(datDebugTool, view, layer) {
             type: 'debug',
             update: debugIdUpdate,
             visible: false,
-        }, layer).then((l) => {
+        }, _3dTileslayer).then((l) => {
             gui.add(l, 'visible').name('Bounding boxes').onChange(() => {
                 view.notifyChange();
             });
         });
 
     // The sse Threshold for each tile
-    gui.add(layer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
+    gui.add(_3dTileslayer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
         view.notifyChange();
     });
 }

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -59,11 +59,11 @@ export default {
                 for (const pts of layer.group.children) {
                     pts.material.visible = false;
                     for (const name of stickies) {
-                        if (pts.owner.name == name) {
+                        if (pts.userData.metadata.name == name) {
                             pts.material.visible = true;
-                        } else if (!isInHierarchy(pts.owner, name)) {
+                        } else if (!isInHierarchy(pts.userData.metadata, name)) {
                             continue;
-                        } else if (pts.owner.name.length < name.length) {
+                        } else if (pts.userData.metadata.name.length < name.length) {
                             pts.material.visible = layer.dbgDisplayParents;
                             break;
                         } else {


### PR DESCRIPTION
Some layers use separated objects for metadata and drawable objects.
For instance PointCloudProvider or 3dTilesProvider.

Attached layers (e.g texture layers) expect to receive a drawable object,
in their update function.

So this commit adds an optional metadataToElements function to layers,
allowing them to returns the to-be-updated object from metadata, and
its parent.
