### PR TITLE
fix(core): implement preSSE once and fix the formula

### DIFF
--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -227,15 +227,6 @@ export function pre3dTilesUpdate(context, layer) {
         return [];
     }
 
-    // pre-sse
-    const hypotenuse = Math.sqrt(context.camera.width * context.camera.width + context.camera.height * context.camera.height);
-    const radAngle = context.camera.camera3D.fov * Math.PI / 180;
-
-     // TODO: not correct -> see new preSSE
-    // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
-    const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / context.camera.width);
-    context.camera.preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
-
     // once in a while, garbage collect
     if (Math.random() > 0.98) {
         // Make sure we don't clean root tile
@@ -282,7 +273,7 @@ export function computeNodeSSE(camera, node) {
         // This test is needed in case geometricError = distance = 0
         return Infinity;
     }
-    return camera.preSSE * (node.geometricError / node.distance);
+    return camera._preSSE * (node.geometricError / node.distance);
 }
 
 export function init3dTilesLayer(view, scheduler, layer) {

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -11,18 +11,6 @@ let SSE_SUBDIVISION_THRESHOLD;
 
 const worldToScaledEllipsoid = new THREE.Matrix4();
 
-function _preSSE(view) {
-    const canvasSize = view.mainLoop.gfxEngine.getWindowSize();
-    const hypotenuse = canvasSize.length();
-    const radAngle = view.camera.camera3D.fov * Math.PI / 180;
-
-     // TODO: not correct -> see new preSSE
-    // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
-    const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / canvasSize.x);
-
-    return hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
-}
-
 export function preGlobeUpdate(context, layer) {
     // We're going to use the method described here:
     //    https://cesiumjs.org/2013/04/25/Horizon-culling/
@@ -39,9 +27,6 @@ export function preGlobeUpdate(context, layer) {
     // cV is camera's position in worldToScaledEllipsoid system
     cV.copy(context.camera.camera3D.position).applyMatrix4(worldToScaledEllipsoid);
     vhMagnitudeSquared = cV.lengthSq() - 1.0;
-
-    // pre-sse
-    context.camera.preSSE = _preSSE(context.view);
 
     const elevationLayers = context.view.getLayers((l, a) => a && a.id == layer.id && l.type == 'elevation');
     context.maxElevationLevel = -1;
@@ -111,7 +96,7 @@ function computeNodeSSE(camera, node) {
 
     // TODO: node.geometricError is computed using a hardcoded 18 level
     // The computation of node.geometricError is surely false
-    return camera.preSSE * (node.geometricError * v.x) / distance;
+    return camera._preSSE * (node.geometricError * v.x) / distance;
 }
 
 export function globeSubdivisionControl(minLevel, maxLevel, sseThreshold, maxDeltaElevationLevel) {

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -14,6 +14,8 @@ function Camera(crs, width, height, options = {}) {
     this._viewMatrix = new THREE.Matrix4();
     this.width = width;
     this.height = height;
+
+    this._preSSE = Infinity;
 }
 
 function resize(camera, width, height) {
@@ -44,7 +46,50 @@ Camera.prototype.update = function update(width, height) {
 
     // keep our visibility testing matrix ready
     this._viewMatrix.multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse);
+
+    // sse = projected geometric error on screen plane from distance
+    // We're using an approximation, assuming that the geometric error of all
+    // objects is perpendicular to the camera view vector (= we always compute
+    // for worst case).
+    //
+    //            screen plane             object
+    //               |                         __
+    //               |                        /  \
+    //               |             geometric{|
+    //  < fov angle  . } sse          error {|    |
+    //               |                        \__/
+    //               |
+    //               |<--------------------->
+    //               |        distance
+    //
+    //              geometric_error * screen_width      (resp. screen_height)
+    //     =  ---------------------------------------
+    //        2 * distance * tan (horizontal_fov / 2)   (resp. vertical_fov)
+    //
+    //
+    // We pre-compute the preSSE (= constant part of the screen space error formula) once here
+
+    const verticalFOV = THREE.Math.degToRad(this.camera3D.fov);
+    const verticalPreSSE = this.height / (2.0 * Math.tan(verticalFOV * 0.5));
+
+    // Note: the preSSE for the horizontal FOV is the same value
+    // focale = (this.height * 0.5) / Math.tan(verticalFOV * 0.5);
+    // horizontalFOV = 2 * Math.atan(this.width * 0.5 / focale);
+    // horizontalPreSSE = this.width / (2.0 * Math.tan(horizontalFOV * 0.5)); (1)
+    // => replacing horizontalFOV in Math.tan(horizontalFOV * 0.5)
+    // Math.tan(horizontalFOV * 0.5) = Math.tan(2 * Math.atan(this.width * 0.5 / focale) * 0.5)
+    //                               = Math.tan(Math.atan(this.width * 0.5 / focale))
+    //                               = this.width * 0.5 / focale
+    // => now replacing focale
+    //                               = this.width * 0.5 / (this.height * 0.5) / Math.tan(verticalFOV * 0.5)
+    //                               = Math.tan(verticalFOV * 0.5) * this.width / this.height
+    // => back to (1)
+    // horizontalPreSSE = this.width / (2.0 * Math.tan(verticalFOV * 0.5) * this.width / this.height)
+    //                  = this.height / 2.0 * Math.tan(verticalFOV * 0.5)
+    //                  = verticalPreSSE
+    this._preSSE = verticalPreSSE;
 };
+
 
 /**
  * Return the position in the requested CRS, or in camera's CRS if undefined.

--- a/test/unit/camera.js
+++ b/test/unit/camera.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import Camera from '../../src/Renderer/Camera';
+
+describe('preSSE checks', function () {
+    it('should increase when fov decrease', function () {
+        const camera = new Camera('', 100, 50);
+
+        camera.update(100, 50);
+        const initial = camera._preSSE;
+
+        camera.camera3D.fov *= 0.5;
+        camera.update(100, 50);
+
+        assert.ok(camera._preSSE > initial);
+    });
+});


### PR DESCRIPTION
3dTilesProcessing and GlobeTileProcessing use the same wrong SSE formula.

PR #633 proposed to fix this, but wasn't merged.

This commit fixes the computation, and comment it so the details should
be clearer and less dependant on an external reference that might go away.

The fixed bug can be seen easily in the oriented image example: if you
zoom in, the moutains behind the photos loses precision instead of increase it
(ping @gliegard since you noticed this issue while working on this example)

This should be fixed, and I added a unit test for this problem.