### PR TITLE
batchId option in Feature2Mesh

### DIFF
--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -161,7 +161,6 @@
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
                     color: colorBuildings,
-                    // batchId: (prop, id) => id,
                     altitude: altitudeBuildings,
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -161,6 +161,7 @@
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
                     color: colorBuildings,
+                    // batchId: (prop, id) => id,
                     altitude: altitudeBuildings,
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {

--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -127,6 +127,9 @@ function featureToPoint(feature, options) {
     const vertices = new Float32Array(ptsIn.length);
     const colors = new Uint8Array(ptsIn.length);
 
+    const batchIds = options.batchId ?  new Uint32Array(ptsIn.length / 3) : undefined;
+    let FeatureId = 0;
+
     coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
 
     for (const geometry of feature.geometry) {
@@ -134,11 +137,20 @@ function featureToPoint(feature, options) {
         const start = geometry.indices[0].offset;
         const count = geometry.indices[0].count;
         fillColorArray(colors, count, color, start);
+
+        if (batchIds) {
+            const id = options.batchId(geometry.properties, FeatureId);
+            for (let i = start; i < start + count; i++) {
+                batchIds[i] = id;
+            }
+            FeatureId++;
+        }
     }
 
     const geom = new THREE.BufferGeometry();
     geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
     geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+    if (batchIds) { geom.addAttribute('batchId', new THREE.BufferAttribute(batchIds, 1)); }
 
     return new THREE.Points(geom, pointMaterial);
 }
@@ -150,6 +162,9 @@ function featureToLine(feature, options) {
     const vertices = new Float32Array(ptsIn.length);
     const colors = new Uint8Array(ptsIn.length);
     const count = ptsIn.length / 3;
+
+    const batchIds = options.batchId ?  new Uint32Array(count) : undefined;
+    let FeatureId = 0;
 
     coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
     const geom = new THREE.BufferGeometry();
@@ -179,14 +194,29 @@ function featureToLine(feature, options) {
                     break;
                 }
             }
+            if (batchIds) {
+                const id = options.batchId(geometry.properties, FeatureId);
+                for (let i = start; i < end; i++) {
+                    batchIds[i] = id;
+                }
+                FeatureId++;
+            }
         }
         geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+        if (batchIds) { geom.addAttribute('batchId', new THREE.BufferAttribute(batchIds, 1)); }
         geom.setIndex(new THREE.BufferAttribute(indices, 1));
         return new THREE.LineSegments(geom, lineMaterial);
     } else {
         const color = getProperty('color', options, randomColor, feature.geometry.properties);
         fillColorArray(colors, count, color);
         geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+        if (batchIds) {
+            const id = options.batchId(feature.geometry.properties, FeatureId);
+            for (let i = 0; i < count; i++) {
+                batchIds[i] = id;
+            }
+            geom.addAttribute('batchId', new THREE.BufferAttribute(batchIds, 1));
+        }
         return new THREE.Line(geom, lineMaterial);
     }
 }
