### PR TITLE
feat(core): compute camera near/far automatically

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -21,9 +21,11 @@
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
 
-            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true });
             view.camera.camera3D.near = 5;
             setupLoadingScreen(viewerDiv, view);
+
+            var controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
 
             var menuGlobe = new GuiTools('menuDiv', view, 300);
 
@@ -32,6 +34,7 @@
             // function use :
             // For preupdate Layer geomtry :
             var preUpdateGeo = itowns.pre3dTilesUpdate;
+            var pickingEnabled = true;
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
@@ -78,8 +81,12 @@
             debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume, d);
             d.zoom = function() {
-                view.camera.camera3D.position.set(1215013.9, -4736315.5, 4081597.5);
-                view.camera.camera3D.quaternion.set(0.9108514448729665, 0.13456816437801225, 0.1107206134840362, 0.3741416847378546);
+                pickingEnabled = false;
+                const pos = new itowns.Coordinates('EPSG:4978', 1215020.1908037297, -4736310.743783287, 4081602.6452904404);
+                pos.xyz(view.camera.camera3D.position);
+                view.camera.camera3D.up.copy(pos.geodesicNormal);
+                view.camera.camera3D.lookAt(new itowns.THREE.Vector3(1215012, -4736310, 4081602));
+                controls.reset();
                 view.notifyChange(view.camera.camera3D);
             }
             menuGlobe.gui.add(d, 'zoom').name('Go to point cloud');
@@ -96,6 +103,9 @@
                 }
             }
             function picking(event) {
+                if (!pickingEnabled) {
+                    return;
+                }
                 var htmlInfo = document.getElementById('info');
                 htmlInfo.innerHTML = ' ';
 

--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -21,11 +21,9 @@
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
 
-            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true });
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             view.camera.camera3D.near = 5;
             setupLoadingScreen(viewerDiv, view);
-
-            var controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
 
             var menuGlobe = new GuiTools('menuDiv', view, 300);
 
@@ -34,7 +32,6 @@
             // function use :
             // For preupdate Layer geomtry :
             var preUpdateGeo = itowns.pre3dTilesUpdate;
-            var pickingEnabled = true;
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
@@ -81,12 +78,8 @@
             debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD, d);
             debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume, d);
             d.zoom = function() {
-                pickingEnabled = false;
-                const pos = new itowns.Coordinates('EPSG:4978', 1215020.1908037297, -4736310.743783287, 4081602.6452904404);
-                pos.xyz(view.camera.camera3D.position);
-                view.camera.camera3D.up.copy(pos.geodesicNormal);
+                view.camera.camera3D.position.set(1215020.1908037297, -4736310.743783287, 4081602.6452904404);
                 view.camera.camera3D.lookAt(new itowns.THREE.Vector3(1215012, -4736310, 4081602));
-                controls.reset();
                 view.notifyChange(view.camera.camera3D);
             }
             menuGlobe.gui.add(d, 'zoom').name('Go to point cloud');
