### PR TITLE
material to make projective texture from cameras

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -47,6 +47,8 @@
 
             "src/Provider/URLBuilder.js",
 
+            "src/Renderer/OrientedImageMaterial.js",
+
             "src/Renderer/ColorLayersOrdering.js",
             "src/Renderer/ThreeExtended/OBB.js",
             "src/Renderer/OrientedImageCamera.js",

--- a/src/Renderer/OrientedImageMaterial.js
+++ b/src/Renderer/OrientedImageMaterial.js
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+import textureVS from './Shader/ProjectiveTextureVS.glsl';
+import textureFS from './Shader/ProjectiveTextureFS.glsl';
+import ShaderUtils from './Shader/ShaderUtils';
+import Capabilities from '../Core/System/Capabilities';
+
+var ndcToTextureMatrix = new THREE.Matrix4().set(
+    1, 0, 0, 1,
+    0, 1, 0, 1,
+    0, 0, 2, 0,
+    0, 0, 0, 2);
+
+/**
+ * @classdesc OrientedImageMaterial is a custom shader material used to do projective texture mapping.<br/>
+ *
+ * This Material is designed to project many textures simultaneously.
+ * Each projected texture setting is stored as an {@link OrientedImageCamera}.<br/>
+ * <br/>
+ * All cameras settings, like distorsion, can be specified in a configuration file.
+ * See [CameraCalibrationParser]{@link module:CameraCalibrationParser.parse}
+ * used to parse a configuration file and create an array of camera.<br/>
+ * <br/>
+ * The current implementation supports the following distortion models : <br/>
+ *  - no distortion (polynom==vec3(0),l1l2==vec2(0))<br/>
+ *  - radial distortion (polynom!=vec3(0),l1l2==vec2(0)) (see <b>15.2.2 Radial Model</b> in {@link https://github.com/micmacIGN/Documentation/blob/master/DocMicMac.pdf|MicMac doc}) </br>
+ *  - equilinear fish eye distortion (polynom!=vec3(0),l1l2 != vec2(0)) (see <b>15.3.4 Fish eye models</b> in {@link https://github.com/micmacIGN/Documentation/blob/master/DocMicMac.pdf|MicMac doc}) </br>
+ * (Note: radial decentric parameters P1 are P2 not supported and assumed to be 0).<br/>
+ * <br/>
+ * To get a more comprehensive support of camera Micmac models, you can consider using {@link https://github.com/mbredif/three-photogrammetric-camera|three-photogrammetric-camera} instead.
+ */
+class OrientedImageMaterial extends THREE.RawShaderMaterial {
+    /**
+     * @constructor
+     * @param { OrientedImageCamera[]} cameras - Array of {@link OrientedImageCamera}. Each camera will project a texture.
+     * [CameraCalibrationParser]{@link module:CameraCalibrationParser.parse} can used to create this array of camera from a configuration file.
+     * @param {Object} [options={}] - Object with one or more properties defining the material's appearance.
+     * Any property of the material (including any property inherited from
+     * {@link https://threejs.org/docs/#api/en/materials/Material|THREE.Material} and
+     * {@link https://threejs.org/docs/#api/en/materials/ShaderMaterial|THREE.ShaderMaterial}) can be passed in here.
+     * @param {Number} [options.side=THREE.DoubleSide] - We override default
+     * {@link https://threejs.org/docs/#api/en/materials/Material.side|THREE.Material.side} from FrontSide to DoubleSide.
+     * @param {Boolean} [options.transparent=true] - We override default
+     * {@link https://threejs.org/docs/#api/en/materials/Material.transparent|THREE.Material.transparent} from false to true.
+     * @param {Number} [options.opacity=0.1] - We override default
+     * {@link https://threejs.org/docs/#api/en/materials/Material.opacity|THREE.Material.opacity} from 1 to 0.1.
+     * @param {Number} [options.alphaBorder=20] - Part of the texture that is blended, when texture crosses each other.
+     * For example, 10 means a border as large as 1 / 10 of the size of the texture is used to blend colors.
+     * @param {Number} [options.debugAlphaBorder=0] - Set this option to 1 to see influence of alphaBorder option.
+     */
+    constructor(cameras, options = {}) {
+        options.side = options.side !== undefined ? options.side : THREE.DoubleSide;
+        options.transparent = options.transparent !== undefined ? options.transparent : true;
+        options.opacity = options.opacity !== undefined ? options.opacity : 0.1;
+        super(options);
+
+        this.defines.NUM_TEXTURES = cameras.length;
+
+        // verify that number of textures doesn't exceed GPU capabilities
+        const maxTexturesUnits = Capabilities.getMaxTextureUnitsCount();
+        if (this.defines.NUM_TEXTURES > maxTexturesUnits) {
+            console.warn(`OrientedImageMaterial: Can't project ${cameras.length} textures, because it's more than GPU capabilities maximum texture units (${maxTexturesUnits})`);
+
+            // Clamp number of textures used
+            this.defines.NUM_TEXTURES = maxTexturesUnits - 1;
+            console.warn(`OrientedImageMaterial: We'll use only the first ${this.defines.NUM_TEXTURES} cameras.`);
+        }
+
+        this.defines.USE_DISTORTION = Number(cameras.some(camera => camera.distortion !== undefined));
+        this.alphaBorder = options.alphaBorder | 20;
+        this.defines.DEBUG_ALPHA_BORDER = options.debugAlphaBorder | 0;
+        this.cameras = cameras;
+        const textureMatrix = [];
+        const texture = [];
+        const distortion = [];
+        this.group = new THREE.Group();
+
+        for (let i = 0; i < this.defines.NUM_TEXTURES; ++i) {
+            const camera = cameras[i];
+            camera.needsUpdate = true;
+            camera.textureMatrix = new THREE.Matrix4();
+            camera.textureMatrixWorldInverse = new THREE.Matrix4();
+            textureMatrix[i] = new THREE.Matrix4();
+            texture[i] = new THREE.Texture();
+            distortion[i] = {};
+            distortion[i].size = camera.size;
+            if (camera.distortion) {
+                distortion[i].polynom = camera.distortion.polynom;
+                distortion[i].pps = camera.distortion.pps;
+                distortion[i].l1l2 = camera.distortion.l1l2;
+            }
+            this.group.add(camera);
+        }
+
+        this.uniforms.projectiveTextureAlphaBorder = new THREE.Uniform(this.alphaBorder);
+        this.uniforms.projectiveTextureDistortion = new THREE.Uniform(distortion);
+        this.uniforms.projectiveTextureMatrix = new THREE.Uniform(textureMatrix);
+        this.uniforms.projectiveTexture = new THREE.Uniform(texture);
+
+        if (Capabilities.isLogDepthBufferSupported()) {
+            this.defines.USE_LOGDEPTHBUF = 1;
+            this.defines.USE_LOGDEPTHBUF_EXT = 1;
+        }
+
+        this.vertexShader = textureVS;
+        this.fragmentShader = ShaderUtils.unrollLoops(textureFS, this.defines);
+    }
+
+    /**
+     * Set new textures and new position/orientation of the camera set.
+     * @param {THREE.Texture} textures - Array of {@link https://threejs.org/docs/#api/en/textures/Texture|THREE.Texture}.
+     * @param {Object} feature - New position / orientation of the set of cameras
+     * @param {THREE.Vector3} feature.position - New position.
+     * @param {THREE.Quaternion} feature.quaternion - New orientation.
+     */
+    setTextures(textures, feature) {
+        if (!textures) { return; }
+        this.group.position.copy(feature.position);
+        this.group.quaternion.copy(feature.quaternion);
+        this.group.updateMatrixWorld(true); // update the matrixWorldInverse of the cameras
+
+        for (let i = 0; i < textures.length && i < this.defines.NUM_TEXTURES; ++i) {
+            var oldTexture = this.uniforms.projectiveTexture.value[i];
+            this.uniforms.projectiveTexture.value[i] = textures[i];
+            if (oldTexture) {
+                oldTexture.dispose();
+            }
+            this.cameras[i].needsUpdate = true;
+        }
+    }
+
+    /**
+     * Udate the uniforms using the current value of camera.matrixWorld.
+     * Need to be called when the camera of the scene has changed.
+     * @param {THREE.Camera} viewCamera - Camera of the scene.
+     */
+    updateUniforms(viewCamera) {
+        for (var i = 0; i < this.defines.NUM_TEXTURES; ++i) {
+            const camera = this.cameras[i];
+            if (camera.needsUpdate) {
+                camera.updateMatrixWorld(true);
+                camera.textureMatrix.multiplyMatrices(ndcToTextureMatrix, camera.projectionMatrix);
+                camera.textureMatrixWorldInverse.multiplyMatrices(camera.textureMatrix, camera.matrixWorldInverse);
+                camera.needsUpdate = false;
+            }
+            this.uniforms.projectiveTextureMatrix.value[i].multiplyMatrices(camera.textureMatrixWorldInverse, viewCamera.matrixWorld);
+        }
+    }
+}
+
+export default OrientedImageMaterial;

