### PR TITLE
feat(converter): add batchId attribute in mesh from convert of feature2Mesh

### DIFF
--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -114,7 +114,7 @@
                     altitude: altitudeLine }),
                 linewidth: 5,
                 filter: acceptFeatureBus,
-                source: lyonTclBusSource 
+                source: lyonTclBusSource
             });
             view.addLayer(lyonTclBusLayer);
 
@@ -149,7 +149,7 @@
                     mesh = meshes[i];
                     if (mesh) {
                         mesh.scale.z = Math.min(
-                            1.0, mesh.scale.z + 0.02);
+                            1.0, mesh.scale.z + 0.1);
                         mesh.updateMatrixWorld(true);
                     }
                 }
@@ -178,6 +178,7 @@
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
                     color: colorBuildings,
+                    batchId: function (property, featureId) { return featureId; },
                     altitude: altitudeBuildings,
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {
@@ -199,41 +200,19 @@
             var d = new debug.Debug(view, menuGlobe.gui);
             debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
-            var binarySearch = function(array, value) {
-                var guess,
-                    min = 0,
-                    max = array.length - 1;
-
-                while(min <= max){
-                    guess = Math.floor((min + max) / 2);
-                var indices = array[guess].indices;
-                var start = indices[0].offset;
-                var end = indices[indices.length - 1].offset + indices[indices.length - 1].count;
-
-                if(start <= value && value <= end)
-                    return guess;
-                else if(value > end)
-                    min = guess + 1;
-                else
-                    max = guess - 1;
-                 }
-
-                 return -1;
-            }
-
             function picking(event) {
                 if(view.controls.isPaused()) {
                     var htmlInfo = document.getElementById('info');
                     var intersects = view.pickObjectsAt(event, 3, 'WFS Building');
                     var properties;
                     var info;
+                    var batchId;
+
                     htmlInfo.innerHTML = ' ';
 
                     if (intersects.length) {
-                        var geometry = intersects[0].object.feature.geometry;
-                        var idPt = (intersects[0].face.a) % (intersects[0].object.feature.vertices.length / 3);
-                        var id = binarySearch(geometry, idPt);
-                        properties = geometry[id].properties;
+                        batchId = intersects[0].object.geometry.attributes.batchId.array[intersects[0].face.a];
+                        properties = intersects[0].object.feature.geometry[batchId].properties;
 
                         Object.keys(properties).map(function (objectKey) {
                             var value = properties[objectKey];

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -31,11 +31,17 @@
         <script src="js/proj4defs/3946.js"></script>
         <script src="js/loading_screen.js"></script>
         <script type="text/javascript">
+            /* global itowns,document, setupLoadingScreen, window */
+
             var extent;
             var viewerDiv;
             var view;
             var meshes;
             var p;
+            var wmsImagerySource;
+            var wmsImageryLayer;
+            var rgb;
+            var lyonTclBusSource;
             var color = new itowns.THREE.Color();
 
             // Define geographic extent: CRS, min/max X, min/max Y
@@ -51,7 +57,7 @@
             view = new itowns.PlanarView(viewerDiv, extent, { disableSkirt: true });
             setupLoadingScreen(viewerDiv, view);
 
-            var wmsImagerySource = new itowns.WMSSource({
+            wmsImagerySource = new itowns.WMSSource({
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 networkOptions: { crossOrigin: 'anonymous' },
                 version: '1.3.0',
@@ -62,21 +68,24 @@
             });
 
             // Add a WMS imagery layer
-            var wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+            wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
                 transparent: false,
                 source: wmsImagerySource,
             });
+
             view.addLayer(wmsImageryLayer);
 
-            p = { coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0), heading: -45, range: 1800, tilt: 30 };
+            p = {
+                coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0),
+                heading: -45,
+                range: 1800,
+                tilt: 30,
+            };
+
             itowns.CameraUtils.transformCameraToLookAtTarget(view, view.camera.camera3D, p);
 
             // eslint-disable-next-line no-new
             new itowns.PlanarControls(view, {});
-
-            // Request redraw
-            // view.notifyChange();
-
 
             function setMaterialLineWidth(result) {
                 result.traverse(function _setLineWidth(mesh) {
@@ -88,12 +97,13 @@
 
             function colorLine(properties) {
                 if (properties) {
-                    var rgb = properties.couleur.split(' ');
+                    rgb = properties.couleur.split(' ');
                     return color.setRGB(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
                 }
+                return color.setRGB(1, 1, 1);
             }
 
-            var lyonTclBusSource = new itowns.WFSSource({
+            lyonTclBusSource = new itowns.WFSSource({
                 url: 'https://download.data.grandlyon.com/wfs/rdata?',
                 protocol: 'wfs',
                 version: '2.0.0',
@@ -109,6 +119,7 @@
                 zoom: { min: 2, max: 2 },
                 format: 'geojson',
             });
+
             var lyonTclBusLayer = new itowns.GeometryLayer('lyon_tcl_bus', new itowns.THREE.Group(), {
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
@@ -116,12 +127,14 @@
                 onMeshCreated: setMaterialLineWidth,
                 source: lyonTclBusSource,
             });
+
             view.addLayer(lyonTclBusLayer);
 
             function colorBuildings(properties) {
                 if (properties.id.indexOf('bati_remarquable') === 0) {
                     return color.set(0x5555ff);
-                } else if (properties.id.indexOf('bati_industriel') === 0) {
+                }
+                if (properties.id.indexOf('bati_industriel') === 0) {
                     return color.set(0xff5555);
                 }
                 return color.set(0xeeeeee);
@@ -141,7 +154,7 @@
                 for (i = 0; i < meshes.length; i++) {
                     mesh = meshes[i];
                     mesh.scale.z = Math.min(
-                        1.0, mesh.scale.z + 0.016);
+                        1.0, mesh.scale.z + 0.1);
                     mesh.updateMatrixWorld(true);
                 }
                 meshes = meshes.filter(function filter(m) { return m.scale.z < 1; });
@@ -168,10 +181,12 @@
                     north: 46.03,
                 },
             });
+
             var wfsBuildingLayer = new itowns.GeometryLayer('wfsBuilding', new itowns.THREE.Group(), {
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
                     color: colorBuildings,
+                    batchId: function (property, featureId) { return featureId; },
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {
                     mesh.scale.z = 0.01;
@@ -181,43 +196,20 @@
                 projection: 'EPSG:3946',
                 source: wfsBuildingSource,
             });
+
             view.addLayer(wfsBuildingLayer);
-
-            function binarySearch(array, value) {
-                var guess,
-                    min = 0,
-                    max = array.length - 1;
-
-                while(min <= max){
-                    guess = Math.floor((min + max) / 2);
-                var indices = array[guess].indices;
-                var start = indices[0].offset;
-                var end = indices[indices.length - 1].offset + indices[indices.length - 1].count;
-
-                if(start <= value && value <= end)
-                    return guess;
-                else if(value > end)
-                    min = guess + 1;
-                else
-                    max = guess - 1;
-                }
-
-                return -1;
-            }
 
             function picking(event) {
                 var htmlInfo = document.getElementById('info');
                 var intersects = view.pickObjectsAt(event, 2, 'wfsBuilding');
                 var properties;
                 var info;
+                var batchId;
                 htmlInfo.innerHTML = ' ';
 
                 if (intersects.length) {
-                    var geometry = intersects[0].object.feature.geometry;
-                    var idPt = (intersects[0].face.a) % (intersects[0].object.feature.vertices.length / 3);
-                    var id = binarySearch(geometry, idPt);
-                    properties = geometry[id].properties;
-
+                    batchId = intersects[0].object.geometry.attributes.batchId.array[intersects[0].face.a];
+                    properties = intersects[0].object.feature.geometry[batchId].properties;
                     Object.keys(properties).map(function (objectKey) {
                         var value = properties[objectKey];
                         var key = objectKey.toString();


### PR DESCRIPTION
Resumption of the work of @mbredif in #909

## Description
adds a `batchId`  attribute in `mesh.material` that creates a `batchId` attribute to be consumed by shaders.

## Motivation and Context
restore the functionnality. may be used for  feature selection, selective shading with the selected `batchId` passed as a uniform...

