### PR TITLE
Refacto limit dependency on layeredmaterial

### DIFF
--- a/examples/split.html
+++ b/examples/split.html
@@ -86,17 +86,12 @@
 
             function changeLayerVisibility(ortho, osm) {
                 var material;
-                var orthoIndex;
-                var opensmIndex;
 
                 globeView.scene.traverse(function _(obj) {
                     if (obj.material && obj.material.setLayerVisibility && obj.material.visible) {
                         material = obj.material;
-                        orthoIndex = material.indexOfColorLayer(orthoLayer.id);
-                        opensmIndex = material.indexOfColorLayer(osmLayer.id);
-
-                        material.setLayerVisibility(orthoIndex, ortho);
-                        material.setLayerVisibility(opensmIndex, osm);
+                        material.setLayerVisibility(orthoLayer, ortho);
+                        material.setLayerVisibility(osmLayer, osm);
                     }
                 });
             }

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { ellipsoidSizes } from '../Core/Geographic/Coordinates';
 import { SIZE_TEXTURE_TILE } from '../Provider/OGCWebServiceHelper';
 import Extent from '../Core/Geographic/Extent';
+import { l_ELEVATION } from '../Renderer/LayeredMaterialConstants';
 
 const cV = new THREE.Vector3();
 let vhMagnitudeSquared;
