### PR TITLE
fix(geometryLayer): wireFrame property change 

### DIFF
--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -80,7 +80,7 @@ class GeometryLayer extends Layer {
                     object.material.wireframe = this.wireframe;
                 } else if (object.content && object.content.layer == this) {
                     object.content.traverse((o) => {
-                        if (o.material) {
+                        if (o.material && o.layer == this) {
                             o.material.wireframe = this.wireframe;
                         }
                     });

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -105,12 +105,12 @@ export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) 
 
     View.prototype.addLayer.call(view, obbLayer, _3dTileslayer).then((l) => {
         gui.add(l, 'visible').name('Bounding boxes').onChange(() => {
-            view.notifyChange();
+            view.notifyChange(view.camera.camera3D);
         });
     });
 
     // The sse Threshold for each tile
     gui.add(_3dTileslayer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
-        view.notifyChange();
+        view.notifyChange(view.camera.camera3D);
     });
 }


### PR DESCRIPTION

## Description
fix(geometryLayer): wireFrame property change only affect This layer objects. 

Before this commit, it could also affect objects on attached layers (for example, bounding box from attached debug layers). 

## Motivation and Context
fix #940

