### PR TITLE
fix(protocols): wrong xbil/DEM texture's min and max

### DIFF
--- a/src/Parser/XbilParser.js
+++ b/src/Parser/XbilParser.js
@@ -11,7 +11,7 @@ export function computeMinMaxElevation(buffer, width, height, offsetScale) {
     let max = -1000000;
 
     if (!buffer) {
-        return { min: null, max: null };
+        return { min: 0, max: 0 };
     }
 
     const sizeX = offsetScale ? Math.floor(offsetScale.z * width) : buffer.length;
@@ -33,7 +33,7 @@ export function computeMinMaxElevation(buffer, width, height, offsetScale) {
     }
 
     if (max === -1000000 || min === 1000000) {
-        return { min: null, max: null };
+        return { min: 0, max: 0 };
     }
     return { min, max };
 }


### PR DESCRIPTION
Wrong xbil/DEM texture's min and max was computed during fetching.

xbil/DEM texture's min and max was only calculated on an entire texture, during fetching.
it didn't consider the smaller pitchs

