### PR TITLE
docs: clean and update of the Source/ folder

### DIFF
--- a/examples/cubic_planar.html
+++ b/examples/cubic_planar.html
@@ -139,7 +139,7 @@
                     version: '1.3.0',
                     name: 'MNT2012_Altitude_10m_CC46',
                     projection: 'EPSG:3946',
-                    heightMapWidth: 256,
+                    width: 256,
                     format: 'image/jpeg',
                     url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 });

--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -16,7 +16,7 @@
         "transparent" : true,
         "featureInfoMimeType" : "",
         "dateTime"  : "",
-        "heightMapWidth" : 256,
+        "width" : 256,
         "waterMask"      : false,
         "updateStrategy": {
             "type": 0,

--- a/examples/planar.html
+++ b/examples/planar.html
@@ -79,7 +79,7 @@
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 name: 'MNT2012_Altitude_10m_CC46',
                 projection: 'EPSG:3946',
-                heightMapWidth: 256,
+                width: 256,
                 format: 'image/jpeg',
             });
 

--- a/examples/planar_vector.html
+++ b/examples/planar_vector.html
@@ -74,7 +74,7 @@
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 name: 'MNT2012_Altitude_10m_CC46',
                 projection: 'EPSG:3946',
-                heightMapWidth: 256,
+                width: 256,
                 format: 'image/jpeg',
             });
 

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -107,7 +107,8 @@ function fileParser(text) {
 class FileSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * FileSource. Only <code>url</code> and <code>projection</code> are mandatory.
+     * FileSource and {@link Source}. Only <code>url</code> and
+     * <code>projection</code> are mandatory.
      * @param {string} crsOut - The projection of the output data after parsing.
      *
      * @constructor

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -5,8 +5,8 @@ import Extent from 'Core/Geographic/Extent';
  * Sources are object containing informations on how to fetch resources, from a
  * set source.
  *
- * To extend a Source, it is necessary to implement two functions: {@link
- * Source#urlFromExtent} and {@link Source#extentInsideLimit}.
+ * To extend a Source, it is necessary to implement two functions:
+ * <code>urlFromExtent</code> and <code>extentInsideLimit</code>.
  *
  * @property {boolean} isSource - Used to checkout whether this source is a
  * Source. Default is true. You should not change this, as it is used internally

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -16,9 +16,9 @@ import Extent from 'Core/Geographic/Extent';
  * @property {boolean} isInverted - The isInverted property is to be set to the
  * correct value, true or false (default being false) if the computation of the
  * coordinates needs to be inverted to match the same scheme as OSM, Google Maps
- * or other system. See {@link
- * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/|this
- * link} for more information.
+ * or other system. See [this link]{@link
+ * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/}
+ * for more information.
  * @property {string} tileMatrixSet - Tile matrix set of the layer, used in the
  * generation of the coordinates to build the url. Default value is 'WGS84'.
  * @property {Object} zoom - Object containing the minimum and maximum values of
@@ -51,7 +51,7 @@ import Extent from 'Core/Geographic/Extent';
 class TMSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * TMSSource. Only <code>url</code> is mandatory.
+     * TMSSource and {@link Source}. Only <code>url</code> is mandatory.
      *
      * @constructor
      */

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -85,7 +85,7 @@ import URLBuilder from 'Provider/URLBuilder';
 class WFSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * WFSSource. <code>url</code>, <code>typeName</code> and
+     * WFSSource and {@link Source}. <code>url</code>, <code>typeName</code> and
      * <code>projection</code> are mandatory.
      *
      * @constructor

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -59,9 +59,9 @@ import URLBuilder from 'Provider/URLBuilder';
  */
 class WMSSource extends Source {
     /**
-     * @param {Object} source - An object that can contain all properties of a
-     * WMSSource. <code>url</code>, <code>name</code>, <code>extent</code> and
-     * <code>projection</code> are mandatory.
+     * @param {Object} source - An object that can contain all properties of
+     * WMSSource and {@link Source}. <code>url</code>, <code>name</code>,
+     * <code>extent</code> and <code>projection</code> are mandatory.
      *
      * @constructor
      */

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -18,8 +18,10 @@ import URLBuilder from 'Provider/URLBuilder';
  * Default value is '1.3.0'.
  * @property {string} style - The style to query on the WMS server. Default
  * value is 'normal'.
- * @property {number} heightMapWidth - The size of the image to fetch, in pixel.
- * Default value is 256.
+ * @property {number} width - The width of the image to fetch, in pixel.
+ * Default value is the height if set or 256.
+ * @property {number} height - The height of the image to fetch, in pixel.
+ * Default value is the width if set or 256.
  * @property {string} axisOrder - The order of the axis, that helps building the
  * BBOX to put in the url requesting a resource. Default value is 'wsen', other
  * value can be 'swne'.
@@ -84,7 +86,15 @@ class WMSSource extends Source {
         this.zoom = source.zoom || { min: 0, max: 21 };
         this.format = this.format || 'image/png';
         this.style = source.style || '';
-        this.width = source.heightMapWidth || 256;
+
+        // TODO: remove in 2.7.0
+        if (source.heightMapWidth) {
+            console.warn('source.heightMapWidth is deprecated, please use source.width instead.');
+            source.width = source.width || source.heightMapWidth;
+        }
+
+        this.width = source.width || source.height || 256;
+        this.height = source.height || source.width || 256;
         this.version = source.version || '1.3.0';
         this.transparent = source.transparent || false;
 
@@ -109,7 +119,7 @@ class WMSSource extends Source {
             this.format}&TRANSPARENT=${
             this.transparent}&BBOX=%bbox&${
             crsPropName}=${
-            this.projection}&WIDTH=${this.width}&HEIGHT=${this.width}`;
+            this.projection}&WIDTH=${this.width}&HEIGHT=${this.height}`;
     }
 
     urlFromExtent(extent) {

--- a/src/Source/WMTSSource.js
+++ b/src/Source/WMTSSource.js
@@ -18,6 +18,9 @@ import URLBuilder from 'Provider/URLBuilder';
  * Default value is '1.0.0'.
  * @property {string} style - The style to query on the WMTS server. Default
  * value is 'normal'.
+ * @property {string} projection - The projection in which to fetch the data. If
+ * not specified, it is deduced from <code>tileMatrixSet</code>. Default value
+ * is 'EPSG:3857'.
  * @property {string} tileMatrixSet - Tile matrix set of the layer, used in the
  * generation of the url. Default value is 'WGS84'.
  * @property {Object} tileMatrixSetLimits - Limits of the tile matrix
@@ -59,7 +62,8 @@ import URLBuilder from 'Provider/URLBuilder';
 class WMTSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * WMTSSource. Only <code>url</code> and <code>name</code> are mandatory.
+     * WMTSSource and {@link Source}. Only <code>url</code> and
+     * <code>name</code> are mandatory.
      *
      * @constructor
      */


### PR DESCRIPTION
Part of #968 

I also deprecated `heightMapWidth` in profit of `width` which is the real name of the parameter in the creation of as `WMS` url. I don't know if I could also add the `height` property ? So we could have something like:

```js
this.width = source.width || source.height || 256;
this.height = source.height || source.width || 256;
```