### PR TITLE
Reduce examples test time

### DIFF
--- a/examples/collada.html
+++ b/examples/collada.html
@@ -30,14 +30,14 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Add one imagery layer to the scene
@@ -56,9 +56,9 @@
 
                 // building coordinate
                 var coord = new itowns.Coordinates('EPSG:4326', 4.2165, 44.844, 1417);
-                var colladaID = globeView.mainLoop.gfxEngine.getUniqueThreejsLayer();
+                var colladaID = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
 
-                model.position.copy(coord.as(globeView.referenceCrs).xyz());
+                model.position.copy(coord.as(view.referenceCrs).xyz());
                 // align up vector with geodesic normal
                 model.lookAt(model.position.clone().add(coord.geodesicNormal));
                 // user rotate building to align with ortho image
@@ -67,18 +67,18 @@
 
                 // set camera's layer to do not disturb the picking
                 model.traverse(function _(obj) { obj.layers.set(colladaID); });
-                globeView.camera.camera3D.layers.enable(colladaID);
+                view.camera.camera3D.layers.enable(colladaID);
 
                 // update coordinate of the mesh
                 model.updateMatrixWorld();
 
-                globeView.scene.add(model);
-                globeView.notifyChange();
+                view.scene.add(model);
+                view.notifyChange();
             });
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function init() {
-                globeView.controls.lookAtCoordinate({ heading: 180, tilt: 60 });
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function init() {
+                view.controls.lookAtCoordinate({ heading: 180, tilt: 60 });
             });
         </script>
     </body>

--- a/examples/externalscene.html
+++ b/examples/externalscene.html
@@ -20,14 +20,14 @@
 
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
-            var globeView = new itowns.GlobeView(
+            var view = new itowns.GlobeView(
                     viewerDiv, positionOnGlobe, { scene3D: scene });
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
-            globeView.mainLoop.name = 'external-ML';
+            view.mainLoop.name = 'external-ML';
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer);
+                view.addLayer(layer);
             }
 
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);

--- a/examples/globe.html
+++ b/examples/globe.html
@@ -46,10 +46,10 @@
             var miniDiv = document.getElementById('miniDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            setupLoadingScreen(viewerDiv, globeView);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            setupLoadingScreen(viewerDiv, view);
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Dont' instance mini viewer if it's Test env
@@ -59,7 +59,7 @@
                 // since the mini globe will always be seen from a far point of view (see minDistance above)
                 maxSubdivisionLevel: 2,
                 // Don't instance default controls since miniview's camera will be synced
-                // on the main view's one (see globeView.addFrameRequester)
+                // on the main view's one (see view.addFrameRequester)
                 noControls: true,
             });
 
@@ -68,13 +68,13 @@
             // to see the main view "behind"
             miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
 
-            // update miniview's camera with the globeView's camera position
-            globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, function updateMiniView() {
+            // update miniview's camera with the view's camera position
+            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, function updateMiniView() {
                 // clamp distance camera from globe
-                var distanceCamera = globeView.camera.camera3D.position.length();
+                var distanceCamera = view.camera.camera3D.position.length();
                 var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);
                 var camera = miniView.camera.camera3D;
-                var cameraTargetPosition = globeView.controls.getCameraTargetPosition();
+                var cameraTargetPosition = view.controls.getCameraTargetPosition();
                 // Update target miniview's camera
                 camera.position.copy(cameraTargetPosition).setLength(distance);
                 camera.lookAt(cameraTargetPosition);
@@ -93,15 +93,15 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
 
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
             var divScaleWidget = document.querySelectorAll('.divScaleWidget')[0];
 
             function updateScaleWidget() {
-                var value = globeView.controls.pixelsToMeters(200);
+                var value = view.controls.pixelsToMeters(200);
                 value = Math.floor(value);
                 var digit = Math.pow(10, value.toString().length - 1);
                 value = Math.round(value / digit) * digit;
-                var pix = globeView.controls.metersToPixels(value);
+                var pix = view.controls.metersToPixels(value);
                 var unit = 'm';
                 if (value >= 1000) {
                     value /= 1000;
@@ -112,12 +112,12 @@
             }
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 updateScaleWidget();
             });
-            globeView.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
+            view.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
                 updateScaleWidget();
             });
         </script>

--- a/examples/globe_geojson_to3D.html
+++ b/examples/globe_geojson_to3D.html
@@ -27,10 +27,10 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Add one imagery layer to the scene
@@ -65,13 +65,13 @@
                 zoom: { min: 7, max: 7 },
             };
 
-            globeView.addLayer(ariege).then(function menue(layer) {
+            view.addLayer(ariege).then(function menue(layer) {
                 var gui = debug.GeometryDebug
-                    .createGeometryDebugUI(menuGlobe.gui, globeView, layer);
-                debug.GeometryDebug.addWireFrameCheckbox(gui, globeView, layer);
+                    .createGeometryDebugUI(menuGlobe.gui, view, layer);
+                debug.GeometryDebug.addWireFrameCheckbox(gui, view, layer);
             });
 
-            menuGlobe = new GuiTools('menuDiv', globeView);
+            menuGlobe = new GuiTools('menuDiv', view);
 </script>
 </body>
 </html>

--- a/examples/globe_travel.html
+++ b/examples/globe_travel.html
@@ -38,10 +38,10 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             var time = 50000;
             var pathTravel = [];
-            globeView.setRealisticLightingOn(true);
+            view.setRealisticLightingOn(true);
 
             pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 2.0889, 42.809), range: 100000, time: time * 0.2 });
             pathTravel.push({ range: 13932, time: time * 0.2, tilt: 7.59, heading: -110.9 });
@@ -55,13 +55,13 @@
             pathTravel.push({ range: 16601, time: time * 0.2 });
 
             function addLayerCb(layer) {
-                return globeView.addLayer(layer);
+                return view.addLayer(layer);
             }
 
             function travel() {
-                var camera = globeView.camera.camera3D;
+                var camera = view.camera.camera3D;
                 return itowns.CameraUtils
-                    .sequenceAnimationsToLookAtTarget(globeView, camera, pathTravel);
+                    .sequenceAnimationsToLookAtTarget(view, camera, pathTravel);
             }
 
             // Add one imagery layer to the scene
