### PR TITLE
Fix picking feature

### DIFF
--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line no-unused-vars
 function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
     var mouseDown = 0;
-    var layers = viewer.getLayers(function _(l) { return l.source && l.source.protocol === 'file'; });
+    var layers = viewer.getLayers(function _(l) { return l.source && l.source.isFileSource; });
 
     document.body.onmousedown = function onmousedown() {
         ++mouseDown;

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -63,7 +63,7 @@ class ColorLayer extends Layer {
         this.defineLayerProperty('opacity', 1.0);
         this.defineLayerProperty('sequence', 0);
         this.transparent = config.transparent || (this.opacity < 1.0);
-        this.noTextureParentOutsideLimit = config.source ? config.source.protocol == 'file' : false;
+        this.noTextureParentOutsideLimit = config.source ? config.source.isFileSource : false;
     }
 
     update(context, layer, node, parent) {

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -23,7 +23,7 @@ function wrapTo180(angle) {
 }
 
 function tileLayer(view) {
-    return view.getLayers(l => l.protocol == 'tile')[0];
+    return view.getLayers(l => l.isTiledGeometryLayer)[0];
 }
 
 function getLookAtFromMath(view, camera) {

--- a/test/examples/globe_vector.js
+++ b/test/examples/globe_vector.js
@@ -9,4 +9,24 @@ describe('globe_vector', function _() {
     it('should run', async () => {
         assert.ok(result);
     });
+
+    it('should pick feature from Layer with SourceFile', async () => {
+        const pickFeatureCount = await page.evaluate(() => {
+            const precision = view.controls.pixelsToDegrees(5);
+            const layers = view.getLayers(l => l.source && l.source.isFileSource);
+            const geoCoord = new itowns.Coordinates('EPSG:4326', 1.41955, 42.88613, 0);
+            for (i = 0; i < layers.length; i++) {
+                const p = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(
+                    geoCoord, layers[i].source.parsedData, precision,
+                );
+                if (p.length) {
+                    return Promise.resolve(p.length);
+                }
+            }
+
+            return 0;
+        });
+
+        assert.equal(1, pickFeatureCount);
+    });
 });


### PR DESCRIPTION
## Description

1. Example used the removed properties : `Source.Protocol`. It should be verified that this property isn't longer used. see #1001
2. `filterFeaturesUnderCoordinate` didn't work with 3D coordinates

**TODO: verify why 3D coordinates are computed for features used in textures.
The expected behaviour is a feature with a 2D coordinates array**
