### PR TITLE
fix(parser): change the internal structure of geojson

### DIFF
--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -1,6 +1,7 @@
 import proj4 from 'proj4';
 import assert from 'assert';
 import GeoJsonParser from '../../src/Parser/GeoJsonParser';
+import Extent from '../../src/Core/Geographic/Extent';
 
 const holes = require('../data/geojson/holes.geojson.json');
 const gpx = require('../data/geojson/gpx.geojson.json');
@@ -21,5 +22,15 @@ describe('GeoJsonParser', function () {
     it('should respect all z coordinates', () =>
         parse(gpx).then((collection) => {
             assert.ok(collection.features[0].vertices.every(v => v.z() != 1));
+        }));
+
+    it('should return an empty collection', () =>
+        GeoJsonParser.parse(holes, {
+            crsIn: 'EPSG:3946',
+            crsOut: 'EPSG:3946',
+            buildExtent: true,
+            filteringExtent: new Extent('EPSG:3946', 10, 20, 10, 20),
+        }).then((collection) => {
+            assert.ok(collection.features.length == 0);
         }));
 });


### PR DESCRIPTION
There was a problem with the destructuration when parsing multitypes in
the GeojsonParser, so the internal used structure has been changed to
fix this issue.

A test has been added at the same time, verifying part of this issue as
it could happened when the features were out of the specified filtering
extent.

This replaces the second commit of #825.