### PR TITLE
feat(utils) meridian convergence

### DIFF
--- a/examples/orientation_utils.html
+++ b/examples/orientation_utils.html
@@ -102,16 +102,15 @@
                     var coord = feature.vertices[0];
 
                     // set model position
-                    model.position.copy(coord.xyz());
+                    coord.xyz(model.position);
 
-                    // set model orientation (using target parameter)
-                    itowns.OrientationUtils.quaternionFromAttitude(feature.properties, coord, true, model.quaternion);
+                    // set model quaternion
+                    itowns.OrientationUtils.quaternionFromAttitudeAndCoordinates(feature.properties, coord, globeView.referenceCrs, model.quaternion);
 
                     // store base position
                     model.positionBase = model.position.clone();
 
                     // compute position on the ground
-                    var coord = feature.vertices[0];
                     result = itowns.DEMUtils.getElevationValueAt(globeView.tileLayer, coord, 1, undefined);
                     coord = coord.as('EPSG:4326');
                     coord.setAltitude(result.z);

--- a/examples/orientation_utils_planar.html
+++ b/examples/orientation_utils_planar.html
@@ -19,10 +19,21 @@
             var view;
             var meshes;
 
+            // Input data are given in Lambert93 projection
+            itowns.proj4.defs('EPSG:2154',
+                '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
             var extent = new itowns.Extent(
                 'EPSG:3857',
                 -20037508.342789, 20037508.342789,
                 -20037508.342789, 20037508.342789);
+
+/*
+            var extent = new itowns.Extent(
+                'EPSG:2154',
+                651100, 651200,
+                6861300, 6861400);
+*/
 
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             viewerDiv = document.getElementById('viewerDiv');
@@ -36,9 +47,9 @@
                 return view.addLayer(layer);
             }
 
-             itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(addLayerCb);
-
+            itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(addLayerCb);
             view.camera.camera3D.position.set(259880, 6249400, 40);
+            // view.camera.camera3D.position.set(651150, 6861350, 200);
 
             // eslint-disable-next-line no-new
             new itowns.PlanarControls(view, {
@@ -52,16 +63,13 @@
                 // Don't zoom too much on smart zoom
                smartZoomHeightMax: 100000,
             });
-            
+
             // Input data : a geoJson file, with point features, with orientation specific properties
             var panoramics = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/immersive/exampleParis1/panoramicsMetaDataParis.geojson';
             var layer = {
                 crsOut: view.referenceCrs,
             };
-            // Input data are given in Lambert93 projection
-            itowns.proj4.defs('EPSG:2154',
-                '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-            
+
             // Add a promise to load oriented point datas
             var promises = [];
             promises.push(
@@ -69,8 +77,8 @@
                 itowns.Fetcher.json(panoramics, {})
                 // then get geographic informations (coordinates) using GeoJson parser
                 .then(function parseGeoJSON(orientations) { return itowns.GeoJsonParser.parse(orientations, layer);})
-            );        
-            
+            );
+
             // load collada model of a renault trafic
             promises.push(ThreeLoader.load('Collada',
              'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/models/collada/renault_trafic_no_texture.dae')
@@ -82,17 +90,17 @@
                 // put the model in a group, to allow user to do other transformation (rotation..)
                 var group = new itowns.THREE.Group();
                 group.add(colladaModel);
-                return group; 
+                return group;
              }));
 
             // wait for all the promises
             Promise.all(promises).then(function loadFeaturesModel(res) { loadFeatures(res[0], res[1]);});
