### PR TITLE
feat(pointclouds): make point picking independant of the source type

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -49,6 +49,7 @@
             $3dTilesLayerRequestVolume.url = 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithRequestVolume/tileset.json';
             $3dTilesLayerRequestVolume.protocol = '3d-tiles'
             $3dTilesLayerRequestVolume.overrideMaterials = true;  // custom cesium shaders are not functional
+            $3dTilesLayerRequestVolume.material = new itowns.PointsMaterial({ size: 3 });
             $3dTilesLayerRequestVolume.sseThreshold = 1;
             // add an event for have information when you move your mouse on a building
             itowns.View.prototype.addLayer.call(view, $3dTilesLayerRequestVolume).then(function _() { window.addEventListener('mousemove', picking, false); })

--- a/examples/pointcloud.html
+++ b/examples/pointcloud.html
@@ -197,7 +197,7 @@
                         var pick = view.pickObjectsAt(event, 5, pointcloud);
 
                         for (const p of pick) {
-                            console.log('Selected point #' + p.index + ' in Points "' + p.object.owner.name + '"');
+                            console.log('Selected point #' + p.index + ' in Points "' + p.object.userData.metadata.name + '"');
                         }
                     }
                     view.mainLoop.gfxEngine.renderer.domElement.addEventListener('dblclick', dblClickHandler);

--- a/src/Main.js
+++ b/src/Main.js
@@ -26,3 +26,4 @@ export { default as PlanarControls } from './Renderer/ThreeExtended/PlanarContro
 export { default as FeaturesUtils } from './Renderer/ThreeExtended/FeaturesUtils';
 export { CONTROL_EVENTS } from './Renderer/ThreeExtended/GlobeControls';
 export { default as DEMUtils } from './utils/DEMUtils';
+export { default as Picking } from './Core/Picking';

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -344,14 +344,23 @@ export function process3dTilesNode(cullingTest = $3dTilesCulling, subdivisionTes
                     markForDeletion(layer, n);
                 }
             }
-            // toggle wireframe
+            // update material
             if (node.content && node.content.visible) {
                 node.content.traverse((o) => {
                     if (o.layer == layer && o.material) {
                         o.material.wireframe = layer.wireframe;
+
+                        if (o.isPoints) {
+                            if (o.material.update) {
+                                o.material.update(layer.material);
+                            } else {
+                                o.material.copy(layer.material);
+                            }
+                        }
                     }
                 });
             }
+
             return returnValue;
         }
 

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -6,7 +6,7 @@ import OBB from '../Renderer/ThreeExtended/OBB';
 import Extent from '../Core/Geographic/Extent';
 import { pre3dTilesUpdate, process3dTilesNode, init3dTilesLayer } from '../Process/3dTilesProcessing';
 import utf8Decoder from '../utils/Utf8Decoder';
