### PR TITLE
test: retry cubic_planar test if necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "doclint": "npm run doc -- -t templates/silent",
     "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-examples && npm run test-with-coverage",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --require babel-core/register test/unit",
-    "test-examples": "mocha -t 300000 --recursive test/examples",
+    "test-examples": "mocha -t 60000 --recursive test/examples",
     "test-with-coverage": "nyc -n src -r html cross-env npm run test-unit",
     "build": "webpack -p",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",

--- a/test/examples/cubic_planar.js
+++ b/test/examples/cubic_planar.js
@@ -3,6 +3,9 @@ const assert = require('assert');
 
 describe('cubic_planar', () => {
     it('should run', async function _() {
+        // This test hangs up one time out of three, so retry it 2 times
+        this.retries(2);
+
         const page = await browser.newPage();
         const result = await loadExample(page,
             `http://localhost:${itownsPort}/examples/cubic_planar.html`,


### PR DESCRIPTION
This test fails at least one times out of three, and we always have to rerun it. Using `retries()` (see https://mochajs.org/#retry-tests) we can stop having to relaunch it everytime.

Note that this could be extended to every test, but I feel that this is the only one that really needs it. 