### PR TITLE
fix(packaging): fix package_lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,7 +208,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "requires": {
-        "@mapbox/point-geometry": "0.1.0"
+        "@mapbox/point-geometry": "~0.1.0"
       }
     },
     "accepts": {
@@ -7791,8 +7791,8 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
       "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "requires": {
-        "ieee754": "1.1.8",
-        "resolve-protobuf-schema": "2.0.0"
+        "ieee754": "^1.1.6",
+        "resolve-protobuf-schema": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -8324,7 +8324,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.0.0.tgz",
       "integrity": "sha1-5nsGKmfwLRG9aIbnDv2niEB+D7Q=",
       "requires": {
-        "protocol-buffers-schema": "2.2.0"
+        "protocol-buffers-schema": "^2.0.2"
       }
     },
     "resolve-url": {


### PR DESCRIPTION
Fix package-lock.json

Prior to this change, since commit 6411908e, package_lock was generated with npm 5.6
Now, package_lock is generated with npm 6.1.0
