### PR TITLE
fix(shaderUtils): use boundary delimiter in the regex

### DIFF
--- a/src/Renderer/Shader/ShaderUtils.js
+++ b/src/Renderer/Shader/ShaderUtils.js
@@ -40,7 +40,7 @@ export default {
             start = start in defines ? defines[start] : parseInt(start, 10);
             end = end in defines ? defines[end] : parseInt(end, 10);
             for (var i = start; i < end; i++) {
-                unroll += snippet.replace(/\s+i\s+/g, ` ${i} `);
+                unroll += snippet.replace(/\bi\b/g, ` ${i} `);
             }
             return unroll;
         }


### PR DESCRIPTION
## Description
This PR change the regex of the unroll loop method.
It uses the boundary delimiter, that allow a more flexible usage of this method in the shader.

