### PR TITLE
Add info object in layer TiledGeometryLayer

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -29,6 +29,7 @@
             "src/Layer/ElevationLayer.js",
             "src/Layer/GeometryLayer.js",
             "src/Layer/TiledGeometryLayer.js",
+            "src/Layer/InfoLayer.js",
 
             "src/Source/Source.js",
             "src/Source/WMTSSource.js",

--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -17,12 +17,17 @@ dat.GUI.prototype.removeFolder = function removeFolder(name) {
     this.onResize();
 };
 
-dat.GUI.prototype.hideFolder = function hideFolder(name, value) {
+dat.GUI.prototype.colorLayerFolder = function colorLayerFolder(name, value) {
     var folder = this.__folders[name];
+    var title;
     if (!folder) {
         return;
     }
-    folder.__ul.hidden = value;
+    title = folder.__ul.getElementsByClassName('title')[0];
+
+    if (title.style) {
+        title.style.background = value;
+    }
 };
 
 function GuiTools(domId, view, w) {
@@ -114,6 +119,6 @@ GuiTools.prototype.addGUI = function addGUI(name, value, callback) {
     this.gui.add(this, name).onChange(callback);
 };
 
-GuiTools.prototype.hideFolder = function hideFolder(nameLayer, value) {
-    this.colorGui.hideFolder(nameLayer, value);
+GuiTools.prototype.colorLayerFolder = function colorLayerFolder(nameLayer, value) {
+    this.colorGui.colorLayerFolder(nameLayer, value);
 };

--- a/examples/layersColorVisible.html
+++ b/examples/layersColorVisible.html
@@ -15,70 +15,39 @@
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
         <script type="text/javascript">
-            /* global itowns,document,GuiTools*/
+            /* global itowns,document,GuiTools, setupLoadingScreen */
 
             var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
             // iTowns namespace defined here
             var viewerDiv = document.getElementById('viewerDiv');
             var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
-            setupLoadingScreen(viewerDiv, view);
             var menuGlobe = new GuiTools('menuDiv', view);
+            setupLoadingScreen(viewerDiv, view);
 
             function addLayerCb(layer) {
+                layer.visible = true;
                 view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
 
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(addLayerCb);
-            itowns.Fetcher.json('./layers/JSONLayers/Region.json').then(addLayerCb);
+            itowns.Fetcher.json('./layers/JSONLayers/Cada.json').then(addLayerCb);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT.json').then(addLayerCb);
 
-            function removeDups(a) {
-                var temp = {};
-                for (var i = 0; i < a.length; i++) {
-                    temp[a[i]] = true;
-                }
-                var result = [];
-                for (var val in temp) {
-                    result.push(val);
-                }
-                return result;
-            }
-
-            function getLayersColorVisible(node, layers) {
-                if (!node || !node.visible) {
-                    return;
-                }
-                if (node.level) {
-                    // if node.material.visible is true then the node is diplayed in viewer
-                    // if node.material.colorLayersId is defined then the node have color layers
-                    if (node.material.visible && node.material.colorLayersId) {
-                        // get all node's color layers
-                        var tileColorLayers = node.material.colorLayersId;
-                        layers.id = removeDups(layers.id.concat(tileColorLayers));
-                    }
-                }
-                if (node.children) {
-                    for (var child of node.children) {
-                        getLayersColorVisible(child, layers);
-                    }
-                }
-            }
-
-            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function _() {
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
+                // Open folder color
+                menuGlobe.colorGui.closed = false;
             });
 
             // Use frame requester to update menu before rendering
-            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, function () {
-                var layers = { id: [] };
-                // view.scene is THREE.js scene
-                getLayersColorVisible(view.scene, layers);
-                var colorLayers = view.getLayers(function (l) { return l.type == 'color'; });
+            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, function _() {
+                var dlayers = view.tileLayer.info.displayed.layers;
+                var layers = view.getLayers(function a(l) { return l.type !== 'geometry'; });
 
-                colorLayers.forEach(function (layer) {
-                    menuGlobe.hideFolder(layer.id, layers.id.indexOf(layer.id) == -1)
+                layers.forEach(function b(layer) {
+                    menuGlobe.colorLayerFolder(layer.id, dlayers.find(l => l.id == layer.id)? 'rgb(57, 167, 57)' : 'rgb(255, 125, 125)');
                 });
             });
         </script>

--- a/src/Core/MainLoop.js
+++ b/src/Core/MainLoop.js
@@ -107,6 +107,7 @@ function filterChangeSources(updateSources, geometryLayer) {
     const filtered = new Set();
     updateSources.forEach((src) => {
         if (src === geometryLayer || src.isCamera) {
+            geometryLayer.info.clear();
             fullUpdate = true;
         } else if (src.layer === geometryLayer) {
             filtered.add(src);

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -57,6 +57,7 @@ TileMesh.prototype.isVisible = function isVisible() {
 
 TileMesh.prototype.setDisplayed = function setDisplayed(show) {
     this.material.visible = show;
+    this.layer.info.update(this);
 };
 
 TileMesh.prototype.setVisibility = function setVisibility(show) {

--- a/src/Layer/InfoLayer.js
+++ b/src/Layer/InfoLayer.js
@@ -1,0 +1,71 @@
+import Extent from '../Core/Geographic/Extent';
+
+export default class InfoLayer {
+    constructor(layer) {
+        this.layer = layer;
+    }
+    // eslint-disable-next-line
+    clear() {}
+    // eslint-disable-next-line
+    update() {}
+}
+
+
+/**
+ * InfoTiledGeometryLayer that provides some states layer informations.
+ * These informations are displayed tiles, displayed {@link ColorLayer} and {@link ElevationLayer} and
+ * extent of displayed tiles;
+ * @class InfoTiledGeometryLayer
+ * @property {object} displayed
+ * @property {Layer[]} displayed.layers Displayed {@link ColorLayer} and {@link ElevationLayer}.
+ * @property {Extent} displayed.extent {@link Extent} of displayed tiles.
+ * @property {Set} displayed.tiles Set of displayed tiles.
+ */
+export class InfoTiledGeometryLayer extends InfoLayer {
+    constructor(tiledGeometryLayer) {
+        super(tiledGeometryLayer);
+        this.displayed = { tiles: new Set() };
+        Object.defineProperty(
+            this.displayed,
+            'layers',
+            {
+                get: () => {
+                    let layers = [];
+                    this.displayed.tiles.forEach((tile) => {
+                        layers = [...new Set([...layers, ...tile.material.colorLayersId, tile.material.elevationlayerId])];
+                    });
+
+                    return this.layer.attachedLayers.filter(l => layers.indexOf(l.id) >= 0);
+                },
+            });
+        Object.defineProperty(
+            this.displayed,
+            'extent',
+            {
+                get: () => {
+                    const extent = new Extent(this.layer.extent.crs(), Infinity, -Infinity, Infinity, -Infinity);
+                    extent.min = +Infinity;
+                    extent.max = -Infinity;
+                    this.displayed.tiles.forEach((tile) => {
+                        extent.union(tile.extent);
+                        extent.min = Math.min(tile.obb.z.min, extent.min);
+                        extent.max = Math.max(tile.obb.z.max, extent.max);
+                    });
+
+                    return extent;
+                },
+            });
+    }
+
+    clear() {
+        this.displayed.tiles.clear();
+    }
+
+    update(tile) {
+        if (tile.material.visible) {
+            this.displayed.tiles.add(tile);
+        } else {
+            this.displayed.tiles.delete(tile);
+        }
+    }
+}

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { STRATEGY_MIN_NETWORK_TRAFFIC } from './LayerUpdateStrategy';
+import InfoLayer from './InfoLayer';
 
 class Layer extends THREE.EventDispatcher {
     /**
@@ -80,6 +81,8 @@ class Layer extends THREE.EventDispatcher {
         }
 
         this.defineLayerProperty('frozen', false);
+
+        this.info = new InfoLayer(this);
     }
 
     /**

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -1,8 +1,10 @@
 import GeometryLayer from './GeometryLayer';
+import { InfoTiledGeometryLayer } from './InfoLayer';
 import Picking from '../Core/Picking';
 import convertToTile from '../Parser/convertToTile';
 import CancelledCommandException from '../Core/Scheduler/CancelledCommandException';
 import ObjectRemovalHelper from '../Process/ObjectRemovalHelper';
+
 
 class TiledGeometryLayer extends GeometryLayer {
     /**
@@ -10,6 +12,7 @@ class TiledGeometryLayer extends GeometryLayer {
      *
      * @constructor
      * @extends GeometryLayer
+     * @property {InfoTiledGeometryLayer} info Statut information of layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
@@ -40,6 +43,7 @@ class TiledGeometryLayer extends GeometryLayer {
 
         this.schemeTile = schemeTile;
         this.builder = builder;
+        this.info = new InfoTiledGeometryLayer(this);
 
         if (!this.schemeTile) {
             throw new Error(`Cannot init tiled layer without schemeTile for layer ${this.id}`);

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -303,6 +303,10 @@ LayeredMaterial.prototype.setLayerTextures = function setLayerTextures(layer, te
         if (Array.isArray(textures)) {
             textures = textures[0];
         }
+        // Add save layer.id elevation to get info of displayed layer.
+        // These properties will soon be clearly exposed
+        // in a next soon refactoring of this material
+        this.elevationlayerId = layer.id;
         this._setTexture(textures, l_ELEVATION, 0, pitchs);
     } else if (layer.type === 'color') {
         const index = this.indexOfColorLayer(layer.id);

--- a/test/examples/layersColorVisible.js
+++ b/test/examples/layersColorVisible.js
@@ -9,4 +9,18 @@ describe('layersColorVisible', function _() {
     it('should run', async () => {
         assert.ok(result);
     });
+
+    it('should display correct count of tiles', async () => {
+        // test displayed tile
+        const count = await page.evaluate(() => view.tileLayer.info.displayed.tiles.size);
+        assert.equal(count, 26);
+    });
+
+    it('should display correct color layer', async () => {
+        // test displayed tile
+        const layer = await page.evaluate(() => view.tileLayer.info.displayed.layers[0].id);
+        const count = await page.evaluate(() => view.tileLayer.info.displayed.layers.length);
+        assert.equal(count, 1);
+        assert.equal(layer, 'Ortho');
+    });
 });

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -89,7 +89,7 @@ describe('Provide in Sources', function () {
         });
         const zoom = 4;
         const tile = new TileMesh(
-            colorlayer,
+            globelayer,
             geom,
             new LayeredMaterial(),
             new Extent('EPSG:4326', 0, 10, 0, 10),
@@ -124,7 +124,7 @@ describe('Provide in Sources', function () {
         });
         const zoom = 4;
         const tile = new TileMesh(
-            colorlayer,
+            globelayer,
             geom,
             new LayeredMaterial(),
             new Extent('EPSG:4326', 0, 10, 0, 10),
@@ -148,7 +148,7 @@ describe('Provide in Sources', function () {
     });
     it('should get 4 TileMesh from TileProvider', () => {
         const tile = new TileMesh(
-            colorlayer,
+            globelayer,
             geom,
             new LayeredMaterial(),
             new Extent('EPSG:4326', 0, 10, 0, 10),
@@ -167,7 +167,7 @@ describe('Provide in Sources', function () {
     });
     it('should get 3 meshs with WFS source and DataSourceProvider', () => {
         const tile = new TileMesh(
-            colorlayer,
+            globelayer,
             geom,
             new LayeredMaterial(),
             new Extent('EPSG:4326', 0, 10, 0, 10),
@@ -183,7 +183,7 @@ describe('Provide in Sources', function () {
     });
     it('should get 1 mesh with WFS source and DataSourceProvider and mergeFeatures == true', () => {
         const tile = new TileMesh(
-            colorlayer,
+            globelayer,
             geom,
             new LayeredMaterial(),
             new Extent('EPSG:4326', -10, 0, 0, 10),

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -32,6 +32,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
             protocol: 'dummy',
             extent: new Extent('EPSG:4326', 0, 0, 0, 0),
         },
+        info: { update: () => {} },
     };
 
     beforeEach('reset state', function () {


### PR DESCRIPTION
## Description
Add property **`info`** object in `TiledGeometryLayer`.
`Info` is `InfoTiledGeometryLayer` that provides some states layer informations.
These informations are:
- displayed tiles;
- displayed `colorLayer` and `elevationLayer`;
- `extent` of displayed tiles;

## Motivation and Context
This prevents the user from re-browsing the tiles while `mainLoop` is already doing it.

- Displayed `colorLayer` and `elevationLayer` information can used to show **Attributions**
- `Extent` of displayed tiles information can used to compute a automatic near and far

### Extent of displayed tiles 
![global obb](https://user-images.githubusercontent.com/11291849/48137664-d7eccd80-e2a2-11e8-8b7e-db99a4c84d64.gif)

### Displayed colorLayer
![info vibility layer](https://user-images.githubusercontent.com/11291849/48137755-08346c00-e2a3-11e8-9d05-ddbd6070448a.gif)

