### PR TITLE
fix(source): always build an extent in FileSource

### DIFF
--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -100,7 +100,7 @@ class FileSource extends Source {
         this.parsedData = [];
         this.zoom = source.zoom || { min: 5, max: 21 };
         const options = {
-            buildExtent: source.toTexture,
+            buildExtent: true,
             crsIn: this.projection,
             crsOut,
             withNormal: !source.toTexture,


### PR DESCRIPTION
As the potential extent of the file is always tested in
extentInsideLimit, it doesn't make sense to not always build the extent.
If the extent is not built, errors are emitted.

Fix an error in examples like `globe_geojson_to3D.html`.