### PR TITLE
Refacto geojson parsing and converting features

### DIFF
--- a/examples/globe_wfs_color.html
+++ b/examples/globe_wfs_color.html
@@ -53,7 +53,7 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
 
             function isValidData(data) {
-                return data.features.length < 1000;
+                return data.features[0].geometry.length < 1000;
             }
 
             view.addLayer({

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -55,29 +55,29 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addLayerCb);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addLayerCb);
 
+            var color = new itowns.THREE.Color();
+            var tile;
             function altitudeLine(properties, contour) {
-                var altitudes = [];
-                var i = 0;
                 var result;
-                var tile;
-                var layer = view.tileLayer;
-                if (contour.length && contour.length > 0) {
-                    for (; i < contour.length; i++) {
-                        result = itowns.DEMUtils.getElevationValueAt(layer, contour[i], 0, tile);
-                        if (!result) {
-                            result = itowns.DEMUtils.getElevationValueAt(layer, contour[i], 0);
-                        }
-                        tile = [result.tile];
-                        altitudes.push(result.z + 2);
+                var z = 0;
+                if (contour) {
+                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0, tile);
+                    if (!result) {
+                        result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0);
                     }
-                    return altitudes;
+                    tile = [result.tile];
+                    if (result) {
+                        z = result.z;
+                    }
+                    return z + 5;
                 }
-                return 0;
             }
 
             function colorLine(properties) {
-                var rgb = properties.couleur.split(' ');
-                return new itowns.THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+                if (properties) {
+                    var rgb = properties.couleur.split(' ');
+                    return color.setRGB(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+                }
             }
 
             function acceptFeatureBus(properties) {
@@ -113,17 +113,16 @@
                     },
                     zoom: { min: 9, max: 9 },
                     format: 'geojson',
-                    networkOptions: { crossOrigin: 'anonymous' },
                 }
             });
 
             function colorBuildings(properties) {
                 if (properties.id.indexOf('bati_remarquable') === 0) {
-                    return new itowns.THREE.Color(0x5555ff);
+                    return color.set(0x5555ff);
                 } else if (properties.id.indexOf('bati_industriel') === 0) {
-                    return new itowns.THREE.Color(0xff5555);
+                    return color.set(0xff5555);
                 }
-                return new itowns.THREE.Color(0xeeeeee);
+                return color.set(0xeeeeee);
             }
 
             function altitudeBuildings(properties) {
@@ -142,13 +141,13 @@
                 var i;
                 var mesh;
                 if (meshes.length) {
-                    view.notifyChange();
+                    view.notifyChange(view.camera.camera3D, true);
                 }
                 for (i = 0; i < meshes.length; i++) {
                     mesh = meshes[i];
-                    if (mesh.children.length) {
+                    if (mesh) {
                         mesh.scale.z = Math.min(
-                            1.0, mesh.scale.z + 0.016);
+                            1.0, mesh.scale.z + 0.02);
                         mesh.updateMatrixWorld(true);
                     }
                 }
@@ -171,7 +170,6 @@
                 filter: acceptFeature,
                 source: {
                     url: 'http://wxs.ign.fr/72hpsel8j8nhb5qgdh07gcyp/geoportail/wfs?',
-                    networkOptions: { crossOrigin: 'anonymous' },
                     protocol: 'wfs',
                     version: '2.0.0',
                     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
@@ -209,31 +207,33 @@
             function altitudePoint(properties, contour) {
                 var result;
                 var z = 0;
-                if (contour.length && contour.length > 0) {
-                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour[0]);
+                if (contour) {
+                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0, tile);
+                    if (!result) {
+                        result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0);
+                    }
+                    tile = [result.tile];
                     if (result) {
                         z = result.z;
                     }
                     return z + 5;
                 }
-                return 0;
             }
 
             view.addLayer({
                 type: 'geometry',
+                id: 'WFS Route points',
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
                     altitude: altitudePoint,
                     color: colorPoint }),
-                size: 5,
+                size: 100,
                 onMeshCreated: configPointMaterial,
                 filter: selectRoad,
                 source: {
                     url: 'http://wxs.ign.fr/72hpsel8j8nhb5qgdh07gcyp/geoportail/wfs?',
-                    networkOptions: { crossOrigin: 'anonymous' },
                     protocol: 'wfs',
                     version: '2.0.0',
-                    id: 'WFS Route points',
                     typeName: 'BDPR_BDD_FXX_LAMB93_20170911:pr',
                     zoom: { min: 12, max: 12 },
                     projection: 'EPSG:2154',
@@ -252,38 +252,66 @@
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
-                view.controls.setTilt(45, true);
+                view.controls.setTilt(45);
             });
             var d = new debug.Debug(view, menuGlobe.gui);
             debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
