### PR TITLE
Fix and unify sse computing

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -78,3 +78,24 @@ body {
     right: 0;
     bottom: 0;
 }
+
+.circleBase {
+    display: none;
+    border-radius: 50%;
+    margin-top: 0px;
+    margin-left: 0px;
+    padding: 0px;
+    position: absolute;
+    z-index: 1000;
+    font-family: 'Open Sans',
+    sans-serif;
+    font-size: 20px;
+    line-height: 0px;
+    text-align: center;
+    pointer-events: none;
+    width: 10px;
+    height: 10px;
+    background: rgba(160, 160, 160, .4);
+    border: 2px solid #775555;
+    vertical-align: middle;
+}

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -22,7 +22,7 @@
               <li>Y: move camera to start position</li>
             </ul>
         </div>
-        <div id="viewerDiv"></div>
+        <div id="viewerDiv" class="viewer"></div>
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
         <script src="../dist/debug.js"></script>

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -160,7 +160,7 @@
                 projection: 'EPSG:4326',
                 ipr: 'IGN',
                 format: 'application/json',
-                zoom: { min: 5, max: 5 },
+                zoom: { min: 4, max: 4 },
                 extent: {
                     west: 4.568,
                     east: 5.18,

--- a/index.html
+++ b/index.html
@@ -7,35 +7,18 @@ and open the template in the editor.
 <html>
     <head>
         <title>Globe</title>
-
-    <style type="text/css">
-            html {height: 100%}
-        body { margin: 0; overflow:hidden; height:100%}
-
-            #viewerDiv {
-                margin : auto auto;
-                width: 100%;
-                height: 100%;
-                padding: 0;
-            }
-            #menuDiv {position: absolute; top:0px; margin-left: 0px;}
-
-
-        </style>
+        <link rel="stylesheet" type="text/css" href="examples/css/example.css">
         <meta charset="UTF-8">
-
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script src="examples/js/GUI/dat.gui/dat.gui.min.js"></script>
     </head>
     <body>
-        <div id="viewerDiv"></div>
+        <div id="viewerDiv" class="viewer"></div>
         <script src="examples/js/GUI/GuiTools.js"></script>
         <script src="dist/itowns.js"></script>
         <script src="dist/debug.js"></script>
         <script type="text/javascript">
             /* global itowns,document,GuiTools, debug, window */
-
-
             var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000000 };
 
             // iTowns namespace defined here
@@ -72,8 +55,11 @@ and open the template in the editor.
                 var layer = new itowns.ElevationLayer(config.id, config);
                 view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             }
-            itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json').then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
-            itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json').then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
+
+            itowns.Fetcher.json('examples/layers/JSONLayers/WORLD_DTM.json')
+                .then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
+            itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json')
+                .then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
 
             menuGlobe.addGUI('RealisticLighting', false, view.setRealisticLightingOn.bind(view));
 
@@ -86,6 +72,7 @@ and open the template in the editor.
             const d = new debug.Debug(view, menuGlobe.gui);
             debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
             window.view = view;
-</script>
+
+        </script>
     </body>
 </html>

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -558,10 +558,6 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
                 case states.PANORAMIC:
                     rotateStart.copy(coords);
                     break;
