### PR TITLE
fix(example) 3dTile

### DIFF
--- a/examples/3dtiles.html
+++ b/examples/3dtiles.html
@@ -31,8 +31,8 @@
 
             var menuGlobe = new GuiTools('menuDiv', view, 300);
 
-            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
-                config.source = new itowns.WMTSSource(config.source);
+            itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(function _(config) {
+                config.source = new itowns.TMSSource(config.source);
                 var layer = new itowns.ColorLayer('Ortho', config);
                 view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             });


### PR DESCRIPTION
## Description
Fix 3d Tiles example : Change ortho image layer source to openSM data to avoid many warnings.

Before this commit, the example was using an imcomplete ortho image source, so there was a lot of error and warning, because data was not available in US.
Now, using OpenSM datas, there is no warning and error, because the data is available.