@@ -200,6 +230,9 @@ function featureToPolygon(feature, options) {
     const colors = new Uint8Array(ptsIn.length);
     const indices = [];
     vertices.minAltitude = Infinity;
+
+    const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
+    let FeatureId = 0;
 
     for (const geometry of feature.geometry) {
         const altitude = getProperty('altitude', options, 0, geometry.properties);
@@ -229,11 +262,20 @@ function featureToPolygon(feature, options) {
         for (let i = 0; i < triangles.length; i++) {
             indices[startIndice + i] = triangles[i] + start;
         }
+
+        if (batchIds) {
+            const id = options.batchId(geometry.properties, FeatureId);
+            for (let i = start; i < end; i++) {
+                batchIds[i] = id;
+            }
+            FeatureId++;
+        }
     }
 
     const geom = new THREE.BufferGeometry();
     geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
     geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+    if (batchIds) { geom.addAttribute('batchId', new THREE.BufferAttribute(batchIds, 1)); }
 
     geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
 
@@ -267,6 +309,9 @@ function featureToExtrudedPolygon(feature, options) {
     const totalVertices = ptsIn.length / 3;
 
     vertices.minAltitude = Infinity;
+
+    const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
+    let FeatureId = 0;
 
     for (const geometry of feature.geometry) {
         const altitude = getProperty('altitude', options, 0, geometry.properties);
@@ -308,11 +353,20 @@ function featureToExtrudedPolygon(feature, options) {
                 indice.count,
                 isClockWise);
         }
+
+        if (batchIds) {
+            const id = options.batchId(geometry.properties, FeatureId);
+            for (let i = start; i < endTop; i++) {
+                batchIds[i] = id;
+            }
+            FeatureId++;
+        }
     }
 
     const geom = new THREE.BufferGeometry();
     geom.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
     geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
+    if (batchIds) { geom.addAttribute('batchId', new THREE.BufferAttribute(batchIds, 1)); }
 
     geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
 
@@ -399,6 +453,7 @@ export default {
      * @param {number|function} options.altitude - define the base altitude of the mesh
      * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
      * @param {object|function} options.color - define per feature color
+     * @param {function} options.batchId - optional function to create batchId attribute. It is passed the feature property and the feature index
      * @return {function}
      */
     convert(options = {}) {

--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -444,6 +444,43 @@ function featuresToThree(features, options) {
 /**
  * @module Feature2Mesh
  */
+/**
+* @example <caption>Example usage of batchId with featureId.</caption>
+* view.addLayer({
+*     id: 'WFS Buildings',
+*     type: 'geometry',
+*     update: itowns.FeatureProcessing.update,
+*     convert: itowns.Feature2Mesh.convert({
+*         color: colorBuildings,
+*         batchId: (property, featureId) => featureId,
+*         altitude: altitudeBuildings,
+*         extrude: extrudeBuildings }),
+*     onMeshCreated: function scaleZ(mesh) {
+*         mesh.scale.z = 0.01;
+*         meshes.push(mesh);
+*     },
+*     filter: acceptFeature,
+*     source,
+* });
+*
+* @example <caption>Example usage of batchId with property.</caption>
+* view.addLayer({
+*     id: 'WFS Buildings',
+*     type: 'geometry',
+*     update: itowns.FeatureProcessing.update,
+*     convert: itowns.Feature2Mesh.convert({
+*         color: colorBuildings,
+*         batchId: (property, featureId) => property.house ? 10 : featureId,
+*         altitude: altitudeBuildings,
+*         extrude: extrudeBuildings }),
+*     onMeshCreated: function scaleZ(mesh) {
+*         mesh.scale.z = 0.01;
+*         meshes.push(mesh);
+*     },
+*     filter: acceptFeature,
+*     source,
+* });
+**/
 export default {
     /**
      * Return a function that converts [Features]{@link module:GeoJsonParser} to Meshes. Feature collection will be converted to a

--- a/src/Renderer/ThreeExtended/Feature2Mesh.js
+++ b/src/Renderer/ThreeExtended/Feature2Mesh.js
@@ -128,7 +128,7 @@ function featureToPoint(feature, options) {
     const colors = new Uint8Array(ptsIn.length);
 
     const batchIds = options.batchId ?  new Uint32Array(ptsIn.length / 3) : undefined;
-    let FeatureId = 0;
+    let featureId = 0;
 
     coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
 
@@ -139,11 +139,11 @@ function featureToPoint(feature, options) {
         fillColorArray(colors, count, color, start);
 
         if (batchIds) {
-            const id = options.batchId(geometry.properties, FeatureId);
+            const id = options.batchId(geometry.properties, featureId);
             for (let i = start; i < start + count; i++) {
                 batchIds[i] = id;
             }
-            FeatureId++;
+            featureId++;
         }
     }
 
@@ -164,7 +164,7 @@ function featureToLine(feature, options) {
     const count = ptsIn.length / 3;
 
     const batchIds = options.batchId ?  new Uint32Array(count) : undefined;
-    let FeatureId = 0;
+    let featureId = 0;
 
     coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
     const geom = new THREE.BufferGeometry();
@@ -195,11 +195,11 @@ function featureToLine(feature, options) {
                 }
             }
             if (batchIds) {
-                const id = options.batchId(geometry.properties, FeatureId);
+                const id = options.batchId(geometry.properties, featureId);
                 for (let i = start; i < end; i++) {
                     batchIds[i] = id;
                 }
-                FeatureId++;
+                featureId++;
             }
         }
         geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
@@ -211,7 +211,7 @@ function featureToLine(feature, options) {
         fillColorArray(colors, count, color);
         geom.addAttribute('color', new THREE.BufferAttribute(colors, 3, true));
         if (batchIds) {
-            const id = options.batchId(feature.geometry.properties, FeatureId);
+            const id = options.batchId(feature.geometry.properties, featureId);
             for (let i = 0; i < count; i++) {
                 batchIds[i] = id;
             }
@@ -232,7 +232,7 @@ function featureToPolygon(feature, options) {
     vertices.minAltitude = Infinity;
 
     const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
-    let FeatureId = 0;
+    let featureId = 0;
 
     for (const geometry of feature.geometry) {
         const altitude = getProperty('altitude', options, 0, geometry.properties);
@@ -264,11 +264,11 @@ function featureToPolygon(feature, options) {
         }
 
         if (batchIds) {
-            const id = options.batchId(geometry.properties, FeatureId);
+            const id = options.batchId(geometry.properties, featureId);
             for (let i = start; i < end; i++) {
                 batchIds[i] = id;
             }
-            FeatureId++;
+            featureId++;
         }
     }
 
@@ -311,7 +311,7 @@ function featureToExtrudedPolygon(feature, options) {
     vertices.minAltitude = Infinity;
 
     const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
-    let FeatureId = 0;
+    let featureId = 0;
 
     for (const geometry of feature.geometry) {
         const altitude = getProperty('altitude', options, 0, geometry.properties);
@@ -355,11 +355,11 @@ function featureToExtrudedPolygon(feature, options) {
         }
 
         if (batchIds) {
-            const id = options.batchId(geometry.properties, FeatureId);
+            const id = options.batchId(geometry.properties, featureId);
             for (let i = start; i < endTop; i++) {
                 batchIds[i] = id;
             }
-            FeatureId++;
+            featureId++;
         }
     }
 
@@ -453,7 +453,7 @@ export default {
      * @param {number|function} options.altitude - define the base altitude of the mesh
      * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
      * @param {object|function} options.color - define per feature color
-     * @param {function} options.batchId - optional function to create batchId attribute. It is passed the feature property and the feature index
+     * @param {function} [options.batchId] - optional function to create batchId attribute. It is passed the feature property and the feature index
      * @return {function}
      */
     convert(options = {}) {


### PR DESCRIPTION
## Description
adds a batchId option to Feature2Mesh that creates a batchId attribute to be consumed by shaders.

## Motivation and Context
restore the functionnality. may be used for  feature selection, selective shading with the selecred batchId passed as a uniform...
