### PR TITLE
refactor: move TiledNodeProcessing internals to TiledGeometryLayer

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -427,4 +427,31 @@ Extent.prototype.toString = function toString(separator = '') {
     }
 };
 
+const center = new Coordinates('EPSG:4326', 0, 0, 0);
+/**
+ * Subdivide equally an extent from its center to return four extents:
+ * north-west, north-east, south-west and south-east.
+ *
+ * @returns {Extent[]} An array containing the four sections of the extent. The
+ * order of the sections is [NW, NE, SW, SE].
+ */
+Extent.prototype.subdivision = function subdivision() {
+    this.center(center);
+
+    const northWest = new Extent(this.crs(),
+        this.west(), center._values[0],
+        center._values[1], this.north());
+    const northEast = new Extent(this.crs(),
+        center._values[0], this.east(),
+        center._values[1], this.north());
+    const southWest = new Extent(this.crs(),
+        this.west(), center._values[0],
+        this.south(), center._values[1]);
+    const southEast = new Extent(this.crs(),
+        center._values[0], this.east(),
+        this.south(), center._values[1]);
+
+    return [northWest, northEast, southWest, southEast];
+};
+
 export default Extent;

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -104,7 +104,9 @@ class GeometryLayer extends Layer {
             }
         };
 
+        // Placeholders
         this.postUpdate = () => {};
+        this.culling = () => true;
     }
 
     /**

--- a/src/Main.js
+++ b/src/Main.js
@@ -17,7 +17,6 @@ export { default as GeoJsonParser } from './Parser/GeoJsonParser';
 export { process3dTilesNode, init3dTilesLayer, $3dTilesCulling, $3dTilesSubdivisionControl, pre3dTilesUpdate } from './Process/3dTilesProcessing';
 export { default as FeatureProcessing } from './Process/FeatureProcessing';
 export { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } from './Process/LayeredMaterialNodeProcessing';
-export { default as processTiledGeometryNode } from './Process/TiledNodeProcessing';
 export { ColorLayersOrdering } from './Renderer/ColorLayersOrdering';
 export { default as PointsMaterial } from './Renderer/PointsMaterial';
 export { default as PointCloudProcessing } from './Process/PointCloudProcessing';

--- a/src/Parser/convertToTile.js
+++ b/src/Parser/convertToTile.js
@@ -72,6 +72,20 @@ export default {
             tile.setBBoxZ(layer.materialOptions.colorTextureElevationMinZ, layer.materialOptions.colorTextureElevationMaxZ);
         }
 
+        tile.add(tile.OBB());
+
+        tile.material.setLightingOn(layer.lighting.enable);
+        tile.material.uniforms.lightPosition.value = layer.lighting.position;
+
+        if (layer.noTextureColor) {
+            tile.material.uniforms.noTextureColor.value.copy(layer.noTextureColor);
+        }
+
+        if (__DEBUG__) {
+            tile.material.uniforms.showOutline = { value: layer.showOutline || false };
+            tile.material.wireframe = layer.wireframe || false;
+        }
+
         return Promise.resolve(tile);
     },
 };

--- a/src/Process/TiledNodeProcessing.js
+++ b/src/Process/TiledNodeProcessing.js
@@ -38,7 +38,7 @@ function subdivideNode(context, layer, node) {
             layer,
             priority: 10000,
             /* specific params */
-            extentsSource: extents,
+            extentssource: extents,
             redraw: false,
         };
 

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import assert from 'assert';
 import { updateLayeredMaterialNodeImagery } from '../../src/Process/LayeredMaterialNodeProcessing';
-import processTiledGeometryNode from '../../src/Process/TiledNodeProcessing';
 import FeatureProcessing from '../../src/Process/FeatureProcessing';
 import TileMesh from '../../src/Core/TileMesh';
 import Extent from '../../src/Core/Geographic/Extent';
@@ -147,7 +146,6 @@ describe('Provide in Sources', function () {
         });
     });
     it('should get 4 TileMesh from TileProvider', () => {
-        const tileProcess = processTiledGeometryNode(null, () => true);
         const tile = new TileMesh(
             colorlayer,
             geom,
@@ -157,7 +155,7 @@ describe('Provide in Sources', function () {
         tile.material.visible = true;
         tile.parent = { pendingSubdivision: false };
         tile.material.isColorLayerLoaded = () => true;
-        tileProcess(context, globelayer, tile);
+        globelayer.subdivideNode(context, tile);
         TileProvider.executeCommand(context.scheduler.commands[0]).then((tiles) => {
             assert.equal(tiles.length, 4);
             assert.equal(tiles[0].extent.west(), tile.extent.west());

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -55,4 +55,20 @@ describe('Extent constructors', function () {
         assert.equal(fromBox.north(), box.max.y);
         assert.equal(fromBox.south(), box.min.y);
     });
+
+    it('should subdivide the extent in four piece', function () {
+        const toSubdivide = new Extent('EPSG:4326', -10, 10, -10, 10);
+        const subdivided = toSubdivide.subdivision();
+
+        assert.equal(subdivided.length, 4);
+
+        // NW
+        assert.deepStrictEqual(subdivided[0]._values, new Float64Array([-10, 0, 0, 10]));
+        // NE
+        assert.deepStrictEqual(subdivided[1]._values, new Float64Array([0, 10, 0, 10]));
+        // SW
+        assert.deepStrictEqual(subdivided[2]._values, new Float64Array([-10, 0, -10, 0]));
+        // SE
+        assert.deepStrictEqual(subdivided[3]._values, new Float64Array([0, 10, -10, 0]));
+    });
 });


### PR DESCRIPTION
To begin the removal of some Processing files in Process, we can began
with TiledNodeProcessing. All methods in it have been scattered between
TiledNodeGeometry and Extent. Changes should have been made everywhere it needed.

A unit test has been added to the new subdivision method of Extent.