-                case states.SELECT:
-                    // If the key 'S' is down, the view selects node under mouse
-                    view.selectNodeAt(coords);
-                    break;
                 case states.MOVE_GLOBE: {
                     // update picking on sphere
                     if (view.getPickingPositionFromDepth(coords, pickingPoint)) {

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -71,14 +71,6 @@ class StateControl {
             keyboard: CONTROL_KEYS.SHIFT,
             enable: true,
         };
-        /**
-         * object selection
-         */
-        this.SELECT = {
-            mouseButton: THREE.MOUSE.LEFT,
-            keyboard: CONTROL_KEYS.S,
-            enable: true,
-        };
     }
 
     /**

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -18,7 +18,7 @@ function hideEverythingElse(view, object, threejsLayer = 0) {
 
 const depthRGBA = new THREE.Vector4();
 // TileMesh picking support function
-function screenCoordsToNodeId(view, tileLayer, viewCoords, radius) {
+function screenCoordsToNodeId(view, tileLayer, viewCoords, radius = 0) {
     const dim = view.mainLoop.gfxEngine.getWindowSize();
 
     viewCoords = viewCoords || new THREE.Vector2(Math.floor(dim.x / 2), Math.floor(dim.y / 2));

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -13,11 +13,6 @@ let magnitudeSquared = 0.0;
 
 // vectors for operation purpose
 const cullingVector = new THREE.Vector3();
-const subdivisionVector = new THREE.Vector3();
-const boundingSphereCenter = new THREE.Vector3();
-
-// subdivison ratio
-let subdivisionRatio = 0;
 
 /**
  * @property {boolean} isGlobeLayer - Used to checkout whether this layer is a
@@ -87,8 +82,6 @@ class GlobeLayer extends TiledGeometryLayer {
                 1 / ellipsoidSizes.x,
                 1 / ellipsoidSizes.y,
                 1 / ellipsoidSizes.z));
-
-        subdivisionRatio = 1 / 2 ** this.maxDeltaElevationLevel;
     }
 
     preUpdate(context, changeSources) {
@@ -113,7 +106,7 @@ class GlobeLayer extends TiledGeometryLayer {
 
     // eslint-disable-next-line
     culling(node, camera) {
-        if (!camera.isBox3Visible(node.obb.box3D, node.obb.matrixWorld)) {
+        if (super.culling(node, camera)) {
             return true;
         }
 

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -98,17 +98,6 @@ class GlobeLayer extends TiledGeometryLayer {
         cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(worldToScaledEllipsoid);
         magnitudeSquared = cameraPosition.lengthSq() - 1.0;
 
-        // pre-sse
-        const canvasSize = context.view.mainLoop.gfxEngine.getWindowSize();
-        const hypothenuse = canvasSize.length();
-        const radAngle = context.view.camera.camera3D.fov * Math.PI / 180;
-        const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypothenuse / canvasSize.x);
-        context.camera.preSSE = hypothenuse * (2.0 * Math.tan(HYFOV * 0.5));
-
-        // Leaving the correct SSE below to be added later, as it is too heavy for now.
-        // const FOV = THREE.Math.degToRad(context.camera.camera3D.fov);
-        // context.camera.preSSE = context.camera.height / (2.0 * Math.tan(FOV * 0.5));
-
         return super.preUpdate(context, changeSources);
     }
 
@@ -196,7 +185,7 @@ class GlobeLayer extends TiledGeometryLayer {
 
         // TODO: node.geometricError is computed using a hardcoded 18 level
         // The computation of node.geometricError is surely false
-        const sse = context.camera.preSSE * (node.geometricError * subdivisionVector.x) / distance;
+        const sse = context.camera._preSSE * (node.geometricError * subdivisionVector.x) / distance;
 
         return this.sseSubdivisionThreshold < sse;
     }

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -255,26 +255,6 @@ GlobeView.prototype.removeLayer = function removeLayer(layerId) {
     }
 };
 
-GlobeView.prototype.selectNodeAt = function selectNodeAt(mouse) {
-    const picked = this.tileLayer.pickObjectsAt(this, mouse);
-    const selectedId = picked.length ? picked[0].object.id : undefined;
-
-    for (const n of this.tileLayer.level0Nodes) {
-        n.traverse((node) => {
-            if (node.material) {
-                const selected = node.id === selectedId;
-                node.material.overlayAlpha = selected ? 0.5 : 0;
-                if (selected) {
-                    // eslint-disable-next-line no-console
-                    console.info(node);
-                }
-            }
-        });
-    }
-
-    this.notifyChange();
-};
-
 GlobeView.prototype.setRealisticLightingOn = function setRealisticLightingOn(value) {
     const coSun = CoordStars.getSunPositionInScene(new Date().getTime(), 48.85, 2.35).normalize();
 

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -45,11 +45,6 @@ class PlanarLayer extends TiledGeometryLayer {
         this.maxSubdivisionLevel = this.maxSubdivisionLevel || 5.0;
         this.maxDeltaElevation = this.maxDeltaElevation || 4.0;
     }
-
-    // eslint-disable-next-line
-    culling(node, camera) {
-        return !camera.isBox3Visible(node.obb.box3D, node.obb.matrixWorld);
-    }
 }
 
 export default PlanarLayer;

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -41,60 +41,14 @@ class PlanarLayer extends TiledGeometryLayer {
         super(id, object3d || new THREE.Group(), [extent], new PlanarTileBuilder(), config);
         this.isPlanarLayer = true;
         this.extent = extent;
+        this.minSubdivisionLevel = this.minSubdivisionLevel || 0;
+        this.maxSubdivisionLevel = this.maxSubdivisionLevel || 5.0;
+        this.maxDeltaElevation = this.maxDeltaElevation || 4.0;
     }
 
     // eslint-disable-next-line
     culling(node, camera) {
         return !camera.isBox3Visible(node.obb.box3D, node.obb.matrixWorld);
-    }
-
-    /**
-     * Test the subdvision of a node, compared to this layer.
-     *
-     * @param {Object} context - The context of the update; see the {@link
-     * MainLoop} for more informations.
-     * @param {PlanarLayer} layer - This layer, parameter to be removed.
-     * @param {TileMesh} node - The node to test.
-     *
-     * @return {boolean} - True if the node is subdivisable, otherwise false.
-     */
-    subdivision(context, layer, node) {
-        const maxLevel = this.maxSubdivisionLevel || 5;
-        const maxDeltaElevationLevel = this.maxDeltaElevationLevel || 4;
-
-        if (maxLevel <= node.level) {
-            return false;
-        }
-
-        // Prevent to subdivise the node if the current elevation level
-        // we must avoid a tile, with level 20, inherits a level 3 elevation texture.
-        // The induced geometric error is much too large and distorts the SSE
-        const nodeLayer = node.material.getElevationLayer();
-        if (nodeLayer) {
-            const currentTexture = nodeLayer.textures[0];
-            if (currentTexture && currentTexture.extent) {
-                const offsetScale = nodeLayer.offsetScales[0];
-                const ratio = offsetScale.z;
-                // ratio is node size / texture size
-                if (ratio < 1 / (2 ** maxDeltaElevationLevel)) {
-                    return false;
-                }
-            }
-        }
-
-        const onScreen = context.camera.box3SizeOnScreen(node.obb.box3D, node.matrixWorld);
-
-        // onScreen.x/y/z are [-1, 1] so divide by 2
-        // (so x = 0.4 means the object width on screen is 40% of the total screen width)
-        const dim = {
-            x: 0.5 * (onScreen.max.x - onScreen.min.x) * context.camera.width,
-            y: 0.5 * (onScreen.max.y - onScreen.min.y) * context.camera.height,
-        };
-
-        // subdivide if on-screen width (and resp. height) is bigger than 30% of the screen width (resp. height)
-        // TODO: the 30% value is arbitrary and needs to be configurable by the user
-        // TODO: we might want to use texture resolution here as well
-        return (dim.x >= 256 && dim.y >= 256);
     }
 }
 

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -50,24 +50,4 @@ PlanarView.prototype.addLayer = function addLayer(layer) {
     return View.prototype.addLayer.call(this, layer, this.tileLayer);
 };
 
