### PR TITLE
puppeteer tests refactor / multiglobe fix

### DIFF
--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -85,7 +85,7 @@
 
                 if (t < 1) {
                     // animation is not finished, schedule a new view update
-                    globeView.notifyChange();
+                    globeView.notifyChange(globeView.camera.camera3D);
                 } else {
                     // animation is finished, remove the frame requester
                     globeView.removeFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
@@ -99,7 +99,7 @@
                     t = 0;
                     // schedule the animation
                     globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
-                    globeView.notifyChange();
+                    globeView.notifyChange(globeView.camera.camera3D);
                 }
             }
             viewerDiv.focus();
@@ -122,7 +122,7 @@
                     geo.setAltitude(geo.altitude() * 1.1);
                 }
                 globeView.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
-                globeView.notifyChange();
+                globeView.notifyChange(globeView.camera.camera3D);
             };
             viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);
             viewerDiv.addEventListener('mousewheel', onMouseWheel);

--- a/test/examples/3dtiles.js
+++ b/test/examples/3dtiles.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('3dtiles', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/3dtiles.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/3dtiles.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();
@@ -18,12 +15,9 @@ describe('3dtiles', () => {
 
     it('should return the dragon and the globe', async function _() {
         const page = await browser.newPage();
-
-        page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/3dtiles.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        await exampleCanRenderTest(page, this.test.fullTitle());
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/3dtiles.html`,
+            this.test.fullTitle());
 
         const layers = await page.evaluate(
             () => view.pickObjectsAt({ x: 195, y: 146 }).map(p => p.layer.id));
@@ -36,27 +30,19 @@ describe('3dtiles', () => {
 
     it('should return points', async function _() {
         const page = await browser.newPage();
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/3dtiles.html`);
 
-        page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/3dtiles.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        await exampleCanRenderTest(page, this.test.fullTitle());
-
+        // click on the 'goto pointcloud' button
         await page.evaluate(() => d.zoom());
 
+        await waitUntilItownsIsIdle(page, this.test.fullTitle());
+
         const pickingCount = await page.evaluate(() =>
-            new Promise((resolve) => {
-                view.mainLoop.addEventListener('command-queue-empty', () => {
-                    if (view.mainLoop.renderingState === 0) {
-                        resolve(view.pickObjectsAt(
-                            { x: 200, y: 150 },
-                            1,
-                            '3d-tiles-request-volume').length);
-                    }
-                });
-                view.notifyChange(undefined, false);
-            }));
+            view.pickObjectsAt(
+                { x: 200, y: 150 },
+                1,
+                '3d-tiles-request-volume').length);
         assert.ok(pickingCount > 0);
         await page.close();
     });

--- a/test/examples/collada.js
+++ b/test/examples/collada.js
@@ -1,18 +1,14 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('collada', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/collada.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/collada.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
-        page.close();
         await page.close();
     });
 });

--- a/test/examples/cubic_planar.js
+++ b/test/examples/cubic_planar.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('cubic_planar', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/cubic_planar.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/cubic_planar.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/globe.js
+++ b/test/examples/globe.js
@@ -1,36 +1,28 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('globe', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/globe.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/globe.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
-        page.close();
         await page.close();
     });
 
     it('should return the correct tile', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/globe.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        await exampleCanRenderTest(page, this.test.fullTitle());
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/globe.html`,
+            this.test.fullTitle());
 
         const level = await page.evaluate(() =>
             globeView.pickObjectsAt(
                 { x: 221, y: 119 })[0].object.level);
 
         assert.equal(2, level);
-        page.close();
         await page.close();
     });
 });

--- a/test/examples/globe_vector.js
+++ b/test/examples/globe_vector.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('globe_vector', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/globe_vector.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/globe_vector.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/globe_wfs_extruded.js
+++ b/test/examples/globe_wfs_extruded.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('globe_wfs_extruded', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/globe_wfs_extruded.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/globe_wfs_extruded.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/gpx.js
+++ b/test/examples/gpx.js
@@ -1,14 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('gpx', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/gpx.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/gpx.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/layersColorVisible.js
+++ b/test/examples/layersColorVisible.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('layersColorVisible', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/layersColorVisible.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/layersColorVisible.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/multiglobe.js
+++ b/test/examples/multiglobe.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('multiglobe', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/multiglobe.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/multiglobe.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/multiglobe.js
+++ b/test/examples/multiglobe.js
@@ -11,4 +11,33 @@ describe('multiglobe', () => {
         assert.ok(result);
         await page.close();
     });
+
+    it('zoom and check that the level is correct', async function _() {
+        const page = await browser.newPage();
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/multiglobe.html`);
+
+        // press-space and zoom in
+        await page.evaluate(() => {
+            onKeyPress({ keyCode: 32 });
+            for (let i = 0; i < 50; i++) {
+                onMouseWheel({ detail: -1 });
+            }
+        });
+
+        await waitUntilItownsIsIdle(page, this.test.fullTitle());
+
+        // verify that we properly updated the globe
+        const { layer, level } = await page.evaluate(() => {
+            const pick = globeView.pickObjectsAt({ x: 200, y: 150 })[0];
+            return {
+                layer: pick.layer.id,
+                level: pick.object.level,
+            };
+        });
+
+        assert.equal('globe2', layer);
+        assert.equal(8, level);
+        await page.close();
+    });
 });

