### PR TITLE
refactor(core): improved results and performance of the culling horizon

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -37,17 +37,6 @@ class TileMesh extends THREE.Mesh {
     }
 
     /**
-     * Update the global transform of the object and its children.
-     * Update the OBB of the object.
-     *
-     * @param {Boolean} force
-     */
-    updateMatrixWorld(force) {
-        super.updateMatrixWorld(force);
-        this.obb.update();
-    }
-
-    /**
      * If specified, update the min and max elevation of the OBB
      * and updates accordingly the bounding sphere and the geometric error
      *

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -18,13 +18,6 @@ class OBB extends THREE.Object3D {
         this.box3D = new THREE.Box3(min.clone(), max.clone());
         this.natBox = this.box3D.clone();
         this.z = { min: 0, max: 0 };
-        this.topPointsWorld = [
-            new THREE.Vector3(),
-            new THREE.Vector3(),
-            new THREE.Vector3(),
-            new THREE.Vector3(),
-        ];
-        this.update();
     }
 
     /**
@@ -48,26 +41,15 @@ class OBB extends THREE.Object3D {
         this.natBox.copy(cOBB.natBox);
         this.z.min = cOBB.z.min;
         this.z.max = cOBB.z.max;
-        for (let i = 0, max = this.topPointsWorld.length; i < max; i++) {
-            this.topPointsWorld[i].copy(cOBB.topPointsWorld[i]);
-        }
         return this;
     }
 
     /**
      * Update the top point world
      *
-     * @return {Array<THREE.Vector3>} the top point world
      */
     update() {
         this.updateMatrixWorld(true);
-        this.toPoints(this.topPointsWorld);
-
-        for (let i = 0, max = this.topPointsWorld.length; i < max; i++) {
-            this.topPointsWorld[i].applyMatrix4(this.matrixWorld);
-        }
-
-        return this.topPointsWorld;
     }
 
     /**
@@ -80,7 +62,6 @@ class OBB extends THREE.Object3D {
         this.z = { min, max };
         this.box3D.min.z = this.natBox.min.z + min;
         this.box3D.max.z = this.natBox.max.z + max;
-        this.update();
     }
 
     /**
@@ -95,13 +76,10 @@ class OBB extends THREE.Object3D {
         points[1].set(this.box3D.min.x, this.box3D.max.y, this.box3D.max.z);
         points[2].set(this.box3D.min.x, this.box3D.min.y, this.box3D.max.z);
         points[3].set(this.box3D.max.x, this.box3D.min.y, this.box3D.max.z);
-        // bottom points of bounding box
-        if (points.length > 4) {
-            points[4].set(this.box3D.max.x, this.box3D.max.y, this.box3D.min.z);
-            points[5].set(this.box3D.min.x, this.box3D.max.y, this.box3D.min.z);
-            points[6].set(this.box3D.min.x, this.box3D.min.y, this.box3D.min.z);
-            points[7].set(this.box3D.max.x, this.box3D.min.y, this.box3D.min.z);
-        }
+        points[4].set(this.box3D.max.x, this.box3D.max.y, this.box3D.min.z);
+        points[5].set(this.box3D.min.x, this.box3D.max.y, this.box3D.min.z);
+        points[6].set(this.box3D.min.x, this.box3D.min.y, this.box3D.min.z);
+        points[7].set(this.box3D.max.x, this.box3D.min.y, this.box3D.min.z);
 
         return points;
     }
@@ -160,7 +138,7 @@ class OBB extends THREE.Object3D {
         obb.updateZ(minHeight, maxHeight);
         obb.position.copy(position);
         obb.quaternion.copy(quaternion);
-        obb.update();
+        obb.updateMatrixWorld(true);
 
         // Calling geometry.dispose() is not needed since this geometry never gets rendered
         return obb;

--- a/test/examples/globe.js
+++ b/test/examples/globe.js
@@ -26,7 +26,7 @@ describe('globe', function _() {
                 .forEach(t => (!r[t.level] ? r[t.level] = 1 : r[t.level]++));
             return r;
         });
-        assert.equal(displayedTiles['2'], 26);
+        assert.equal(displayedTiles['2'], 20);
     });
 
     it('should not add layer with id already used', async () => {

--- a/test/examples/layersColorVisible.js
+++ b/test/examples/layersColorVisible.js
@@ -13,7 +13,7 @@ describe('layersColorVisible', function _() {
     it('should display correct count of tiles', async () => {
         // test displayed tile
         const count = await page.evaluate(() => view.tileLayer.info.displayed.tiles.size);
-        assert.equal(count, 26);
+        assert.equal(count, 20);
     });
 
     it('should display correct color layer', async () => {


### PR DESCRIPTION
## Description
Improved results and performance of the culling horizon and therefore less image are fetched.

Stop to use top obb points to compute horizon culling. Computes one point, if the point is below the horizon, the tile is guaranteed to be below the horizon as well.

## Motivation and Context
Some tiles, on the horizon, are displayed while they are almost invisible.

## Screenshots (if appropriate)
Before: 
![cullinghbefore](https://user-images.githubusercontent.com/11291849/50215083-446aea00-0382-11e9-9c63-50f2ffbc5a13.png)

After:
![afterhc](https://user-images.githubusercontent.com/11291849/50215486-79c40780-0383-11e9-9af5-b2435200a45f.png)


