### PR TITLE
feat(wms): enable vendor specific parameters

### DIFF
--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -22,6 +22,12 @@ import URLBuilder from 'Provider/URLBuilder';
  * is 0.
  * @property {number} zoom.max - The maximum level of the source. Default value
  * is 21.
+ * @property {Object} vendorSpecific - An object containing vendor specific
+ * parameters. See for example a [list of these parameters for GeoServer]{@link
+ * https://docs.geoserver.org/latest/en/user/services/wfs/vendor.html}. This
+ * object is read simply with the <code>key</code> being the name of the
+ * parameter and <code>value</code> being the value of the parameter. If used,
+ * this property should be set in the constructor parameters.
  *
  * @example
  * // Add color layer with WFS source
@@ -113,6 +119,13 @@ class WFSSource extends Source {
         }&BBOX=%bbox,${this.projection}`;
 
         this.zoom = source.zoom || { min: 0, max: 21 };
+
+        this.vendorSpecific = source.vendorSpecific;
+        for (const name in this.vendorSpecific) {
+            if (Object.prototype.hasOwnProperty.call(this.vendorSpecific, name)) {
+                this.url = `${this.url}&${name}=${this.vendorSpecific[name]}`;
+            }
+        }
     }
 
     handlingError(err, url) {

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -33,6 +33,12 @@ import URLBuilder from 'Provider/URLBuilder';
  * is 0.
  * @property {number} zoom.max - The maximum level of the source. Default value
  * is 21.
+ * @property {Object} vendorSpecific - An object containing vendor specific
+ * parameters. See for example a [list of these parameters for GeoServer]{@link
+ * https://docs.geoserver.org/latest/en/user/services/wms/vendor.html}. This
+ * object is read simply with the <code>key</code> being the name of the
+ * parameter and <code>value</code> being the value of the parameter. If used,
+ * this property should be set in the constructor parameters.
  *
  * @example
  * // Create the source
@@ -120,6 +126,13 @@ class WMSSource extends Source {
             this.transparent}&BBOX=%bbox&${
             crsPropName}=${
             this.projection}&WIDTH=${this.width}&HEIGHT=${this.height}`;
+
+        this.vendorSpecific = source.vendorSpecific;
+        for (const name in this.vendorSpecific) {
+            if (Object.prototype.hasOwnProperty.call(this.vendorSpecific, name)) {
+                this.url = `${this.url}&${name}=${this.vendorSpecific[name]}`;
+            }
+        }
     }
 
     urlFromExtent(extent) {

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -72,6 +72,18 @@ describe('Source', function () {
         assert.ok(source.extentInsideLimit(extent));
         assert.ok(source.extentsInsideLimit([extent, extent]));
     });
+    it('Should use vendor specific parameters for the creation of the WMS url', function () {
+        paramsWMS.vendorSpecific = {
+            buffer: 4096,
+            format_options: 'dpi:300;quantizer:octree',
+            tiled: true,
+        };
+        const source = new WMSSource(paramsWMS);
+        const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
+        const url = source.urlFromExtent(extent);
+        const end = '&buffer=4096&format_options=dpi:300;quantizer:octree&tiled=true';
+        assert.ok(url.endsWith(end));
+    });
     it('Should instance and use TMSSource', function () {
         const source = new TMSSource(paramsTMS);
         const extent = new Extent('WMTS:PM', 5, 0, 0);


### PR DESCRIPTION
Many map servers provide their own, vendor-specific URL parameters when
handling WMS calls. Such parameters are out of standard Web Map Service
specification, but contribute large amount during actual implementation.
A good example of such parameters is in the GeoServer documentation:
https://docs.geoserver.org/latest/en/user/services/wms/vendor.html

Solves #959

PS: @SesticM I used your message for the commit message :wink: 