--- a/test/examples/oriented_images.js
+++ b/test/examples/oriented_images.js
@@ -1,14 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('oriented_images', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/oriented_images.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/oriented_images.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/orthographic.js
+++ b/test/examples/orthographic.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('orthographic', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/orthographic.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/orthographic.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/panorama.js
+++ b/test/examples/panorama.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('panorama', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/panorama.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/panorama.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/planar.js
+++ b/test/examples/planar.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('planar', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/planar.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/planar.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/planar_vector.js
+++ b/test/examples/planar_vector.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('planar_vector', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/planar_vector.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/planar_vector.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/pointcloud.js
+++ b/test/examples/pointcloud.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('pointcloud', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/pointcloud.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/pointcloud.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/pointcloud_globe.js
+++ b/test/examples/pointcloud_globe.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('pointcloud_globe', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/pointcloud_globe.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/pointcloud_globe.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/positionGlobe.js
+++ b/test/examples/positionGlobe.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('positionGlobe', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/positionGlobe.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/positionGlobe.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();
@@ -17,12 +14,9 @@ describe('positionGlobe', () => {
 
     it('bug #747', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/positionGlobe.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        await exampleCanRenderTest(page, this.test.fullTitle());
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/positionGlobe.html`,
+            this.test.fullTitle());
 
         // wait cone creation
         await page.evaluate(() =>

--- a/test/examples/postprocessing.js
+++ b/test/examples/postprocessing.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('postprocessing', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/postprocessing.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/postprocessing.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/split.js
+++ b/test/examples/split.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('split', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/split.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/split.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/stereo.js
+++ b/test/examples/stereo.js
@@ -1,15 +1,12 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('stereo', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/stereo.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/stereo.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
         await page.close();

--- a/test/examples/wfs.js
+++ b/test/examples/wfs.js
@@ -1,27 +1,22 @@
-/* global browser, exampleCanRenderTest, itownsPort */
+/* global browser, itownsPort */
 const assert = require('assert');
 
 describe('wfs', () => {
     it('should run', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/wfs.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        const result = await exampleCanRenderTest(page, this.test.fullTitle());
+        const result = await loadExample(page,
+            `http://localhost:${itownsPort}/examples/wfs.html`,
+            this.test.fullTitle());
 
         assert.ok(result);
+        await page.close();
     });
 
     it('should pick the correct building', async function _() {
         const page = await browser.newPage();
-
-        await page.setViewport({ width: 400, height: 300 });
-        await page.goto(`http://localhost:${itownsPort}/examples/wfs.html`);
-        await page.waitFor('#viewerDiv > canvas');
-
-        await exampleCanRenderTest(page, this.test.fullTitle());
+        await loadExample(page,
+            `http://localhost:${itownsPort}/examples/wfs.html`,
+            this.test.fullTitle());
 
         // test picking
         const buildingId = await page.evaluate(() => picking({ x: 342, y: 243 }).properties.id);


### PR DESCRIPTION
This PR started a simple bugfix for the `multiglobe.html` example (see 2nd commit).

But when I tried to add a test to make sure the bug won't come back I faced an issue in the puppeteer tests...

This PR refactors the `test-examples` code (1st commit) to ease test writing and limit the boilerplate needed. The 2nd commit fixes and tests the initial issue