--- a/src/Renderer/Shader/Chunk/project_pars_vertex.glsl
+++ b/src/Renderer/Shader/Chunk/project_pars_vertex.glsl
@@ -1,0 +1,3 @@
+attribute vec3 position;
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;

--- a/src/Renderer/Shader/Chunk/projective_texturing_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/projective_texturing_pars_fragment.glsl
@@ -1,0 +1,74 @@
+uniform sampler2D projectiveTexture[NUM_TEXTURES];
+varying vec4      projectiveTextureCoords[NUM_TEXTURES];
+uniform float     projectiveTextureAlphaBorder;
+
+struct Distortion {
+    vec2 size;
+#if USE_DISTORTION
+    vec2 pps;
+    vec4 polynom;
+    vec3 l1l2;
+#endif
+};
+
+uniform Distortion projectiveTextureDistortion[NUM_TEXTURES];
+
+float getAlphaBorder(vec2 p)
+{
+    vec2 d = clamp(projectiveTextureAlphaBorder * min(p, 1. - p), 0., 1.);
+    return min(d.x, d.y);
+}
+
+#if USE_DISTORTION
+void distort(inout vec2 p, vec4 polynom, vec2 pps)
+{
+    vec2 v = p - pps;
+    float v2 = dot(v, v);
+    if (v2 > polynom.w) {
+        p = vec2(-1.);
+    }
+    else {
+        p += (v2 * (polynom.x + v2 * (polynom.y + v2 * polynom.z) ) ) * v;
+    }
+}
+
+void distort(inout vec2 p, vec4 polynom, vec3 l1l2, vec2 pps)
+{ 
+    if ((l1l2.x == 0.) && (l1l2.y == 0.)) {
+        distort(p, polynom, pps);
+    } else {
+        vec2 AB = (p - pps) / l1l2.z;
+        float R = length(AB);
+        float lambda = atan(R) / R;
+        vec2 ab = lambda * AB;
+        float rho2 = dot(ab, ab);
+        float r357 = 1. + rho2* (polynom.x + rho2* (polynom.y + rho2 * polynom.z));
+        p = pps + l1l2.z * (r357 * ab + vec2(dot(l1l2.xy, ab), l1l2.y * ab.x));
+    }
+}
+#endif
+
+vec4 projectiveTextureColor(vec4 coords, Distortion distortion, sampler2D texture)
+{
+    vec3 p = coords.xyz / coords.w;
+    if(p.z * p.z < 1.) {
+#if USE_DISTORTION
+        p.xy *= distortion.size;
+        distort(p.xy, distortion.polynom, distortion.l1l2, distortion.pps);
+        p.xy /= distortion.size;
+#endif
+
+        float d = getAlphaBorder(p.xy);
+        if(d > 0.) {
+
+#if DEBUG_ALPHA_BORDER
+            vec3 r = texture2D(texture, p.xy).rgb;
+            return vec4( r.r * d, r.g, r.b, 1.0);
+#else
+            return d * texture2D(texture, p.xy);
+#endif
+
+        }
+    }
+    return vec4(0.);
+}