-PlanarView.prototype.selectNodeAt = function selectNodeAt(mouse) {
-    const picked = this.tileLayer.pickObjectsAt(this, mouse);
-    const selectedId = picked.length ? picked[0].object.id : undefined;
-
-    for (const n of this.tileLayer.level0Nodes) {
-        n.traverse((node) => {
-            if (node.material) {
-                const selected = node.id === selectedId;
-                node.material.overlayAlpha = selected ? 0.5 : 0;
-                if (selected) {
-                    // eslint-disable-next-line no-console
-                    console.info(node);
-                }
-            }
-        });
-    }
-
-    this.notifyChange();
-};
-
 export default PlanarView;

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import OGCWebServiceHelper, { SIZE_TEXTURE_TILE } from 'Provider/OGCWebServiceHelper';
+import OGCWebServiceHelper from 'Provider/OGCWebServiceHelper';
 import { is4326 } from 'Core/Geographic/Coordinates';
 
 /**
@@ -27,7 +27,6 @@ class TileMesh extends THREE.Mesh {
         this.obb = this.geometry.OBB.clone();
         this.boundingSphere = new THREE.Sphere();
         this.obb.box3D.getBoundingSphere(this.boundingSphere);
-        this.updateGeometricError();
         this.wmtsCoords = {};
 
         this.frustumCulled = false;
@@ -63,7 +62,6 @@ class TileMesh extends THREE.Mesh {
         if (Math.floor(min) !== Math.floor(this.obb.z.min) || Math.floor(max) !== Math.floor(this.obb.z.max)) {
             this.obb.updateZ(min, max);
             this.obb.box3D.getBoundingSphere(this.boundingSphere);
-            this.updateGeometricError();
         }
     }
 
@@ -100,15 +98,6 @@ class TileMesh extends THREE.Mesh {
 
     getZoomForLayer(layer) {
         return this.getCoordsForSource(layer.source)[0].zoom || this.level;
-    }
-
-    /**
-     * Update the geometric error based on the bounding sphere radius.
-     */
-    updateGeometricError() {
-        // The geometric error is calculated to have a correct texture display.
-        // For the projection of a texture's texel to be less than or equal to one pixel
-        this.geometricError = this.boundingSphere.radius / SIZE_TEXTURE_TILE;
     }
 
     /**

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -256,6 +256,11 @@ class TiledGeometryLayer extends GeometryLayer {
         return layers.length;
     }
 
+    // eslint-disable-next-line
+    culling(node, camera) {
+        return !camera.isBox3Visible(node.obb.box3D, node.obb.matrixWorld);
+    }
+
     /**
      * Tell if a node has enough elevation or color textures to subdivide.
      * Subdivision is prevented if:

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -223,19 +223,10 @@ function _cleanupObject3D(n) {
 }
 
 // this is a layer
-export function pre3dTilesUpdate(context) {
+export function pre3dTilesUpdate() {
     if (!this.visible) {
         return [];
     }
-
-    // pre-sse
-    const hypotenuse = Math.sqrt(context.camera.width * context.camera.width + context.camera.height * context.camera.height);
-    const radAngle = context.camera.camera3D.fov * Math.PI / 180;
-
-    // TODO: not correct -> see new preSSE
-    // const HFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) / context.camera.ratio);
-    const HYFOV = 2.0 * Math.atan(Math.tan(radAngle * 0.5) * hypotenuse / context.camera.width);
-    context.camera.preSSE = hypotenuse * (2.0 * Math.tan(HYFOV * 0.5));
 
     // Elements removed are added in the layer._cleanableTiles list.
     // Since we simply push in this array, the first item is always
@@ -290,7 +281,7 @@ export function computeNodeSSE(camera, node) {
         // This test is needed in case geometricError = distance = 0
         return Infinity;
     }
-    return camera.preSSE * (node.geometricError / node.distance);
+    return camera._preSSE * (node.geometricError / node.distance);
 }
 
 export function init3dTilesLayer(view, scheduler, layer) {

--- a/src/Provider/OGCWebServiceHelper.js
+++ b/src/Provider/OGCWebServiceHelper.js
@@ -1,7 +1,9 @@
 import Projection from 'Core/Geographic/Projection';
 import Extent from 'Core/Geographic/Extent';
 
+// Size in pixel
 export const SIZE_TEXTURE_TILE = 256;
+export const SIZE_DIAGONAL_TEXTURE = Math.pow(2 * (SIZE_TEXTURE_TILE * SIZE_TEXTURE_TILE), 0.5);
 
 const tileCoord = new Extent('WMTS:WGS84G', 0, 0, 0);
 

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -14,6 +14,8 @@ function Camera(crs, width, height, options = {}) {
     this._viewMatrix = new THREE.Matrix4();
     this.width = width;
     this.height = height;
+
+    this._preSSE = Infinity;
 }
 
 function resize(camera, width, height) {
@@ -44,7 +46,50 @@ Camera.prototype.update = function update(width, height) {
 
     // keep our visibility testing matrix ready
     this._viewMatrix.multiplyMatrices(this.camera3D.projectionMatrix, this.camera3D.matrixWorldInverse);
+
+    // sse = projected geometric error on screen plane from distance
+    // We're using an approximation, assuming that the geometric error of all
+    // objects is perpendicular to the camera view vector (= we always compute
+    // for worst case).
+    //
+    //            screen plane             object
+    //               |                         __
+    //               |                        /  \
+    //               |             geometric{|
+    //  < fov angle  . } sse          error {|    |
+    //               |                        \__/
+    //               |
+    //               |<--------------------->
+    //               |        distance
+    //
+    //              geometric_error * screen_width      (resp. screen_height)
+    //     =  ---------------------------------------
+    //        2 * distance * tan (horizontal_fov / 2)   (resp. vertical_fov)
+    //
+    //
+    // We pre-compute the preSSE (= constant part of the screen space error formula) once here
+
+    const verticalFOV = THREE.Math.degToRad(this.camera3D.fov);
+    const verticalPreSSE = this.height / (2.0 * Math.tan(verticalFOV * 0.5));
+
+    // Note: the preSSE for the horizontal FOV is the same value
+    // focale = (this.height * 0.5) / Math.tan(verticalFOV * 0.5);
+    // horizontalFOV = 2 * Math.atan(this.width * 0.5 / focale);
+    // horizontalPreSSE = this.width / (2.0 * Math.tan(horizontalFOV * 0.5)); (1)
+    // => replacing horizontalFOV in Math.tan(horizontalFOV * 0.5)
+    // Math.tan(horizontalFOV * 0.5) = Math.tan(2 * Math.atan(this.width * 0.5 / focale) * 0.5)
+    //                               = Math.tan(Math.atan(this.width * 0.5 / focale))
+    //                               = this.width * 0.5 / focale
+    // => now replacing focale
+    //                               = this.width * 0.5 / (this.height * 0.5) / Math.tan(verticalFOV * 0.5)
+    //                               = Math.tan(verticalFOV * 0.5) * this.width / this.height
+    // => back to (1)
+    // horizontalPreSSE = this.width / (2.0 * Math.tan(verticalFOV * 0.5) * this.width / this.height)
+    //                  = this.height / 2.0 * Math.tan(verticalFOV * 0.5)
+    //                  = verticalPreSSE
+    this._preSSE = verticalPreSSE;
 };
+
 
 /**
  * Return the position in the requested CRS, or in camera's CRS if undefined.

--- a/test/examples/globe.js
+++ b/test/examples/globe.js
@@ -17,6 +17,18 @@ describe('globe', function _() {
 
         assert.equal(2, level);
     });
+
+    it('should subdivise globe correctly', async () => {
+        const displayedTiles = await page.evaluate(() => {
+            r = {};
+            [...view.tileLayer.info.displayed.tiles]
+            // eslint-disable-next-line
+                .forEach(t => (!r[t.level] ? r[t.level] = 1 : r[t.level]++));
+            return r;
+        });
+        assert.equal(displayedTiles['2'], 26);
+    });
+
     it('should not add layer with id already used', async () => {
         const error = await page.evaluate(() => itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(view.addLayer).catch(() => true));
         const colorLayersCount = await page.evaluate(() => view.getLayers(l => l.type === 'color').length);

--- a/test/examples/planar.js
+++ b/test/examples/planar.js
@@ -10,6 +10,19 @@ describe('planar', function _() {
         assert.ok(result);
     });
 
+    it('should subdivise planar correctly', async () => {
+        const displayedTiles = await page.evaluate(() => {
+            r = {};
+            [...view.tileLayer.info.displayed.tiles]
+            // eslint-disable-next-line
+                .forEach(t => (!r[t.level] ? r[t.level] = 1 : r[t.level]++));
+            return r;
+        });
+        assert.equal(displayedTiles['1'], 1);
+        assert.equal(displayedTiles['2'], 6);
+        assert.equal(displayedTiles['3'], 5);
+    });
+
     it('should get picking position from depth', async function __() {
         const length = 1500;
 

--- a/test/unit/camera.js
+++ b/test/unit/camera.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import Camera from '../../src/Renderer/Camera';
+
+describe('preSSE checks', function () {
+    it('should increase when fov decrease', function () {
+        const camera = new Camera('', 100, 50);
+
+        camera.update(100, 50);
+        const initial = camera._preSSE;
+
+        camera.camera3D.fov *= 0.5;
+        camera.update(100, 50);
+
+        assert.ok(camera._preSSE > initial);
+    });
+});


### PR DESCRIPTION
**Resume work from #818 and #633**

- implement preSSE once and fix the formula
- Unify culling for `TiledGeometryLayer`
- add sse helper on tiled geometry layer
- unify sse for Planar and globe
- show console info param `selectNodeAt`

**Remaining work**

- [x] fix `GlobeLayer.computeTileZoomFromDistanceCamera`.
- [x] fix  `GlobeLayer.computeDistanceCameraFromTileZoom`.
- [x] write tests.
