### PR TITLE
feat(fetcher): add the possibility to specify fetcher

### DIFF
--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -13,6 +13,11 @@ import Extent from 'Core/Geographic/Extent';
  * for optimisation.
  * @property {string} url - The url of the resources that are fetched.
  * @property {string} format - The format of the resources that are fetched.
+ * @property {function} fetcher - The method used to fetch the resources from
+ * the source. iTowns provides some methods in {@link Fetcher}, but it can be
+ * specified a custom one. This method should return a <code>Promise</code>
+ * containing the fetched resource. If this property is set, it overrides the
+ * chosen fetcher method with <code>format</code>.
  * @property {Object} networkOptions - Fetch options (passed directly to
  * <code>fetch()</code>), see {@link
  * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax|the
@@ -39,6 +44,7 @@ class Source {
 
         this.url = source.url;
         this.format = source.format;
+        this.fetcher = source.fetcher;
         this.networkOptions = source.networkOptions || { crossOrigin: 'anonymous' };
         this.projection = source.projection;
         this.attribution = source.attribution;


### PR DESCRIPTION
Before this commit, the fetching in DataSourceProvider (default
providers for most resources) was limited to a list of format linked to
a fetching method. Now, it is possible to declare the fetching method in
the Source, and by default it is using the texture fetching.

Note that this doesn't break and change anything in the current way of
doing things. The default value being `Fetcher.texture` is of course
subject to some debate.

Solves #954
