### PR TITLE
fix(layer): declare GeometryLayer placeholder in prototype

### DIFF
--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -103,10 +103,16 @@ class GeometryLayer extends Layer {
                 };
             }
         };
+    }
 
-        // Placeholders
-        this.postUpdate = () => {};
-        this.culling = () => true;
+    // Placeholder
+    // eslint-disable-next-line
+    postUpdate() {}
+
+    // Placeholder
+    // eslint-disable-next-line
+    culling() {
+        return true;
     }
 
     /**


### PR DESCRIPTION
It was declared in the constructor before, thus overwriting the ones set
in the prototype of child layers.
