### PR TITLE
refactor(gis): change ellipsoidSizes from function to object

### DIFF
--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -12,15 +12,13 @@ proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
 
 const projectionCache = {};
 
-export function ellipsoidSizes() {
-    return {
-        x: 6378137,
-        y: 6378137,
-        z: 6356752.3142451793,
-    };
-}
+export const ellipsoidSizes = {
+    x: 6378137,
+    y: 6378137,
+    z: 6356752.3142451793,
+};
 
-const ellipsoid = new Ellipsoid(ellipsoidSizes());
+const ellipsoid = new Ellipsoid(ellipsoidSizes);
 
 export const UNIT = {
     DEGREE: 1,

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -42,8 +42,7 @@ function Atmosphere() {
         wireframe: false,
     });
 
-    var size = ellipsoidSizes();
-    var geometry = (new THREE.SphereGeometry(1.14, 64, 64)).scale(size.x, size.y, size.z);
+    var geometry = (new THREE.SphereGeometry(1.14, 64, 64)).scale(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z);
 
     THREE.Mesh.call(this, geometry, material);
 
@@ -68,7 +67,7 @@ function Atmosphere() {
         depthWrite: false,
     });
 
-    this.atmosphereIN = new THREE.Mesh((new THREE.SphereGeometry(1.002, 64, 64)).scale(size.x, size.y, size.z), materialAtmoIn);
+    this.atmosphereIN = new THREE.Mesh((new THREE.SphereGeometry(1.002, 64, 64)).scale(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z), materialAtmoIn);
 
     this.add(this.atmosphereIN);
 }

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -84,7 +84,6 @@ export function createGlobeLayer(id, options = {}) {
  */
 function GlobeView(viewerDiv, coordCarto, options = {}) {
     THREE.Object3D.DefaultUp.set(0, 0, 1);
-    const size = ellipsoidSizes().x;
     // Setup View
     View.call(this, 'EPSG:4978', viewerDiv, options);
 
@@ -94,8 +93,8 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         coordCarto.latitude,
         coordCarto.altitude);
 
-    this.camera.camera3D.near = Math.max(15.0, 0.000002352 * size);
-    this.camera.camera3D.far = size * 10;
+    this.camera.camera3D.near = Math.max(15.0, 0.000002352 * ellipsoidSizes.x);
+    this.camera.camera3D.far = ellipsoidSizes.x * 10;
 
     const tileLayer = new GlobeLayer('globe', options.object3d);
 
@@ -125,11 +124,11 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
         this.camera.setPosition(positionCamera);
         this.camera.camera3D.lookAt(positionTargetCamera.as('EPSG:4978').xyz());
     } else {
-        this.controls = new GlobeControls(this, positionTargetCamera, coordCarto.altitude, size);
+        this.controls = new GlobeControls(this, positionTargetCamera, coordCarto.altitude, ellipsoidSizes.x);
         this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
     }
 
-    const mfogDistance = size * 160.0;
+    const mfogDistance = ellipsoidSizes.x * 160.0;
     this._renderState = RendererConstant.FINAL;
     this._fullSizeDepthBuffer = null;
 
@@ -157,7 +156,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
 
         // Compute fog distance, this function makes it possible to have a shorter distance
         // when the camera approaches the ground
-        this.fogDistance = mfogDistance * Math.pow((len - size * 0.99) * 0.25 / size, 1.5);
+        this.fogDistance = mfogDistance * Math.pow((len - ellipsoidSizes.x * 0.99) * 0.25 / ellipsoidSizes.x, 1.5);
 
         // get altitude camera
         coordCam.set(this.referenceCrs, this.camera.camera3D.position).as('EPSG:4326', coordGeoCam);

--- a/src/Process/GlobeTileProcessing.js
+++ b/src/Process/GlobeTileProcessing.js
@@ -31,9 +31,9 @@ export function preGlobeUpdate(context, layer) {
     worldToScaledEllipsoid.getInverse(layer.object3d.matrixWorld);
     worldToScaledEllipsoid.premultiply(
         new THREE.Matrix4().makeScale(
-            1 / ellipsoidSizes().x,
-            1 / ellipsoidSizes().y,
-            1 / ellipsoidSizes().z));
+            1 / ellipsoidSizes.x,
+            1 / ellipsoidSizes.y,
+            1 / ellipsoidSizes.z));
 
     // pre-horizon culling
     // cV is camera's position in worldToScaledEllipsoid system