@@ -74,7 +74,7 @@
             promises.push(itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb));
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function init() {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function init() {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 Promise.all(promises).then(function _() {

--- a/examples/globe_vector.html
+++ b/examples/globe_vector.html
@@ -52,12 +52,12 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv', view);
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Add one imagery layer to the scene
@@ -69,7 +69,7 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
 
-            globeView.addLayer({
+            view.addLayer({
                 type: 'color',
                 id: 'Kml',
                 name: 'kml',
@@ -81,7 +81,7 @@
                 },
             });
 
-            globeView.addLayer({
+            view.addLayer({
                 type: 'color',
                 id: 'Gpx',
                 name: 'Ultra 2009',
@@ -93,7 +93,7 @@
                 },
             });
 
-            globeView.addLayer({
+            view.addLayer({
                 type: 'color',
                 id: 'ariege',
                 name: 'ariege',
@@ -111,11 +111,11 @@
             });
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function _() {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function _() {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                itowns.ColorLayersOrdering.moveLayerToIndex(globeView, 'Ortho', 0);
-                new ToolTip(globeView, document.getElementById('viewerDiv'), document.getElementById('tooltipDiv'));
+                itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
+                new ToolTip(view, document.getElementById('viewerDiv'), document.getElementById('tooltipDiv'));
             });
         </script>
     </body>

--- a/examples/globe_wfs_color.html
+++ b/examples/globe_wfs_color.html
@@ -29,13 +29,13 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            var menuGlobe = new GuiTools('menuDiv', globeView);
-            var d = new debug.Debug(globeView, menuGlobe.gui);
-            setupLoadingScreen(viewerDiv, globeView);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var menuGlobe = new GuiTools('menuDiv', view);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
@@ -56,7 +56,7 @@
                 return data.features.length < 1000;
             }
 
-            globeView.addLayer({
+            view.addLayer({
                 type: 'color',
                 id: 'wfsBuilding',
                 transparent: true,
@@ -85,12 +85,12 @@
             });
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                itowns.ColorLayersOrdering.moveLayerToIndex(globeView, 'Ortho', 0);
+                itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
             });
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.tileLayer, d);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 </script>
     </body>
 </html>

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -33,10 +33,10 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            setupLoadingScreen(viewerDiv, globeView);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            setupLoadingScreen(viewerDiv, view);
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
@@ -60,7 +60,7 @@
                 var i = 0;
                 var result;
                 var tile;
-                var layer = globeView.tileLayer;
+                var layer = view.tileLayer;
                 if (contour.length && contour.length > 0) {
                     for (; i < contour.length; i++) {
                         result = itowns.DEMUtils.getElevationValueAt(layer, contour[i], 0, tile);
@@ -89,7 +89,7 @@
                 return false;
             }
 
-            globeView.addLayer({
+            view.addLayer({
                 name: 'lyon_tcl_bus',
                 id: 'WFS Bus lines',
                 type: 'geometry',
@@ -142,7 +142,7 @@
                 var i;
                 var mesh;
                 if (meshes.length) {
-                    globeView.notifyChange();
+                    view.notifyChange();
                 }
                 for (i = 0; i < meshes.length; i++) {
                     mesh = meshes[i];
@@ -155,8 +155,8 @@
                 meshes = meshes.filter(function filter(m) { return m.scale.z < 1; });
             };
 
-            globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
-            globeView.addLayer({
+            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
+            view.addLayer({
                 id: 'WFS Buildings',
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
@@ -210,7 +210,7 @@
                 var result;
                 var z = 0;
                 if (contour.length && contour.length > 0) {
-                    result = itowns.DEMUtils.getElevationValueAt(globeView.tileLayer, contour[0]);
+                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour[0]);
                     if (result) {
                         z = result.z;
                     }
@@ -219,7 +219,7 @@
                 return 0;
             }
 
-            globeView.addLayer({
+            view.addLayer({
                 type: 'geometry',
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
@@ -247,19 +247,19 @@
                 }
             });
 
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                globeView.controls.setTilt(45, true);
+                view.controls.setTilt(45, true);
             });
-            var d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.tileLayer, d);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
             function picking(event) {
                 var htmlInfo = document.getElementById('info');
-                var intersects = globeView.pickObjectsAt(event, 3, 'WFS Buildings');
+                var intersects = view.pickObjectsAt(event, 3, 'WFS Buildings');
                 var properties;
                 var info;
                 htmlInfo.innerHTML = ' ';
@@ -277,24 +277,24 @@
                 }
             }
 
-            for (let layer of globeView.getLayers()) {
+            for (let layer of view.getLayers()) {
                 // if (layer.id === 'WFS Bus lines') {
                 //     layer.whenReady.then( function _(layer) {
-                //         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, globeView, layer);
-                //         debug.GeometryDebug.addMaterialLineWidth(gui, globeView, layer, 1, 10);
+                //         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
+                //         debug.GeometryDebug.addMaterialLineWidth(gui, view, layer, 1, 10);
                 //     });
                 // }
                 if (layer.id === 'WFS Buildings') {
                     layer.whenReady.then( function _(layer) {
-                        var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, globeView, layer);
-                        debug.GeometryDebug.addWireFrameCheckbox(gui, globeView, layer);
+                        var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
+                        debug.GeometryDebug.addWireFrameCheckbox(gui, view, layer);
                         window.addEventListener('mousemove', picking, false);
                     });
                 }
                 // if (layer.id === 'WFS Route points') {
                 //     layer.whenReady.then( function _(layer) {
-                //         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, globeView, layer);
-                //         debug.GeometryDebug.addMaterialSize(gui, globeView, layer, 1, 50);
+                //         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
+                //         debug.GeometryDebug.addMaterialSize(gui, view, layer, 1, 50);
                 //     });
                 // }
             }

--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -21,12 +21,12 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer);
+                view.addLayer(layer);
             }
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -38,12 +38,12 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
-                itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx').then(xml => itowns.GpxParser.parse(xml, { crs: globeView.referenceCrs })).then(function (gpx) {
+                itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx').then(xml => itowns.GpxParser.parse(xml, { crs: view.referenceCrs })).then(function (gpx) {
                     if (gpx) {
-                        globeView.scene.add(gpx);
-                        globeView.controls.setTilt(45, true);
+                        view.scene.add(gpx);
+                        view.controls.setTilt(45, true);
                     }
                 });
             });

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -21,12 +21,12 @@
 
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            setupLoadingScreen(viewerDiv, globeView);
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            setupLoadingScreen(viewerDiv, view);
+            var menuGlobe = new GuiTools('menuDiv', view);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
@@ -65,17 +65,17 @@
                 }
             }
 
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
             });
 
             // Use frame requester to update menu before rendering
-            globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, function () {
+            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, function () {
                 var layers = { id: [] };
-                // globeView.scene is THREE.js scene
-                getLayersColorVisible(globeView.scene, layers);
-                var colorLayers = globeView.getLayers(function (l) { return l.type == 'color'; });
+                // view.scene is THREE.js scene
+                getLayersColorVisible(view.scene, layers);
+                var colorLayers = view.getLayers(function (l) { return l.type == 'color'; });
 
                 colorLayers.forEach(function (layer) {
                     menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1)

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -40,12 +40,12 @@
 
             // Create the first globe
             object3d = new itowns.THREE.Object3D();
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true, object3d });
-            setupLoadingScreen(viewerDiv, globeView);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { noControls: true, object3d });
+            setupLoadingScreen(viewerDiv, view);
             object3ds.push(object3d);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer);
+                view.addLayer(layer);
             }
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
 
@@ -61,9 +61,9 @@
             globe2.noTextureColor = new itowns.THREE.Color(0xd0d5d8);
 
             // add globe2 to the view so it gets updated
-            itowns.View.prototype.addLayer.call(globeView, globe2);
+            itowns.View.prototype.addLayer.call(view, globe2);
             itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(function _(osm) {
-                itowns.View.prototype.addLayer.call(globeView, osm, globe2);
+                itowns.View.prototype.addLayer.call(view, osm, globe2);
             });
 
             // Globe animation
@@ -85,10 +85,10 @@
 
                 if (t < 1) {
                     // animation is not finished, schedule a new view update
-                    globeView.notifyChange(globeView.camera.camera3D);
+                    view.notifyChange(view.camera.camera3D);
                 } else {
                     // animation is finished, remove the frame requester
-                    globeView.removeFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
+                    view.removeFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
                 }
             }
 
@@ -98,8 +98,8 @@
                     front = 1 - front;
                     t = 0;
                     // schedule the animation
-                    globeView.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
-                    globeView.notifyChange(globeView.camera.camera3D);
+                    view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, animator);
+                    view.notifyChange(view.camera.camera3D);
                 }
             }
             viewerDiv.focus();
@@ -107,7 +107,7 @@
 
             // Zoom on mouse-wheel
             var onMouseWheel = function onMouseWheel(event) {
-                var geo = new itowns.Coordinates('EPSG:4978', globeView.camera.camera3D.position).as('EPSG:4326');
+                var geo = new itowns.Coordinates('EPSG:4978', view.camera.camera3D.position).as('EPSG:4326');
                 // WebKit / Opera / Explorer 9
                 if (event.wheelDelta !== undefined) {
                     delta = event.wheelDelta;
@@ -121,8 +121,8 @@
                 } else {
                     geo.setAltitude(geo.altitude() * 1.1);
                 }
-                globeView.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
-                globeView.notifyChange(globeView.camera.camera3D);
+                view.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
+                view.notifyChange(view.camera.camera3D);
             };
             viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);
             viewerDiv.addEventListener('mousewheel', onMouseWheel);

--- a/examples/orientation_utils.html
+++ b/examples/orientation_utils.html
@@ -27,17 +27,17 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe, {
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, {
                 handleCollision: false,
             });
-           globeView.controls.minDistance = 30;
+           view.controls.minDistance = 30;
 
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
-                return globeView.addLayer(layer);
+                return view.addLayer(layer);
             }
 
             // Add one imagery layer to the scene
@@ -50,7 +50,7 @@
             // Input data : a geoJson file, with point features, with orientation specific properties
             var panoramics = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/immersive/exampleParis1/panoramicsMetaDataParis.geojson';
             var layer = {
-                crsOut: globeView.referenceCrs,
+                crsOut: view.referenceCrs,
                 onGround: false,
             };
             // Input data are given in Lambert93 projection
@@ -81,12 +81,12 @@
             var onGround = false;
 
             // wait for all layer to be loaded, we need for elevation layer
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function init() {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function init() {
 
                 // wait for all the promises
                 Promise.all(promises).then(function loadFeaturesModel(res) { loadFeatures(res[1], res[2]);});
 
-                globeView.controls.setTilt(20, true);
+                view.controls.setTilt(20, true);
             })
 
 
@@ -112,27 +112,27 @@
 
                     // compute position on the ground
                     var coord = feature.vertices[0];
-                    result = itowns.DEMUtils.getElevationValueAt(globeView.tileLayer, coord, 1, undefined);
+                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, coord, 1, undefined);
                     coord = coord.as('EPSG:4326');
                     coord.setAltitude(result.z);
-                    model.positionOnGround = coord.as(globeView.referenceCrs).xyz();
+                    model.positionOnGround = coord.as(view.referenceCrs).xyz();
 
                     // update matrix world and add the model
                     model.updateMatrixWorld();
-                    globeView.scene.add(model);
+                    view.scene.add(model);
 
                     // store the model
                     feature.model = model;
                 }
-                globeView.notifyChange();
+                view.notifyChange();
 
                 // store the features
                 layer.features = points.features;
             }
 
             // add debug GUI
-            var d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.tileLayer, d);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
             // Add a checkbox to put the cars on the ground.
             folder = menuGlobe.gui.addFolder('Cars Layer');
@@ -141,7 +141,7 @@
                     feature.model.position.copy(layer.onGround? feature.model.positionOnGround : feature.model.positionBase);
                     feature.model.updateMatrixWorld();
                 }
