### PR TITLE
chore: update THREE r98 to r99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3974,8 +3974,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3996,14 +3995,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4018,14 +4015,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4147,8 +4142,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4160,7 +4154,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4175,7 +4168,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4294,8 +4286,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4428,7 +4419,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4448,7 +4438,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9357,9 +9346,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.98.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.98.0.tgz",
-      "integrity": "sha512-fihjYVjCmQbI03zt1+YCl/m+UrZCcDHFNLexgqBOIdPwnO6PYkQaYUsIbqtvNNse+BiMeu+pQWzZn9/NSnIv6A==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.99.0.tgz",
+      "integrity": "sha512-DmNNq6H6nRGaqxScJ8x7v5VjdtDZR72oTVwDdKbB2BYNFxCkAoo9vdFAznEsMu9YzTV2yFvbVs7qHRzvJZzTIg==",
       "dev": true
     },
     "three.meshline": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.98.0",
+    "three": "^0.99.0",
     "three.meshline": "^1.1.0"
   },
   "devDependencies": {
@@ -78,7 +78,7 @@
     "proj4": "^2.5.0",
     "puppeteer": "^1.10.0",
     "replace-in-file": "^3.4.2",
-    "three": "^0.98.0",
+    "three": "^0.99.0",
     "three.meshline": "^1.1.0",
     "url-polyfill": "^1.1.0",
     "webpack": "^4.25.1",


### PR DESCRIPTION
### Migration Guide

- [ ] WebGLRenderTarget.texture.generateMipmaps is now set to false by default.
- [ ] There is a new (not backwards compatible) implementation for SSAOShader and SSAOPass.
- [ ] JSONLoader has been removed from core. It is now located in examples/js/loaders/deprecated/LegacyJSONLoader.js.
- [ ] Removed Geometry support from ObjectLoader. You have to include LegacyJSONLoader if you still want to load geometry data of type Geometry.
- [ ] Removed Geometry support from SkinnedMesh. Use BufferGeometry instead.
- [ ] Removed SkinnedMesh.initBones(). The SkinnedMesh constructor does not build the bone hierarchy anymore. You have to do this by yourself and then call SkinnedMesh.bind() in order to bind the prepared skeleton.

