### PR TITLE
fix(core): compute globe fog distance after camera update

### DIFF
--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -239,12 +239,14 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
             // clean depth buffer
             this._fullSizeDepthBuffer = null;
         }
+    });
+
+    this.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, () => {
         const v = new THREE.Vector3();
         v.setFromMatrixPosition(wgs84TileLayer.object3d.matrixWorld);
         var len = v.distanceTo(this.camera.camera3D.position);
         v.setFromMatrixScale(wgs84TileLayer.object3d.matrixWorld);
 
-        // TODO: may be move in camera update
         // Compute fog distance, this function makes it possible to have a shorter distance
         // when the camera approaches the ground
         this.fogDistance = mfogDistance * Math.pow((len - size * 0.99) * 0.25 / size, 1.5);


### PR DESCRIPTION
The fog distance is used during the update process of each tile of the
globe so the computation must happen between the camera update and the
tile update.

This commit moves this update to MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE.
