### PR TITLE
fix(3dtiles): dont stop subdivision at tileset boundaries

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -324,6 +324,9 @@ export function $3dTilesSubdivisionControl(context, layer, node) {
     if (layer.tileIndex.index[node.tileId].children === undefined) {
         return false;
     }
+    if (layer.tileIndex.index[node.tileId].isTileset) {
+        return true;
+    }
     const sse = computeNodeSSE(context.camera, node);
     return sse > layer.sseThreshold;
 }

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -56,6 +56,7 @@ function $3dTilesIndex(tileset, baseURL) {
     this.extendTileset = function extendTileset(tileset, nodeId, baseURL) {
         recurse(tileset.root, baseURL, this.index[nodeId]);
         this.index[nodeId].children = [tileset.root];
+        this.index[nodeId].isTileset = true;
     };
 }
 


### PR DESCRIPTION
In this scenario:
  - a tileset references an external tileset at node N
  - the subdivision algorithm decides to stop at N and display N
We must go one step further and display the content of the root
node R from the external tileset.

The reason is that R and N are the same node regarding content,
but are stored in different tilesets (for technical reasons)  and
thus considered as different node in iTowns (with N having R as
its only child).

Here's an example of the bug.

This is the same pointcloud as we use for the pointcloud.html example, but converted as 3dtiles. I forced the first nodes to be external tilesets to easily see the problem.
The top part is master, the bottom part is with this PR applied:

![3dtiles_external_tileset_bug](https://user-images.githubusercontent.com/2198295/42154629-919c218a-7de6-11e8-9486-4057db856b5d.jpg)