@@ -103,9 +96,6 @@
                 }
             }
             function picking(event) {
-                if (!pickingEnabled) {
-                    return;
-                }
                 var htmlInfo = document.getElementById('info');
                 htmlInfo.innerHTML = ' ';
 

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -132,7 +132,10 @@ MainLoop.prototype._update = function _update(view, updateSources, dt) {
     const previousFar = view.camera.camera3D.far;
     view.camera.camera3D.near = 0.1;
     view.camera.camera3D.far = 2000000000;
-    view.camera.camera3D.updateMatrixWorld();
+    // We can't just use camera3D.updateProjectionMatrix() because part of
+    // the update process use camera._viewMatrix, and this matrix depends
+    // on near/far values.
+    view.camera.update();
 
     // replace layer with their parent where needed
     updateSources.forEach((src) => {
@@ -173,7 +176,7 @@ MainLoop.prototype._update = function _update(view, updateSources, dt) {
         view.camera.camera3D.near = previousNear;
         view.camera.camera3D.far = previousFar;
     }
-    view.camera.camera3D.updateProjectionMatrix();
+    view.camera.update();
 };
 
 MainLoop.prototype._step = function _step(view, timestamp) {

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -170,8 +170,9 @@ MainLoop.prototype._update = function _update(view, updateSources, dt) {
     }
 
     if (context.distance.min != Infinity) {
-        view.camera.camera3D.near = Math.max(0.1, 0.5 * context.distance.min);
-        view.camera.camera3D.far = 2 * context.distance.max;
+        // Multiply min/max by (0.9, 1.1) to be on the safe side
+        view.camera.camera3D.near = Math.max(0.1, 0.9 * context.distance.min);
+        view.camera.camera3D.far = 1.1 * context.distance.max;
     } else {
         view.camera.camera3D.near = previousNear;
         view.camera.camera3D.far = previousFar;

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -124,13 +124,12 @@ export function createGlobeLayer(id, options) {
             }
         }
         if (commonAncestor) {
+            context.fastUpdateHint = commonAncestor;
             if (__DEBUG__) {
                 layer._latestUpdateStartingLevel = commonAncestor.level;
             }
-            return [commonAncestor];
-        } else {
-            return layer.level0Nodes;
         }
+        return layer.level0Nodes;
     };
 
     function subdivision(context, layer, node) {
@@ -185,9 +184,6 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
 
     this.camera.setPosition(positionCamera);
     this.camera.camera3D.lookAt({ x: 0, y: 0, z: 0 });
-    this.camera.camera3D.near = Math.max(15.0, 0.000002352 * size);
-    this.camera.camera3D.far = size * 10;
-    this.camera.camera3D.updateProjectionMatrix();
     this.camera.camera3D.updateMatrixWorld(true);
 
     const wgs84TileLayer = createGlobeLayer('globe', options);

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -68,13 +68,12 @@ export function createPlanarLayer(id, extent, options) {
             }
         }
         if (commonAncestor) {
+            context.fastUpdateHint = commonAncestor;
             if (__DEBUG__) {
                 layer._latestUpdateStartingLevel = commonAncestor.level;
             }
-            return [commonAncestor];
-        } else {
-            return layer.level0Nodes;
         }
+        return layer.level0Nodes;
     };
 
 
@@ -117,9 +116,6 @@ function PlanarView(viewerDiv, extent, options = {}) {
 
     this.camera.setPosition(positionCamera);
     this.camera.camera3D.lookAt(lookat);
-    this.camera.camera3D.near = 0.1;
-    this.camera.camera3D.far = 2 * Math.max(dim.x, dim.y);
-    this.camera.camera3D.updateProjectionMatrix();
     this.camera.camera3D.updateMatrixWorld(true);
 
     const tileLayer = createPlanarLayer('planar', extent, options);

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -239,4 +239,8 @@ TileMesh.prototype.findCommonAncestor = function findCommonAncestor(tile) {
     }
 };
 
+TileMesh.prototype.isAncestorOf = function isAncestorOf(node) {
+    return node.findCommonAncestor(this) === this;
+};
+
 export default TileMesh;

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -257,36 +257,27 @@ export function pre3dTilesUpdate(context, layer) {
 
 const boundingVolumeBox = new THREE.Box3();
 const boundingVolumeSphere = new THREE.Sphere();
-export function computeNodeSSE(context, camera, node) {
+export function computeNodeSSE(context, node) {
     node.distance = 0;
     if (node.boundingVolume.region) {
         boundingVolumeBox.copy(node.boundingVolume.region.box3D);
         boundingVolumeBox.applyMatrix4(node.boundingVolume.region.matrixWorld);
-        node.distance = boundingVolumeBox.distanceToPoint(camera.camera3D.position);
-        // update distance min/max
-        const s = node.boundingVolume.region.box3D.getSize();
-        const maxComponent = Math.max(s.x, Math.max(s.y, s.z));
-        context.distance.min = Math.min(context.distance.min, node.distance - maxComponent);
-        context.distance.max = Math.max(context.distance.max, node.distance + maxComponent);
+        node.distance = boundingVolumeBox.distanceToPoint(context.camera.camera3D.position);
+        context.distance.update(node.distance, node.boundingVolume.region.box3D.getSize());
     } else if (node.boundingVolume.box) {
         // boundingVolume.box is affected by matrixWorld
         boundingVolumeBox.copy(node.boundingVolume.box);
         boundingVolumeBox.applyMatrix4(node.matrixWorld);
-        node.distance = boundingVolumeBox.distanceToPoint(camera.camera3D.position);
-        // update distance min/max
-        const s = node.boundingVolume.box.getSize();
-        const maxComponent = Math.max(s.x, Math.max(s.y, s.z));
-        context.distance.min = Math.min(context.distance.min, node.distance);
-        context.distance.max = Math.max(context.distance.max, node.distance + maxComponent);
+        node.distance = boundingVolumeBox.distanceToPoint(context.camera.camera3D.position);
+        context.distance.update(node.distance, node.boundingVolume.box.getSize());
     } else if (node.boundingVolume.sphere) {
         // boundingVolume.sphere is affected by matrixWorld
         boundingVolumeSphere.copy(node.boundingVolume.sphere);
         boundingVolumeSphere.applyMatrix4(node.matrixWorld);
         // TODO: see https://github.com/iTowns/itowns/issues/800
         node.distance = Math.max(0.0,
-            boundingVolumeSphere.distanceToPoint(camera.camera3D.position));
-        context.distance.min = Math.min(context.distance.min, node.distance);
-        context.distance.max = Math.max(context.distance.max, node.distance + 2 * node.boundingVolume.sphere.radius);
+            boundingVolumeSphere.distanceToPoint(context.camera.camera3D.position));
+        context.distance.update(node.distance, 2 * node.boundingVolume.sphere.radius);
     } else {
         return Infinity;
     }
@@ -294,7 +285,7 @@ export function computeNodeSSE(context, camera, node) {
         // This test is needed in case geometricError = distance = 0
         return Infinity;
     }
-    return camera.preSSE * (node.geometricError / node.distance);
+    return context.camera.preSSE * (node.geometricError / node.distance);
 }
 
 export function init3dTilesLayer(view, scheduler, layer) {
@@ -378,6 +369,6 @@ export function $3dTilesSubdivisionControl(context, layer, node) {
     if (layer.tileIndex.index[node.tileId].isTileset) {
         return true;
     }
-    const sse = computeNodeSSE(context, context.camera, node);
+    const sse = computeNodeSSE(context, node);
     return sse > layer.sseThreshold;
 }

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -257,17 +257,27 @@ export function pre3dTilesUpdate(context, layer) {
 
 const boundingVolumeBox = new THREE.Box3();
 const boundingVolumeSphere = new THREE.Sphere();
-export function computeNodeSSE(camera, node) {
+export function computeNodeSSE(context, camera, node) {
     node.distance = 0;
     if (node.boundingVolume.region) {
         boundingVolumeBox.copy(node.boundingVolume.region.box3D);
         boundingVolumeBox.applyMatrix4(node.boundingVolume.region.matrixWorld);
         node.distance = boundingVolumeBox.distanceToPoint(camera.camera3D.position);
+        // update distance min/max
+        const s = node.boundingVolume.region.box3D.getSize();
+        const maxComponent = Math.max(s.x, Math.max(s.y, s.z));
+        context.distance.min = Math.min(context.distance.min, node.distance - maxComponent);
+        context.distance.max = Math.max(context.distance.max, node.distance + maxComponent);
     } else if (node.boundingVolume.box) {
         // boundingVolume.box is affected by matrixWorld
         boundingVolumeBox.copy(node.boundingVolume.box);
         boundingVolumeBox.applyMatrix4(node.matrixWorld);
         node.distance = boundingVolumeBox.distanceToPoint(camera.camera3D.position);
+        // update distance min/max
+        const s = node.boundingVolume.box.getSize();
+        const maxComponent = Math.max(s.x, Math.max(s.y, s.z));
+        context.distance.min = Math.min(context.distance.min, node.distance);
+        context.distance.max = Math.max(context.distance.max, node.distance + maxComponent);
     } else if (node.boundingVolume.sphere) {
         // boundingVolume.sphere is affected by matrixWorld
         boundingVolumeSphere.copy(node.boundingVolume.sphere);
@@ -275,6 +285,8 @@ export function computeNodeSSE(camera, node) {
         // TODO: see https://github.com/iTowns/itowns/issues/800
         node.distance = Math.max(0.0,
             boundingVolumeSphere.distanceToPoint(camera.camera3D.position));
+        context.distance.min = Math.min(context.distance.min, node.distance);
+        context.distance.max = Math.max(context.distance.max, node.distance + 2 * node.boundingVolume.sphere.radius);
     } else {
         return Infinity;
     }
@@ -366,6 +378,6 @@ export function $3dTilesSubdivisionControl(context, layer, node) {
     if (layer.tileIndex.index[node.tileId].isTileset) {
         return true;
     }
-    const sse = computeNodeSSE(context.camera, node);
+    const sse = computeNodeSSE(context, context.camera, node);
     return sse > layer.sseThreshold;
 }

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -88,10 +88,7 @@ function markForDeletion(elt) {
 
 function updateMinMaxDistance(context, bbox) {
     const distance = bbox.distanceToPoint(context.camera.camera3D.position);
-    const bboxSize = bbox.getSize();
-    context.distance.min = Math.min(context.distance.min, distance);
-    context.distance.max = Math.max(context.distance.max,
-        distance + Math.max(bboxSize.x, Math.max(bboxSize.y, bboxSize.z)));
+    context.distance.update(distance, bbox.getSize());
     return distance;
 }
 

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -95,8 +95,7 @@ function updateMinMaxDistance(context, node) {
     const bbox = node.OBB().box3D.clone()
         .applyMatrix4(node.OBB().matrixWorld);
     const distance = bbox.distanceToPoint(context.camera.camera3D.position);
-    context.distance.min = Math.min(context.distance.min, distance);
-    context.distance.max = Math.max(context.distance.max, distance + 2 * node.boundingSphere.radius);
+    context.distance.update(distance, 2 * node.boundingSphere.radius);
 }
 
 export function processTiledGeometryNode(cullingTest, subdivisionTest) {

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -10,6 +10,9 @@ function Camera(crs, width, height, options = {}) {
     Object.defineProperty(this, 'crs', { get: () => crs });
 
     this.camera3D = options.camera ? options.camera : new THREE.PerspectiveCamera(30, width / height);
+    this.camera3D.near = 0.1;
+    this.camera3D.far = 2000000000;
+    this.camera3D.updateProjectionMatrix();
 
     this._viewMatrix = new THREE.Matrix4();
     this.width = width;

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -20,17 +20,19 @@ function Camera(crs, width, height, options = {}) {
 }
 
 function resize(camera, width, height) {
-    camera.width = width;
-    camera.height = height;
-    const ratio = width / height;
+    if (width && height) {
+        camera.width = width;
+        camera.height = height;
+        const ratio = width / height;
 
-    if (camera.camera3D.aspect !== ratio) {
-        camera.camera3D.aspect = ratio;
-        if (camera.camera3D.isOrthographicCamera) {
-            const halfH = (camera.camera3D.right - camera.camera3D.left) * 0.5 / ratio;
-            const y = (camera.camera3D.top + camera.camera3D.bottom) * 0.5;
-            camera.camera3D.top = y + halfH;
-            camera.camera3D.bottom = y - halfH;
+        if (camera.camera3D.aspect !== ratio) {
+            camera.camera3D.aspect = ratio;
+            if (camera.camera3D.isOrthographicCamera) {
+                const halfH = (camera.camera3D.right - camera.camera3D.left) * 0.5 / ratio;
+                const y = (camera.camera3D.top + camera.camera3D.bottom) * 0.5;
+                camera.camera3D.top = y + halfH;
+                camera.camera3D.bottom = y - halfH;
+            }
         }
     }
 

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -11,7 +11,6 @@ import Capabilities from '../Core/System/Capabilities';
 import { unpack1K } from './LayeredMaterial';
 
 function c3DEngine(rendererOrDiv, options = {}) {
-    const NOIE = !Capabilities.isInternetExplorer();
     // pick sensible default options
     if (options.antialias === undefined) {
         options.antialias = true;
@@ -20,7 +19,7 @@ function c3DEngine(rendererOrDiv, options = {}) {
         options.alpha = true;
     }
     if (options.logarithmicDepthBuffer === undefined) {
-        options.logarithmicDepthBuffer = this.gLDebug || NOIE;
+        options.logarithmicDepthBuffer = false;
     }
 
     const renderer = rendererOrDiv.domElement ? rendererOrDiv : undefined;

--- a/test/unit/3dtiles.js
+++ b/test/unit/3dtiles.js
@@ -59,7 +59,7 @@ describe('Distance computation using boundingVolume.region', function () {
     const camera = new Camera('EPSG:4978', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:4326', 0, 0, 10000).as('EPSG:4978').xyz());
     camera.camera3D.updateMatrixWorld(true);
-    const context = { distance: { min: 0, max: 0 } };
+    const context = { distance: { min: 0, max: 0, update: () => { } }, camera };
 
     it('should compute distance correctly', function () {
         const tileset = tilesetWithRegion();
@@ -67,7 +67,7 @@ describe('Distance computation using boundingVolume.region', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(context, camera, tile);
+        computeNodeSSE(context, tile);
 
         assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude());
     });
@@ -80,7 +80,7 @@ describe('Distance computation using boundingVolume.region', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(context, camera, tile);
+        computeNodeSSE(context, tile);
 
         assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude());
     });
@@ -93,7 +93,7 @@ describe('Distance computation using boundingVolume.box', function () {
     const camera = new Camera('EPSG:3946', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).xyz());
     camera.camera3D.updateMatrixWorld(true);
-    const context = { distance: { min: 0, max: 0 } };
+    const context = { distance: { min: 0, max: 0, update: () => { } }, camera };
 
     it('should compute distance correctly', function () {
         const tileset = tilesetWithBox();
@@ -102,7 +102,7 @@ describe('Distance computation using boundingVolume.box', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(context, camera, tile);
+        computeNodeSSE(context, tile);
 
         assert.equal(tile.distance, 100 - 1);
     });
@@ -119,7 +119,7 @@ describe('Distance computation using boundingVolume.box', function () {
 
         tile.updateMatrixWorld(true);
 
-        computeNodeSSE(context, camera, tile);
+        computeNodeSSE(context, tile);
 
         assert.equal(tile.distance, 100 - 1 * 0.01 - 10);
     });
@@ -132,7 +132,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
     const camera = new Camera('EPSG:3946', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).xyz());
     camera.camera3D.updateMatrixWorld(true);
-    const context = { distance: { min: 0, max: 0 } };
+    const context = { distance: { min: 0, max: 0, update: () => { } }, camera };
 
     it('should compute distance correctly', function () {
         const tileset = tilesetWithSphere();
@@ -141,7 +141,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(context, camera, tile);
+        computeNodeSSE(context, tile);
 
         assert.equal(tile.distance, 100 - 1);
     });
@@ -158,7 +158,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
 
         tile.updateMatrixWorld(true);
 
-        computeNodeSSE(context, camera, tile);
+        computeNodeSSE(context, tile);
 
         assert.equal(tile.distance, 100 - 1 * 0.01 - 10);
     });

--- a/test/unit/3dtiles.js
+++ b/test/unit/3dtiles.js
@@ -59,6 +59,7 @@ describe('Distance computation using boundingVolume.region', function () {
     const camera = new Camera('EPSG:4978', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:4326', 0, 0, 10000).as('EPSG:4978').xyz());
     camera.camera3D.updateMatrixWorld(true);
+    const context = { distance: { min: 0, max: 0 } };
 
     it('should compute distance correctly', function () {
         const tileset = tilesetWithRegion();
@@ -66,7 +67,7 @@ describe('Distance computation using boundingVolume.region', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(camera, tile);
+        computeNodeSSE(context, camera, tile);
 
         assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude());
     });
@@ -79,7 +80,7 @@ describe('Distance computation using boundingVolume.region', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(camera, tile);
+        computeNodeSSE(context, camera, tile);
 
         assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude());
     });
@@ -92,6 +93,7 @@ describe('Distance computation using boundingVolume.box', function () {
     const camera = new Camera('EPSG:3946', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).xyz());
     camera.camera3D.updateMatrixWorld(true);
+    const context = { distance: { min: 0, max: 0 } };
 
     it('should compute distance correctly', function () {
         const tileset = tilesetWithBox();
@@ -100,7 +102,7 @@ describe('Distance computation using boundingVolume.box', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(camera, tile);
+        computeNodeSSE(context, camera, tile);
 
         assert.equal(tile.distance, 100 - 1);
     });
@@ -117,7 +119,7 @@ describe('Distance computation using boundingVolume.box', function () {
 
         tile.updateMatrixWorld(true);
 
-        computeNodeSSE(camera, tile);
+        computeNodeSSE(context, camera, tile);
 
         assert.equal(tile.distance, 100 - 1 * 0.01 - 10);
     });
@@ -130,6 +132,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
     const camera = new Camera('EPSG:3946', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).xyz());
     camera.camera3D.updateMatrixWorld(true);
+    const context = { distance: { min: 0, max: 0 } };
 
     it('should compute distance correctly', function () {
         const tileset = tilesetWithSphere();
@@ -138,7 +141,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
         const tile = new Object3D();
         configureTile(tile, { }, tileIndex.index['1']);
 
-        computeNodeSSE(camera, tile);
+        computeNodeSSE(context, camera, tile);
 
         assert.equal(tile.distance, 100 - 1);
     });
@@ -155,7 +158,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
 
         tile.updateMatrixWorld(true);
 
-        computeNodeSSE(camera, tile);
+        computeNodeSSE(context, camera, tile);
 
         assert.equal(tile.distance, 100 - 1 * 0.01 - 10);
     });

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -1,6 +1,7 @@
 import { CameraHelper, Color, Vector3 } from 'three';
 import Coordinates from '../../src/Core/Geographic/Coordinates';
 import ThreeStatsChart from './charts/ThreeStatsChart';
+import CameraNearFarChart from './charts/CameraNearFarChart';
 import { MAIN_LOOP_EVENTS } from '../../src/Core/MainLoop';
 import PanoramaView from '../../src/Core/Prefab/PanoramaView';
 
@@ -25,10 +26,12 @@ function Debug(view, datDebugTool, chartDivContainer) {
 
     this.chartDivContainer = chartDivContainer;
     this.createChartContainer('three-info');
+    this.createChartContainer('camera-range');
 
     this.charts = [];
 
     this.charts.push(new ThreeStatsChart('three-info', view.mainLoop.gfxEngine.renderer));
+    this.charts.push(new CameraNearFarChart('camera-range', view.camera.camera3D));
 
     const charts = this.charts;
     const tileLayer = view.tileLayer || view.wgs84TileLayer || view.baseLayer;

--- a/utils/debug/charts/CameraNearFarChart.js
+++ b/utils/debug/charts/CameraNearFarChart.js
@@ -1,0 +1,91 @@
+import Chart from 'chart.js';
+
+export default function CameraNearFarChart(chartId, camera) {
+    let lastValidCompareIndex = -1;
+    const timestamp = Date.now();
+    const label = ['0s'];
+    const chart = new Chart(chartId, {
+        type: 'line',
+        data: {
+            labels: label,
+            datasets: [
+                {
+                    label: 'near',
+                    data: [Math.round(camera.near)],
+                    fill: '-1',
+                },
+                {
+                    label: 'far',
+                    data: [Math.round(camera.far)],
+                    fill: '-1',
+                },
+            ],
+        },
+        options: {
+            animation: { duration: 10 },
+            scales: {
+                yAxes: [{
+                    stacked: true,
+                }],
+            },
+        },
+    });
+
+    this.update = (displayed) => {
+        if (!displayed) {
+            return;
+        }
+
+        const f = Math.round(camera.far);
+        const n = Math.round(camera.near);
+
+        const count = chart.data.datasets[1].data.length;
+        if (f == chart.data.datasets[1].data[count - 1] &&
+            n == chart.data.datasets[0].data[count - 1]) {
+            return;
+        }
+
+        const timeInS = Math.floor((Date.now() - timestamp) / 1000);
+        const lbl = `${timeInS}s`;
+        const identical = (lastValidCompareIndex > 0 && label[lastValidCompareIndex] == lbl);
+        if (identical) {
+            label.push('');
+        } else {
+            label.push(lbl);
+            lastValidCompareIndex = label.length - 1;
+        }
+
+        chart.data.datasets[0].data.push(n);
+        chart.data.datasets[1].data.push(f);
+
+        const limit = 60;
+        if (chart.data.datasets[0].data.length > limit) {
+            chart.data.datasets[0].data.shift();
+            chart.data.datasets[1].data.shift();
+            label.shift();
+        }
+
+        // const identical = (lastValidCompareIndex > 0 && label[lastValidCompareIndex] == lbl);
+        // if (identical) {
+        //     label.push('');
+        // } else {
+        //     lastValidCompareIndex = label.length - 1;
+        // }
+
+        // if (label.length > limit) {
+        //     label.shift();
+        //     lastValidCompareIndex--;
+        // }
+
+        // const memory = renderer.info.memory;
+        // geometryDataset.data.push({ x: timeInS, y: memory.geometries });
+
+        if (displayed) {
+            chart.update();
+        }
+    };
+
+    this.resize = () => {
+        chart.resize();
+    };
+}

--- a/utils/debug/charts/CameraNearFarChart.js
+++ b/utils/debug/charts/CameraNearFarChart.js
@@ -65,21 +65,6 @@ export default function CameraNearFarChart(chartId, camera) {
             label.shift();
         }
 
-        // const identical = (lastValidCompareIndex > 0 && label[lastValidCompareIndex] == lbl);
-        // if (identical) {
-        //     label.push('');
-        // } else {
-        //     lastValidCompareIndex = label.length - 1;
-        // }
-
-        // if (label.length > limit) {
-        //     label.shift();
-        //     lastValidCompareIndex--;
-        // }
-
-        // const memory = renderer.info.memory;
-        // geometryDataset.data.push({ x: timeInS, y: memory.geometries });
-
         if (displayed) {
             chart.update();
         }


### PR DESCRIPTION
Adds a new feature to compute automatically min/max distance of displayed elements.
The near/far values are then deduced.

The advantage of this solution is we can disable the logarithmicDepthBuffer by default which improve itowns compatibility with lower end / mobile devices.

