### PR TITLE
fix: windows install no more backslash

### DIFF
--- a/config/replace.config.js
+++ b/config/replace.config.js
@@ -72,7 +72,7 @@ patchs.push(() => replace({
             return match + [...importTables[basename]].map((n) => {
                 const from = path.dirname(filesExamples.find(f => path.basename(f, '.js') === basename)).replace('.', '');
                 const to = path.dirname(filesExamples.find(f => path.basename(f, '.js') === n)).replace('.', '');
-                const relative = path.relative(`_/${from}`, `_/${to}`);
+                const relative = path.relative(`_/${from}`, `_/${to}`).replace('\\', '\/');
                 if (relative == '') {
                     return `import ${n} from './${n}';`;
                 } else {


### PR DESCRIPTION
## Description
Correct the bug while installing on windows due to inserted backslash on Patching source files

## Motivation and Context
It is necessary for win install in dev mode: npm install using itowns source code.