### PR TITLE
chore(examples): Simplify example page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -21,172 +21,178 @@
         </p>
         <div id="error-nowebgl"></div>
         <div class="exampleContainer">
-            <h3><a href='./orthographic.html' target='_blank'>Orthographic</a></h3>
-            <img src='screenshots/orthographic.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./orthographic.html' target='_blank'>
+                <h3>Orthographic</h3>
+                <img src='screenshots/orthographic.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./pointcloud.html' target='_blank'>Pointcloud</a></h3>
-            <img src='screenshots/pointcloud.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./pointcloud.html' target='_blank'>
+                <h3>Pointcloud</h3>
+                <img src='screenshots/pointcloud.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./pointcloud_globe.html' target='_blank'>Pointcloud on globe</a></h3>
-            <img src='screenshots/pointcloud_globe.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./pointcloud_globe.html' target='_blank'>
+                <h3>Pointcloud on globe</h3>
+                <img src='screenshots/pointcloud_globe.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./planar.html' target='_blank'>Planar mode</a></h3>
-            <img src='screenshots/planar.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./planar.html' target='_blank'>
+                <h3>Planar mode</h3>
+                <img src='screenshots/planar.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe.html' target='_blank'>Globe</a></h3>
-            <img src='screenshots/globe.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe.html' target='_blank'>
+                <h3>Globe</h3>
+                <img src='screenshots/globe.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./oriented_images.html' target='_blank'>Oriented images</a></h3>
-            <img src='screenshots/oriented_picture.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./oriented_images.html' target='_blank'>
+                <h3>Oriented images</h3>
+                <img src='screenshots/oriented_picture.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./postprocessing.html' target='_blank'>Post processing</a></h3>
-            <img src='screenshots/postprocessing.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./postprocessing.html' target='_blank'>
+                <h3>Post processing</h3>
+                <img src='screenshots/postprocessing.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./3dtiles.html' target='_blank'>3d tiles</a></h3>
-            <img src='screenshots/3dtiles.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./3dtiles.html' target='_blank'>
+                <h3>3d tiles</h3>
+                <img src='screenshots/3dtiles.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./multiglobe.html' target='_blank'>Multiple globes</a></h3>
-            <img src='screenshots/multiglobe.jpg' target='_blank'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./multiglobe.html' target='_blank'>
+                <h3>Multiple globes</h3>
+                <img src='screenshots/multiglobe.jpg' target='_blank'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./layersColorVisible.html' target='_blank'>Layer visibility</a></h3>
-            <img src='screenshots/globe.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./layersColorVisible.html' target='_blank'>
+                <h3>Layer visibility</h3>
+                <img src='screenshots/globe.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./split.html' target='_blank'>Splitted rendering</a></h3>
-            <img src='screenshots/split.jpg' target='_blank'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./split.html' target='_blank'>
+                <h3>Splitted rendering</h3>
+                <img src='screenshots/split.jpg' target='_blank'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./cubic_planar.html' target='_blank'>Layers transformations</a></h3>
-            <img src='screenshots/cubic_planar.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./cubic_planar.html' target='_blank'>
+                <h3>Layers transformations</h3>
+                <img src='screenshots/cubic_planar.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./wfs.html' target='_blank'>WFS data with reprojection</a></h3>
-            <img src='screenshots/wfs.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./wfs.html' target='_blank'>
+                <h3>WFS data with reprojection</h3>
+                <img src='screenshots/wfs.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./gpx.html' target='_blank'>Gpx</a></h3>
-            <img src='screenshots/gpx.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./gpx.html' target='_blank'>
+                <h3>Gpx</h3>
+                <img src='screenshots/gpx.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./positionGlobe.html' target='_blank'>Position a mesh</a></h3>
-            <img src='screenshots/position.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./positionGlobe.html' target='_blank'>
+                <h3>Position a mesh</h3>
+                <img src='screenshots/position.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe_vector.html' target='_blank'>globe with data vector</a></h3>
-            <img src='screenshots/globe_vector.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe_vector.html' target='_blank'>
+                <h3>globe with data vector</h3>
+                <img src='screenshots/globe_vector.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./planar_vector.html' target='_blank'>Plane mode with data vector</a></h3>
-            <img src='screenshots/planar_vector.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./planar_vector.html' target='_blank'>
+                <h3>Plane mode with data vector</h3>
+                <img src='screenshots/planar_vector.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe_wfs_extruded.html' target='_blank'>WFS extruded on globe</a></h3>
-            <img src='screenshots/globe_wfs_extruded.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe_wfs_extruded.html' target='_blank'>
+                <h3>WFS extruded on globe</h3>
+                <img src='screenshots/globe_wfs_extruded.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./panorama.html' target='_blank'>Panoramas</a></h3>
-            <img src='screenshots/panorama.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./panorama.html' target='_blank'>
+                <h3>Panoramas</h3>
+                <img src='screenshots/panorama.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./stereo.html' target='_blank'>Stereo effects</a></h3>
-            <img src='screenshots/stereo.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./stereo.html' target='_blank'>
+                <h3>Stereo effects</h3>
+                <img src='screenshots/stereo.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./collada.html' target='_blank'>3D model loader</a></h3>
-            <img src='screenshots/collada.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./collada.html' target='_blank'>
+                <h3>3D model loader</h3>
+                <img src='screenshots/collada.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe_vector_tiles.html' target='_blank'>Globe with
-                    vector tiles data</a></h3>
-            <img src='screenshots/globe_vector_tiles.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe_vector_tiles.html' target='_blank'>
+                <h3>Globe with vector tiles data</h3>
+                <img src='screenshots/globe_vector_tiles.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./planar_vector_tiles.html' target='_blank'>Plane mode
-                    with vector tiles data</a></h3>
-            <img src='screenshots/planar_vector_tiles.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./planar_vector_tiles.html' target='_blank'>
+                <h3>Plane mode with vector tiles data</h3>
+                <img src='screenshots/planar_vector_tiles.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe_travel.html' target='_blank'>camera's animations with CameraUtils</a></h3>
-            <img src='screenshots/globe_travel.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe_travel.html' target='_blank'>
+                <h3>camera's animations with CameraUtils</h3>
+                <img src='screenshots/globe_travel.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./syncCameras.html' target='_blank'>synchronisation cameras with CameraUtils</a></h3>
-            <img src='screenshots/syncCameras.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./syncCameras.html' target='_blank'>
+                <h3>synchronisation cameras with CameraUtils</h3>
+                <img src='screenshots/syncCameras.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe_wfs_color.html' target='_blank'>wfs source to color layer</a></h3>
-            <img src='screenshots/globe_wfs_color.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe_wfs_color.html' target='_blank'>
+                <h3>wfs source to color layer</h3>
+                <img src='screenshots/globe_wfs_color.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./globe_geojson_to3D.html' target='_blank'>geojson to geometry layer</a></h3>
-            <img src='screenshots/globe_geojson_to3D.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./globe_geojson_to3D.html' target='_blank'>
+                <h3>geojson to geometry layer</h3>
+                <img src='screenshots/globe_geojson_to3D.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./orientation_utils.html' target='_blank'>Orientation utils</a></h3>
-            <img src='screenshots/camera_parser.jpg'>
-            <iframe src="" style="display: none;"></iframe>
-        </div>
+            <a href='./orientation_utils.html' target='_blank'>
+                <h3>Orientation utils</h3>
+                <img src='screenshots/camera_parser.jpg'>
+            </a>
         </div>
         <div class="exampleContainer">