--- a/src/Renderer/Shader/Chunk/projective_texturing_pars_vertex.glsl
+++ b/src/Renderer/Shader/Chunk/projective_texturing_pars_vertex.glsl
@@ -1,0 +1,2 @@
+uniform mat4 projectiveTextureMatrix[NUM_TEXTURES];
+varying vec4 projectiveTextureCoords[NUM_TEXTURES];

--- a/src/Renderer/Shader/Chunk/projective_texturing_vertex.glsl
+++ b/src/Renderer/Shader/Chunk/projective_texturing_vertex.glsl
@@ -1,0 +1,2 @@
+for(int i = 0; i < NUM_TEXTURES; ++i)
+    projectiveTextureCoords[i] = projectiveTextureMatrix[i] * mvPosition;

--- a/src/Renderer/Shader/ProjectiveTextureFS.glsl
+++ b/src/Renderer/Shader/ProjectiveTextureFS.glsl
@@ -1,0 +1,19 @@
+#include <itowns/precision_qualifier>
+#include <logdepthbuf_pars_fragment>
+#include <itowns/projective_texturing_pars_fragment>
+
+void main(void)
+{
+    #include <logdepthbuf_fragment>
+
+    vec4 color  = vec4(0.);
+
+    #pragma unroll_loop
+    for ( int i = 0; i < NUM_TEXTURES; i ++ ) {
+        color += projectiveTextureColor(projectiveTextureCoords[ i ], projectiveTextureDistortion[ i ], projectiveTexture[ i ]);
+    }
+
+    if (color.a > 0.0) color /= color.a;
+    color.a = 1.;
+    gl_FragColor = color;
+}

