### PR TITLE
feat(pointclouds): compute extent for pointclouds elements

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -389,4 +389,13 @@ Extent.prototype.expandByPoint = function expandByPoint(coordinates) {
     }
 };
 
+Extent.fromBox3 = function fromBox3(crs, box) {
+    return new Extent(crs, {
+        west: box.min.x,
+        east: box.max.x,
+        south: box.min.y,
+        north: box.max.y,
+    });
+};
+
 export default Extent;

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -27,6 +27,8 @@ function subdivideNode(context, layer, node, cullingTest) {
     }
 }
 
+const tmpBox3 = new THREE.Box3();
+const tmpSphere = new THREE.Sphere();
 function boundingVolumeToExtent(crs, volume, transform) {
     if (volume.region) {
         return new Extent('EPSG:4326',
@@ -35,10 +37,10 @@ function boundingVolumeToExtent(crs, volume, transform) {
             THREE.Math.radToDeg(volume.region[1]),
             THREE.Math.radToDeg(volume.region[3]));
     } else if (volume.box) {
-        const box = volume.box.clone().applyMatrix4(transform);
+        const box = tmpBox3.copy(volume.box).applyMatrix4(transform);
         return Extent.fromBox3(crs, box);
     } else {
-        const sphere = volume.sphere.clone().applyMatrix4(transform);
+        const sphere = tmpSphere.copy(volume.sphere).applyMatrix4(transform);
         return new Extent(crs, {
             west: sphere.center.x - sphere.radius,
             east: sphere.center.x + sphere.radius,

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -36,12 +36,7 @@ function boundingVolumeToExtent(crs, volume, transform) {
             THREE.Math.radToDeg(volume.region[3]));
     } else if (volume.box) {
         const box = volume.box.clone().applyMatrix4(transform);
-        return new Extent(crs, {
-            west: box.min.x,
-            east: box.max.x,
-            south: box.min.y,
-            north: box.max.y,
-        });
+        return Extent.fromBox3(crs, box);
     } else {
         const sphere = volume.sphere.clone().applyMatrix4(transform);
         return new Extent(crs, {

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -27,7 +27,7 @@ function subdivideNode(context, layer, node, cullingTest) {
     }
 }
 
-function boundingVolumeToExtent(crs, layer, volume, transform) {
+function boundingVolumeToExtent(crs, volume, transform) {
     if (volume.region) {
         return new Extent('EPSG:4326',
             THREE.Math.radToDeg(volume.region[0]),
@@ -78,7 +78,7 @@ function _subdivideNodeAdditive(context, layer, node, cullingTest) {
             node.add(tile);
             tile.updateMatrixWorld();
 
-            const extent = boundingVolumeToExtent(layer.extent.crs(), tile.layer, tile.boundingVolume, tile.matrixWorld);
+            const extent = boundingVolumeToExtent(layer.extent.crs(), tile.boundingVolume, tile.matrixWorld);
             tile.traverse((obj) => {
                 obj.extent = extent;
             });
@@ -288,7 +288,7 @@ export function init3dTilesLayer(view, scheduler, layer) {
                 layer.tileIndex.index[tile.tileId].loaded = true;
                 layer.root = tile;
                 layer.extent = boundingVolumeToExtent(layer.projection || view.referenceCrs,
-                    tile, tile.boundingVolume, tile.matrixWorld);
+                    tile.boundingVolume, tile.matrixWorld);
             });
 }
 

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -143,14 +143,14 @@ function addPickingAttribute(points) {
     return points;
 }
 
-function bboxToExtent(view, bbox) {
-    if (view.referenceCrs == 'EPSG:4978') {
+function bboxToExtent(crs, bbox) {
+    if (crs == 'EPSG:4978') {
         const extent = new Extent('EPSG:4326',
             new Coordinates('EPSG:4978', bbox.min).as('EPSG:4326'),
             new Coordinates('EPSG:4978', bbox.max).as('EPSG:4326'));
         return extent;
     } else {
-        return new Extent(view.referenceCrs, {
+        return new Extent(crs, {
             west: bbox.min.x,
             east: bbox.max.x,
             south: bbox.min.y,
@@ -243,7 +243,7 @@ export default {
             console.log('LAYER metadata:', root);
             layer.root = root;
             root.findChildrenByName = findChildrenByName.bind(root, root);
-            layer.extent = bboxToExtent(view, root.bbox);
+            layer.extent = bboxToExtent(view.referenceCrs, root.bbox);
 
             return layer;
         });
@@ -275,7 +275,7 @@ export default {
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
             points.layers.set(layer.threejsLayer);
             points.layer = layer;
-            points.extent = bboxToExtent(command.view, node.bbox);
+            points.extent = bboxToExtent(command.view.referenceCrs, node.bbox);
             return points;
         });
     },

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -5,6 +5,8 @@ import PotreeBinParser from '../Parser/PotreeBinParser';
 import PotreeCinParser from '../Parser/PotreeCinParser';
 import PointsMaterial from '../Renderer/PointsMaterial';
 import Picking from '../Core/Picking';
+import Extent from '../Core/Geographic/Extent';
+import Coordinates from '../Core/Geographic/Coordinates';
 
 // Create an A(xis)A(ligned)B(ounding)B(ox) for the child `childIndex` of one aabb.
 // (PotreeConverter protocol builds implicit octree hierarchy by applying the same
@@ -141,8 +143,24 @@ function addPickingAttribute(points) {
     return points;
 }
 
+function bboxToExtent(view, bbox) {
+    if (view.referenceCrs == 'EPSG:4978') {
+        const extent = new Extent('EPSG:4326',
+            new Coordinates('EPSG:4978', bbox.min).as('EPSG:4326'),
+            new Coordinates('EPSG:4978', bbox.max).as('EPSG:4326'));
+        return extent;
+    } else {
+        return new Extent(view.referenceCrs, {
+            west: bbox.min.x,
+            east: bbox.max.x,
+            south: bbox.min.y,
+            north: bbox.max.y,
+        });
+    }
+}
+
 export default {
-    preprocessDataLayer(layer) {
+    preprocessDataLayer(layer, view) {
         if (!layer.file) {
             layer.file = 'cloud.js';
         }
@@ -225,6 +243,7 @@ export default {
             console.log('LAYER metadata:', root);
             layer.root = root;
             root.findChildrenByName = findChildrenByName.bind(root, root);
+            layer.extent = bboxToExtent(view, root.bbox);
 
             return layer;
         });
@@ -256,6 +275,7 @@ export default {
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
             points.layers.set(layer.threejsLayer);
             points.layer = layer;
+            points.extent = bboxToExtent(command.view, node.bbox);
             return points;
         });
     },

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -6,7 +6,6 @@ import PotreeCinParser from '../Parser/PotreeCinParser';
 import PointsMaterial from '../Renderer/PointsMaterial';
 import Picking from '../Core/Picking';
 import Extent from '../Core/Geographic/Extent';
-import Coordinates from '../Core/Geographic/Coordinates';
 
 // Create an A(xis)A(ligned)B(ounding)B(ox) for the child `childIndex` of one aabb.
 // (PotreeConverter protocol builds implicit octree hierarchy by applying the same
@@ -143,22 +142,6 @@ function addPickingAttribute(points) {
     return points;
 }
 
-function bboxToExtent(crs, bbox) {
-    if (crs == 'EPSG:4978') {
-        const extent = new Extent('EPSG:4326',
-            new Coordinates('EPSG:4978', bbox.min).as('EPSG:4326'),
-            new Coordinates('EPSG:4978', bbox.max).as('EPSG:4326'));
-        return extent;
-    } else {
-        return new Extent(crs, {
-            west: bbox.min.x,
-            east: bbox.max.x,
-            south: bbox.min.y,
-            north: bbox.max.y,
-        });
-    }
-}
-
 export default {
     preprocessDataLayer(layer, view) {
         if (!layer.file) {
@@ -243,7 +226,7 @@ export default {
             console.log('LAYER metadata:', root);
             layer.root = root;
             root.findChildrenByName = findChildrenByName.bind(root, root);
-            layer.extent = bboxToExtent(view.referenceCrs, root.bbox);
+            layer.extent = Extent.fromBox3(view.referenceCrs, root.bbox);
 
             return layer;
         });
@@ -275,7 +258,7 @@ export default {
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
             points.layers.set(layer.threejsLayer);
             points.layer = layer;
-            points.extent = bboxToExtent(command.view.referenceCrs, node.bbox);
+            points.extent = Extent.fromBox3(command.view.referenceCrs, node.bbox);
             return points;
         });
     },

--- a/test/extent_unit_test.js
+++ b/test/extent_unit_test.js
@@ -1,5 +1,6 @@
 /* global describe, it */
 import assert from 'assert';
+import { Box3, Vector3 } from 'three';
 import Coordinates from '../src/Core/Geographic/Coordinates';
 import Extent from '../src/Core/Geographic/Extent';
 
@@ -42,5 +43,17 @@ describe('Extent constructors', function () {
         assert.equal(maxX, withValues.east());
         assert.equal(minY, withValues.south());
         assert.equal(maxY, withValues.north());
+    });
+
+    it('should build the expected extent from box3', function () {
+        const box = new Box3(
+            new Vector3(Math.random(), Math.random()),
+            new Vector3(Math.random(), Math.random()));
+        const fromBox = Extent.fromBox3('EPSG:4978', box);
+
+        assert.equal(fromBox.west(), box.min.x);
+        assert.equal(fromBox.east(), box.max.x);
+        assert.equal(fromBox.north(), box.max.y);
+        assert.equal(fromBox.south(), box.min.y);
     });
 });


### PR DESCRIPTION
In order to be able to unify processing for elements of heterogeneous sources we must have some shared properties.
`layer.extent` and `element.extent` is one of these, and will allow to build colorization for pointcloud.