### PR TITLE
fix(3dtiles): simplify 3dtiles layer creation

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -29,25 +29,14 @@
 
             itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then(function (result) { return view.addLayer(result) });
 
-            // function use :
-            // For preupdate Layer geomtry :
-            var preUpdateGeo = itowns.pre3dTilesUpdate;
-
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
             var $3dTilesLayerDiscreteLOD = new itowns.GeometryLayer('3d-tiles-discrete-lod', new itowns.THREE.Group());
 
-            $3dTilesLayerDiscreteLOD.preUpdate = preUpdateGeo;
-            $3dTilesLayerDiscreteLOD.update = itowns.process3dTilesNode(
-                itowns.$3dTilesCulling,
-                itowns.$3dTilesSubdivisionControl
-            );
             $3dTilesLayerDiscreteLOD.name = 'DiscreteLOD';
             $3dTilesLayerDiscreteLOD.url = 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithDiscreteLOD/tileset.json';
             $3dTilesLayerDiscreteLOD.protocol = '3d-tiles'
             $3dTilesLayerDiscreteLOD.overrideMaterials = true;  // custom cesium shaders are not functional
-            $3dTilesLayerDiscreteLOD.type = 'geometry';
-            $3dTilesLayerDiscreteLOD.visible = true;
 
             itowns.View.prototype.addLayer.call(view, $3dTilesLayerDiscreteLOD);
 
@@ -56,18 +45,10 @@
 
             var $3dTilesLayerRequestVolume = new itowns.GeometryLayer('3d-tiles-request-volume', new itowns.THREE.Group());
 
-            $3dTilesLayerRequestVolume.preUpdate = preUpdateGeo;
-            $3dTilesLayerRequestVolume.update = itowns.process3dTilesNode(
-                itowns.$3dTilesCulling,
-                itowns.$3dTilesSubdivisionControl
-            );
-
             $3dTilesLayerRequestVolume.name = 'RequestVolume';
             $3dTilesLayerRequestVolume.url = 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithRequestVolume/tileset.json';
             $3dTilesLayerRequestVolume.protocol = '3d-tiles'
             $3dTilesLayerRequestVolume.overrideMaterials = true;  // custom cesium shaders are not functional
-            $3dTilesLayerRequestVolume.type = 'geometry';
-            $3dTilesLayerRequestVolume.visible = true;
             $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
             itowns.View.prototype.addLayer.call(view, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })

--- a/src/Core/Layer/Layer.js
+++ b/src/Core/Layer/Layer.js
@@ -67,6 +67,8 @@ function GeometryLayer(id, object3d) {
         object3d.name = id;
     }
 
+    this.type = 'geometry';
+
     Object.defineProperty(this, 'object3d', {
         value: object3d,
         writable: false,

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -146,7 +146,6 @@ export function createGlobeLayer(id, options) {
     wgs84TileLayer.update = processTiledGeometryNode(globeCulling(2), subdivision);
     wgs84TileLayer.builder = new BuilderEllipsoidTile();
     wgs84TileLayer.onTileCreated = nodeInitFn;
-    wgs84TileLayer.type = 'geometry';
     wgs84TileLayer.protocol = 'tile';
     wgs84TileLayer.visible = true;
     wgs84TileLayer.lighting = {

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -139,7 +139,6 @@ export function createPanoramaLayer(id, coordinates, type, options = {}) {
     tileLayer.update = processTiledGeometryNode(panoramaCulling, subdivision);
     tileLayer.builder = new PanoramaTileBuilder(type, options.ratio);
     tileLayer.onTileCreated = nodeInitFn;
-    tileLayer.type = 'geometry';
     tileLayer.protocol = 'tile';
     tileLayer.visible = true;
     tileLayer.segments = 8;

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -89,7 +89,6 @@ export function createPlanarLayer(id, extent, options) {
     tileLayer.update = processTiledGeometryNode(planarCulling, subdivision);
     tileLayer.builder = new PlanarTileBuilder();
     tileLayer.onTileCreated = nodeInitFn;
-    tileLayer.type = 'geometry';
     tileLayer.protocol = 'tile';
     tileLayer.visible = true;
     tileLayer.lighting = {

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -314,7 +314,7 @@ function markForDeletion(layer, elt) {
     }
 }
 
-export function process3dTilesNode(cullingTest, subdivisionTest) {
+export function process3dTilesNode(cullingTest = $3dTilesCulling, subdivisionTest = $3dTilesSubdivisionControl) {
     return function _process3dTilesNodes(context, layer, node) {
         // early exit if parent's subdivision is in progress
         if (node.parent.pendingSubdivision && !node.parent.additiveRefinement) {

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -4,8 +4,9 @@ import PntsParser from '../Parser/PntsParser';
 import Fetcher from './Fetcher';
 import OBB from '../Renderer/ThreeExtended/OBB';
 import Extent from '../Core/Geographic/Extent';
-import { init3dTilesLayer } from '../Process/3dTilesProcessing';
+import { pre3dTilesUpdate, process3dTilesNode, init3dTilesLayer } from '../Process/3dTilesProcessing';
 import utf8Decoder from '../utils/Utf8Decoder';
+
 
 export function $3dTilesIndex(tileset, baseURL) {
     let counter = 1;
@@ -83,6 +84,8 @@ export function getObjectToUpdateForAttachedLayers(meta) {
 }
 
 function preprocessDataLayer(layer, view, scheduler) {
+    layer.preUpdate = layer.preUpdate || pre3dTilesUpdate;
+    layer.update = layer.update || process3dTilesNode();
     layer.sseThreshold = layer.sseThreshold || 16;
     layer.cleanupDelay = layer.cleanupDelay || 1000;
     // override the default method, since updated objects are metadata in this case

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -237,7 +237,6 @@ export default {
         layer.pointBudget = layer.pointBudget || 2000000;
         layer.pointSize = layer.pointSize === 0 || !isNaN(layer.pointSize) ? layer.pointSize : 4;
         layer.sseThreshold = layer.sseThreshold || 2;
-        layer.type = 'geometry';
         layer.material = layer.material || {};
         layer.material = layer.material.isMaterial ? layer.material : new PointsMaterial(layer.material);
         layer.material.defines = layer.material.defines || {};


### PR DESCRIPTION
Add default parameters for the main layer properties to avoid forcing the user to define them each time.

(commit extracted from PR #802)