@@ -154,14 +154,13 @@ export function globeSchemeTileWMTS(type) {
 }
 
 export function computeTileZoomFromDistanceCamera(distance, view) {
-    const sizeEllipsoid = ellipsoidSizes().x;
-    const preSinus = SIZE_TEXTURE_TILE * (SSE_SUBDIVISION_THRESHOLD * 0.5) / view.camera.preSSE / sizeEllipsoid;
+    const preSinus = SIZE_TEXTURE_TILE * (SSE_SUBDIVISION_THRESHOLD * 0.5) / view.camera.preSSE / ellipsoidSizes.x;
 
     let sinus = distance * preSinus;
     let zoom = Math.log(Math.PI / (2.0 * Math.asin(sinus))) / Math.log(2);
 
     const delta = Math.PI / Math.pow(2, zoom);
-    const circleChord = 2.0 * sizeEllipsoid * Math.sin(delta * 0.5);
+    const circleChord = 2.0 * ellipsoidSizes.x * Math.sin(delta * 0.5);
     const radius = circleChord * 0.5;
 
     // adjust with bounding sphere rayon
@@ -173,7 +172,7 @@ export function computeTileZoomFromDistanceCamera(distance, view) {
 
 export function computeDistanceCameraFromTileZoom(zoom, view) {
     const delta = Math.PI / Math.pow(2, zoom);
-    const circleChord = 2.0 * ellipsoidSizes().x * Math.sin(delta * 0.5);
+    const circleChord = 2.0 * ellipsoidSizes.x * Math.sin(delta * 0.5);
     const radius = circleChord * 0.5;
     const error = radius / SIZE_TEXTURE_TILE;
 

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -1122,8 +1122,7 @@ GlobeControls.prototype.pixelsToMeters = function pixelsToMeters(pixels, pixelPi
 
 GlobeControls.prototype.pixelsToDegrees = function pixelsToDegrees(pixels, pixelPitch = 0.28) {
     const chord = this.pixelsToMeters(pixels, pixelPitch);
-    const radius = ellipsoidSizes().x;
-    return THREE.Math.radToDeg(2 * Math.asin(chord / (2 * radius)));
+    return THREE.Math.radToDeg(2 * Math.asin(chord / (2 * ellipsoidSizes.x)));
 };
 
 /**

--- a/src/utils/CameraUtils.js
+++ b/src/utils/CameraUtils.js
@@ -8,7 +8,7 @@ import Ellipsoid from '../Core/Math/Ellipsoid';
 THREE.Object3D.DefaultUp.set(0, 0, 1);
 const targetPosition = new THREE.Vector3();
 const targetCoord = new Coordinates('EPSG:4326', 0, 0, 0);
-const ellipsoid = new Ellipsoid(ellipsoidSizes());
+const ellipsoid = new Ellipsoid(ellipsoidSizes);
 const rigs = [];
 const slerp = [];
 

--- a/test/examples/CameraUtils.js
+++ b/test/examples/CameraUtils.js
@@ -10,7 +10,7 @@ async function newGlobePage() {
         window.THREE = itowns.THREE;
         const raycaster = new itowns.THREE.Raycaster();
         const screen = new itowns.THREE.Vector2();
-        const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes());
+        const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes);
         globeView
             .getPickingPositionFromDepth = function fn(mouse, target = new itowns.THREE.Vector3()) {
                 const g = this.mainLoop.gfxEngine;

--- a/test/examples/GlobeControls.js
+++ b/test/examples/GlobeControls.js
@@ -13,7 +13,7 @@ async function newGlobePage() {
             .getPickingPositionFromDepth = function fn(mouse, target = new itowns.THREE.Vector3()) {
                 const g = this.mainLoop.gfxEngine;
                 const dim = g.getWindowSize();
-                const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes());
+                const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes);
                 screen.copy(mouse || dim.clone().multiplyScalar(0.5));
                 screen.x = Math.floor(screen.x);
                 screen.y = Math.floor(screen.y);

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -11,7 +11,7 @@ DEMUtils.getElevationValueAt = () => ({ z: 0 });
 
 const raycaster = new THREE.Raycaster();
 const center = new THREE.Vector2();
-const ellipsoid = new Ellipsoid(ellipsoidSizes());
+const ellipsoid = new Ellipsoid(ellipsoidSizes);
 
 function pickEllipsoid(camera) {
     raycaster.setFromCamera(center, camera);


### PR DESCRIPTION
The `ellipsoidSizes` export in `Coordinates` was a function, which was
creating an object each time it was called. It has now be changed to an
object, meaning that we don't have to execute the function each time.

BREAKING CHANGE: `ellipsoidSizes` from `Coordinates.js` is no longer a
function but an object.
