### PR TITLE
fix(parser): upgrade the version of meshline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9105,9 +9105,9 @@
       "dev": true
     },
     "three.meshline": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/three.meshline/-/three.meshline-1.0.3.tgz",
-      "integrity": "sha1-hekZDZ3ha73P/MCDdGw+qCvhWps=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/three.meshline/-/three.meshline-1.1.0.tgz",
+      "integrity": "sha512-YJmFMKP9udGMCNIxx6ntTu6qMti3y2a8w/Z2Ado/n8N837YAqm5kkJX55E8jGRyc0IWahlRkO+B2i+XXZluVGw==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "proj4": "^2.4.4",
     "three": "^0.97.0",
-    "three.meshline": "^1.0.3"
+    "three.meshline": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -77,7 +77,7 @@
     "proj4": "^2.4.4",
     "puppeteer": "^1.5.0",
     "three": "^0.97.0",
-    "three.meshline": "^1.0.3",
+    "three.meshline": "^1.1.0",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.11.1"
   }

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -7,8 +7,6 @@
 import * as THREE from 'three';
 import Line from 'three.meshline';
 import Coordinates from '../Core/Geographic/Coordinates';
-import Capabilities from '../Core/System/Capabilities';
-import shaderUtils from '../Renderer/Shader/ShaderUtils';
 
 function _gpxToWayPointsArray(gpxXML) {
     return gpxXML.getElementsByTagName('wpt');
@@ -113,12 +111,6 @@ function _gpxToWTrackPointsMesh(gpxXML, options) {
                     sizeAttenuation: 0,
                     color: new THREE.Color(0xFF0000),
                 });
-
-                if (Capabilities.isLogDepthBufferSupported()) {
-                    material.fragmentShader = material.fragmentShader.replace(/.*/, '').substr(1);
-                    shaderUtils.patchMaterialForLogDepthSupport(material);
-                    console.warn('MeshLineMaterial shader has been patched to add log depth buffer support');
-                }
 
                 const pathMesh = new THREE.Mesh(line.geometry, material);
                 // update size screen uniform


### PR DESCRIPTION
and remove the check for the log depth support for meshline.