-
+import Picking from '../Core/Picking';
 
 export function $3dTilesIndex(tileset, baseURL) {
     let counter = 1;
@@ -163,6 +163,10 @@ function pntsParse(data, layer) {
         const material = layer.material ?
             layer.material.clone() :
             new THREE.PointsMaterial({ size: 0.05, vertexColors: THREE.VertexColors });
+
+        if (material.enablePicking) {
+            Picking.preparePointGeometryForPicking(result.point.geometry);
+        }
 
         // creation points with geometry and material
         const points = new THREE.Points(result.point.geometry, material);

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -20,7 +20,7 @@ class PointsMaterial extends RawShaderMaterial {
         this.scale = options.scale || 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
         this.overlayColor = options.overlayColor || new Vector4(0, 0, 0, 0);
         this.mode = options.mode || MODE.COLOR;
-        this.picking = false;
+        this.pickingId = 0;
 
         for (const key in MODE) {
             if (Object.prototype.hasOwnProperty.call(MODE, key)) {
@@ -30,7 +30,7 @@ class PointsMaterial extends RawShaderMaterial {
 
         this.uniforms.size = new Uniform(this.size);
         this.uniforms.mode = new Uniform(this.mode);
-        this.uniforms.pickingMode = new Uniform(this.picking);
+        this.uniforms.pickingId = new Uniform(this.pickingId);
         this.uniforms.opacity = new Uniform(this.opacity);
         this.uniforms.overlayColor = new Uniform(this.overlayColor);
 
@@ -45,8 +45,14 @@ class PointsMaterial extends RawShaderMaterial {
         this.updateUniforms();
     }
 
+    clone() {
+        const cl = super.clone(this);
+        cl.update(this);
+        return cl;
+    }
+
     enablePicking(picking) {
-        this.picking = picking;
+        this.pickingId = picking;
         this.blending = picking ? NoBlending : NormalBlending;
         this.updateUniforms();
     }
@@ -55,7 +61,7 @@ class PointsMaterial extends RawShaderMaterial {
         // if size is null, switch to autosizing using the canvas height
         this.uniforms.size.value = (this.size > 0) ? this.size : -this.scale * window.innerHeight;
         this.uniforms.mode.value = this.mode;
-        this.uniforms.pickingMode.value = this.picking;
+        this.uniforms.pickingId.value = this.pickingId;
         this.uniforms.opacity.value = this.opacity;
         this.uniforms.overlayColor.value = this.overlayColor;
     }
@@ -66,7 +72,7 @@ class PointsMaterial extends RawShaderMaterial {
         this.transparent = source.transparent;
         this.size = source.size;
         this.mode = source.mode;
-        this.picking = source.picking;
+        this.pickingId = source.pickingId;
         this.scale = source.scale;
         this.overlayColor.copy(source.overlayColor);
         this.updateUniforms();

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -9,7 +9,7 @@ uniform mat4 projectionMatrix;
 uniform mat4 modelViewMatrix;
 uniform float size;
 
-uniform bool pickingMode;
+uniform int pickingId;
 uniform int mode;
 uniform float opacity;
 uniform vec4 overlayColor;
@@ -70,8 +70,21 @@ void main() {
     vec3 normal = color;
 #endif
 
-    if (pickingMode) {
+    if (pickingId > 0) {
         vColor = unique_id;
+
+        float left4bitsShift = pow(2.0, 4.0); // << 4 <=> * 2^4
+        float right4bitsShift = 1.0 / left4bitsShift; // << 4 <=> / 1 * 2^4
+        float fId = float(pickingId);
+        // 20 bits for 'unique_id' (= the point index in the buffer)
+        // 12 bits for 'pickingId' (= the point instance id)
+        // (see Picking.js)
+        // upperPart = pickingId >> 4
+        float upperPart = floor(fId * right4bitsShift);
+        vColor.r = upperPart / 255.0;
+        // lowerPart = pickingId - upperPart << 4
+        float lowerPart = fId - upperPart * left4bitsShift;
+        vColor.g += (lowerPart * left4bitsShift) / 255.0;
     } else if (mode == MODE_INTENSITY) {
         vColor = vec4(intensity, intensity, intensity, opacity);
     } else if (mode == MODE_NORMAL) {

--- a/test/examples/3dtiles.js
+++ b/test/examples/3dtiles.js
@@ -39,10 +39,11 @@ describe('3dtiles', () => {
         await waitUntilItownsIsIdle(page, this.test.fullTitle());
 
         const pickingCount = await page.evaluate(() =>
-            view.pickObjectsAt(
+            itowns.Picking.pickPointsAt(
+                view,
                 { x: 200, y: 150 },
-                1,
-                '3d-tiles-request-volume').length);
+                3,
+                $3dTilesLayerRequestVolume).length);
         assert.ok(pickingCount > 0);
         await page.close();
     });


### PR DESCRIPTION
This commit reworks the picking code for pointclouds to allow pointclouds
from 3dtiles to be picked in the same way.

The default picking behavior for a 3dtiles layer is still using raycasting
because a 3dtiles layer can be composed of several objects type.
But this commit allows to use 'Picking.pickPointsAt' if one wants to select
points (see test/examples/3dtiles.js).