--- a/src/Renderer/Shader/ProjectiveTextureVS.glsl
+++ b/src/Renderer/Shader/ProjectiveTextureVS.glsl
@@ -1,0 +1,11 @@
+#include <itowns/precision_qualifier>
+#include <itowns/project_pars_vertex>
+#include <itowns/projective_texturing_pars_vertex>
+#include <logdepthbuf_pars_vertex>
+
+void main() {
+    #include <begin_vertex>
+    #include <project_vertex>
+    #include <itowns/projective_texturing_vertex>
+    #include <logdepthbuf_vertex>
+}

--- a/src/Renderer/Shader/ShaderChunk.js
+++ b/src/Renderer/Shader/ShaderChunk.js
@@ -2,10 +2,18 @@ import * as THREE from 'three';
 
 import pitUV from './Chunk/pitUV.glsl';
 import precision_qualifier from './Chunk/precision_qualifier.glsl';
+import project_pars_vertex from './Chunk/project_pars_vertex.glsl';
+import projective_texturing_vertex from './Chunk/projective_texturing_vertex.glsl';
+import projective_texturing_pars_vertex from './Chunk/projective_texturing_pars_vertex.glsl';
+import projective_texturing_pars_fragment from './Chunk/projective_texturing_pars_fragment.glsl';
 
 const ShaderChunk = {
     pitUV,
     precision_qualifier,
+    projective_texturing_vertex,
+    projective_texturing_pars_vertex,
+    projective_texturing_pars_fragment,
+    project_pars_vertex,
 };
 
 /**


### PR DESCRIPTION
## Description
feat(OrientedImageMaterial): Material used to compute projective texture
The material is created with a set of cameras.
It supports distortion.

## Motivation and Context
Long-term goal : Immersive view