-            <h3><a href='./orientation_utils_planar.html' target='_blank'>Orientation utils planar</a></h3>
-            <img src='screenshots/orientation_utils_planar.jpg'>
-            <iframe src="" style="display: none;"></iframe>
+            <a href='./orientation_utils_planar.html' target='_blank'>
+                <h3>Orientation utils planar</h3>
+                <img src='screenshots/orientation_utils_planar.jpg'>
+            </a>
         </div>
-        <script src="https://unpkg.com/three@0.97.0/examples/js/WebGL.js"></script>
-        <script type="text/javascript">
-            if (!WEBGL.isWebGLAvailable()) {
-                document.getElementById('error-nowebgl').append(WEBGL.getWebGLErrorMessage());
-            } else if (!WEBGL.isWebGL2Available()) {
-                document.getElementById('error-nowebgl').append(WEBGL.getWebGL2ErrorMessage());
-            } else {
-                function enableOnClick(evt) {
-                    this.getElementsByTagName('img')[0].style.display = 'none';
-                    this.getElementsByTagName('iframe')[0].style.display = '';
-                    this.getElementsByTagName('iframe')[0].src = this.getElementsByTagName('a')[0].href;
-                }
-
-                    var divs = document.getElementsByClassName('exampleContainer');
-                    var i;
-                    for (i=0; i<divs.length; i++) {
-                        divs[i].addEventListener('click', enableOnClick.bind(divs[i]));
-                }
-            }
-        </script>
     </body>
 </html>


### PR DESCRIPTION
Before this commit, the example was running in a tiny frame when we clicked on it.
Now, when we click on an example, it loads a new tab.
