### PR TITLE
refactor(layer): replace all layer.type by layer.isLayer

### DIFF
--- a/examples/planar.html
+++ b/examples/planar.html
@@ -105,7 +105,7 @@
 
             if (view.isDebugMode) {
                 menuGlobe = new GuiTools('menuDiv', view);
-                menuGlobe.addImageryLayersGUI(view.getLayers(function gui(l) { return l.type === 'color'; }));
+                menuGlobe.addImageryLayersGUI(view.getLayers(function gui(l) { return l.isColorLayer; }));
                 d = new debug.Debug(view, menuGlobe.gui);
                 debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
             }

--- a/src/Converter/textureConverter.js
+++ b/src/Converter/textureConverter.js
@@ -32,9 +32,9 @@ export default {
             throw (new Error('Data type is not supported to convert into texture'));
         }
 
-        if (layer.type === 'color') {
+        if (layer.isColorLayer) {
             return textureColorLayer(texture, layer.transparent);
-        } else if (layer.type === 'elevation') {
+        } else if (layer.isElevationLayer) {
             if (texture.flipY) {
                 // DataTexture default to false, so make sure other Texture types
                 // do the same (eg image texture)

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -204,11 +204,11 @@ GlobeView.prototype.addLayer = function addLayer(layer) {
     if (!layer) {
         return new Promise((resolve, reject) => reject(new Error('layer is undefined')));
     }
-    if (layer.type == 'color') {
-        const colorLayerCount = this.getLayers(l => l.type === 'color').length;
+    if (layer.isColorLayer) {
+        const colorLayerCount = this.getLayers(l => l.isColorLayer).length;
         layer.sequence = colorLayerCount;
-    } else if (layer.type == 'elevation') {
-        if (layer.source.protocol === 'wmts' && layer.source.tileMatrixSet !== 'WGS84G') {
+    } else if (layer.isElevationLayer) {
+        if (layer.source.isWMTSSource && layer.source.tileMatrixSet !== 'WGS84G') {
             throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');
         }
     }
@@ -232,11 +232,11 @@ GlobeView.prototype.addLayer = function addLayer(layer) {
  */
 GlobeView.prototype.removeLayer = function removeLayer(layerId) {
     const layer = this.getLayers(l => l.id === layerId)[0];
-    if (layer && layer.type === 'color' && this.tileLayer.detach(layer)) {
+    if (layer && layer.isColorLayer && this.tileLayer.detach(layer)) {
         for (const root of this.tileLayer.level0Nodes) {
             root.traverse(removeLayeredMaterialNodeLayer(layerId));
         }
-        const imageryLayers = this.getLayers(l => l.type === 'color');
+        const imageryLayers = this.getLayers(l => l.isColorLayer);
         for (const color of imageryLayers) {
             if (color.sequence > layer.sequence) {
                 color.sequence--;

--- a/src/Core/Prefab/PanoramaView.js
+++ b/src/Core/Prefab/PanoramaView.js
@@ -57,7 +57,7 @@ PanoramaView.prototype.addLayer = function addLayer(layer) {
     if (!layer) {
         return new Promise((resolve, reject) => reject(new Error('layer is undefined')));
     }
-    if (layer.type != 'color') {
+    if (!layer.isColorLayer) {
         throw new Error(`Unsupported layer type ${layer.type} (PanoramaView only support 'color' layers)`);
     }
     return View.prototype.addLayer.call(this, layer, this.tileLayer);

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -56,7 +56,7 @@ class ColorLayer extends Layer {
      * view.addLayer(color);
      */
     constructor(id, config = {}) {
-        super(id, 'color', config);
+        super(id, config);
         this.isColorLayer = true;
         this.style = config.style || {};
         this.defineLayerProperty('visible', true);

--- a/src/Layer/ElevationLayer.js
+++ b/src/Layer/ElevationLayer.js
@@ -40,7 +40,7 @@ class ElevationLayer extends Layer {
      * view.addLayer(elevation);
      */
     constructor(id, config = {}) {
-        super(id, 'elevation', config);
+        super(id, config);
         this.isElevationLayer = true;
     }
 

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -50,7 +50,7 @@ class GeometryLayer extends Layer {
      * view.addLayer(geometry);
      */
     constructor(id, object3d, config = {}) {
-        super(id, 'geometry', config);
+        super(id, config);
 
         this.isGeometryLayer = true;
 

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -19,16 +19,6 @@ class Layer extends THREE.EventDispatcher {
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
      * {@link View} that already has a layer going by that id.
-     * @param {string} type - The type of the layer, used to determine
-     * operations to do on a layer later in the rendering loop. There are three
-     * type of layers in itowns:
-     * <ul>
-     *  <li><code>color</code>, used for simple layer containing a texture</li>
-     *  <li><code>elevation</code>, used for adding an elevation to the globe or
-     *  plane the layer is attached to</li>
-     *  <li><code>geometry</code>, used for complex layer containing meshes,
-     *  like a WFS layer with extruded buildings</li>
-     * </ul>
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
      * contains three elements <code>name, protocol, extent</code>, these
@@ -37,7 +27,7 @@ class Layer extends THREE.EventDispatcher {
      *
      * @example
      * // Add and create a new Layer
-     * const newLayer = new Layer('id', 'custom', options);
+     * const newLayer = new Layer('id', options);
      * view.addLayer(newLayer);
      *
      * // Change layer's visibility
@@ -55,8 +45,15 @@ class Layer extends THREE.EventDispatcher {
      * layerToListen.addEventListener('visible-property-changed', (event) => console.log(event));
      * layerToListen.addEventListener('opacity-property-changed', (event) => console.log(event));
      */
-    constructor(id, type, config = {}) {
+    constructor(id, config = {}) {
         super();
+
+        if (typeof config == 'string') {
+            console.warn('Deprecation warning: layer.type is deprecated, use a boolean flag instead as a property of the layer');
+            this.type = config;
+            // eslint-disable-next-line
+            config = arguments[2] || {};
+        }
 
         this.isLayer = true;
 
@@ -64,11 +61,6 @@ class Layer extends THREE.EventDispatcher {
 
         Object.defineProperty(this, 'id', {
             value: id,
-            writable: false,
-        });
-
-        Object.defineProperty(this, 'type', {
-            value: type,
             writable: false,
         });
 

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -139,9 +139,9 @@ class TiledGeometryLayer extends GeometryLayer {
         }
 
         context.colorLayers = context.view.getLayers(
-            (l, a) => a && a.id == this.id && l.type == 'color');
+            (l, a) => a && a.id == this.id && l.isColorLayer);
         context.elevationLayers = context.view.getLayers(
-            (l, a) => a && a.id == this.id && l.type == 'elevation');
+            (l, a) => a && a.id == this.id && l.isElevationLayer);
 
         context.maxElevationLevel = -1;
         for (const e of context.elevationLayers) {

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -52,7 +52,7 @@ function refinementCommandCancellationFn(cmd) {
     // Cancel the command if the tile already has a better texture.
     // This is only needed for elevation layers, because we may have several
     // concurrent layers but we can only use one texture.
-    if (cmd.layer.type == 'elevation' && cmd.requester.material.getElevationLayer() &&
+    if (cmd.layer.isElevationLayer && cmd.requester.material.getElevationLayer() &&
         cmd.targetLevel <= cmd.requester.material.getElevationLayer().level) {
         return true;
     }
@@ -95,7 +95,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
             nodeLayer = material.addLayer(layer, tileMT);
 
             // TODO: Sequence must be returned by parent geometry layer
-            const colorLayers = context.view.getLayers(l => l.type === 'color');
+            const colorLayers = context.view.getLayers(l => l.isColorLayer);
             const sequence = ImageryLayers.getColorLayersIdOrderedBySequence(colorLayers);
             material.setSequence(sequence);
 

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -27,17 +27,17 @@ function isValidData(data, extentDestination, validFn) {
 function parseData(data, layer, extentDestination) {
     const type = data.isTexture || data.isFeature || layer.source.format;
     const options = {
-        buildExtent: layer.type !== 'geometry',
+        buildExtent: !layer.isGeometryLayer,
         crsIn: layer.source.projection,
         crsOut: layer.projection,
         // TODO FIXME: error in filtering vector tile
         // filteringExtent: extentDestination.as(layer.projection),
-        filteringExtent: layer.type === 'geometry' ? extentDestination : undefined,
+        filteringExtent: layer.isGeometryLayer ? extentDestination : undefined,
         filter: layer.filter,
         isInverted: layer.source.isInverted,
         mergeFeatures: layer.mergeFeatures === undefined ? true : layer.mergeFeatures,
-        withNormal: layer.type === 'geometry',
-        withAltitude: layer.type === 'geometry',
+        withNormal: layer.isGeometryLayer,
+        withAltitude: layer.isGeometryLayer,
     };
     return supportedParsers.get(type)(data, options);
 }

--- a/src/Utils/DEMUtils.js
+++ b/src/Utils/DEMUtils.js
@@ -219,7 +219,7 @@ function _readTextureValueAt(layer, texture, ...uv) {
         ctx.drawImage(texture.image, minx, miny, dw, dh, 0, 0, dw, dh);
         const d = ctx.getImageData(0, 0, dw, dh);
 
-        const elevationLayer = layer.attachedLayers.filter(l => l.type == 'elevation')[0];
+        const elevationLayer = layer.attachedLayers.filter(l => l.isElevationLayer)[0];
 
         const result = [];
         for (let i = 0; i < uv.length; i += 2) {

--- a/test/examples/.eslintrc.js
+++ b/test/examples/.eslintrc.js
@@ -54,7 +54,8 @@ module.exports = {
 
         // turned off to use the this object in describe
         'prefer-arrow-callback': 'off',
-        
+
         'prefer-destructuring': 'off',
+        'max-len': 'off',
     }
 }

--- a/test/examples/globe.js
+++ b/test/examples/globe.js
@@ -31,7 +31,7 @@ describe('globe', function _() {
 
     it('should not add layer with id already used', async () => {
         const error = await page.evaluate(() => itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(view.addLayer).catch(() => true));
-        const colorLayersCount = await page.evaluate(() => view.getLayers(l => l.type === 'color').length);
+        const colorLayersCount = await page.evaluate(() => view.getLayers(l => l.isColorLayer).length);
 
         assert.ok(error && colorLayersCount === 1);
     });
@@ -39,7 +39,7 @@ describe('globe', function _() {
         const maxColorSamplerUnitsCount = await page.evaluate(
             () => itowns.getMaxColorSamplerUnitsCount(),
         );
-        const colorSamplerUnitsCount = await page.evaluate(() => view.tileLayer.countColorLayersTextures(view.getLayers(l => l.type === 'color')[0]));
+        const colorSamplerUnitsCount = await page.evaluate(() => view.tileLayer.countColorLayersTextures(view.getLayers(l => l.isColorLayer)[0]));
         const limit = maxColorSamplerUnitsCount - colorSamplerUnitsCount;
 
         // add layers just below the capacity limit

--- a/test/examples/layersColorVisible.js
+++ b/test/examples/layersColorVisible.js
@@ -19,7 +19,7 @@ describe('layersColorVisible', function _() {
     it('should display correct color layer', async () => {
         // test displayed tile
         const layer = await page.evaluate(() => view.tileLayer.info.displayed.layers[0].id);
-        const count = await page.evaluate(() => view.tileLayer.info.displayed.layers.filter(l => l.type === 'color').length);
+        const count = await page.evaluate(() => view.tileLayer.info.displayed.layers.filter(l => l.isColorLayer).length);
         assert.equal(count, 1);
         assert.equal(layer, 'Ortho');
     });

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -38,7 +38,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
         extent: new Extent('EPSG:4326', 0, 0, 0, 0),
     });
 
-    const layer = new Layer('foo', 'bar', {
+    const layer = new Layer('foo', {
         source,
         info: { update: () => {} },
     });


### PR DESCRIPTION
In 36c6d03 (PR #951), the isXXXLayer has been added, but wasn't used
everywhere. The change has been reflected in this commit to remove all
occurence of layer.type, leaving only the use for the debug layer (to be
removed).

DEPRECATION NOTICE: type is no longer a property of a Layer