-                globeView.notifyChange();
+                view.notifyChange();
             });
         </script>
     </body>

--- a/examples/oriented_images.html
+++ b/examples/oriented_images.html
@@ -39,7 +39,7 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, dummyPositionOnGlobe, {
+            var view = new itowns.GlobeView(viewerDiv, dummyPositionOnGlobe, {
                 sseSubdivisionThreshold: 6,
                 noControls: true,
             });
@@ -52,7 +52,7 @@
             var camera;
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer);
+                view.addLayer(layer);
             }
 
             // Add one imagery layer to the scene
@@ -118,7 +118,7 @@
             rotationMatrix = parseAircraftConventionOrientationToMatrix(pictureInfos.panoramic);
 
             // eslint-disable-next-line no-unused-vars
-            camera = initCamera(globeView, pictureInfos.panoramic.image, coord,
+            camera = initCamera(view, pictureInfos.panoramic.image, coord,
                 pictureInfos.camera.enhToOrientationUp, pictureInfos.camera.enhToOrientationLookAt,
                 rotationMatrix,
                 pictureInfos.camera.orientationToCameraUp, pictureInfos.camera.orientationToCameraLookAt,
@@ -129,28 +129,28 @@
             plane = setupPictureFromCamera(camera, pictureInfos.panoramic.image, pictureInfos.opacity,
                 pictureInfos.distance);
 
-            setupViewCameraDecomposing(globeView, camera);
+            setupViewCameraDecomposing(view, camera);
 
             // open view camera FOV of 10° to see landscape around the picture.
-            globeView.camera.camera3D.fov += 10;
-            globeView.camera.camera3D.updateProjectionMatrix();
+            view.camera.camera3D.fov += 10;
+            view.camera.camera3D.updateProjectionMatrix();
 
             // uncomment to debug camera
-            // addCameraHelper(globeView, camera);
+            // addCameraHelper(view, camera);
 
             // eslint-disable-next-line no-new
-            new itowns.FirstPersonControls(globeView);
+            new itowns.FirstPersonControls(view);
 
-            /* global itowns, document, GuiTools, globeView, promises */
+            /* global itowns, document, GuiTools, view, promises */
             var menuGlobe = new GuiTools('menuDiv');
             // setup GUI
             function updatePlaneDistance() {
                 transformTexturedPlane(camera, pictureInfos.distance, plane);
             }
-            setupPictureUI(menuGlobe, pictureInfos, plane, updatePlaneDistance, globeView, 3000, 15000);
+            setupPictureUI(menuGlobe, pictureInfos, plane, updatePlaneDistance, view, 3000, 15000);
 
-            var d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.tileLayer, d);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
         </script>
     </body>

--- a/examples/positionGlobe.html
+++ b/examples/positionGlobe.html
@@ -29,13 +29,13 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
-            var menuGlobe = new GuiTools('menuDiv', globeView);
-            setupLoadingScreen(viewerDiv, globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -54,14 +54,14 @@
                 var mesh = new THREE.Mesh(geometry, material);
 
                 // get the position on the globe, from the camera
-                var cameraTargetPosition = globeView.controls.getLookAtCoordinate();
+                var cameraTargetPosition = view.controls.getLookAtCoordinate();
 
                 // position of the mesh
                 var meshCoord = cameraTargetPosition;
                 meshCoord.setAltitude(cameraTargetPosition.altitude() + 30);
 
                 // position and orientation of the mesh
-                mesh.position.copy(meshCoord.as(globeView.referenceCrs).xyz());
+                mesh.position.copy(meshCoord.as(view.referenceCrs).xyz());
                 mesh.lookAt(new THREE.Vector3(0, 0, 0));
                 mesh.rotateX(Math.PI / 2);
 
@@ -69,18 +69,18 @@
                 mesh.updateMatrixWorld();
 
                 // add the mesh to the scene
-                globeView.scene.add(mesh);
+                view.scene.add(mesh);
 
                 // make the object usable from outside of the function
-                globeView.mesh = mesh;
+                view.mesh = mesh;
             }
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function globeInitialized() {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function globeInitialized() {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 addMeshToScene();
-                globeView.controls.setTilt(60, true);
+                view.controls.setTilt(60, true);
             });
         </script>
     </body>

--- a/examples/postprocessing.html
+++ b/examples/postprocessing.html
@@ -54,7 +54,7 @@
 
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
             // Simple postprocessing setup
             //
@@ -62,7 +62,7 @@
             var quad = new itowns.THREE.Mesh(new itowns.THREE.PlaneBufferGeometry(2, 2), null);
             var cam = new itowns.THREE.OrthographicCamera(-1, 1, 1, -1, 0, 10);
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
             quad.frustumCulled = false;
             quad.material = new itowns.THREE.ShaderMaterial({
@@ -78,15 +78,15 @@
             });
             postprocessScene.add(quad);
 
-            globeView.render = function render() {
-                var g = globeView.mainLoop.gfxEngine;
+            view.render = function render() {
+                var g = view.mainLoop.gfxEngine;
                 var r = g.renderer;
                 r.setRenderTarget(g.fullSizeRenderTarget);
                 r.clear();
                 r.setViewport(0, 0, g.getWindowSize().x, g.getWindowSize().y);
                 r.render(
-                    globeView.scene,
-                    globeView.camera.camera3D, g.fullSizeRenderTarget);
+                    view.scene,
+                    view.camera.camera3D, g.fullSizeRenderTarget);
 
                 quad.material.uniforms.tDiffuse.value = g.fullSizeRenderTarget.texture;
                 quad.material.uniforms.tSize.value.set(
@@ -101,7 +101,7 @@
             };
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer);
+                view.addLayer(layer);
             }
 
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);

--- a/examples/split.html
+++ b/examples/split.html
@@ -39,7 +39,7 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
             var promises = [];
 
@@ -49,10 +49,10 @@
             var splitPosition;
             var xD;
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
-                return globeView.addLayer(layer);
+                return view.addLayer(layer);
             }
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -72,7 +72,7 @@
                 var s = (evt.clientX - xD) / splitSlider.parentElement.offsetWidth;
                 splitSlider.style.left = (100.0 * s) + '%';
                 splitPosition = s * window.innerWidth;
