### PR TITLE
chore(features): remove unused minAltitude property

### DIFF
--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -258,7 +258,7 @@ function featureToMesh(feature, options) {
         return;
     }
 
-    var mesh;
+    let mesh;
     switch (feature.type) {
         case 'point':
         case 'multipoint': {
@@ -306,12 +306,9 @@ function featuresToThree(features, options) {
     }
 
     const group = new THREE.Group();
-    group.minAltitude = Infinity;
-
     for (const feature of features) {
         const mesh = featureToMesh(feature, options);
         group.add(mesh);
-        group.minAltitude = Math.min(mesh.minAltitude, group.minAltitude);
     }
 
     return group;


### PR DESCRIPTION
The minAltitude property when creating a Mesh from a Feature was not
assigned and always equal to a NaN, so it has been removed.

Not sure if we could remove it from FeatureProcessing too.