@@ -125,11 +126,14 @@ export function globeSubdivisionControl(minLevel, maxLevel, sseThreshold, maxDel
         // Prevent to subdivise the node if the current elevation level
         // we must avoid a tile, with level 20, inherits a level 3 elevation texture.
         // The induced geometric error is much too large and distorts the SSE
-        const currentElevationLevel = node.material.getElevationLayerLevel();
-        if (node.level < context.maxElevationLevel + maxDeltaElevationLevel &&
-            currentElevationLevel >= 0 &&
-            (node.level - currentElevationLevel) >= maxDeltaElevationLevel) {
-            return false;
+        const currentTexture = node.material.textures[l_ELEVATION][0];
+        if (currentTexture.extent) {
+            const offsetScale = node.material.offsetScale[l_ELEVATION][0];
+            const ratio = offsetScale.z;
+            // ratio is node size / texture size
+            if (ratio < 1 / Math.pow(2, maxDeltaElevationLevel)) {
+                return false;
+            }
         }
 
         const sse = computeNodeSSE(context.camera, node);

--- a/src/Process/PlanarTileProcessing.js
+++ b/src/Process/PlanarTileProcessing.js
@@ -1,3 +1,5 @@
+import { l_ELEVATION } from '../Renderer/LayeredMaterialConstants';
+
 function frustumCullingOBB(node, camera) {
     return camera.isBox3Visible(node.OBB().box3D, node.OBB().matrixWorld);
 }
@@ -42,11 +44,14 @@ export function planarSubdivisionControl(maxLevel, maxDeltaElevationLevel) {
         // Prevent to subdivise the node if the current elevation level
         // we must avoid a tile, with level 20, inherits a level 3 elevation texture.
         // The induced geometric error is much too large and distorts the SSE
-        const currentElevationLevel = node.material.getElevationLayerLevel();
-        if (node.level < context.maxElevationLevel + maxDeltaElevationLevel &&
-            currentElevationLevel >= 0 &&
-            (node.level - currentElevationLevel) >= maxDeltaElevationLevel) {
-            return false;
+        const currentTexture = node.material.textures[l_ELEVATION][0];
+        if (currentTexture.extent) {
+            const offsetScale = node.material.offsetScale[l_ELEVATION][0];
+            const ratio = offsetScale.z;
+            // ratio is node size / texture size
+            if (ratio < 1 / Math.pow(2, maxDeltaElevationLevel)) {
+                return false;
+            }
         }
 
         return _isTileBigOnScreen(context.camera, node);

--- a/src/Process/SubdivisionControl.js
+++ b/src/Process/SubdivisionControl.js
@@ -10,7 +10,7 @@ export default {
         // Prevent subdivision if node is covered by at least one elevation layer
         // and if node doesn't have a elevation texture yet.
         for (const e of context.elevationLayers) {
-            if (!e.frozen && e.ready && e.tileInsideLimit(node, e) && !node.isElevationLayerLoaded()) {
+            if (!e.frozen && e.ready && e.tileInsideLimit(node, e) && !node.material.isElevationLayerLoaded()) {
                 // no stop subdivision in the case of a loading error
                 if (node.layerUpdateState[e.id] && node.layerUpdateState[e.id].inError()) {
                     continue;
@@ -28,7 +28,7 @@ export default {
             if (node.layerUpdateState[c.id] && node.layerUpdateState[c.id].inError()) {
                 continue;
             }
-            if (c.tileInsideLimit(node, c) && !node.isColorLayerLoaded(c.id)) {
+            if (c.tileInsideLimit(node, c) && !node.material.isColorLayerLoaded(c)) {
                 return false;
             }
         }

--- a/src/Provider/OGCWebServiceHelper.js
+++ b/src/Provider/OGCWebServiceHelper.js
@@ -44,11 +44,6 @@ export default {
             }), Cache.POLICIES.ELEVATION);
     },
     computeTileMatrixSetCoordinates(tile, tileMatrixSet) {
-        // Are WMTS coordinates ready?
-        if (!tile.wmtsCoords) {
-            tile.wmtsCoords = {};
-        }
-
         tileMatrixSet = tileMatrixSet || 'WGS84G';
         if (!(tileMatrixSet in tile.wmtsCoords)) {
             if (tile.wmtsCoords.WGS84G) {
@@ -58,6 +53,7 @@ export default {
                 tileCoord.row = c.row;
             } else {
                 Projection.WGS84toWMTS(tile.extent, tileCoord);
+                tile.wmtsCoords.WGS84G = [tileCoord.clone()];
             }
 
             tile.wmtsCoords[tileMatrixSet] =

--- a/src/Provider/StaticProvider.js
+++ b/src/Provider/StaticProvider.js
@@ -3,7 +3,6 @@ import { Vector4 } from 'three';
 import Extent from '../Core/Geographic/Extent';
 import OGCWebServiceHelper from './OGCWebServiceHelper';
 import Fetcher from './Fetcher';
-import { l_COLOR, l_ELEVATION } from '../Renderer/LayeredMaterialConstants';
 
 function _selectImagesFromSpatialIndex(index, images, extent) {
     return index.search(
@@ -168,8 +167,7 @@ export default {
             return false;
         }
         const mat = tile.material;
-        const layerType = layer.type === 'color' ? l_COLOR : l_ELEVATION;
-        const currentTexture = mat.getLayerTextures(layerType, layer.id)[0];
+        const currentTexture = mat.getLayerTextures(layer)[0];
         if (!currentTexture.file) {
             return true;
         }

--- a/src/Provider/TileProvider.js
+++ b/src/Provider/TileProvider.js
@@ -6,6 +6,7 @@
 import * as THREE from 'three';
 import TileGeometry from '../Core/TileGeometry';
 import TileMesh from '../Core/TileMesh';
+import LayeredMaterial from '../Renderer/LayeredMaterial';
 import CancelledCommandException from '../Core/Scheduler/CancelledCommandException';
 import Cache from '../Core/Scheduler/Cache';
 import { requestNewTile } from '../Process/TiledNodeProcessing';
@@ -73,15 +74,9 @@ function executeCommand(command) {
     }
 
     // build tile
-    const params = {
-        extent,
-        level,
-        materialOptions: layer.materialOptions,
-    };
-
     geometry._count++;
-    const tile = new TileMesh(geometry, params);
-    tile.layer = layer;
+    const material = new LayeredMaterial(layer.materialOptions);
+    const tile = new TileMesh(layer, geometry, material, extent, level);
     tile.layers.set(command.threejsLayer);
 
     if (parent && parent instanceof TileMesh) {

--- a/src/utils/DEMUtils.js
+++ b/src/utils/DEMUtils.js
@@ -169,7 +169,7 @@ function tileAt(pt, tile) {
                 return t;
             }
         }
-        if (tile.getLayerTextures(l_ELEVATION)[0].coords.zoom > -1) {
+        if (tile.material.isElevationLayerLoaded()) {
             return tile;
         }
         return undefined;
@@ -371,7 +371,7 @@ function _readZ(layer, method, coord, nodes, cache) {
     }
 
     const tile = tileWithValidElevationTexture;
-    const src = tileWithValidElevationTexture.getLayerTextures(l_ELEVATION)[0];
+    const src = tileWithValidElevationTexture.material.textures[l_ELEVATION][0];
 
     // check cache value if existing
     if (cache) {

--- a/test/layeredmaterialnodeprocessing_unit_test.js
+++ b/test/layeredmaterialnodeprocessing_unit_test.js
@@ -3,6 +3,7 @@ import { updateLayeredMaterialNodeImagery } from '../src/Process/LayeredMaterial
 import TileMesh from '../src/Core/TileMesh';
 import Extent from '../src/Core/Geographic/Extent';
 import OBB from '../src/Renderer/ThreeExtended/OBB';
+import LayeredMaterial from '../src/Renderer/LayeredMaterial';
 import { STRATEGY_MIN_NETWORK_TRAFFIC } from '../src/Core/Layer/LayerUpdateStrategy';
 /* global describe, it, beforeEach */
 
@@ -30,6 +31,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
     const layer = {
         id: 'foo',
         protocol: 'dummy',
+        extent: new Extent('EPSG:4326', 0, 0, 0, 0),
     };
 
     beforeEach('reset state', function () {
@@ -49,7 +51,11 @@ describe('updateLayeredMaterialNodeImagery', function () {
 
 
     it('hidden tile should not execute commands', () => {
-        const tile = new TileMesh(geom, { extent: new Extent('EPSG:4326', 0, 0, 0, 0) });
+        const tile = new TileMesh(
+            layer,
+            geom,
+            new LayeredMaterial(),
+            new Extent('EPSG:4326', 0, 0, 0, 0));
         tile.material.visible = false;
         tile.material.indexOfColorLayer = () => 0;
         tile.parent = { };
@@ -58,7 +64,11 @@ describe('updateLayeredMaterialNodeImagery', function () {
     });
 
     it('tile with best texture should not execute commands', () => {
-        const tile = new TileMesh(geom, { extent: new Extent('EPSG:4326', 0, 0, 0, 0) });
+        const tile = new TileMesh(
+            layer,
+            geom,
+            new LayeredMaterial(),
+            new Extent('EPSG:4326', 0, 0, 0, 0));
         tile.material.visible = true;
         tile.material.indexOfColorLayer = () => 0;
         tile.parent = { };
@@ -69,10 +79,12 @@ describe('updateLayeredMaterialNodeImagery', function () {
     });
 
     it('tile with downscaled texture should execute 1 command', () => {
-        const tile = new TileMesh(geom, {
-            extent: new Extent('EPSG:4326', 0, 0, 0, 0),
-            level: 2,
-        });
+        const tile = new TileMesh(
+            layer,
+            geom,
+            new LayeredMaterial(),
+            new Extent('EPSG:4326', 0, 0, 0, 0),
+            2);
         tile.material.visible = true;
         tile.parent = { };
         tile.material.indexOfColorLayer = () => 0;
@@ -89,10 +101,12 @@ describe('updateLayeredMaterialNodeImagery', function () {
     });
 
     it('tile should not request texture with level > layer.zoom.max', () => {
-        const tile = new TileMesh(geom, {
-            extent: new Extent('EPSG:4326', 0, 0, 0, 0),
-            level: 15,
-        });
+        const tile = new TileMesh(
+            layer,
+            geom,
+            new LayeredMaterial(),
+            new Extent('EPSG:4326', 0, 0, 0, 0),
+            15);
         tile.material.visible = true;
         tile.parent = { };
         // Emulate a situation where tile inherited a level 1 texture


### PR DESCRIPTION
2  commits, related to the same context: stop leaking internal attributes (WMTS level, LayeredMateiral texture indexing schema) in all iTowns.

First commit content:

    fix: stop using 'level' property where it's not mandatory
    
    Currently the 'level' concept from WMTS has leaked everywhere in iTowns
    codebase.
    
    This commits replace its usage in one part of iTowns, by something
    equivalent but that doesn't force texture Providers to mock WMTS level
    mechanism.

2nd one is:
    refacto(core): avoid manipulating LayeredMaterial internal state
    
    This commits is a step forward stopping to rely on LayeredMaterial
    internal representation of textures (using an index and such) in other
    parts of iTowns.
    
    This will allow to reuse all this code for objects that don't use a
    LayerMaterial instance as their material.