### PR TITLE
fix(3d tiles):v1.0 patch 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ The following people have contributed to iTowns 2.
   * [Nicolas Saul](https://github.com/NikoSaul)
   * [Emmanuel Schmück](https://github.com/EmmanuelSchmuck/)
   * [Marie Lamure](https://github.com/mlamure)
+  * [Vincent Jaillot](https://github.com/jailln)
 
 The following organizations supported iTowns2 :
 * IGN ( http://www.ign.fr )

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -97,7 +97,10 @@ export default {
             byteOffset += Uint32Array.BYTES_PER_ELEMENT;
 
             const promises = [];
+            // Parse batch table
             if (b3dmHeader.BTJSONLength > 0) {
+                // sizeBegin in the index where the batch table starts. 28
+                // is the byte length of the b3dm header
                 const sizeBegin = 28 + b3dmHeader.FTJSONLength + b3dmHeader.FTBinaryLength;
                 promises.push(BatchTableParser.parse(
                     buffer.slice(sizeBegin, b3dmHeader.BTJSONLength + sizeBegin)));

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -203,7 +203,9 @@ function executeCommand(command) {
     const metadata = command.metadata;
     const tile = new THREE.Object3D();
     configureTile(tile, layer, metadata, command.requester);
-    const path = metadata.content ? metadata.content.url : undefined;
+    // Patch for supporting 3D Tiles pre 1.0 (metadata.content.url) and 1.0
+    // (metadata.content.uri)
+    const path = metadata.content && (metadata.content.url || metadata.content.uri);
 
     const setLayer = (obj) => {
         obj.layers.set(layer.threejsLayer);


### PR DESCRIPTION
## Description
* Support  [3D Tiles v1.0](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification) _uri_ attribute of [tile.content](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/specification/schema/tile.content.schema.json) and keeps backwards compatibility for 3D Tiles tilesets generated pre-v1.0.
* Add myself as an iTowns contributor.

## Motivation and Context
In [3D Tiles v1.0](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification) the _url_ attribute of a [tile content](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/specification/schema/tile.content.schema.json) has been changed to _uri_.

An example tileset compliant with 3D Tiles v1.0 is available [here](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Apps/SampleData/Cesium3DTiles/Hierarchy/BatchTableHierarchy). I have an upcoming PR exploiting this tileset and introducing [3D Tiles extension](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/extensions) in iTowns.

## Screenshots (if appropriate)
