### PR TITLE
fix(examples): fix the debug menu in oriented_images

### DIFF
--- a/examples/oriented_images.html
+++ b/examples/oriented_images.html
@@ -149,7 +149,7 @@
             new itowns.FirstPersonControls(view);
 
             /* global itowns, document, GuiTools, view, promises */
-            var menuGlobe = new GuiTools('menuDiv');
+            var menuGlobe = new GuiTools('menuDiv', view);
             // setup GUI
             function updatePlaneDistance() {
                 transformTexturedPlane(camera, pictureInfos.distance, plane);


### PR DESCRIPTION
The menu was broken, for example when trying to change the opacity of the `Ortho` layer in `oriented_images`.