-            
+
             // place a 3d model oriented for each feature
             function loadFeatures(collection, colladaModel) {
-   
-                for (const feature of collection.features) {                  
-                
+
+                for (const feature of collection.features) {
+
                     // clone the collada model
                     var model = colladaModel.clone();
 
@@ -100,12 +108,11 @@
                     var coord = feature.vertices[0];
 
                     // set model position to the ground
-                    var position = coord.xyz();
-                    position.z = 0;
-                    model.position.copy(position);
-                                        
+                    coord.xyz(model.position);
+                    model.position.z = 0;
+
                     // set model orientation (quaternion is the target parameter)
-                    itowns.OrientationUtils.quaternionFromAttitude(feature.properties, undefined, false, model.quaternion);
+                    itowns.OrientationUtils.quaternionFromAttitudeAndCoordinates(feature.properties, coord, view.referenceCrs, model.quaternion);
 
                     model.updateMatrixWorld();
                     view.scene.add(model);

--- a/src/utils/OrientationUtils.js
+++ b/src/utils/OrientationUtils.js
@@ -1,121 +1,226 @@
 import * as THREE from 'three';
+import proj4 from 'proj4';
+import Coordinates from '../Core/Geographic/Coordinates';
 
 /** @module OrientationUtils */
 
 const DEG2RAD = THREE.Math.DEG2RAD;
-
-// The transform from world to local is  RotationZ(heading).RotationX(pitch).RotationY(roll)
-// The transform from local to world is (RotationZ(heading).RotationX(pitch).RotationY(roll)).transpose()
-function quaternionFromRollPitchHeading(roll = 0, pitch = 0, heading = 0, target) {
-    roll *= DEG2RAD;
-    pitch *= DEG2RAD;
-    heading *= DEG2RAD;
-    // return this.setFromEuler(new THREE.Euler(pitch, roll, heading , 'ZXY')).conjugate();
-    return target.setFromEuler(new THREE.Euler(-pitch, -roll, -heading, 'YXZ')); // optimized version of above
-}
-
-// From DocMicMac, the transform from local to world is:
-// RotationX(omega).RotationY(phi).RotationZ(kappa).RotationX(PI)
-// RotationX(PI) = Scale(1, -1, -1) converts between the 2 conventions for the camera local frame:
-//  X right, Y bottom, Z front : convention in webGL, threejs and computer vision
-//  X right, Y top,    Z back  : convention in photogrammetry
-function quaternionFromOmegaPhiKappa(omega = 0, phi = 0, kappa = 0, target) {
-    omega *= DEG2RAD;
-    phi *= DEG2RAD;
-    kappa *= DEG2RAD;
-    target.setFromEuler(new THREE.Euler(omega, phi, kappa, 'XYZ'));
-    // target.setFromRotationMatrix(new THREE.Matrix4().makeRotationFromQuaternion(target).scale(new THREE.Vector3(1, -1, -1)));
-    target.set(target.w, target.z, -target.y, -target.x); // optimized version of above
-    return target;
-}
-
-// Set East North Up Orientation from geodesic normal
-// target - the quaternion to set
-// up - the normalized geodetic normal to the ellipsoid (given by Coordinates.geodeticNormal)
-var quaternionENUFromGeodesicNormal = (() => {
-    const matrix = new THREE.Matrix4();
-    const elements = matrix.elements;
-    const north = new THREE.Vector3();
-    const east = new THREE.Vector3();
-    return function setENUFromGeodesicNormal(up, target = new THREE.Quaternion()) {
-        // this is an optimized version of matrix.lookAt(up, new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 0, 1));
-        east.set(-up.y, up.x, 0);
-        east.normalize();
-        north.crossVectors(up, east);
-        elements[0] = east.x; elements[4] = north.x; elements[8] = up.x;
-        elements[1] = east.y; elements[5] = north.y; elements[9] = up.y;
-        elements[2] = east.z; elements[6] = north.z; elements[10] = up.z;
-        return target.setFromRotationMatrix(matrix);
-    };
-})();
-
-/**
- *
- * @typedef Attitude
- * @type {Object}
- *
- * @property {Number} omega - angle in degrees
- * @property {Number} phi - angle in degrees
- * @property {Number} kappa - angle in degrees
- * @property {Number} roll - angle in degrees
- * @property {Number} pitch - angle in degrees
- * @property {Number} heading - angle in degrees
- */
-
-
-const ENUQuat = new THREE.Quaternion();
+const quat = new THREE.Quaternion();
+const quaternionFromCoordinates_cache = {};
 
 export default {
+    /**
+     * The transform from the platform frame to the local East, North, Up (ENU) frame is
+     * <pre>RotationZ(heading).RotationX(pitch).RotationY(roll)</pre>
+     * @function quaternionFromRollPitchHeading
+     * @param {Number} roll - angle in degrees
+     * @param {Number} pitch - angle in degrees
+     * @param {Number} heading - angle in degrees
+     * @param {THREE.Quaternion} target Quaternion to set
+     * @returns {THREE.Quaternion} target
+     */
+    quaternionFromRollPitchHeading(roll = 0, pitch = 0, heading = 0, target = new THREE.Quaternion()) {
+        roll *= DEG2RAD;
+        pitch *= DEG2RAD;
+        heading *= DEG2RAD;
+        return target.setFromEuler(new THREE.Euler(pitch, roll, heading, 'ZXY')).conjugate();
+    },
 
     /**
-     * @function localQuaternionFromAttitude
-     * @param {Attitude} attitude - [Attitude]{@link module:OrientationParser~Attitude}
-     * with properties: (omega, phi, kappa), (roll, pitch, heading) or none.
-     * Note that convergence of the meridians is not taken into account.
+     * From DocMicMac, the transform from the platform frame to the local East, North, Up (ENU) frame is
+     * <pre>
+     * RotationX(omega).RotationY(phi).RotationZ(kappa).RotationX(PI)
+     * RotationX(PI) <=> Quaternion(1,0,0,0) : converts between the 2 conventions for the camera local frame:
+     * X right, Y bottom, Z front : convention in photogrammetry and computer vision
+     * X right, Y top,    Z back  : convention in webGL, threejs
+     * </pre>
+     * @function quaternionFromOmegaPhiKappa
+     * @param {Number} omega - angle in degrees
+     * @param {Number} phi - angle in degrees
+     * @param {Number} kappa - angle in degrees
      * @param {THREE.Quaternion} target Quaternion to set
-     * @returns {THREE.Quaternion} Quaternion representing the rotation
+     * @returns {THREE.Quaternion} target
      */
-    localQuaternionFromAttitude(attitude, target = new THREE.Quaternion()) {
+    quaternionFromOmegaPhiKappa(omega = 0, phi = 0, kappa = 0, target = new THREE.Quaternion()) {
+        omega *= DEG2RAD;
+        phi *= DEG2RAD;
+        kappa *= DEG2RAD;
+        target.setFromEuler(new THREE.Euler(omega, phi, kappa, 'XYZ'));
+        target.set(target.w, target.z, -target.y, -target.x); // <=> target.multiply(new THREE.Quaternion(1, 0, 0, 0));
+        return target;
+    },
+
+    /**
+     * Properties are either defined as (omega, phi, kappa) or as (roll, pitch, heading) or all undefined.
+     * @typedef Attitude
+     * @type {Object}
+     * @property {Number} omega - angle in degrees
+     * @property {Number} phi - angle in degrees
+     * @property {Number} kappa - angle in degrees
+     * @property {Number} roll - angle in degrees
+     * @property {Number} pitch - angle in degrees
+     * @property {Number} heading - angle in degrees
+     */
+
+    /**
+     * Set the quaternion according to the rotation from the platform frame to the local frame
+     * @function quaternionFromAttitude
+     * @param {Attitude} attitude - [Attitude]{@link module:OrientedImageParser~Attitude}
+     * @param {THREE.Quaternion} target Quaternion to set
+     * @returns {THREE.Quaternion} target
+     */
+    quaternionFromAttitude(attitude, target = new THREE.Quaternion()) {
         if ((attitude.roll !== undefined) || (attitude.pitch !== undefined) || (attitude.heading !== undefined)) {
-            return quaternionFromRollPitchHeading(attitude.roll, attitude.pitch, attitude.heading, target);
+            return this.quaternionFromRollPitchHeading(attitude.roll, attitude.pitch, attitude.heading, target);
         }
         if ((attitude.omega !== undefined) || (attitude.phi !== undefined) || (attitude.kappa !== undefined)) {
-            return quaternionFromOmegaPhiKappa(attitude.omega, attitude.phi, attitude.kappa, target);
+            return this.quaternionFromOmegaPhiKappa(attitude.omega, attitude.phi, attitude.kappa, target);
         }
         return target.set(0, 0, 0, 1);
     },
 
     /**
-     * @function globeQuaternionFromAttitude
-     * @param {Attitude} attitude - [Attitude]{@link module:OrientationParser~Attitude}
-     * with properties: (omega, phi, kappa), (roll, pitch, heading) or none.
-     * @param {Coordinates} coordinate position on the globe
-     * @param {THREE.Quaternion} target Quaternion to set
-     * @returns {THREE.Quaternion} Quaternion representing the rotation
+     * Set the quaternion according to the rotation from the East North Up (ENU) frame to the geocentric frame.
+     * The up direction of the ENU frame is provided by the normalized geodetic normal of the provided coordinates (geodeticNormal property)
+     * @function quaternionFromCoordinatesGeocent
+     * @param {Object} proj (unused)
+     * @param {Coordinates} coordinates - The origin of the East North Up (ENU) frame
+     * @param {THREE.Quaternion} target - Quaternion to set
+     * @returns {(THREE.Quaternion|function)} the modified target if coordinates is defined, or the curried function(target, coordinates) to later apply the function
      */
-    globeQuaternionFromAttitude(attitude, coordinate, target = new THREE.Quaternion()) {
-        quaternionENUFromGeodesicNormal(coordinate.geodesicNormal, ENUQuat);
-        this.localQuaternionFromAttitude(attitude, target);
-        target.premultiply(ENUQuat);
-        return target;
+    quaternionFromCoordinatesGeocent(proj, coordinates, target = new THREE.Quaternion()) {
+        const matrix = new THREE.Matrix4();
+        const north = new THREE.Vector3();
+        const east = new THREE.Vector3();
+        const quaternionFromCoordinatesGeocent = (coordinates, target = new THREE.Quaternion()) => {
+            const up = coordinates.geodesicNormal;
+            if (up.x == 0 && up.y == 0) return target.set(0, 0, 0, 1);
+            // this is an optimized version of matrix.lookAt(up, new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 0, 1));
+            east.set(-up.y, up.x, 0).normalize();
+            north.crossVectors(up, east);
+            matrix.makeBasis(east, north, up);
+            return target.setFromRotationMatrix(matrix);
+        };
+        return coordinates ? quaternionFromCoordinatesGeocent(coordinates, target) : quaternionFromCoordinatesGeocent;
     },
 
-    /** Read rotation information (roll pitch heading or omega phi kappa),
-     * Create a ThreeJs quaternion representing a rotation.
+    /**
+     * Set the quaternion to correct for the meridian convergence of the East North Up (ENU) frame to the Lambert Conformal Conic (LCC) frame.
+     * This is a generally small rotation around Z.
+     * @function quaternionFromCoordinatesLCC
+     * @param {Object} proj the lcc projection (may be parsed using proj4)
+     * @param {Number} proj.lat0 - the latitude of origin
+     * @param {Number} proj.long0 - the longitude of the central meridian
+     * @param {Coordinates} coordinates - The origin of the East North Up (ENU) frame
+     * @param {THREE.Quaternion} target - Quaternion to set
+     * @returns {(THREE.Quaternion|function)} the modified target if coordinates is defined, or the curried function(target, coordinates) to later apply the function
+    */
+    quaternionFromCoordinatesLCC(proj, coordinates, target = new THREE.Quaternion()) {
+        const sinlat0 = Math.sin(proj.lat0);
+        const axis = new THREE.Vector3().set(0, 0, 1);
+        const coord = new Coordinates('EPSG:4326', 0, 0, 0);
+        const quaternionFromCoordinatesLCC = (coordinates, target = new THREE.Quaternion()) => {
+            const long = coordinates.as(coord.crs, coord).longitude() * DEG2RAD;
+            return target.setFromAxisAngle(axis, sinlat0 * (proj.long0 - long));
+        };
+        return coordinates ? quaternionFromCoordinatesLCC(coordinates, target) : quaternionFromCoordinatesLCC;
+    },
+
+    /**
+     * Set the quaternion to correct for the meridian convergence of the East North Up (ENU) frame to the Mercator frame.
+     * This is a generally small rotation around Z.
+     * @function quaternionFromCoordinatesMerc
+     * @param {Object} proj the merc projection (may be parsed using proj4)
+     * @param {Number} proj.e - the excentricity of the ellipsoid (supersedes {proj.a} and {proj.b})
+     * @param {Number} proj.a - the semimajor radius of the ellipsoid axis
+     * @param {Number} proj.b - the semiminor radius of the ellipsoid axis
+     * @param {Number} proj.long0 - the longitude of the central meridian
+     * @param {Coordinates} coordinates - The origin of the East North Up (ENU) frame
+     * @param {THREE.Quaternion} target - Quaternion to set
+     * @returns {(THREE.Quaternion|function)} the modified target if coordinates is defined, or the curried function(target, coordinates) to later apply the function
+    */
+    quaternionFromCoordinatesMerc(proj, coordinates, target = new THREE.Quaternion()) {
+        const a2 = proj.a * proj.a;
+        const b2 = proj.b * proj.b;
+        const e2 = proj.e * proj.e;
+        const eta0 = proj.e ? (e2 / (1 - e2)) : (a2 / b2 - 1);
+        const axis = new THREE.Vector3().set(0, 0, 1);
+        const coord = new Coordinates('EPSG:4326', 0, 0, 0);
+        const quaternionFromCoordinatesMerc = (coordinates, target = new THREE.Quaternion()) => {
+            coordinates.as(coord.crs, coord);
+            const long = coord.longitude() * DEG2RAD;
+            const lat = coord.latitude() * DEG2RAD;
+            const dlong = proj.long0 - long;
+            const coslat = Math.cos(lat);
+            const sinlat = Math.sin(lat);
+            const tanlat = sinlat / coslat;
+            const coslat2 = coslat * coslat;
+            const dl2 = dlong * dlong * coslat2;
+            const eta2 = eta0 * coslat2;
+            const gamma = dlong * sinlat * (1 + dl2 / 3 * (1 + 3 * eta2 + 2 * eta2 * eta2) + dl2 * dl2 * (2 - tanlat) / 15);
+            return target.setFromAxisAngle(axis, gamma);
+        };
+        return coordinates ? quaternionFromCoordinatesMerc(coordinates, target) : quaternionFromCoordinatesMerc;
+    },
+
+
+    /**
+     * Warns for an unimplemented projection, set the quaternion to the identity (0,0,0,1).
+     * @function quaternionFromCoordinatesWarn
+     * @param {Object} proj the unimplemented projection (may be parsed using proj4)
+     * @param {String} proj.projName - the projection name shown in the warning message
+     * @param {Coordinates} coordinates -(unused)
+     * @param {THREE.Quaternion} target - Quaternion to set
+     * @returns {(THREE.Quaternion|function)} the modified target if coordinates is defined, or the curried function(target, coordinates) to later apply the function
+     */
+    quaternionFromCoordinatesWarn(proj, coordinates, target = new THREE.Quaternion()) {
+        console.warn('quaternionFromCoordinatesCRS is not implemented for projections of type', proj.projName);
+        const quaternionFromCoordinatesWarn = (coordinates, target = new THREE.Quaternion()) => target.set(0, 0, 0, 1);
+        return coordinates ? quaternionFromCoordinatesWarn(coordinates, target) : quaternionFromCoordinatesWarn;
+    },
+
+    /**
+     * Compute the quaternion that models the rotation from the local East North Up (ENU) frame of the coordinates parameter to the frame of the given crs.
+     * @function quaternionFromCoordinatesCRS
+     * @param {Coordinates} coordinates - the origin of the East North Up (ENU) frame
+     * @param {String} crs the CRS of the target frame (default : the coordinates crs).
+     * @param {THREE.Quaternion} target - Quaternion to set
+     * @returns {(THREE.Quaternion|function)} the modified target if coordinates is defined, or the curried function(target, coordinates) to later apply the function
+     */
+    quaternionFromCoordinatesCRS(coordinates, crs = coordinates.crs, target = new THREE.Quaternion()) {
+        let quaternionFromCoordinates = quaternionFromCoordinates_cache[crs];
+        if (!quaternionFromCoordinates) {
+            const proj = proj4.defs(crs);
+            switch (proj.projName) {
+                case 'geocent': quaternionFromCoordinates = this.quaternionFromCoordinatesGeocent(proj); break;
+                case 'lcc': quaternionFromCoordinates = this.quaternionFromCoordinatesLCC(proj); break;
+                case 'merc': quaternionFromCoordinates = this.quaternionFromCoordinatesMerc(proj); break;
+                default: quaternionFromCoordinates = this.quaternionFromCoordinatesWarn(proj);
+            }
+            quaternionFromCoordinates_cache[crs] = quaternionFromCoordinates;
+        }
+        return coordinates ? quaternionFromCoordinates(coordinates, target) : quaternionFromCoordinates;
+    },
+
+
+    /**
+     * Compute the quaternion that represents a rotation from coordinates in platform frame,
+     * defined using an [attitude]{@link module:OrientationParser~Attitude}
+     * relative to a local East North Up (ENU) frame, to coordinates expressed in the target crs frame
      *
-     * @function quaternionFromAttitude
+     * @function quaternionFromAttitudeAndCoordinates
      * @param {Attitude} attitude - [Attitude]{@link module:OrientationParser~Attitude}
-     * @param {Coordinates} coordinate position the oject (used to apply another rotation on Globe CRS)
-     * @param {Boolean} needsENUFromGeodesicNormal should be true on globe CRS.
-     * If true, we will apply another rotation : The rotation use to create ENU local space at coordinate parameter position.
+     * @param {Coordinates} coordinates the origin of the local East North Up (ENU) frame
+     * @param {String} crs the CRS of the target frame (default : the coordinates crs).
      * @param {THREE.Quaternion} target Quaternion to set
      * @returns {THREE.Quaternion} Quaternion representing the rotation
      */
-    quaternionFromAttitude(attitude, coordinate, needsENUFromGeodesicNormal, target = new THREE.Quaternion()) {
-        if (needsENUFromGeodesicNormal) {
-            return this.globeQuaternionFromAttitude(attitude, coordinate, target);
-        } else {
-            return this.localQuaternionFromAttitude(attitude, target);
-        }
+    quaternionFromAttitudeAndCoordinates(attitude, coordinates, crs = coordinates.crs, target = new THREE.Quaternion()) {
+        // get rotation from the local East/North/Up (ENU) frame to the target CRS.
+        this.quaternionFromCoordinatesCRS(coordinates, crs, target);
+
+        // get the rotation from the platform frame to the local East/North/Up (ENU) frame
+        this.quaternionFromAttitude(attitude, quat);
+        return target.multiply(quat);
     },
 };

--- a/test/unit/orientationUtils.js
+++ b/test/unit/orientationUtils.js
@@ -11,12 +11,12 @@ function quaternionToString(q) {
     return `quaternion : _x: ${q._x}, _y: ${q._y}, _z: ${q._z}, _w: ${q._w}`;
 }
 // Assert two quaternion objects are equals.
-function assertQuatEqual(q1, q2, message = 'Quaternion comparaison') {
+function assertQuatEqual(q1, q2, precision = 15, message = 'Quaternion comparaison') {
     try {
-        assertFloatEqual(q1._x, q2._x, '_x not equal');
-        assertFloatEqual(q1._y, q2._y, '_y not equal');
-        assertFloatEqual(q1._z, q2._z, '_z not equal');
-        assertFloatEqual(q1._w, q2._w, '_w not equal');
+        assertFloatEqual(q1._x, q2._x, '_x not equal', precision);
+        assertFloatEqual(q1._y, q2._y, '_y not equal', precision);
+        assertFloatEqual(q1._z, q2._z, '_z not equal', precision);
+        assertFloatEqual(q1._w, q2._w, '_w not equal', precision);
     } catch (e) {
         if (e instanceof assert.AssertionError) {
             assert.fail(`${message}\n${e}\nExpected : ${quaternionToString(q1)}\nActual : ${quaternionToString(q2)}`);
@@ -26,11 +26,11 @@ function assertQuatEqual(q1, q2, message = 'Quaternion comparaison') {
     }
 }
 
-function testQuaternionFromAttitude(input, expected) {
-    var actual = OrientationUtils.localQuaternionFromAttitude(input);
+function testQuaternionFromAttitude(input, expected, precision = 15) {
+    var actual = OrientationUtils.quaternionFromAttitude(input);
     var message = `Input should be parsed properly : ${input}`;
 
-    assertQuatEqual(expected, actual, message);
+    assertQuatEqual(expected, actual, precision, message);
 }
 
 function RollPitchHeadingToString() {
@@ -41,7 +41,7 @@ function OmegaPhiKappaToString() {
     return `omega: ${this.omega}, phi: ${this.phi}, kappa: ${this.kappa}`;
 }
 
-describe('OrientationUtils localQuaternionFromAttitude', function () {
+describe('OrientationUtils quaternionFromAttitude', function () {
     it('should parse empty input', function () {
         var input = {};
         var expected = new THREE.Quaternion();
@@ -108,7 +108,7 @@ describe('OrientationUtils localQuaternionFromAttitude', function () {
 });
 
 
-describe('OrientationUtils globeQuaternionFromAttitude', function () {
+describe('OrientationUtils quaternionFromAttitudeAndCoordinates', function () {
     it('should set ENU quaternion from greenwich on ecuador', function () {
         var coord = new Coordinates('EPSG:4326', 0, 0);
         var input = {
@@ -118,7 +118,7 @@ describe('OrientationUtils globeQuaternionFromAttitude', function () {
             toString() { return `roll: ${this.roll}, pitch: ${this.pitch}, heading: ${this.heading}`; },
         };
 
-        var actual = OrientationUtils.globeQuaternionFromAttitude(input, coord);
+        var actual = OrientationUtils.quaternionFromAttitudeAndCoordinates(input, coord, 'EPSG:4978');
 
         var expected = new THREE.Quaternion();
         expected.setFromEuler(new THREE.Euler(0, Math.PI / 2, Math.PI / 2, 'YZX'));
@@ -130,10 +130,8 @@ describe('OrientationUtils globeQuaternionFromAttitude', function () {
 describe('OrientationUtils parser', function () {
     it('should parse most simple empty data', function () {
         var properties = {};
-        var coord; // coord is undefined because it's not used when applyRotationForGlobe is false.
-        var applyRotationForGlobeView = false;
-
-        var actual = OrientationUtils.quaternionFromAttitude(properties, coord, applyRotationForGlobeView);
+        var coord = new Coordinates('EPSG:4978', 0, 0, 0); // local frame is a geocent frame
+        var actual = OrientationUtils.quaternionFromAttitudeAndCoordinates(properties, coord);
 
         var expected = new THREE.Quaternion();
         assertQuatEqual(expected, actual);
@@ -142,9 +140,7 @@ describe('OrientationUtils parser', function () {
     it('should parse simple data in globe crs', function () {
         var properties = {};
         var coord = new Coordinates('EPSG:4326', 0, 0);
-        var applyRotationForGlobeView = true;
-
-        var actual = OrientationUtils.quaternionFromAttitude(properties, coord, applyRotationForGlobeView);
+        var actual = OrientationUtils.quaternionFromAttitudeAndCoordinates(properties, coord, 'EPSG:4978');
 
         var expected = new THREE.Quaternion();
         expected.setFromEuler(new THREE.Euler(0, Math.PI / 2, Math.PI / 2, 'YZX'));
@@ -152,3 +148,56 @@ describe('OrientationUtils parser', function () {
     });
 });
 
+const RAD2DEG = THREE.Math.RAD2DEG;
+const axis = new THREE.Vector3().set(0, 0, 1);
+
+// https://geodesie.ign.fr/contenu/fichiers/documentation/algorithmes/alg0060.pdf
+describe('OrientationUtils quaternionFromCoordinatesLCC', function () {
+    it('should compute the correct meridian convergence 1/2', function () {
+        var coord = new Coordinates('EPSG:4326', 0.0523598776 * RAD2DEG, 0.8796459430 * RAD2DEG);
+        var proj = { lat0: Math.asin(0.7604059656), long0: 0.0407923443 };
+        var actual = OrientationUtils.quaternionFromCoordinatesLCC(proj, coord);
+        var expected = new THREE.Quaternion();
+        expected.setFromAxisAngle(axis, -0.008796);
+        assertQuatEqual(expected, actual, 7);
+    });
+
+    it('should compute the correct meridian convergence 2/2', function () {
+        var coord = new Coordinates('EPSG:4326', 0.1570796327 * RAD2DEG, 0.7330382858 * RAD2DEG);
+        var proj = { lat0: Math.asin(0.6712679323), long0: 0.0407923443 };
+        var actual = OrientationUtils.quaternionFromCoordinatesLCC(proj, coord);
+        var expected = new THREE.Quaternion();
+        expected.setFromAxisAngle(axis, -0.07806);
+        assertQuatEqual(expected, actual, 7);
+    });
+});
+
+// https://geodesie.ign.fr/contenu/fichiers/documentation/algorithmes/alg0061.pdf
+describe('OrientationUtils quaternionFromCoordinatesMerc', function () {
+    it('should compute the correct meridian convergence 1/3', function () {
+        var coord = new Coordinates('EPSG:4326', -0.0785398163 * RAD2DEG, 0.8552113335 * RAD2DEG);
+        var proj = { e: 0.0818191910, long0: -0.0523598776 };
+        var actual = OrientationUtils.quaternionFromCoordinatesMerc(proj, coord);
+        var expected = new THREE.Quaternion();
+        expected.setFromAxisAngle(axis, 0.01976);
+        assertQuatEqual(expected, actual, 6);
+    });
+
+    it('should compute the correct meridian convergence 2/3', function () {
+        var coord = new Coordinates('EPSG:4326', 0.0523598776 * RAD2DEG, 0.837758041 * RAD2DEG);
+        var proj = { e: 0.0818191910, long0: 0.0523598776 };
+        var actual = OrientationUtils.quaternionFromCoordinatesMerc(proj, coord);
+        var expected = new THREE.Quaternion();
+        expected.setFromAxisAngle(axis, 0);
+        assertQuatEqual(expected, actual, 6);
+    });
+
+    it('should compute the correct meridian convergence 3/3', function () {
+        var coord = new Coordinates('EPSG:4326', 0.2094395102 * RAD2DEG, 0.872664626 * RAD2DEG);
+        var proj = { e: 0.0818191910, long0: 0.1570796327 };
+        var actual = OrientationUtils.quaternionFromCoordinatesMerc(proj, coord);
+        var expected = new THREE.Quaternion();
+        expected.setFromAxisAngle(axis, -0.040125);
+        assertQuatEqual(expected, actual, 6);
+    });
+});


### PR DESCRIPTION
## Description
Adds automatic support for correcting the meridian convergence of view projections of type 'merc', 'lcc' and 'geocent'. 

## Motivation and Context
While meridian convergence correction is a small angle for current examples, this PR proposes to account for it automatically right away (based on proj4-defined values), instead of settling with the current error-prone code (needsENUFromGeodesicNormal).

## Testing
tests have been added for lcc and merc, checking expected values against https://geodesie.ign.fr/contenu/fichiers/documentation/algorithmes/alg0060.pdf and https://geodesie.ign.fr/contenu/fichiers/documentation/algorithmes/alg0061.pdf