### PR TITLE
fix THREE warning: trying to use xx texture units

### DIFF
--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -86,7 +86,6 @@ function setUniformProperty(object, property, initValue) {
         set: (value) => {
             if (object.uniforms[property].value != value) {
                 object.uniforms[property].value = value;
-                object.uniformsNeedUpdate = true;
             }
         },
     });
@@ -196,7 +195,6 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         if (this.elevationLayerIds.some(id => this.getLayer(id))) {
             updateLayersUniforms(this.getUniformByType('elevation'), [this.getElevationLayer()], this.defines.NUM_VS_TEXTURES);
         }
-        this.uniformsNeedUpdate = true;
         this.layersNeedUpdate = false;
     }
 

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -10,7 +10,6 @@ function defineLayerProperty(layer, property, initValue, defaultValue) {
         get: () => _value,
         set: (value) => {
             if (_value !== value) {
-                layer.material.uniformsNeedUpdate = true;
                 _value = value;
             }
         },
@@ -34,8 +33,6 @@ class MaterialLayer {
                 if (_valueOpacity !== value) {
                     if (value === 0 || _valueOpacity === 0) {
                         this.material.layersNeedUpdate = true;
-                    } else {
-                        this.material.uniformsNeedUpdate = true;
                     }
                     _valueOpacity = value;
                 }

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -1,10 +1,12 @@
 #include <itowns/precision_qualifier>
 #include <logdepthbuf_pars_fragment>
 #include <itowns/pitUV>
-#include <itowns/fog_pars_fragment>
 #include <itowns/color_layers_pars_fragment>
+#if MODE == MODE_FINAL
+#include <itowns/fog_pars_fragment>
 #include <itowns/overlay_pars_fragment>
 #include <itowns/lighting_pars_fragment>
+#endif
 #include <itowns/mode_pars_fragment>
 
 uniform vec3        diffuse;

--- a/src/Renderer/Shader/TileVS.glsl
+++ b/src/Renderer/Shader/TileVS.glsl
@@ -2,17 +2,18 @@
 #include <itowns/project_pars_vertex>
 #include <itowns/elevation_pars_vertex>
 #include <logdepthbuf_pars_vertex>
-#include <fog_pars_vertex>
-
 attribute float     uv_pm;
 attribute vec2      uv_wgs84;
 attribute vec3      normal;
 
-uniform mat4        modelMatrix;
+uniform mat4 modelMatrix;
+uniform bool lightingEnabled;
 
+#if MODE == MODE_FINAL
+#include <fog_pars_vertex>
 varying vec3        vUv;
 varying vec3        vNormal;
-
+#endif
 void main() {
         vec2 uv = vec2(uv_wgs84.x, 1.0 - uv_wgs84.y);
 
@@ -20,8 +21,9 @@ void main() {
         #include <itowns/elevation_vertex>
         #include <project_vertex>
         #include <logdepthbuf_vertex>
-      	#include <fog_vertex>
-
+#if MODE == MODE_FINAL
+        #include <fog_vertex>
         vUv = vec3(uv_wgs84, (uv_pm > 0.) ? uv_pm : uv_wgs84.y); // set pm=wgs84 if pm=0 (not computed)
         vNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
+#endif
 }


### PR DESCRIPTION
There was a double callings of `WebGLUniforms.upload` with `uniformsNeedUpdate`. It rolls out a **double allocation** of uniforms and therefore an overflow of `webgl` capabilities texture units.

Fix #979