### PR TITLE
make DataSourceProvider more generic

### DIFF
--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -141,6 +141,12 @@ class Layer extends THREE.EventDispatcher {
                 });
         }
     }
+
+    // Placeholder
+    // eslint-disable-next-line
+    convert(data) {
+        return data;
+    }
 }
 
 export default Layer;


### PR DESCRIPTION
## Description
make DataSourceProvider more generic:
- Add default convert function to Layer object
- In DataSourceProvider, give the requester in parameter to urlFromExtend method

## Motivation and Context
The goal of this PR is to simplify #939 , removing OrientedImageProvider  to use existing DataSourceProvider.
