### PR TITLE
chore: upgrade to THREE r100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9496,9 +9496,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.99.0.tgz",
-      "integrity": "sha512-DmNNq6H6nRGaqxScJ8x7v5VjdtDZR72oTVwDdKbB2BYNFxCkAoo9vdFAznEsMu9YzTV2yFvbVs7qHRzvJZzTIg==",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.100.0.tgz",
+      "integrity": "sha512-/lN2rdE1OqIwJr4/HcSaOisiCY0uVA0sqPpbCG5nil2uICEdS0LfGwSVYTtZDsIpR76r3++h5H3Hzg5D+SJBRQ==",
       "dev": true
     },
     "three.meshline": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.99.0",
+    "three": "^0.100.0",
     "three.meshline": "^1.1.0"
   },
   "devDependencies": {
@@ -77,7 +77,7 @@
     "proj4": "^2.5.0",
     "puppeteer": "^1.11.0",
     "replace-in-file": "^3.4.2",
-    "three": "^0.99.0",
+    "three": "^0.100.0",
     "three.meshline": "^1.1.0",
     "url-polyfill": "^1.1.3",
     "webpack": "^4.27.1",


### PR DESCRIPTION
### Migrate Guide r99 → r100

- [x] `Octree` has been removed.
- [x] Removed Geometry support from `Mesh.updateMorphTargets()`. Use `BufferGeometry` instead.
- [x] The default orientation of `RectAreaLight` has changed. It now looks along the negative z-axis.