-            function picking(event) {
-                var htmlInfo = document.getElementById('info');
-                var intersects = view.pickObjectsAt(event, 3, 'WFS Buildings');
-                var properties;
-                var info;
-                htmlInfo.innerHTML = ' ';
+            var binarySearch = function(array, value) {
+                var guess,
+                    min = 0,
+                    max = array.length - 1;
 
-                if (intersects.length) {
-                    properties = intersects[0].object.properties;
-                    Object.keys(properties).map(function (objectKey) {
-                        var value = properties[objectKey];
-                        var key = objectKey.toString();
-                        if (key[0] !== '_' && key !== 'geometry_name') {
-                            info = value.toString();
-                            htmlInfo.innerHTML +='<li><b>' + key + ': </b>' + info + '</li>';
-                        }
-                    });
+                while(min <= max){
+                    guess = Math.floor((min + max) / 2);
+                var indices = array[guess].indices;
+                var start = indices[0].offset;
+                var end = indices[indices.length - 1].offset + indices[indices.length - 1].count;
+
+                if(start <= value && value <= end)
+                    return guess;
+                else if(value > end)
+                    min = guess + 1;
+                else
+                    max = guess - 1;
+                 }
+
+                 return -1;
+            }
+
+            function picking(event) {
+                if(view.controls.isPaused()) {
+                    var htmlInfo = document.getElementById('info');
+                    var intersects = view.pickObjectsAt(event, 3, 'WFS Buildings');
+                    var properties;
+                    var info;
+                    htmlInfo.innerHTML = ' ';
+
+                    if (intersects.length) {
+                        var geometry = intersects[0].object.feature.geometry;
+                        var idPt = (intersects[0].face.a) % (intersects[0].object.feature.vertices.length / 3);
+                        var id = binarySearch(geometry, idPt);
+                        properties = geometry[id].properties;
+
+                        Object.keys(properties).map(function (objectKey) {
+                            var value = properties[objectKey];
+                            var key = objectKey.toString();
+                            if (key[0] !== '_' && key !== 'geometry_name') {
+                                info = value.toString();
+                                htmlInfo.innerHTML +='<li><b>' + key + ': </b>' + info + '</li>';
+                            }
+                        });
+                    }
                 }
             }
 
-            for (let layer of view.getLayers()) {
-                // if (layer.id === 'WFS Bus lines') {
-                //     layer.whenReady.then( function _(layer) {
-                //         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
-                //         debug.GeometryDebug.addMaterialLineWidth(gui, view, layer, 1, 10);
-                //     });
-                // }
+            for (var layer of view.getLayers()) {
+                if (layer.id === 'WFS Bus lines') {
+                    layer.whenReady.then( function _(layer) {
+                        var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
+                        debug.GeometryDebug.addMaterialLineWidth(gui, view, layer, 1, 10);
+                    });
+                }
                 if (layer.id === 'WFS Buildings') {
                     layer.whenReady.then( function _(layer) {
                         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
@@ -291,12 +319,12 @@
                         window.addEventListener('mousemove', picking, false);
                     });
                 }
-                // if (layer.id === 'WFS Route points') {
-                //     layer.whenReady.then( function _(layer) {
-                //         var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
-                //         debug.GeometryDebug.addMaterialSize(gui, view, layer, 1, 50);
-                //     });
-                // }
+                if (layer.id === 'WFS Route points') {
+                    layer.whenReady.then( function _(layer) {
+                        var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);
+                        debug.GeometryDebug.addMaterialSize(gui, view, layer, 1, 200);
+                    });
+                }
             }
         </script>
     </body>

--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -37,11 +37,11 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                 layer = layers[i];
                 result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(
                     geoCoord, layer.source.parsedData, precision);
-                result.sort(function compare(a, b) { return b.feature.type !== 'point'; });
+
                 for (p = 0; p < result.length; p++) {
                     visible = true;
-                    if (result[p].feature.type === 'polygon') {
-                        polygon = result[p].feature;
+                    if (result[p].type === 'multipolygon') {
+                        polygon = result[p].geometry;
                         color = polygon.properties.fill || layer.style.fill;
                         stroke = polygon.properties.stroke || layer.style.stroke;
                         name = 'polygon' + id;
@@ -50,20 +50,20 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                         document.getElementById(name).style['-webkit-text-stroke'] = '1.25px ' + stroke;
                         document.getElementById(name).style.color = color;
                         ++id;
-                    } else if (result[p].feature.type === 'linestring') {
-                        line = result[p].feature;
+                    } else if (result[p].type === 'multilinestring') {
+                        line = result[p].geometry;
                         color = line.properties.stroke || layer.style.stroke;
                         symb = '<span style=color:' + color + ';>&#9473</span>';
                         tooltip.innerHTML += symb + ' ' + (line.name || layer.name) + '<br />';
-                    } else if (result[p].feature.type === 'point') {
-                        point = result[p].feature;
+                    } else if (result[p].type === 'multipoint') {
+                        point = result[p].geometry;
                         color = 'white';
                         name = 'point' + id;
                         symb = '<span id=' + name + ' style=color:' + color + ';>&#9679</span>';
                         label = point.properties.name || point.properties.description || layer.name;
                         tooltip.innerHTML += '<div>' + symb + ' ' + label + '<br></div>';
-                        tooltip.innerHTML += '<span class=coord>long ' + result[p].coordinates.longitude().toFixed(4) + '<br /></span>';
-                        tooltip.innerHTML += '<span class=coord>lati &nbsp; ' + result[p].coordinates.latitude().toFixed(4) + '<br /></span>';
+                        tooltip.innerHTML += '<span class=coord>long ' + result[p].coordinates[0].toFixed(4) + '<br /></span>';
+                        tooltip.innerHTML += '<span class=coord>lati &nbsp; ' + result[p].coordinates[1].toFixed(4) + '<br /></span>';
                         document.getElementById(name).style['-webkit-text-stroke'] = '1px red';
                         ++id;
                     }

--- a/examples/orientation_utils.html
+++ b/examples/orientation_utils.html
@@ -51,6 +51,7 @@
             var panoramics = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/immersive/exampleParis1/panoramicsMetaDataParis.geojson';
             var layer = {
                 crsOut: view.referenceCrs,
+                mergeFeatures: false,
                 onGround: false,
             };
             // Input data are given in Lambert93 projection
@@ -93,27 +94,27 @@
             // place a 3d model oriented for each feature
             function loadFeatures(points, colladaModel) {
 
-                for (const feature of points.features) {
+                for (var feature of points.features) {
 
                     // clone the collada model
                     var model = colladaModel.clone();
 
+                    var vertices = feature.vertices;
                     // get coordinate from point feature
-                    var coord = feature.vertices[0];
+                    var coord = new itowns.Coordinates(feature.crs, vertices[0], vertices[1], vertices[2]);
 
                     // set model position
                     model.position.copy(coord.xyz());
 
                     // set model orientation (using target parameter)
-                    itowns.OrientationUtils.quaternionFromAttitude(feature.properties, coord, true, model.quaternion);
+                    itowns.OrientationUtils.quaternionFromAttitude(feature.geometry[0].properties, coord, true, model.quaternion);
 
                     // store base position
                     model.positionBase = model.position.clone();
 
                     // compute position on the ground
-                    var coord = feature.vertices[0];
-                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, coord, 1, undefined);
                     coord = coord.as('EPSG:4326');
+                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, coord, 1, undefined);
                     coord.setAltitude(result.z);
                     model.positionOnGround = coord.as(view.referenceCrs).xyz();
 

--- a/examples/orientation_utils_planar.html
+++ b/examples/orientation_utils_planar.html
@@ -52,16 +52,17 @@
                 // Don't zoom too much on smart zoom
                smartZoomHeightMax: 100000,
             });
-            
+
             // Input data : a geoJson file, with point features, with orientation specific properties
             var panoramics = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/immersive/exampleParis1/panoramicsMetaDataParis.geojson';
             var layer = {
                 crsOut: view.referenceCrs,
+                mergeFeatures: false,
             };
             // Input data are given in Lambert93 projection
             itowns.proj4.defs('EPSG:2154',
                 '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-            
+
             // Add a promise to load oriented point datas
             var promises = [];
             promises.push(
@@ -69,8 +70,8 @@
                 itowns.Fetcher.json(panoramics, {})
                 // then get geographic informations (coordinates) using GeoJson parser
                 .then(function parseGeoJSON(orientations) { return itowns.GeoJsonParser.parse(orientations, layer);})
-            );        
-            
+            );
+
             // load collada model of a renault trafic
             promises.push(ThreeLoader.load('Collada',
              'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/models/collada/renault_trafic_no_texture.dae')
@@ -82,30 +83,31 @@
                 // put the model in a group, to allow user to do other transformation (rotation..)
                 var group = new itowns.THREE.Group();
                 group.add(colladaModel);
-                return group; 
+                return group;
              }));
 
             // wait for all the promises
             Promise.all(promises).then(function loadFeaturesModel(res) { loadFeatures(res[0], res[1]);});
-            
+
             // place a 3d model oriented for each feature
             function loadFeatures(collection, colladaModel) {
-   
-                for (const feature of collection.features) {                  
-                
+
+                for (const feature of collection.features) {
+
                     // clone the collada model
                     var model = colladaModel.clone();
+                    var vertices = feature.vertices;
 
                     // get coordinate from point feature
-                    var coord = feature.vertices[0];
+                    var coord = new itowns.Coordinates(feature.crs, vertices[0], vertices[1], vertices[2]);
 
                     // set model position to the ground
                     var position = coord.xyz();
                     position.z = 0;
                     model.position.copy(position);
-                                        
+
                     // set model orientation (quaternion is the target parameter)
-                    itowns.OrientationUtils.quaternionFromAttitude(feature.properties, undefined, false, model.quaternion);
+                    itowns.OrientationUtils.quaternionFromAttitude(feature.geometry[0].properties, undefined, false, model.quaternion);
 
                     model.updateMatrixWorld();
                     view.scene.add(model);

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -35,6 +35,7 @@
             var view;
             var meshes;
             var p;
+            var color = new itowns.THREE.Color();
 
             // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946',
@@ -79,7 +80,8 @@
             new itowns.PlanarControls(view, {});
 
             // Request redraw
-            view.notifyChange();
+            // view.notifyChange();
+
 
             function setMaterialLineWidth(result) {
                 result.traverse(function _setLineWidth(mesh) {
@@ -90,8 +92,10 @@
             }
 
             function colorLine(properties) {
-                var rgb = properties.couleur.split(' ');
-                return new itowns.THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+                if (properties) {
+                    var rgb = properties.couleur.split(' ');
+                    return color.setRGB(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+                }
             }
 
             view.addLayer({
@@ -121,11 +125,11 @@
 
             function colorBuildings(properties) {
                 if (properties.id.indexOf('bati_remarquable') === 0) {
-                    return new itowns.THREE.Color(0x5555ff);
+                    return color.set(0x5555ff);
                 } else if (properties.id.indexOf('bati_industriel') === 0) {
-                    return new itowns.THREE.Color(0xff5555);
+                    return color.set(0xff5555);
                 }
-                return new itowns.THREE.Color(0xeeeeee);
+                return color.set(0xeeeeee);
             }
 
             function extrudeBuildings(properties) {
@@ -148,6 +152,10 @@
                 meshes = meshes.filter(function filter(m) { return m.scale.z < 1; });
             }
 
+            function acceptFeature(properties) {
+                return !!properties.hauteur;
+            }
+
             view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
             view.addLayer({
                 id: 'wfsBuilding',
@@ -160,6 +168,7 @@
                     mesh.scale.z = 0.01;
                     meshes.push(mesh);
                 },
+                filter: acceptFeature,
                 projection: 'EPSG:3946',
                 source: {
                     url: 'http://wxs.ign.fr/72hpsel8j8nhb5qgdh07gcyp/geoportail/wfs?',
@@ -200,6 +209,7 @@
             view.addLayer({
                 id: 'wfsPoint',
                 type: 'geometry',
+                size: 100,
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
                     altitude: 0,
@@ -223,7 +233,28 @@
                 },
             }, view.tileLayer);
 
-            /* global, document, window, view */
+            function binarySearch(array, value) {
+                var guess,
+                    min = 0,
+                    max = array.length - 1;
+
+                while(min <= max){
+                    guess = Math.floor((min + max) / 2);
+                var indices = array[guess].indices;
+                var start = indices[0].offset;
+                var end = indices[indices.length - 1].offset + indices[indices.length - 1].count;
+
+                if(start <= value && value <= end)
+                    return guess;
+                else if(value > end)
+                    min = guess + 1;
+                else
+                    max = guess - 1;
+                }
+
+                return -1;
+            }
+
             function picking(event) {
                 var htmlInfo = document.getElementById('info');
                 var intersects = view.pickObjectsAt(event, 2, 'wfsBuilding');
@@ -232,7 +263,11 @@
                 htmlInfo.innerHTML = ' ';
 
                 if (intersects.length) {
-                    properties = intersects[0].object.properties;
+                    var geometry = intersects[0].object.feature.geometry;
+                    var idPt = (intersects[0].face.a) % (intersects[0].object.feature.vertices.length / 3);
+                    var id = binarySearch(geometry, idPt);
+                    properties = geometry[id].properties;
+
                     Object.keys(properties).map(function (objectKey) {
                         var value = properties[objectKey];
                         var key = objectKey.toString();
@@ -241,7 +276,7 @@
                             htmlInfo.innerHTML +='<li><b>' + key + ': </b>' + info + '</li>';
                         }
                     });
-                    return intersects[0].object;
+                    return properties;
                 }
             }
 

--- a/jsdoc-config.json
+++ b/jsdoc-config.json
@@ -39,7 +39,6 @@
             "src/Parser/VectorTileParser.js",
 
             "src/Provider/URLBuilder.js",
-            "src/Provider/VectorTileHelper.js",
 
             "src/Renderer/ColorLayersOrdering.js",
             "src/Renderer/ThreeExtended/Feature2Mesh.js",

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -192,6 +192,10 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
                 providerPreprocessing = Promise.resolve();
             }
         } else if (layer.source) {
+            // TODO: move to dataSourceProvider
+            // Tempory fix, because sourceFile loads data in his constructor
+            // while it should be loaded in the provider
+            layer.source.toTexture = layer.type != 'geometry';
             const protocol = layer.source.protocol;
             layer.source = new (supportedSource.get(protocol))(layer.source, layer.projection);
             providerPreprocessing = layer.source.whenReady || providerPreprocessing;

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -159,6 +159,9 @@ function readPBF(file, options) {
         crsOut: options.crsOut,
         filteringExtent: options.filteringExtent,
         filter: options.filter,
+        withNormal: options.withNormal,
+        withAltitude: options.withAltitude,
+        mergeFeatures: options.mergeFeatures,
         buildExtent: true,
     }).then((f) => {
         f.extent.zoom = extentSource.zoom;
@@ -182,6 +185,9 @@ export default {
      * @param {Extent} options.coords - Coordinates of the layer.
      * @param {Extent=} options.filteringExtent - Optional filter to reject features
      * outside of this extent.
+     * @param {boolean} [options.mergeFeatures=true] - If true all geometries are merged by type and multi-type
+     * @param {boolean} [options.withNormal=true] - If true each coordinate normal is computed
+     * @param {boolean} [options.withAltitude=true] - If true each coordinate altitude is kept
      * @param {function=} options.filter - Filter function to remove features.
      * @param {string=} options.origin - This option is to be set to the correct
      * value, bottom or top (default being bottom), if the computation of the

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -11,11 +11,15 @@ export default {
         } else {
             if (obj.geometry) {
                 obj.geometry.dispose();
-                obj.geometry = null;
+                // the Object Removal Helper causes inconsistencies
+                // when it assigns null to a geometry present in the Cache.
+                // Actually, the cache can provide a mesh whose geometry is null.
+                // see https://github.com/iTowns/itowns/issues/869
+                // obj.geometry = null;
             }
             if (obj.material) {
                 obj.material.dispose();
-                obj.material = null;
+                // obj.material = null;
             }
         }
     },
@@ -43,11 +47,10 @@ export default {
     removeChildrenAndCleanup(layer, obj) {
         const toRemove = obj.children.filter(c => c.layer === layer);
 
+        obj.remove(...toRemove);
         if (obj.layer === layer) {
             this.cleanup(obj);
         }
-
-        obj.remove(...toRemove);
         return toRemove;
     },
 
@@ -63,10 +66,10 @@ export default {
         for (const c of toRemove) {
             this.removeChildrenAndCleanupRecursively(layer, c);
         }
+        obj.remove(...toRemove);
         if (obj.layer === layer) {
             this.cleanup(obj);
         }
-        obj.remove(...toRemove);
         return toRemove;
     },
 };

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -47,7 +47,7 @@ function fetchData(url, format, networkOptions, extentSource) {
 function parseData(data, layer, extentDestination) {
     const type = data.isTexture || data.isFeature || layer.source.format;
     const options = {
-        buildExtent: true,
+        buildExtent: layer.type !== 'geometry',
         crsIn: layer.source.projection,
         crsOut: layer.projection,
         // TODO FIXME: error in filtering vector tile
@@ -55,6 +55,9 @@ function parseData(data, layer, extentDestination) {
         filteringExtent: layer.type === 'geometry' ? extentDestination : undefined,
         filter: layer.filter,
         origin: layer.source.origin,
+        mergeFeatures: layer.mergeFeatures === undefined ? true : layer.mergeFeatures,
+        withNormal: layer.type === 'geometry',
+        withAltitude: layer.type === 'geometry',
     };
     return supportedParsers.get(type)(data, options);
 }

--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -1,12 +1,16 @@
 import * as THREE from 'three';
 import Earcut from 'earcut';
+import Coordinates from '../../Core/Geographic/Coordinates';
 
 function getProperty(name, options, defaultValue, ...args) {
     const property = options[name];
 
     if (property) {
         if (typeof property === 'function') {
-            return property(...args);
+            const p = property(...args);
+            if (p) {
+                return p;
+            }
         } else {
             return property;
         }
@@ -20,44 +24,56 @@ function getProperty(name, options, defaultValue, ...args) {
 }
 
 function randomColor() {
-    const randomColor = new THREE.Color();
-    randomColor.setHex(Math.random() * 0xffffff);
-    return randomColor;
+    return new THREE.Color(Math.random() * 0xffffff);
 }
 
-function fillColorArray(colors, length, r, g, b, offset) {
-    const len = offset + length;
-    for (let i = offset; i < len; ++i) {
-        colors[3 * i] = r;
-        colors[3 * i + 1] = g;
-        colors[3 * i + 2] = b;
+function fillColorArray(colors, length, color, offset = 0) {
+    offset *= 3;
+    const len = offset + length * 3;
+    for (let i = offset; i < len; i += 3) {
+        colors[i] = color.r * 255;
+        colors[i + 1] = color.g * 255;
+        colors[i + 2] = color.b * 255;
     }
 }
 
-/*
+/**
  * Convert coordinates to vertices positionned at a given altitude
  *
- * @param  {Coordinate[]} contour - Coordinates of a feature
- * @param  {number | number[] } altitude - Altitude of the feature
- * @return {Vector3[]} vertices
+ * @param      {number[]} ptsIn - Coordinates of a feature.
+ * @param      {number[]} normals - Coordinates of a feature.
+ * @param      {number[]} target - Target to copy result.
+ * @param      {(Function|number)}  altitude - Altitude of feature or function to get altitude.
+ * @param      {number} extrude - The extrude amount to apply at each point
+ * @param      {number} offsetOut - The offset array value to copy on target
+ * @param      {number} countIn - The count of coordinates to read in ptsIn
+ * @param      {number} startIn - The offser array to strat reading in ptsIn
  */
-const vec = new THREE.Vector3();
-function coordinatesToVertices(contour, altitude, target, offset = 0, extrude = undefined) {
-    // loop over contour coodinates
-    for (let i = 0; i < contour.length; i++) {
-        const coordinate = contour[i];
-        // convert coordinate to position
-        coordinate.xyz(vec);
+const coord = new Coordinates('EPSG:4326', 0, 0);
+function coordinatesToVertices(ptsIn, normals, target, altitude = 0, extrude = 0, offsetOut = 0, countIn = ptsIn.length / 3, startIn = offsetOut) {
+    startIn *= 3;
+    countIn *= 3;
+    offsetOut *= 3;
+    const endIn = startIn + countIn;
+    let fnAltitude;
+    if (!isNaN(altitude)) {
+        fnAltitude = () => altitude;
+    } else if (Array.isArray(altitude)) {
+        fnAltitude = id => altitude[(id - startIn) / 3];
+    } else {
+        fnAltitude = id => altitude({}, coord.set(ptsIn.crs, ptsIn[id], ptsIn[id + 1], ptsIn[id + 2]));
+    }
+
+    for (let i = startIn, j = offsetOut; i < endIn; i += 3, j += 3) {
         // move the vertex following the normal, to put the point on the good altitude
-        vec.addScaledVector(coordinate.geodesicNormal,
-            Array.isArray(altitude) ? altitude[i] : altitude);
-        if (extrude) {
-            vec.addScaledVector(coordinate.geodesicNormal,
-                Array.isArray(extrude) ? extrude[i] : extrude);
+        const t = fnAltitude(i) + (Array.isArray(extrude) ? extrude[(i - startIn) / 3] : extrude);
+        if (target.minAltitude) {
+            target.minAltitude = Math.min(t, target.minAltitude);
         }
         // fill the vertices array at the offset position
-        vec.toArray(target, offset);
-        offset += 3;
+        target[j] = ptsIn[i] + normals[i] * t;
+        target[j + 1] = ptsIn[i + 1] + normals[i + 1] * t;
+        target[j + 2] = ptsIn[i + 2] + normals[i + 2] * t;
     }
 }
 
@@ -79,168 +95,230 @@ function coordinatesToVertices(contour, altitude, target, offset = 0, extrude = 
 function addExtrudedPolygonSideFaces(indices, length, offset, count, isClockWise) {
     // loop over contour length, and for each point of the contour,
     // add indices to make two triangle, that make the side face
-    for (let i = offset; i < offset + count - 1; ++i) {
+    const startIndice = indices.length;
+    indices.length += (count - 1) * 6;
+    for (let i = offset, j = startIndice; i < offset + count - 1; ++i, ++j) {
         if (isClockWise) {
             // first triangle indices
-            indices.push(i);
-            indices.push(i + length);
-            indices.push(i + 1);
+            indices[j] = i;
+            indices[++j] = i + length;
+            indices[++j] = i + 1;
             // second triangle indices
-            indices.push(i + 1);
-            indices.push(i + length);
-            indices.push(i + length + 1);
+            indices[++j] = i + 1;
+            indices[++j] = i + length;
+            indices[++j] = i + length + 1;
         } else {
             // first triangle indices
-            indices.push(i + length);
-            indices.push(i);
-            indices.push(i + length + 1);
+            indices[j] = i + length;
+            indices[++j] = i;
+            indices[++j] = i + length + 1;
             // second triangle indices
-            indices.push(i + length + 1);
-            indices.push(i);
-            indices.push(i + 1);
+            indices[++j] = i + length + 1;
+            indices[++j] = i;
+            indices[++j] = i + 1;
         }
     }
 }
 
-function prepareBufferGeometry(vert, color, altitude, extrude) {
-    const multiplyVerticesCount = (extrude == undefined) ? 1 : 2;
+const pointMaterial = new THREE.PointsMaterial();
+function featureToPoint(feature, options) {
+    const ptsIn = feature.vertices;
+    const normals = feature.normals;
+    const vertices = new Float32Array(ptsIn.length);
+    const colors = new Uint8Array(ptsIn.length);
 
-    const vertices = new Float32Array(3 * vert.length * multiplyVerticesCount);
-    const colors = new Uint8Array(3 * vert.length * multiplyVerticesCount);
+    coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
 
-    if (multiplyVerticesCount == 1) {
-        coordinatesToVertices(vert, altitude, vertices);
-        fillColorArray(colors, vert.length, color.r * 255, color.g * 255, color.b * 255, 0);
-    } else {
-        coordinatesToVertices(vert, altitude, vertices, 0);
-        fillColorArray(colors, vert.length, color[0].r * 255, color[0].g * 255, color[0].b * 255, 0);
-
-        coordinatesToVertices(vert, altitude, vertices, 3 * vert.length, extrude);
-        fillColorArray(colors, vert.length, color[1].r * 255, color[1].g * 255, color[1].b * 255, vert.length);
+    for (const geometry of feature.geometry) {
+        const color = getProperty('color', options, randomColor, geometry.properties);
+        const start = geometry.indices[0].offset;
+        const count = geometry.indices[0].count;
+        fillColorArray(colors, count, color, start);
     }
 
     const geom = new THREE.BufferGeometry();
     geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
     geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
-    return geom;
+
+    return new THREE.Points(geom, pointMaterial);
 }
 
+var lineMaterial = new THREE.LineBasicMaterial({ vertexColors: THREE.VertexColors });
+function featureToLine(feature, options) {
+    const ptsIn = feature.vertices;
+    const normals = feature.normals;
+    const vertices = new Float32Array(ptsIn.length);
+    const colors = new Uint8Array(ptsIn.length);
+    const count = ptsIn.length / 3;
 
-function featureToPoint(feature, properties, options) {
-    // get altitude / color from properties
-    const altitude = getProperty('altitude', options, 0, properties, feature.vertices);
-    const color = getProperty('color', options, randomColor, properties);
-
-    const geom = prepareBufferGeometry(
-        feature.vertices,
-        color,
-        altitude);
-
-    return new THREE.Points(geom);
-}
-
-function featureToLine(feature, properties, options) {
-    // get altitude / color from properties
-    const altitude = getProperty('altitude', options, 0, properties, feature.vertices);
-    const color = getProperty('color', options, randomColor, properties);
-
-    const geom = prepareBufferGeometry(
-        feature.vertices,
-        color,
-        altitude);
+    coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
+    const geom = new THREE.BufferGeometry();
+    geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
 
     if (feature.geometry.length > 1) {
-        const indices = [];
+        const countIndices = (count - feature.geometry.length) * 2;
+        const indices = new Uint16Array(countIndices);
+        let i = 0;
         // Multi line case
         for (const geometry of feature.geometry) {
+            const color = getProperty('color', options, randomColor, geometry.properties);
             const start = geometry.indices[0].offset;
-            const end = start + geometry.indices[0].count;
-            for (let j = start; j < end; j++) {
-                indices.push(j);
-                indices.push(j + 1);
+            // To avoid integer overflow with indice value (16 bits)
+            if (start > 0xffff) {
+                console.warn('Feature to Line: integer overflow, too many points in lines');
+                break;
+            }
+            const count = geometry.indices[0].count;
+            const end = start + count;
+            fillColorArray(colors, count, color, start);
+            for (let j = start; j < end - 1; j++) {
+                if (j < 0xffff) {
+                    indices[i++] = j;
+                    indices[i++] = j + 1;
+                } else {
+                    break;
+                }
             }
         }
-        geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
-        return new THREE.LineSegments(geom);
+        geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+        geom.setIndex(new THREE.BufferAttribute(indices, 1));
+        return new THREE.LineSegments(geom, lineMaterial);
     } else {
-        return new THREE.Line(geom);
+        const color = getProperty('color', options, randomColor, feature.geometry.properties);
+        fillColorArray(colors, count, color);
+        geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+        return new THREE.Line(geom, lineMaterial);
     }
 }
 
-function featureToPolygon(feature, properties, options) {
-    // get altitude / color from properties
-    const altitude = getProperty('altitude', options, 0, properties, feature.vertices);
-    const color = getProperty('color', options, randomColor, properties);
+const color = new THREE.Color();
+const material = new THREE.MeshBasicMaterial();
+function featureToPolygon(feature, options) {
+    const ptsIn = feature.vertices;
+    const normals = feature.normals;
+    const vertices = new Float32Array(ptsIn.length);
+    const colors = new Uint8Array(ptsIn.length);
+    const indices = [];
+    vertices.minAltitude = Infinity;
 
-    const geom = prepareBufferGeometry(
-        feature.vertices,
-        color,
-        altitude);
-
-    let indices = [];
     for (const geometry of feature.geometry) {
+        const altitude = getProperty('altitude', options, 0, geometry.properties);
+        const color = getProperty('color', options, randomColor, geometry.properties);
+
         const start = geometry.indices[0].offset;
+        // To avoid integer overflow with indice value (16 bits)
+        if (start > 0xffff) {
+            console.warn('Feature to Polygon: integer overflow, too many points in polygons');
+            break;
+        }
+
         const lastIndice = geometry.indices.slice(-1)[0];
         const end = lastIndice.offset + lastIndice.count;
+        const count = end - start;
 
+        coordinatesToVertices(ptsIn, normals, vertices, altitude, 0, start, count);
+        fillColorArray(colors, count, color, start);
+
+        const geomVertices = vertices.slice(start * 3, end * 3);
         const holesOffsets = geometry.indices.map(i => i.offset - start).slice(1);
+        const triangles = Earcut(geomVertices, holesOffsets, 3);
 
-        const triangles = Earcut(geom.attributes.position.array.slice(start * 3, end * 3),
-                holesOffsets, 3);
+        const startIndice = indices.length;
+        indices.length += triangles.length;
 
-        indices = indices.concat(triangles.map(i => i + start));
+        for (let i = 0; i < triangles.length; i++) {
+            indices[startIndice + i] = triangles[i] + start;
+        }
     }
+
+    const geom = new THREE.BufferGeometry();
+    geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
+    geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
 
     geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
-    return new THREE.Mesh(geom);
+
+    const mesh = new THREE.Mesh(geom, material);
+    mesh.minAltitude = vertices.minAltitude;
+    return mesh;
 }
 
+function area(contour, offset, count) {
+    offset *= 3;
+    const n = count * 3;
+    let a = 0.0;
 
-function featureToExtrudedPolygon(feature, properties, options) {
-    // get altitude / color from properties
-    const altitude = getProperty('altitude', options, 0, properties, feature.vertices);
-    const extrude = getProperty('extrude', options, 0, properties);
+    for (let p = n + offset - 3, q = offset; q < n; p = q, q += 3) {
+        a += contour[p] * contour[q + 1] - contour[q] * contour[p + 1];
+    }
 
-    const colors = [getProperty('color', options, randomColor, properties)];
-    colors.push(colors[0].clone());
-    colors[0].multiplyScalar(155 / 255);
+    return a * 0.5;
+}
 
-    const geom = prepareBufferGeometry(
-        feature.vertices,
-        colors,
-        altitude,
-        extrude);
+function featureToExtrudedPolygon(feature, options) {
+    const ptsIn = feature.vertices;
+    const offset = feature.geometry[0].indices[0].offset;
+    const count = feature.geometry[0].indices[0].count;
+    const isClockWise = area(ptsIn, offset, count) < 0;
 
-    const isClockWise = THREE.ShapeUtils.isClockWise(
-        feature.vertices.slice(feature.geometry[0].indices[0].offset,
-            feature.geometry[0].indices[0].offset +
-            feature.geometry[0].indices[0].count).map(c => c.xyz()));
+    const normals = feature.normals;
+    const vertices = new Float32Array(ptsIn.length * 2);
+    const colors = new Uint8Array(ptsIn.length * 2);
+    const indices = [];
+    const totalVertices = ptsIn.length / 3;
 
-    let indices = [];
+    vertices.minAltitude = Infinity;
+
     for (const geometry of feature.geometry) {
+        const altitude = getProperty('altitude', options, 0, geometry.properties);
+        const extrude = getProperty('extrude', options, 0, geometry.properties);
+
+        const colorTop = getProperty('color', options, randomColor, geometry.properties);
+        color.copy(colorTop);
+        color.multiplyScalar(0.6);
+
         const start = geometry.indices[0].offset;
         const lastIndice = geometry.indices.slice(-1)[0];
         const end = lastIndice.offset + lastIndice.count;
+        const count = end - start;
 
+        coordinatesToVertices(ptsIn, normals, vertices, altitude, 0, start, count);
+        fillColorArray(colors, count, color, start);
+
+        const startTop = start + totalVertices;
+        const endTop = end + totalVertices;
+        coordinatesToVertices(ptsIn, normals, vertices, altitude, extrude, startTop, count, start);
+        fillColorArray(colors, count, colorTop, startTop);
+
+        const geomVertices = vertices.slice(startTop * 3, endTop * 3);
         const holesOffsets = geometry.indices.map(i => i.offset - start).slice(1);
+        const triangles = Earcut(geomVertices, holesOffsets, 3);
 
-        const triangles = Earcut(geom.attributes.position.array.slice(start * 3, end * 3),
-                holesOffsets, 3);
+        const startIndice = indices.length;
+        indices.length += triangles.length;
 
-        indices = indices.concat(triangles.map(i => i + start + feature.vertices.length));
+        for (let i = 0; i < triangles.length; i++) {
+            indices[startIndice + i] = triangles[i] + startTop;
+        }
 
         for (const indice of geometry.indices) {
             addExtrudedPolygonSideFaces(
                 indices,
-                feature.vertices.length,
+                totalVertices,
                 indice.offset,
                 indice.count,
                 isClockWise);
         }
     }
 
+    const geom = new THREE.BufferGeometry();
+    geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
+    geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+
     geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
-    return new THREE.Mesh(geom);
+
+    const mesh = new THREE.Mesh(geom, material);
+    mesh.minAltitude = vertices.minAltitude;
+    return mesh;
 }
 
 /**
@@ -262,27 +340,21 @@ function featureToMesh(feature, options) {
     switch (feature.type) {
         case 'point':
         case 'multipoint': {
-            mesh = featureToPoint(feature, feature.properties, options);
+            mesh = featureToPoint(feature, options);
             break;
         }
         case 'linestring':
         case 'multilinestring': {
-            mesh = featureToLine(feature, feature.properties, options);
+            mesh = featureToLine(feature, options);
             break;
         }
         case 'polygon':
         case 'multipolygon': {
             if (options.extrude) {
-                mesh = featureToExtrudedPolygon(
-                    feature,
-                    feature.properties,
-                    options);
+                mesh = featureToExtrudedPolygon(feature, options);
             }
             else {
-                mesh = featureToPolygon(
-                    feature,
-                    feature.properties,
-                    options);
+                mesh = featureToPolygon(feature, options);
             }
             break;
         }
@@ -293,8 +365,7 @@ function featureToMesh(feature, options) {
     mesh.material.vertexColors = THREE.VertexColors;
     mesh.material.color = new THREE.Color(0xffffff);
 
-    mesh.properties = feature.properties;
-
+    mesh.feature = feature;
     return mesh;
 }
 

--- a/src/Renderer/ThreeExtended/Feature2Texture.js
+++ b/src/Renderer/ThreeExtended/Feature2Texture.js
@@ -2,41 +2,44 @@ import * as THREE from 'three';
 
 const pt = new THREE.Vector2();
 
-function _moveTo(ctx, coord, scale, origin) {
-    pt.x = coord._values[0] - origin.x;
-    pt.y = coord._values[1] - origin.y;
+function _moveTo(ctx, x, y, scale, origin) {
+    pt.x = x - origin.x;
+    pt.y = y - origin.y;
     pt.multiply(scale);
-    ctx.moveTo(pt.x, pt.y);
+    ctx.moveTo(Math.round(pt.x), Math.round(pt.y));
 }
 
-function _lineTo(ctx, coord, scale, origin) {
-    pt.x = coord._values[0] - origin.x;
-    pt.y = coord._values[1] - origin.y;
+function _lineTo(ctx, x, y, scale, origin) {
+    pt.x = x - origin.x;
+
+    pt.y = y - origin.y;
     pt.multiply(scale);
-    ctx.lineTo(pt.x, pt.y);
+    ctx.lineTo(Math.round(pt.x), Math.round(pt.y));
 }
 
-function drawPolygon(ctx, vertices, indices, origin, scale, properties, style = {}) {
+function drawPolygon(ctx, vertices, indices = [{ offset: 0, count: 1 }], origin, scale, properties, style = {}, size) {
     if (vertices.length === 0) {
         return;
     }
 
     if (style.length) {
         for (const s of style) {
-            _drawPolygon(ctx, vertices, indices, origin, scale, properties, s);
+            _drawPolygon(ctx, vertices, indices, origin, scale, properties, s, size);
         }
     } else {
-        _drawPolygon(ctx, vertices, indices, origin, scale, properties, style);
+        _drawPolygon(ctx, vertices, indices, origin, scale, properties, style, size);
     }
 }
 
-function _drawPolygon(ctx, vertices, indices, origin, scale, properties, style) {
+function _drawPolygon(ctx, vertices, indices, origin, scale, properties = {}, style, size) {
     // build contour
     ctx.beginPath();
     for (const indice of indices) {
-        _moveTo(ctx, vertices[indice.offset], scale, origin);
-        for (let j = 1; j < indice.count; j++) {
-            _lineTo(ctx, vertices[indice.offset + j], scale, origin);
+        const offset = indice.offset * size;
+        const count = offset + indice.count * size;
+        _moveTo(ctx, vertices[offset], vertices[offset + 1], scale, origin);
+        for (let j = offset + size; j < count; j += size) {
+            _lineTo(ctx, vertices[j], vertices[j + 1], scale, origin);
         }
     }
 
@@ -56,13 +59,13 @@ function _drawPolygon(ctx, vertices, indices, origin, scale, properties, style) 
     }
 }
 
-function drawPoint(ctx, vertice, origin, scale, style = {}) {
-    pt.x = vertice._values[0] - origin.x;
-    pt.y = vertice._values[1] - origin.y;
+function drawPoint(ctx, x, y, origin, scale, style = {}) {
+    pt.x = x - origin.x;
+    pt.y = y - origin.y;
     pt.multiply(scale);
 
     ctx.beginPath();
-    ctx.arc(pt.x, pt.y, style.radius || 3, 0, 2 * Math.PI, false);
+    ctx.arc(Math.round(pt.x), Math.round(pt.y), Math.round(style.radius) || 3, 0, 2 * Math.PI, false);
     ctx.fillStyle = style.fill || 'white';
     ctx.fill();
     ctx.lineWidth = style.lineWidth || 1.0;
@@ -71,17 +74,21 @@ function drawPoint(ctx, vertice, origin, scale, style = {}) {
 }
 
 function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
-    const properties = feature.properties;
-
-    if (typeof (style) == 'function') {
-        style = style(properties, feature);
-    }
-
+    let gStyle = style;
     for (const geometry of feature.geometry) {
+        const properties = geometry.properties;
+
+        if (typeof (style) == 'function') {
+            gStyle = style(properties, feature);
+        }
         if (feature.type === 'point') {
-            drawPoint(ctx, feature.vertices[0], origin, scale, style);
+            drawPoint(ctx, feature.vertices[0], feature.vertices[1], origin, scale, gStyle);
+        } else if (feature.type === 'multipoint') {
+            for (var i = 0; i < feature.vertices.length; i += feature.size) {
+                drawPoint(ctx, feature.vertices[i], feature.vertices[i + 1], origin, scale, gStyle);
+            }
         } else if (geometry.extent.intersectsExtent(extent)) {
-            drawPolygon(ctx, feature.vertices, geometry.indices, origin, scale, properties, style);
+            drawPolygon(ctx, feature.vertices, geometry.indices, origin, scale, properties, gStyle, feature.size);
         }
     }
 }
@@ -112,7 +119,8 @@ export default {
 
             // Draw the canvas
             for (const feature of collection.features) {
-                drawFeature(ctx, feature, origin, scale, extent, style);
+                const ex = feature.crs == extent.crs() ? extent : extent.as(feature.crs);
+                drawFeature(ctx, feature, origin, scale, ex, style);
             }
 
             texture = new THREE.CanvasTexture(c);

--- a/src/Renderer/ThreeExtended/GlobeControls.js
+++ b/src/Renderer/ThreeExtended/GlobeControls.js
@@ -171,6 +171,7 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
     state = states.NONE;
 
     this.getStates = () => states;
+    this.isPaused = () => state == states.NONE;
 
     // Set to false to disable this control
     this.enabled = true;

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -100,9 +100,12 @@ class FileSource extends Source {
         this.parsedData = [];
         this.zoom = source.zoom || { min: 5, max: 21 };
         const options = {
-            buildExtent: true,
+            buildExtent: source.toTexture,
             crsIn: this.projection,
             crsOut,
+            withNormal: !source.toTexture,
+            withAltitude: !source.toTexture,
+            mergeFeatures: true,
         };
 
         this.whenReady = Fetcher.text(this.url, source.networkOptions).then(fileParser).then(parsedFile =>

--- a/test/examples/wfs.js
+++ b/test/examples/wfs.js
@@ -12,7 +12,8 @@ describe('wfs', function _() {
 
     it('should pick the correct building', async () => {
         // test picking
-        const buildingId = await page.evaluate(() => picking({ x: 342, y: 243 }).properties.id);
-        assert.equal(buildingId, 'bati_indifferencie.5751442');
+        const buildingId = await page.evaluate(() =>
+             picking({ x: 342, y: 243 }));
+        assert.equal(buildingId.id, 'bati_indifferencie.5751442');
     });
 });

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -46,6 +46,7 @@ describe('Provide in Sources', function () {
     const featureLayer = new GeometryLayer('geom', new THREE.Group());
     featureLayer.update = FeatureProcessing.update;
     featureLayer.projection = 'EPSG:4978';
+    featureLayer.mergeFeatures = false;
     function extrude() {
         return 5000;
     }
@@ -174,9 +175,26 @@ describe('Provide in Sources', function () {
         tile.material.visible = true;
         tile.parent = { pendingSubdivision: false };
         tile.material.isColorLayerLoaded = () => true;
+        featureLayer.mergeFeatures = false;
         featureLayer.update(context, featureLayer, tile);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((features) => {
             assert.equal(features[0].children.length, 3);
+        });
+    });
+    it('should get 1 mesh with WFS source and DataSourceProvider and mergeFeatures == true', () => {
+        const tile = new TileMesh(
+            colorlayer,
+            geom,
+            new LayeredMaterial(),
+            new Extent('EPSG:4326', -10, 0, 0, 10),
+            4);
+        tile.material.visible = true;
+        tile.parent = { pendingSubdivision: false };
+        tile.material.isColorLayerLoaded = () => true;
+        featureLayer.mergeFeatures = true;
+        featureLayer.update(context, featureLayer, tile);
+        DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((features) => {
+            assert.equal(features[0].children.length, 0);
         });
     });
 });

--- a/test/unit/feature2mesh.js
+++ b/test/unit/feature2mesh.js
@@ -10,7 +10,7 @@ proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 function parse() {
-    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true });
+    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, mergeFeatures: false });
 }
 
 function computeAreaOfMesh(mesh) {

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -5,7 +5,7 @@ import Coordinates from '../../src/Core/Geographic/Coordinates';
 
 const geojson = require('../data/geojson/simple.geojson.json');
 
-const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true });
+const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true, mergeFeatures: false, withAltitude: false, withNormal: false });
 
 describe('FeaturesUtils', function () {
     it('should correctly parse geojson', () =>
@@ -24,24 +24,24 @@ describe('FeaturesUtils', function () {
             const coordinates = new Coordinates('EPSG:4326', 1.26, 42.9);
             const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, collection, 0.1);
             assert.equal(filter.length, 1.0);
-            assert.equal(filter[0].feature.type == 'point', 1.0);
+            assert.equal(filter[0].type == 'point', 1.0);
         }));
     it('should correctly filter polygon', () =>
         promise.then((feature) => {
             const coordinates = new Coordinates('EPSG:4326', 0.62, 43.52);
             const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
             assert.equal(filter.length, 1.0);
-            assert.equal(filter[0].feature.type == 'polygon', 1.0);
+            assert.equal(filter[0].type == 'polygon', 1.0);
         }));
     it('should correctly filter line', () =>
         promise.then((feature) => {
             const coordinates = new Coordinates('EPSG:4326', 2.23, 43.39);
             const filter = FeaturesUtils.filterFeaturesUnderCoordinate(coordinates, feature, 0.1);
             assert.equal(filter.length, 1.0);
-            assert.equal(filter[0].feature.type == 'linestring', 1.0);
+            assert.equal(filter[0].type == 'linestring', 1.0);
         }));
     it('should remember individual feature properties', () =>
         promise.then((feature) => {
-            assert.equal(feature.features[2].properties.my_prop, 14);
+            assert.equal(feature.features[2].geometry[0].properties.my_prop, 14);
         }));
 });

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -16,12 +16,12 @@ function parse(geojson) {
 describe('GeoJsonParser', function () {
     it('should set all z coordinates to 1', () =>
         parse(holes).then((collection) => {
-            assert.ok(collection.features[0].vertices.every(v => v.z() == 1));
+            assert.ok(collection.features[0].vertices.every((v, i) => i == 0 || ((i + 1) % 3) != 0 || v == 0));
         }));
 
     it('should respect all z coordinates', () =>
         parse(gpx).then((collection) => {
-            assert.ok(collection.features[0].vertices.every(v => v.z() != 1));
+            assert.ok(collection.features[0].vertices.every((v, i) => i == 0 || ((i + 1) % 3) != 0 || v != 0));
         }));
 
     it('should return an empty collection', () =>
@@ -32,5 +32,41 @@ describe('GeoJsonParser', function () {
             filteringExtent: new Extent('EPSG:3946', 10, 20, 10, 20),
         }).then((collection) => {
             assert.ok(collection.features.length == 0);
+        }));
+    it('should return an merged collection', () =>
+        GeoJsonParser.parse(holes, {
+            crsIn: 'EPSG:3946',
+            crsOut: 'EPSG:3946',
+            mergeFeatures: true,
+
+        }).then((collection) => {
+            assert.ok(collection.features.length == 1);
+        }));
+    it('should return an no merged collection', () =>
+        GeoJsonParser.parse(holes, {
+            crsIn: 'EPSG:3946',
+            crsOut: 'EPSG:3946',
+            mergeFeatures: false,
+
+        }).then((collection) => {
+            assert.ok(collection.features.length == 3);
+        }));
+    it('should return an collection without altitude', () =>
+        GeoJsonParser.parse(holes, {
+            crsIn: 'EPSG:3946',
+            crsOut: 'EPSG:3946',
+            withAltitude: false,
+
+        }).then((collection) => {
+            assert.ok(collection.features[0].vertices.length == 32);
+        }));
+    it('should return an collection without normal', () =>
+        GeoJsonParser.parse(holes, {
+            crsIn: 'EPSG:3946',
+            crsOut: 'EPSG:3946',
+            withNormal: false,
+
+        }).then((collection) => {
+            assert.ok(collection.features[0].normals == undefined);
         }));
 });

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -95,7 +95,7 @@ describe('Source', function () {
         }, 'EPSG:4326');
 
         const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
-        source.whenReady.then(() => assert.equal(source.parsedData.features.length, 3));
+        source.whenReady.then(() => assert.equal(source.parsedData.features[0].geometry.length, 3));
         assert.ok(source.urlFromExtent(extent));
         assert.ok(source.protocol);
     });

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -15,16 +15,17 @@ function parse(pbf) {
 describe('Vector tiles', function () {
     it('should return two squares', () =>
         parse(multipolygon).then((collection) => {
+            const size = collection.features[0].size;
             // two squares (4 + 1 closing vertices)
-            assert.ok(collection.features[0].vertices.length == 10);
+            assert.ok(collection.features[0].vertices.length / size == 10);
 
-            const square1 = collection.features[0].vertices.slice(0, 5);
-            const square2 = collection.features[0].vertices.slice(5);
+            const square1 = collection.features[0].vertices.slice(0, 5 * size);
+            const square2 = collection.features[0].vertices.slice(5 * size);
 
             // first and last points are the same
-            assert.ok(square1[0].x() == square1[4].x());
-            assert.ok(square1[0].y() == square1[4].y());
-            assert.ok(square2[0].x() == square2[4].x());
-            assert.ok(square2[0].y() == square2[4].y());
+            assert.ok(square1[0] == square1[4 * size]);
+            assert.ok(square1[1] == square1[4 * size + 1]);
+            assert.ok(square2[0] == square2[4 * size]);
+            assert.ok(square2[1] == square2[4 * size + 1]);
         }));
 });

--- a/utils/debug/GeometryDebug.js
+++ b/utils/debug/GeometryDebug.js
@@ -1,3 +1,21 @@
+// TODO: move to GeometryLayer
+function addMaterialLayerProperty(layer, key, value) {
+    layer.defineLayerProperty(key, value, () => {
+        const root = layer.parent ? layer.parent.object3d : layer.object3d;
+        root.traverse((object) => {
+            if (object.layer == layer && object.material) {
+                object.material[key] = layer[key];
+            } else if (object.content && object.content.layer == layer) {
+                object.content.traverse((o) => {
+                    if (o.material) {
+                        o.material[key] = layer[key];
+                    }
+                });
+            }
+        });
+    });
+}
+
 export default {
 
     addWireFrameCheckbox(gui, view, layer) {
@@ -5,12 +23,12 @@ export default {
     },
 
     addMaterialSize(gui, view, layer, begin, end) {
-        layer.size = layer.size || 1;
+        addMaterialLayerProperty(layer, 'size', 1);
         gui.add(layer, 'size', begin, end).name('Size').onChange(() => view.notifyChange(layer));
     },
 
     addMaterialLineWidth(gui, view, layer, begin, end) {
-        layer.linewidth = layer.linewidth || 1;
+        addMaterialLayerProperty(layer, 'linewidth', 1);
         gui.add(layer, 'linewidth', begin, end).name('Line Width').onChange(() => view.notifyChange(layer));
     },
 


### PR DESCRIPTION
## Description
**Refacto `GeojsonParser,` `Feature2Mesh` and `feature2texture`** 

- add merge features option (so the convert creates only one mesh) 
- Use one array of number to store the coordinates

**BREAKING CHANGE**
One array of number to store the coordinates instead of array of coordinates

## Motivation and Context
- **fix #731 bad performance**

   - Before bug from PR #691, total time by functions are :
     - ` geojsonParser.parse`  320 ms
     - `feature2Mesh`  216 ms
         `parse + convert` 536 ms
     - `renderScene` 350 ms
     - **total** 866 ms

   - From introduction of bug with PR #691, total time by functions are :
     - ` geojsonParser.parse`  874 ms (x 2.7 slower)
     - `feature2Mesh`  451 ms (x 2.1 slower)
        `parse + convert ` 1325 ms (x 2.5 slower)
     - `renderScene` 885 ms (x 2.5 slower)
     - **total** 2210 ms (x 2.5 slower)

   - After fix from this PR, total time by functions are :
     - ` geojsonParser.parse`  90 ms (x 10 faster)
     - `feature2Mesh`  115 ms (x 4 faster)
        `parse + convert ` 205 ms (x 6.5 faster)
     - `renderScene` 314 ms (x 2.8 faster)
     - **total** 724 ms (x 3 faster)

- **ref: Improving the Feature type #763**