-                globeView.notifyChange();
+                view.notifyChange();
             }
 
             function mouseDown(evt) {
@@ -87,7 +87,7 @@
             function changeLayerVisibility(ortho, osm) {
                 var material;
 
-                globeView.scene.traverse(function _(obj) {
+                view.scene.traverse(function _(obj) {
                     if (obj.material && obj.material.setLayerVisibility && obj.material.visible) {
                         material = obj.material;
                         material.setLayerVisibility(orthoLayer, ortho);
@@ -101,7 +101,7 @@
 
             // Rendering code
             function splitRendering() {
-                var g = globeView.mainLoop.gfxEngine;
+                var g = view.mainLoop.gfxEngine;
                 var r = g.renderer;
 
                 r.setScissorTest(true);
@@ -110,18 +110,18 @@
                 changeLayerVisibility(true, false);
 
                 r.setScissor(0, 0, splitPosition + 2, window.innerHeight);
-                g.renderView(globeView);
+                g.renderView(view);
 
                 // render osm layer on the right
                 changeLayerVisibility(false, true);
 
                 r.setScissor(splitPosition + 2, 0, window.innerWidth - splitPosition - 2, window.innerHeight);
-                g.renderView(globeView);
+                g.renderView(view);
             }
 
             // Override default rendering method when color layers are ready
             Promise.all(promises).then(
-                function _() { globeView.render = splitRendering; }).catch(console.error);
+                function _() { view.render = splitRendering; }).catch(console.error);
         </script>
     </body>
 </html>

--- a/examples/stereo.html
+++ b/examples/stereo.html
@@ -48,7 +48,7 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
             // Eye separation value
             var eyeSep = 0.064;
@@ -56,7 +56,7 @@
             // Save StereoCamera update function
             var fnUpdateStereoCamera = itowns.THREE.StereoCamera.prototype.update;
 
-            setupLoadingScreen(viewerDiv, globeView);
+            setupLoadingScreen(viewerDiv, view);
 
             itowns.THREE.StereoCamera.prototype.update = function _update(camera) {
                 this.cameraL.far = camera.far;
@@ -68,7 +68,7 @@
             };
 
             function addLayerCb(layer) {
-                globeView.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             // Add one imagery layer to the scene
@@ -87,7 +87,7 @@
 
                 if (!effect) return;
 
-                globeView.notifyChange();
+                view.notifyChange();
             }
 
             function disableEffect() {
@@ -96,14 +96,14 @@
                 }
 
                 effect = null;
-                globeView.render = null;
+                view.render = null;
 
-                globeView.notifyChange();
+                view.notifyChange();
             }
 
             function enableEffect(_eff) {
                 var size;
-                var g = globeView.mainLoop.gfxEngine;
+                var g = view.mainLoop.gfxEngine;
                 var r = g.renderer;
 
                 if (effect) {
@@ -111,15 +111,15 @@
                 }
 
                 effect = _eff;
-                size = globeView.mainLoop.gfxEngine.getWindowSize();
+                size = view.mainLoop.gfxEngine.getWindowSize();
                 effect.setSize(size.x, size.y);
 
-                globeView.render = function render() {
+                view.render = function render() {
                     r.clear();
-                    effect.render(globeView.scene, globeView.camera.camera3D);
+                    effect.render(view.scene, view.camera.camera3D);
                 };
 
-                globeView.notifyChange();
+                view.notifyChange();
             }
 
             /**
@@ -130,8 +130,8 @@
             function enableAnaglyph() {
                 var _eff;
                 if (effect instanceof THREE.AnaglyphEffect) return;
-                _eff = new THREE.AnaglyphEffect(globeView.mainLoop.gfxEngine.renderer,
-                    globeView.camera.camera3D);
+                _eff = new THREE.AnaglyphEffect(view.mainLoop.gfxEngine.renderer,
+                    view.camera.camera3D);
                 enableEffect(_eff);
             }
 
@@ -144,8 +144,8 @@
             function enableParallax() {
                 var _eff;
                 if (effect instanceof THREE.ParallaxBarrierEffect) return;
-                _eff = new THREE.ParallaxBarrierEffect(globeView.mainLoop.gfxEngine.renderer,
-                    globeView.camera.camera3D);
+                _eff = new THREE.ParallaxBarrierEffect(view.mainLoop.gfxEngine.renderer,
+                    view.camera.camera3D);
                 enableEffect(_eff);
             }
 
@@ -155,23 +155,23 @@
             function enableStereo() {
                 var _eff;
                 if (effect instanceof THREE.StereoEffect) return;
-                _eff = new THREE.StereoEffect(globeView.mainLoop.gfxEngine.renderer,
-                    globeView.camera.camera3D);
+                _eff = new THREE.StereoEffect(view.mainLoop.gfxEngine.renderer,
+                    view.camera.camera3D);
                 enableEffect(_eff);
             }
 
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
             var divScaleWidget = document.querySelectorAll('.divScaleWidget')[0];
 
-            var d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.tileLayer, d);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
             function updateScaleWidget() {
-                var value = globeView.controls.pixelsToMeters(200);
+                var value = view.controls.pixelsToMeters(200);
                 value = Math.floor(value);
                 var digit = Math.pow(10, value.toString().length - 1);
                 value = Math.round(value / digit) * digit;
-                var pix = globeView.controls.metersToPixels(value);
+                var pix = view.controls.metersToPixels(value);
                 var unit = 'm';
                 if (value >= 1000) {
                     value /= 1000;
@@ -182,12 +182,12 @@
             }
 
             // Listen for globe full initialisation event
-            globeView.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
                 updateScaleWidget();
             });
-            globeView.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
+            view.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
                 updateScaleWidget();
             });
         </script>

--- a/examples/syncCameras.html
+++ b/examples/syncCameras.html
@@ -66,19 +66,19 @@
             var planarDiv = document.getElementById('planarDiv');
 
             // Instanciate iTowns GlobeView*
-            var globeView = new itowns.GlobeView(viewerDiv, positionOnGlobe);
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             var planarView = new itowns.PlanarView(planarDiv, extent);
 
             var promises = [];
             // var THREE = itowns.THREE;
-            var menuGlobe = new GuiTools('menuDiv', globeView);
+            var menuGlobe = new GuiTools('menuDiv', view);
             var overGlobe = true;
 
             // eslint-disable-next-line
             new itowns.PlanarControls(planarView, {});
 
             function addLayerCb(layer) {
-                return globeView.addLayer(layer);
+                return view.addLayer(layer);
             }
 
             viewerDiv.addEventListener('mousemove', function _() {
@@ -92,23 +92,23 @@
             promises.push(itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb));
 
             // Listen for globe full initialisation event
-            globeView
+            view
                 .addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED,
                     function globeInitialized() {
                         // eslint-disable-next-line no-console
                         console.info('Globe initialized');
                         Promise.all(promises).then(function init() {
                             var planarCamera = planarView.camera.camera3D;
-                            var globeCamera = globeView.camera.camera3D;
+                            var globeCamera = view.camera.camera3D;
                             var params;
-                            menuGlobe.addImageryLayersGUI(globeView.getLayers(function filterColor(l) { return l.type === 'color'; }));
-                            menuGlobe.addElevationLayersGUI(globeView.getLayers(function filterElevation(l) { return l.type === 'elevation'; }));
+                            menuGlobe.addImageryLayersGUI(view.getLayers(function filterColor(l) { return l.type === 'color'; }));
+                            menuGlobe.addElevationLayersGUI(view.getLayers(function filterElevation(l) { return l.type === 'elevation'; }));
 
                             function sync() {
                                 if (overGlobe) {
                                     params = itowns.CameraUtils
                                         .getTransformCameraLookingAtTarget(
-                                            globeView, globeCamera);
+                                            view, globeCamera);
                                     itowns.CameraUtils
                                     .transformCameraToLookAtTarget(
                                             planarView, planarCamera, params);
@@ -118,11 +118,11 @@
                                             planarView, planarCamera);
                                     itowns.CameraUtils
                                         .transformCameraToLookAtTarget(
-                                                globeView, globeCamera, params);
+                                                view, globeCamera, params);
                                 }
                             }
                             sync();
-                            globeView
+                            view
                                 .addFrameRequester(itowns
                                     .MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, sync);
                             planarView
@@ -148,8 +148,8 @@
                     format: 'image/jpeg',
                 },
             });
-            var d = new debug.Debug(globeView, menuGlobe.gui);
-            debug.createTileDebugUI(menuGlobe.gui, globeView, globeView.tileLayer, d);
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
         </script>
     </body>
 </html>

--- a/test/examples/.eslintrc.js
+++ b/test/examples/.eslintrc.js
@@ -51,5 +51,8 @@ module.exports = {
 
         // TODO reactivate all the following rules
         'no-underscore-dangle': 'off',
+
+        // turned off to use the this object in describe
+        'prefer-arrow-callback': 'off',
     }
 }

--- a/test/examples/3dtiles.js
+++ b/test/examples/3dtiles.js
@@ -1,42 +1,29 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('3dtiles', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/3dtiles.html`,
-            this.test.fullTitle());
-
-        assert.ok(result);
-        await page.close();
+describe('3dtiles', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/3dtiles.html`, this.fullTitle());
     });
 
+    it('should run', async () => {
+        assert.ok(result);
+    });
 
-    it('should return the dragon and the globe', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/3dtiles.html`,
-            this.test.fullTitle());
-
+    it('should return the dragon and the globe', async () => {
         const layers = await page.evaluate(
             () => view.pickObjectsAt({ x: 195, y: 146 }).map(p => p.layer.id));
 
         assert.ok(layers.indexOf('globe') >= 0);
         assert.ok(layers.indexOf('3d-tiles-discrete-lod') >= 0);
         assert.equal(layers.indexOf('3d-tiles-request-volume'), -1);
-        await page.close();
     });
 
-    it('should return points', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/3dtiles.html`);
-
+    it('should return points', async function __() {
         // click on the 'goto pointcloud' button
         await page.evaluate(() => d.zoom());
 
-        await waitUntilItownsIsIdle(page, this.test.fullTitle());
+        await waitUntilItownsIsIdle(this.test.fullTitle());
 
         const pickingCount = await page.evaluate(() =>
             view.pickObjectsAt(
@@ -44,6 +31,5 @@ describe('3dtiles', () => {
                 1,
                 '3d-tiles-request-volume').length);
         assert.ok(pickingCount > 0);
-        await page.close();
     });
 });

--- a/test/examples/CameraUtils.js
+++ b/test/examples/CameraUtils.js
@@ -11,7 +11,7 @@ async function newGlobePage() {
         const raycaster = new itowns.THREE.Raycaster();
         const screen = new itowns.THREE.Vector2();
         const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes);
-        globeView
+        view
             .getPickingPositionFromDepth = function fn(mouse, target = new itowns.THREE.Vector3()) {
                 const g = this.mainLoop.gfxEngine;
                 const dim = g.getWindowSize();
@@ -34,9 +34,9 @@ describe('Camera utils with globe example', () => {
         const page = await newGlobePage.bind(this)();
         const params = { range: 10000 };
         const result = await page.evaluate((p) => {
-            const camera = globeView.camera.camera3D;
+            const camera = view.camera.camera3D;
             return itowns.CameraUtils.transformCameraToLookAtTarget(
-                globeView, camera, p).then(final => final.range);
+                view, camera, p).then(final => final.range);
         }, params);
 
         assert.ok(Math.abs(result - params.range) / params.range < 0.05);
@@ -48,9 +48,9 @@ describe('Camera utils with globe example', () => {
         const params = { longitude: 60, latitude: 40 };
         const result = await page.evaluate((p) => {
             const coord = new itowns.Coordinates('EPSG:4326', p.longitude, p.latitude, 0);
-            const camera = globeView.camera.camera3D;
+            const camera = view.camera.camera3D;
             return itowns.CameraUtils.transformCameraToLookAtTarget(
-                globeView, camera, { coord }).then(final => final.coord);
+                view, camera, { coord }).then(final => final.coord);
         }, params);
         assert.equal(Math.round(result._values[0]), params.longitude);
         assert.equal(Math.round(result._values[1]), params.latitude);
@@ -62,9 +62,9 @@ describe('Camera utils with globe example', () => {
         const params = { tilt: 50 };
 
         const result = await page.evaluate((p) => {
-            const camera = globeView.camera.camera3D;
+            const camera = view.camera.camera3D;
             return itowns.CameraUtils.transformCameraToLookAtTarget(
-                globeView, camera, p).then(final => final.tilt);
+                view, camera, p).then(final => final.tilt);
         }, params);
         assert.equal(Math.round(result), params.tilt);
         page.close();
@@ -75,9 +75,9 @@ describe('Camera utils with globe example', () => {
 
         const params = { heading: 170 };
         const result = await page.evaluate((p) => {
-            const camera = globeView.camera.camera3D;
+            const camera = view.camera.camera3D;
             return itowns.CameraUtils.transformCameraToLookAtTarget(
-                globeView, camera, p).then(final => final.heading);
+                view, camera, p).then(final => final.heading);
         }, params);
         assert.equal(Math.round(result), params.heading);
         page.close();
@@ -87,7 +87,7 @@ describe('Camera utils with globe example', () => {
         const page = await newGlobePage.bind(this)();
 
         const result = await page.evaluate(() => {
-            const camera = globeView.camera.camera3D;
+            const camera = view.camera.camera3D;
             const params = { heading: 17,
                 tilt: 44,
                 range: 200000,
@@ -95,7 +95,7 @@ describe('Camera utils with globe example', () => {
                 latitude: 46,
                 coord: new itowns.Coordinates('EPSG:4326', 3, 47, 0) };
             return itowns.CameraUtils.transformCameraToLookAtTarget(
-                globeView, camera, params).then(final => ({ params, final }));
+                view, camera, params).then(final => ({ params, final }));
         });
         assert.equal(Math.round(result.final.heading), result.params.heading);
         assert.equal(Math.round(result.final.tilt), result.params.tilt);
@@ -116,9 +116,9 @@ describe('Camera utils with globe example', () => {
                 latitude: 46,
                 coord: new itowns.Coordinates('EPSG:4326', 3, 47, 0),
                 time: 500 };
-            const camera = globeView.camera.camera3D;
+            const camera = view.camera.camera3D;
             return itowns.CameraUtils
-                .animateCameraToLookAtTarget(globeView, camera, params).then(final =>
+                .animateCameraToLookAtTarget(view, camera, params).then(final =>
                 ({ final, params }));
         });
         assert.equal(Math.round(result.final.heading), result.params.heading);

--- a/test/examples/CameraUtils.js
+++ b/test/examples/CameraUtils.js
@@ -1,37 +1,32 @@
 const assert = require('assert');
 
-async function newGlobePage() {
-    const page = await browser.newPage();
-    await page.setViewport({ width: 400, height: 300 });
-    await loadExample(page, `http://localhost:${itownsPort}/examples/globe.html`,
-        this.test.fullTitle());
+describe('Camera utils with globe example', function _() {
+    before(async () => {
+        await loadExample(`http://localhost:${itownsPort}/examples/globe.html`, this.fullTitle());
 
-    await page.evaluate(() => {
-        window.THREE = itowns.THREE;
-        const raycaster = new itowns.THREE.Raycaster();
-        const screen = new itowns.THREE.Vector2();
-        const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes);
-        view
-            .getPickingPositionFromDepth = function fn(mouse, target = new itowns.THREE.Vector3()) {
-                const g = this.mainLoop.gfxEngine;
-                const dim = g.getWindowSize();
-                screen.copy(mouse || dim.clone().multiplyScalar(0.5));
-                screen.x = Math.floor(screen.x);
-                screen.y = Math.floor(screen.y);
-                screen.x = ((screen.x / dim.x) * 2) - 1;
-                screen.y = (-(screen.y / dim.y) * 2) + 1;
-                raycaster.setFromCamera(screen, this.camera.camera3D);
-                target.copy(ellipsoid.intersection(raycaster.ray));
+        await page.evaluate(() => {
+            window.THREE = itowns.THREE;
+            const raycaster = new THREE.Raycaster();
+            const screen = new THREE.Vector2();
+            const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes);
+            view
+                .getPickingPositionFromDepth = function fn(mouse, target = new THREE.Vector3()) {
+                    const g = this.mainLoop.gfxEngine;
+                    const dim = g.getWindowSize();
+                    screen.copy(mouse || dim.clone().multiplyScalar(0.5));
+                    screen.x = Math.floor(screen.x);
+                    screen.y = Math.floor(screen.y);
+                    screen.x = ((screen.x / dim.x) * 2) - 1;
+                    screen.y = (-(screen.y / dim.y) * 2) + 1;
+                    raycaster.setFromCamera(screen, this.camera.camera3D);
+                    target.copy(ellipsoid.intersection(raycaster.ray));
 
-                return target;
-            };
+                    return target;
+                };
+        });
     });
-    return page;
-}
 
-describe('Camera utils with globe example', () => {
-    it('should set range like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
+    it('should set range like expected', async () => {
         const params = { range: 10000 };
         const result = await page.evaluate((p) => {
             const camera = view.camera.camera3D;
@@ -40,11 +35,8 @@ describe('Camera utils with globe example', () => {
         }, params);
 
         assert.ok(Math.abs(result - params.range) / params.range < 0.05);
-        page.close();
-        await page.close();
     });
-    it('should look at coordinate like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
+    it('should look at coordinate like expected', async () => {
         const params = { longitude: 60, latitude: 40 };
         const result = await page.evaluate((p) => {
             const coord = new itowns.Coordinates('EPSG:4326', p.longitude, p.latitude, 0);
@@ -54,25 +46,19 @@ describe('Camera utils with globe example', () => {
         }, params);
         assert.equal(Math.round(result._values[0]), params.longitude);
         assert.equal(Math.round(result._values[1]), params.latitude);
-        page.close();
-        await page.close();
     });
-    it('should tilt like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
-        const params = { tilt: 50 };
 
+    it('should tilt like expected', async () => {
+        const params = { tilt: 50 };
         const result = await page.evaluate((p) => {
             const camera = view.camera.camera3D;
             return itowns.CameraUtils.transformCameraToLookAtTarget(
                 view, camera, p).then(final => final.tilt);
         }, params);
         assert.equal(Math.round(result), params.tilt);
-        page.close();
-        await page.close();
     });
-    it('should heading like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
 
+    it('should heading like expected', async () => {
         const params = { heading: 170 };
         const result = await page.evaluate((p) => {
             const camera = view.camera.camera3D;
@@ -80,12 +66,9 @@ describe('Camera utils with globe example', () => {
                 view, camera, p).then(final => final.heading);
         }, params);
         assert.equal(Math.round(result), params.heading);
-        page.close();
-        await page.close();
     });
-    it('should heading, tilt, range and coordinate like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
 
+    it('should heading, tilt, range and coordinate like expected', async () => {
         const result = await page.evaluate(() => {
             const camera = view.camera.camera3D;
             const params = { heading: 17,
@@ -102,11 +85,9 @@ describe('Camera utils with globe example', () => {
         assert.equal(Math.round(result.final.coord._values[0]), result.params.coord._values[0]);
         assert.equal(Math.round(result.final.coord._values[1]), result.params.coord._values[1]);
         assert.equal(Math.round(result.final.range / 10000) * 10000, result.params.range);
-        page.close();
-        await page.close();
     });
-    it('should heading, tilt, range and coordinate like expected with animation (500ms)', async function _() {
-        const page = await newGlobePage.bind(this)();
+
+    it('should heading, tilt, range and coordinate like expected with animation (500ms)', async () => {
         const result = await page.evaluate(() => {
             const params = {
                 heading: 17,
@@ -126,8 +107,6 @@ describe('Camera utils with globe example', () => {
         assert.equal(Math.round(result.final.coord._values[0]), result.params.coord._values[0]);
         assert.equal(Math.round(result.final.coord._values[1]), result.params.coord._values[1]);
         assert.equal(Math.round(result.final.range / 1000) * 1000, result.params.range);
-        page.close();
-        await page.close();
     });
 });
 

--- a/test/examples/GlobeControls.js
+++ b/test/examples/GlobeControls.js
@@ -1,23 +1,18 @@
-/* global describe, it */
 const assert = require('assert');
 
 // global variables
-let page;
-let mouse;
 let middleWidth;
 let middleHeight;
-let initial;
 
-describe('GlobeControls with globe example', () => {
-    before(async function _() {
-        page = await browser.newPage();
-        await loadExample(page, `http://localhost:${itownsPort}/examples/globe.html`);
-        initial = await page.evaluate(() => {
+describe('GlobeControls with globe example', function _() {
+    before(async () => {
+        await loadExample(`http://localhost:${itownsPort}/examples/globe.html`, this.fullTitle());
+        await page.evaluate(() => {
             window.THREE = itowns.THREE;
-            const raycaster = new itowns.THREE.Raycaster();
-            const screen = new itowns.THREE.Vector2();
+            const raycaster = new THREE.Raycaster();
+            const screen = new THREE.Vector2();
             view
-                .getPickingPositionFromDepth = function fn(mouse, target = new itowns.THREE.Vector3()) {
+                .getPickingPositionFromDepth = function fn(mouse, target = new THREE.Vector3()) {
                     const g = view.mainLoop.gfxEngine;
                     const dim = g.getWindowSize();
                     const ellipsoid = new itowns.Ellipsoid(itowns.ellipsoidSizes);
@@ -31,37 +26,13 @@ describe('GlobeControls with globe example', () => {
 
                     return target;
                 };
-
-            const init = {
-                coord: view.controls.getLookAtCoordinate(),
-                heading: view.controls.getHeading(),
-                range: view.controls.getRange(),
-                tilt: view.controls.getTilt(),
-            };
-
-            return Promise.resolve(init);
         });
 
         middleWidth = await page.evaluate(() => window.innerWidth / 2);
         middleHeight = await page.evaluate(() => window.innerHeight / 2);
-        mouse = page.mouse;
     });
 
-    // reset page state without reloading one
-    afterEach(async function _() {
-        await page.evaluate((init) => {
-            init.coord = new itowns.Coordinates(init.coord.crs, init.coord._values[0], init.coord._values[1], init.coord._values[2]);
-            view.controls.lookAtCoordinate(init, false);
-            view.notifyChange();
-        }, initial);
-        await mouse.move(0, 0);
-    });
-    return page;
-}
-
-describe('GlobeControls with globe example', () => {
-    it('should move and then tilt, like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
+    it('should move and then tilt, like expected', async () => {
         const tilt = 45;
         const vCoord = { longitude: 22, latitude: 47 };
         const result = await page.evaluate((pTilt, vC) =>
@@ -101,10 +72,9 @@ describe('GlobeControls with globe example', () => {
         assert.ok(Math.abs(tilt - tilts[0]) < eps);
         assert.ok(Math.abs(tilt - tilts[1]) < eps);
         assert.ok(Math.abs(tilt - tilts[2]) < eps);
-        await page.close();
     });
-    it('should get same tilt with event, promise and getTilt, like expected', async function _() {
-        const page = await newGlobePage.bind(this)();
+
+    it('should get same tilt with event, promise and getTilt, like expected', async () => {
         const tilt = 45;
         const tilts = await page.evaluate(pTilt =>
             new Promise((resolve) => {
@@ -130,67 +100,61 @@ describe('GlobeControls with globe example', () => {
         assert.ok(Math.abs(tilt - tilts[0]) < 0.000001);
         assert.ok(Math.abs(tilt - tilts[1]) < 0.000001);
         assert.ok(Math.abs(tilt - tilts[2]) < 0.000001);
-        await page.close();
     });
-    it('should move like expected', async function _() {
+
+    it('should move like expected', async () => {
         await page.evaluate(() => {
             view.controls.enableDamping = false;
         });
 
-        await page.evaluate(() => { globeView.controls.enableDamping = false; });
-        const startCoord = await page.evaluate(() => globeView.controls.getLookAtCoordinate());
         const mouse = page.mouse;
-        await mouse.move(innerWidth / 2, innerHeight / 2);
+        await mouse.move(middleWidth, middleHeight);
         await mouse.down();
-        await mouse.move((innerWidth / 2) + 200, innerHeight / 2, { steps: 100 });
+        await mouse.move(middleWidth + 200, middleHeight, { steps: 100 });
         await mouse.up();
 
         const endCoord = await page.evaluate(() => view.controls.getLookAtCoordinate());
 
-        assert.ok((Math.round(initial.coord._values[0] - endCoord._values[0])) >= 74);
+        assert.ok((Math.round(initialPosition.coord._values[0] - endCoord._values[0])) >= 74);
     });
-    it('should zoom like expected with middle button', async function _() {
-        const page = await newGlobePage.bind(this)();
-        const innerWidth = await page.evaluate(() => window.innerWidth);
-        const innerHeight = await page.evaluate(() => window.innerHeight);
-        const startRange = await page.evaluate(() => globeView.controls.getRange());
+
+    it('should zoom like expected with middle button', async () => {
         const mouse = page.mouse;
-        await mouse.move(innerWidth / 2, innerHeight / 2);
+        await mouse.move(middleWidth, middleHeight);
         await mouse.down({ button: 'middle' });
-        await mouse.move(innerWidth / 2, (innerHeight / 2) - 200, { steps: 100 });
+        await mouse.move(middleWidth, (middleHeight) - 200, { steps: 100 });
         await mouse.up();
         const endRange = await page.evaluate(() => Promise.resolve(view.controls.getRange()));
-        assert.ok((initial.range - endRange) > 20000000);
+        assert.ok((initialPosition.range - endRange) > 20000000);
     });
-    it('should change tilt like expected', async function _() {
+
+    it('should change tilt like expected', async () => {
         await page.evaluate(() => { view.controls.enableDamping = false; });
         await page.keyboard.down('Control');
         const mouse = page.mouse;
-        await mouse.move(innerWidth / 2, innerHeight / 2);
+        await mouse.move(middleWidth, middleHeight);
         await mouse.down();
-        await mouse.move(innerWidth / 2, (innerHeight / 2) - 200, { steps: 100 });
+        await mouse.move(middleWidth, (middleHeight) - 200, { steps: 100 });
         await mouse.up();
         await page.keyboard.up('Control');
         const endTilt = await page.evaluate(() => view.controls.getTilt());
-        assert.ok(initial.tilt - endTilt > 43);
+        assert.ok(initialPosition.tilt - endTilt > 43);
     });
-    it('should change heading like expected', async function _() {
+
+    it('should change heading like expected', async () => {
         await page.evaluate(() => { view.controls.enableDamping = false; });
         await page.keyboard.down('Control');
         const mouse = page.mouse;
-        await mouse.move(innerWidth / 2, innerHeight / 2);
+        await mouse.move(middleWidth, middleHeight);
         await mouse.down();
-        await mouse.move((innerWidth / 2) - 50, (innerHeight / 2), { steps: 100 });
+        await mouse.move((middleWidth) - 50, (middleHeight), { steps: 100 });
         await mouse.up();
         await page.keyboard.up('Control');
         const endHeading = await page.evaluate(() => view.controls.getHeading());
-        assert.ok(Math.floor(initial.heading + endHeading) > 10);
+        assert.ok(Math.floor(initialPosition.heading + endHeading) > 10);
     });
-    it('should zoom like expected with double click', async function _() {
-        const page = await newGlobePage.bind(this)();
-        const innerWidth = await page.evaluate(() => window.innerWidth);
-        const innerHeight = await page.evaluate(() => window.innerHeight);
-        const start = await page.evaluate(() => globeView.controls.getRange());
+
+    it('should zoom like expected with double click', async () => {
         const end = page.evaluate(() =>
             new Promise((resolve) => {
                 const endAni = () => {
@@ -202,12 +166,11 @@ describe('GlobeControls with globe example', () => {
 
         await page.evaluate(() => { view.controls.enableDamping = false; });
         await page.mouse.click(middleWidth, middleHeight, { clickCount: 2, delay: 100 });
-        const result = await end.then(er => (initial.range * 0.6) - er);
+        const result = await end.then(er => (initialPosition.range * 0.6) - er);
         assert.ok(Math.abs(result) < 100);
-
-        await page.close();
     });
-    it('should zoom like expected with mouse wheel', async function _() {
+
+    it('should zoom like expected with mouse wheel', async () => {
         await page.evaluate(() => { view.controls.enableDamping = false; });
         await page.mouse.move(middleWidth, middleHeight);
         const finalRange = await page.evaluate(() =>
@@ -224,8 +187,7 @@ describe('GlobeControls with globe example', () => {
                     .dispatchEvent(wheelEvent, document);
                 window.dispatchEvent(wheelEvent, document);
             }));
-        assert.ok(initRange - finalRange > 2000000);
-        await page.close();
+        assert.ok(initialPosition.range - finalRange > 2000000);
     });
 });
 

--- a/test/examples/bootstrap.js
+++ b/test/examples/bootstrap.js
@@ -104,8 +104,8 @@ before(async () => {
                 if (typeof (view) === 'object') {
                     return Promise.resolve(view);
                 }
-                if (typeof (globeView) === 'object') {
-                    return Promise.resolve(globeView);
+                if (typeof (view) === 'object') {
+                    return Promise.resolve(view);
                 }
                 resolve(false);
                 return Promise.reject();

--- a/test/examples/collada.js
+++ b/test/examples/collada.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('collada', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/collada.html`,
-            this.test.fullTitle());
+describe('collada', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/collada.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/cubic_planar.js
+++ b/test/examples/cubic_planar.js
@@ -1,17 +1,14 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('cubic_planar', () => {
-    it('should run', async function _() {
+describe('cubic_planar', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/cubic_planar.html`, this.fullTitle());
+    });
+
+    it('should run', async () => {
         // This test hangs up one time out of three, so retry it 2 times
-        this.retries(2);
-
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/cubic_planar.html`,
-            this.test.fullTitle());
-
+        // this.retries(2);
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/globe.js
+++ b/test/examples/globe.js
@@ -19,7 +19,7 @@ describe('globe', () => {
             this.test.fullTitle());
 
         const level = await page.evaluate(() =>
-            globeView.pickObjectsAt(
+            view.pickObjectsAt(
                 { x: 221, y: 119 })[0].object.level);
 
         assert.equal(2, level);
@@ -32,10 +32,10 @@ describe('globe', () => {
             this.test.fullTitle());
 
         const maxColorSamplerUnitsCount = await page
-            .evaluate(type => globeView.tileLayer.level0Nodes[0]
+            .evaluate(type => view.tileLayer.level0Nodes[0]
                 .material.textures[type].length, 1);
         const colorSamplerUnitsCount = await page.evaluate(() =>
-                globeView.tileLayer.countColorLayersTextures(globeView.getLayers(l => l.type === 'color')[0]));
+                view.tileLayer.countColorLayersTextures(view.getLayers(l => l.type === 'color')[0]));
         const limit = maxColorSamplerUnitsCount - colorSamplerUnitsCount;
 
         // add layers just below the capacity limit
@@ -45,7 +45,7 @@ describe('globe', () => {
                 for (let i = 0; i < maxLayersCount; i++) {
                     const layerParams = Object.assign({}, params);
                     layerParams.id = `${layerParams.id}_${i}`;
-                    promises.push(globeView.addLayer(layerParams));
+                    promises.push(view.addLayer(layerParams));
                 }
                 return Promise.all(promises).then(() => true).catch(() => false);
             }), limit);
@@ -56,7 +56,7 @@ describe('globe', () => {
             itowns.Fetcher.json('./layers/JSONLayers/OrthosCRS.json').then((params) => {
                 const layerParams = Object.assign({}, params);
                 layerParams.id = 'max';
-                return globeView.addLayer(layerParams).then(() => false).catch(() => true);
+                return view.addLayer(layerParams).then(() => false).catch(() => true);
             }));
 
         assert.ok(underLimit);
@@ -70,8 +70,8 @@ describe('globe', () => {
             `http://localhost:${itownsPort}/examples/globe.html`,
             this.test.fullTitle());
 
-        const error = await page.evaluate(() => itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(globeView.addLayer).catch(() => true));
-        const colorLayersCount = await page.evaluate(() => globeView.getLayers(l => l.type === 'color').length);
+        const error = await page.evaluate(() => itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(view.addLayer).catch(() => true));
+        const colorLayersCount = await page.evaluate(() => view.getLayers(l => l.type === 'color').length);
 
         assert.ok(error && colorLayersCount === 1);
         page.close();

--- a/test/examples/globe.js
+++ b/test/examples/globe.js
@@ -1,36 +1,29 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('globe', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe.html`,
-            this.test.fullTitle());
-
-        assert.ok(result);
-        await page.close();
+describe('globe', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/globe.html`, this.fullTitle());
     });
 
-    it('should return the correct tile', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe.html`,
-            this.test.fullTitle());
+    it('should run', async () => {
+        assert.ok(result);
+    });
 
+    it('should return the correct tile', async () => {
         const level = await page.evaluate(() =>
             view.pickObjectsAt(
                 { x: 221, y: 119 })[0].object.level);
 
         assert.equal(2, level);
-        await page.close();
     });
-    it('should not add layers beyond the capabilities', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe.html`,
-            this.test.fullTitle());
+    it('should not add layer with id already used', async () => {
+        const error = await page.evaluate(() => itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(view.addLayer).catch(() => true));
+        const colorLayersCount = await page.evaluate(() => view.getLayers(l => l.type === 'color').length);
 
+        assert.ok(error && colorLayersCount === 1);
+    });
+    it('should not add layers beyond the capabilities', async () => {
         const maxColorSamplerUnitsCount = await page
             .evaluate(type => view.tileLayer.level0Nodes[0]
                 .material.textures[type].length, 1);
@@ -61,20 +54,5 @@ describe('globe', () => {
 
         assert.ok(underLimit);
         assert.ok(errorOverLimit);
-        await page.close();
-    });
-    it('should not add layer with id already used', async function _() {
-        const page = await browser.newPage();
-
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe.html`,
-            this.test.fullTitle());
-
-        const error = await page.evaluate(() => itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(view.addLayer).catch(() => true));
-        const colorLayersCount = await page.evaluate(() => view.getLayers(l => l.type === 'color').length);
-
-        assert.ok(error && colorLayersCount === 1);
-        page.close();
-        await page.close();
     });
 });

--- a/test/examples/globe_geojson_to3D.js
+++ b/test/examples/globe_geojson_to3D.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('globe geojson to3D', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe_geojson_to3D.html`,
-            this.test.fullTitle());
+describe('globe geojson to3D', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/globe_geojson_to3D.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/globe_vector.js
+++ b/test/examples/globe_vector.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('globe_vector', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe_vector.html`,
-            this.test.fullTitle());
+describe('globe_vector', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/globe_vector.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/globe_vector_tiles.js
+++ b/test/examples/globe_vector_tiles.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('globe_vector_tiles', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe_vector_tiles.html`,
-            this.test.fullTitle());
+describe('globe_vector_tiles', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/globe_vector_tiles.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/globe_wfs_color.js
+++ b/test/examples/globe_wfs_color.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('globe_wfs_color', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe_wfs_color.html`,
-            this.test.fullTitle());
+describe('globe_wfs_color', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/globe_wfs_color.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/globe_wfs_extruded.js
+++ b/test/examples/globe_wfs_extruded.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('globe_wfs_extruded', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/globe_wfs_extruded.html`,
-            this.test.fullTitle());
+describe('globe_wfs_extruded', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/globe_wfs_extruded.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/gpx.js
+++ b/test/examples/gpx.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('gpx', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/gpx.html`,
-            this.test.fullTitle());
+describe('gpx', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/gpx.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/layersColorVisible.js
+++ b/test/examples/layersColorVisible.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('layersColorVisible', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/layersColorVisible.html`,
-            this.test.fullTitle());
+describe('layersColorVisible', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/layersColorVisible.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/multiglobe.js
+++ b/test/examples/multiglobe.js
@@ -29,7 +29,7 @@ describe('multiglobe', () => {
 
         // verify that we properly updated the globe
         const { layer, level } = await page.evaluate(() => {
-            const pick = globeView.pickObjectsAt({ x: 200, y: 150 })[0];
+            const pick = view.pickObjectsAt({ x: 200, y: 150 })[0];
             return {
                 layer: pick.layer.id,
                 level: pick.object.level,

--- a/test/examples/multiglobe.js
+++ b/test/examples/multiglobe.js
@@ -1,22 +1,16 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('multiglobe', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/multiglobe.html`,
-            this.test.fullTitle());
-
-        assert.ok(result);
-        await page.close();
+describe('multiglobe', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/multiglobe.html`, this.fullTitle());
     });
 
-    it('zoom and check that the level is correct', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/multiglobe.html`);
+    it('should run', async () => {
+        assert.ok(result);
+    });
 
+    it('zoom and check that the level is correct', async function __() {
         // press-space and zoom in
         await page.evaluate(() => {
             onKeyPress({ keyCode: 32 });
@@ -25,7 +19,7 @@ describe('multiglobe', () => {
             }
         });
 
-        await waitUntilItownsIsIdle(page, this.test.fullTitle());
+        await waitUntilItownsIsIdle(this.test.fullTitle());
 
         // verify that we properly updated the globe
         const { layer, level } = await page.evaluate(() => {
@@ -38,6 +32,5 @@ describe('multiglobe', () => {
 
         assert.equal('globe2', layer);
         assert.equal(8, level);
-        await page.close();
     });
 });

--- a/test/examples/oriented_images.js
+++ b/test/examples/oriented_images.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('oriented_images', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/oriented_images.html`,
-            this.test.fullTitle());
+describe('oriented_images', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/oriented_images.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/orthographic.js
+++ b/test/examples/orthographic.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('orthographic', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/orthographic.html`,
-            this.test.fullTitle());
+describe('orthographic', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/orthographic.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/panorama.js
+++ b/test/examples/panorama.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('panorama', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/panorama.html`,
-            this.test.fullTitle());
+describe('panorama', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/panorama.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/planar.js
+++ b/test/examples/planar.js
@@ -1,23 +1,16 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('planar', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/planar.html`,
-            this.test.fullTitle());
-
-        assert.ok(result);
-        await page.close();
+describe('planar', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/planar.html`, this.fullTitle());
     });
-    it('should get picking position from depth', async function _() {
-        const page = await browser.newPage();
 
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/planar.html`,
-            this.test.fullTitle());
+    it('should run', async () => {
+        assert.ok(result);
+    });
 
+    it('should get picking position from depth', async function __() {
         const length = 1500;
 
         // get range with depth buffer and altitude
@@ -30,9 +23,9 @@ describe('planar', () => {
             view.notifyChange(view.camera.camera3D, true);
         }, length);
 
-        await waitUntilItownsIsIdle(page, this.test.fullTitle());
+        await waitUntilItownsIsIdle(this.test.fullTitle());
 
-        const result = await page.evaluate(() => {
+        result = await page.evaluate(() => {
             const depthMethod = view
                 .getPickingPositionFromDepth().distanceTo(view.camera.camera3D.position);
 
@@ -45,6 +38,5 @@ describe('planar', () => {
         const theoricalRange = length - result.altitude;
         const diffRange = Math.abs(theoricalRange - result.depthMethod);
         assert.ok(diffRange < 2);
-        await page.close();
     });
 });

--- a/test/examples/planar_vector.js
+++ b/test/examples/planar_vector.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('planar_vector', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/planar_vector.html`,
-            this.test.fullTitle());
+describe('planar_vector', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/planar_vector.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/planar_vector_tiles.js
+++ b/test/examples/planar_vector_tiles.js
@@ -1,15 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('planar_vector_tiles', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
+describe('planar_vector_tiles', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/planar_vector_tiles.html`, this.fullTitle());
+    });
 
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/planar_vector_tiles.html`,
-            this.test.fullTitle());
-
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/pointcloud.js
+++ b/test/examples/pointcloud.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('pointcloud', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/pointcloud.html`,
-            this.test.fullTitle());
+describe('pointcloud', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/pointcloud.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/pointcloud_globe.js
+++ b/test/examples/pointcloud_globe.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('pointcloud_globe', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/pointcloud_globe.html`,
-            this.test.fullTitle());
+describe('pointcloud_globe', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/pointcloud_globe.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/positionGlobe.js
+++ b/test/examples/positionGlobe.js
@@ -1,23 +1,16 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('positionGlobe', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/positionGlobe.html`,
-            this.test.fullTitle());
-
-        assert.ok(result);
-        await page.close();
+describe('positionGlobe', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/positionGlobe.html`, this.fullTitle());
     });
 
-    it('bug #747', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/positionGlobe.html`,
-            this.test.fullTitle());
+    it('should run', async () => {
+        assert.ok(result);
+    });
 
+    it('bug #747', async () => {
         // wait cone creation
         await page.evaluate(() =>
             new Promise((resolve) => {
@@ -54,16 +47,8 @@ describe('positionGlobe', () => {
         });
 
         assert.deepEqual(value.visible, value.hidden);
-
-        await page.close();
     });
-    it('should get picking position from depth', async function _() {
-        const page = await browser.newPage();
-
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/positionGlobe.html`,
-            this.test.fullTitle());
-
+    it('should get picking position from depth', async () => {
         // wait mesh creation
         await page.evaluate(() =>
             new Promise((resolve) => {
@@ -100,7 +85,5 @@ describe('positionGlobe', () => {
 
         assert.ok(Math.abs(controlsMethod - destRange) < 2);
         assert.ok(Math.abs(depthMethod - destRange) < 2);
-
-        await page.close();
     });
 });

--- a/test/examples/positionGlobe.js
+++ b/test/examples/positionGlobe.js
@@ -21,14 +21,14 @@ describe('positionGlobe', () => {
         // wait cone creation
         await page.evaluate(() =>
             new Promise((resolve) => {
-                globeView.addFrameRequester('after_render', () => {
-                    if (globeView.mesh) {
+                view.addFrameRequester('after_render', () => {
+                    if (view.mesh) {
                         resolve();
                     } else {
-                        globeView.notifyChange();
+                        view.notifyChange();
                     }
                 });
-                globeView.notifyChange();
+                view.notifyChange();
             }));
 
         const value = await page.evaluate(() => {
@@ -37,16 +37,16 @@ describe('positionGlobe', () => {
 
             // compute the on screen cone position
             const coneCenter = new itowns.THREE.Vector3(0, 0, 0)
-                .applyMatrix4(globeView.mesh.matrixWorld);
-            coneCenter.applyMatrix4(globeView.camera._viewMatrix);
-            const mouse = globeView.normalizedToViewCoords(coneCenter);
+                .applyMatrix4(view.mesh.matrixWorld);
+            coneCenter.applyMatrix4(view.camera._viewMatrix);
+            const mouse = view.normalizedToViewCoords(coneCenter);
 
             // So read the depth buffer at cone's position
-            const valueVisible = globeView.readDepthBuffer(mouse.x, mouse.y, 1, 1);
+            const valueVisible = view.readDepthBuffer(mouse.x, mouse.y, 1, 1);
 
             // Then hide the cone, and re-read the value
-            globeView.mesh.material.visible = false;
-            const valueHidden = globeView.readDepthBuffer(mouse.x, mouse.y, 1, 1);
+            view.mesh.material.visible = false;
+            const valueHidden = view.readDepthBuffer(mouse.x, mouse.y, 1, 1);
 
             // Both should be equal, since currently readDepthBuffer only
             // supports special materials (see RendererConstant.DEPTH)
@@ -67,36 +67,36 @@ describe('positionGlobe', () => {
         // wait mesh creation
         await page.evaluate(() =>
             new Promise((resolve) => {
-                globeView.addFrameRequester('after_render', () => {
-                    if (globeView.mesh) {
+                view.addFrameRequester('after_render', () => {
+                    if (view.mesh) {
                         resolve();
                     } else {
-                        globeView.notifyChange();
+                        view.notifyChange();
                     }
                 });
-                globeView.notifyChange();
+                view.notifyChange();
             }));
 
         // Hide cone the cone and set range
         const destRange = 1500;
         await page.evaluate((range) => {
-            globeView.mesh.material.visible = false;
-            globeView.controls.setRange(range);
+            view.mesh.material.visible = false;
+            view.controls.setRange(range);
         }, destRange);
 
         // wait camera'transformation and get range value with globeControls method
         const controlsMethod = await page.evaluate(() =>
             new Promise((resolve) => {
                 const endAni = () => {
-                    globeView.controls.removeEventListener('animation-ended', endAni);
-                    resolve(globeView.controls.getRange());
+                    view.controls.removeEventListener('animation-ended', endAni);
+                    resolve(view.controls.getRange());
                 };
-                globeView.controls.addEventListener('animation-ended', endAni);
+                view.controls.addEventListener('animation-ended', endAni);
             }));
 
         // get range with depth buffer
-        const depthMethod = await page.evaluate(() => globeView
-            .getPickingPositionFromDepth().distanceTo(globeView.camera.camera3D.position));
+        const depthMethod = await page.evaluate(() => view
+            .getPickingPositionFromDepth().distanceTo(view.camera.camera3D.position));
 
         assert.ok(Math.abs(controlsMethod - destRange) < 2);
         assert.ok(Math.abs(depthMethod - destRange) < 2);

--- a/test/examples/postprocessing.js
+++ b/test/examples/postprocessing.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('postprocessing', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/postprocessing.html`,
-            this.test.fullTitle());
+describe('postprocessing', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/postprocessing.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/split.js
+++ b/test/examples/split.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('split', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/split.html`,
-            this.test.fullTitle());
+describe('split', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/split.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/stereo.js
+++ b/test/examples/stereo.js
@@ -1,14 +1,12 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('stereo', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/stereo.html`,
-            this.test.fullTitle());
+describe('stereo', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/stereo.html`, this.fullTitle());
+    });
 
+    it('should run', async () => {
         assert.ok(result);
-        await page.close();
     });
 });

--- a/test/examples/wfs.js
+++ b/test/examples/wfs.js
@@ -1,26 +1,18 @@
-/* global browser, itownsPort */
 const assert = require('assert');
 
-describe('wfs', () => {
-    it('should run', async function _() {
-        const page = await browser.newPage();
-        const result = await loadExample(page,
-            `http://localhost:${itownsPort}/examples/wfs.html`,
-            this.test.fullTitle());
-
-        assert.ok(result);
-        await page.close();
+describe('wfs', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(`http://localhost:${itownsPort}/examples/wfs.html`, this.fullTitle());
     });
 
-    it('should pick the correct building', async function _() {
-        const page = await browser.newPage();
-        await loadExample(page,
-            `http://localhost:${itownsPort}/examples/wfs.html`,
-            this.test.fullTitle());
+    it('should run', async () => {
+        assert.ok(result);
+    });
 
+    it('should pick the correct building', async () => {
         // test picking
         const buildingId = await page.evaluate(() => picking({ x: 342, y: 243 }).properties.id);
         assert.equal(buildingId, 'bati_indifferencie.5751442');
-        await page.close();
     });
 });


### PR DESCRIPTION
The current way of testing the example is relatively slow: for each test (`it`), we are creating and loading a new page. For tests on the same example, it doesn't make sense to reload it each time.

So what I'm proposing here is keeping the same page for a same test file. Some states are restored after each test, like the position on the view and the position of the mouse.

On my computer, I'm going from 9'14" to 4'31" in test time, so it is a clear benefit, and we won't have to wait a lot of time when doing a pull request and waiting for CI.

The first commit of this PR also changes all `globeView` variables in examples to `view`.