### PR TITLE
Fix(examples):Center help div to avoid overlapping with debug menu

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -11,6 +11,10 @@
     </head>
     <body>
         <div id="viewerDiv"></div>
+        <div class="help">
+            <p><b>Batch Table Information:</b></p>
+            <ul id="info"></ul>
+        </div>
         <script src="js/GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
@@ -113,9 +117,5 @@
             }
 
         </script>
-        <div class="help" style="right:0;left:auto">
-            <p><b>Information Batch Table: </b></p>
-            <ul id="info"></ul>
-        </div>
     </body>
 </html>

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -35,7 +35,7 @@ body {
     position: absolute;
     z-index: 0;
     top: 0;
-    left: 0;
+    right: 0;
     color: #eee;
     font: 11px 'Lucida Grande',sans-serif;
     line-height: normal;

--- a/examples/globe_wfs_color.html
+++ b/examples/globe_wfs_color.html
@@ -15,8 +15,8 @@
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
         <script src="../dist/debug.js"></script>
-        <div class="help" style="left: unset; right: 0;">
-            <p><b>Information Batiment</b></p>
+        <div class="help">
+            <p><b>Building Information</b></p>
             <ul id="info">
             </ul>
         </div>

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -16,8 +16,8 @@
         <script src="js/loading_screen.js"></script>
         <script src="js/proj4defs/3946.js"></script>
         <script src="../dist/debug.js"></script>
-        <div class="help" style="left: unset; right: 0;">
-            <p><b>Information Batiment</b></p>
+        <div class="help">
+            <p><b>Building Information</b></p>
             <ul id="info">
             </ul>
         </div>

--- a/examples/stereo.html
+++ b/examples/stereo.html
@@ -10,7 +10,7 @@
         <script src="js/GUI/dat.gui/dat.gui.min.js"></script>
     </head>
     <body>
-        <div class="help" style="left: unset; right: 0;">
+        <div class="help">
             <p>Actions</p>
             <button onClick="enableAnaglyph()">enable Anaglyph effect</button>
             <br/>

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -22,7 +22,7 @@
             </ul>
         </div>
         <div id="viewerDiv"></div>
-        <div class="help" style="left: unset; right: 0;">
+        <div class="help" style="left: 0; right: unset;">
             <p><b>Information Batiment</b></p>
             <ul id="info">
             </ul>


### PR DESCRIPTION
## Description
Really small PR that centers the help div which displays the key bindings in the planar examples. It allows to avoid superposition with the debug menu, e.g. in planar example (see following screenshots).

## Screenshots (if appropriate)

Planar example before:

![image](https://user-images.githubusercontent.com/16967916/49098227-b57d1d00-f26e-11e8-84b5-3e4c6a4bcaa4.png)

After:

![image](https://user-images.githubusercontent.com/16967916/49098175-941c3100-f26e-11e8-9a3f-3f485ab7ceeb.png)
