### PR TITLE
feat(core): optimization subdivision with horizon

### DIFF
--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -13,6 +13,7 @@ let magnitudeSquared = 0.0;
 
 // vectors for operation purpose
 const scaledHorizonCullingPoint = new THREE.Vector3();
+const scaledToSphere = new THREE.Vector3(1.0, 1.0, ellipsoidSizes.x / ellipsoidSizes.z);
 
 /**
  * @property {boolean} isGlobeLayer - Used to checkout whether this layer is a
@@ -88,6 +89,15 @@ class GlobeLayer extends TiledGeometryLayer {
         // pre-horizon culling
         cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(worldToScaledEllipsoid);
         magnitudeSquared = cameraPosition.lengthSq() - 1.0;
+
+        // pre-horizon subdivision
+        scaledHorizonCullingPoint.copy(context.camera.camera3D.position).multiply(scaledToSphere);
+
+        const distanceToCenter = scaledHorizonCullingPoint.length();
+        const distanceToHorizon = (distanceToCenter ** 2 - ellipsoidSizes.x ** 2) ** 0.5;
+        const distanceToGround = Math.max(distanceToCenter - ellipsoidSizes.x, 0);
+        const factor = Math.min(distanceToGround / ellipsoidSizes.x, 1.0) ** 0.25;
+        context.horizon = distanceToHorizon - (distanceToHorizon - distanceToGround) * 0.75 * (1 - factor);
 
         return super.preUpdate(context, changeSources);
     }

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -97,7 +97,8 @@ class GlobeLayer extends TiledGeometryLayer {
         const distanceToHorizon = (distanceToCenter ** 2 - ellipsoidSizes.x ** 2) ** 0.5;
         const distanceToGround = Math.max(distanceToCenter - ellipsoidSizes.x, 0);
         const factor = Math.min(distanceToGround / ellipsoidSizes.x, 1.0) ** 0.25;
-        context.horizon = distanceToHorizon - (distanceToHorizon - distanceToGround) * 0.75 * (1 - factor);
+        // context.horizon = distanceToHorizon - (distanceToHorizon - distanceToGround) * 0.75 * (1 - factor);
+        context.horizon = distanceToHorizon - (distanceToHorizon - distanceToGround) * 0.2 * (1 - factor);
 
         return super.preUpdate(context, changeSources);
     }

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -45,6 +45,15 @@ class PlanarLayer extends TiledGeometryLayer {
         this.maxSubdivisionLevel = this.maxSubdivisionLevel || 5.0;
         this.maxDeltaElevation = this.maxDeltaElevation || 4.0;
     }
+
+    preUpdate(context, changeSources) {
+        const fov = THREE.Math.degToRad(context.camera.camera3D.fov * 0.5);
+        const ratioHorizon = 0.1;
+        const distanceToGround = context.camera.camera3D.position.z;
+        context.horizon = distanceToGround / Math.sin(Math.atan(ratioHorizon * Math.tan(fov)));
+
+        return super.preUpdate(context, changeSources);
+    }
 }
 
 export default PlanarLayer;

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -400,8 +400,11 @@ class TiledGeometryLayer extends GeometryLayer {
             0.0,
             context.camera.camera3D.position.distanceTo(boundingSphereCenter) - node.boundingSphere.radius * subdivisionVector.x);
 
-        if (context.horizon && distance > context.horizon) {
-            return false;
+        let o = 0.0;
+        if (context.horizon) {
+            const a = context.horizon / (800.0 * 6378137.0);
+            o += 10.0 / (1.0 + Math.exp(-a * (distance - context.horizon)));
+            // return false;
         }
 
         // Size projection on pixel of bounding
@@ -411,7 +414,7 @@ class TiledGeometryLayer extends GeometryLayer {
         // For the projection of a texture's texel to be less than or equal to one pixel
         const sse = node.screenSize / (SIZE_DIAGONAL_TEXTURE * 2);
 
-        return this.sseSubdivisionThreshold < sse;
+        return this.sseSubdivisionThreshold * (1 + o) < sse;
     }
 }
 

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -396,6 +396,10 @@ class TiledGeometryLayer extends GeometryLayer {
             0.0,
             context.camera.camera3D.position.distanceTo(boundingSphereCenter) - node.boundingSphere.radius * subdivisionVector.x);
 
+        if (context.horizon && distance > context.horizon) {
+            return false;
+        }
+
         // Size projection on pixel of bounding
         node.screenSize = context.camera._preSSE * (2 * node.boundingSphere.radius * subdivisionVector.x) / distance;
 

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -234,6 +234,10 @@ class TiledGeometryLayer extends GeometryLayer {
                     node.material.fogDistance = context.view.fogDistance;
                 }
 
+                if (context.horizon != undefined) {
+                    node.material.horizonDistance = context.horizon;
+                }
+
                 if (!requestChildrenUpdate) {
                     return ObjectRemovalHelper.removeChildren(this, node);
                 }

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -153,6 +153,7 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         setUniformProperty(this, 'overlayAlpha', 0);
         setUniformProperty(this, 'overlayColor', new THREE.Color(1.0, 0.3, 0.0));
         setUniformProperty(this, 'objectId', 0);
+        setUniformProperty(this, 'horizonDistance', 1000000000.0);
 
         // > 0 produces gaps,
         // < 0 causes oversampling of textures

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -11,6 +11,7 @@
 
 uniform vec3        diffuse;
 uniform float       opacity;
+uniform float       horizonDistance;
 varying vec3        vUv; // WGS84.x/PM.x, WGS84.y, PM.y
 
 void main() {
@@ -51,6 +52,10 @@ void main() {
     #include <itowns/fog_fragment>
     #include <itowns/lighting_fragment>
     #include <itowns/overlay_fragment>
+
+    // if (fogDepth > horizonDistance && fogDepth < (horizonDistance + 20000.0)) {
+    //     gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    // }
 
 #endif
 }

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -53,6 +53,12 @@ void main() {
     #include <itowns/lighting_fragment>
     #include <itowns/overlay_fragment>
 
+    float a = horizonDistance / ( 800.0 * 6378137.0);
+    float factor = 10.0 / (1.0 + exp(-a*(fogDepth - horizonDistance)));
+
+    gl_FragColor.rgb = mix(gl_FragColor.rgb, vec3(1.0, 0.0, 0.0), factor);
+
+
     // if (fogDepth > horizonDistance && fogDepth < (horizonDistance + 20000.0)) {
     //     gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
     // }

--- a/src/Renderer/Shader/TileVS.glsl
+++ b/src/Renderer/Shader/TileVS.glsl
@@ -25,5 +25,6 @@ void main() {
         #include <fog_vertex>
         vUv = vec3(uv_wgs84, (uv_pm > 0.) ? uv_pm : uv_wgs84.y); // set pm=wgs84 if pm=0 (not computed)
         vNormal = normalize ( mat3( modelMatrix[0].xyz, modelMatrix[1].xyz, modelMatrix[2].xyz ) * normal );
+        fogDepth = length(mvPosition.xyz);
 #endif
 }


### PR DESCRIPTION
## Description
Reduce subdivision when tiles are near of horizon.

Merge #1004 before this one.

## Screenshots
**Planar : Without optimisation  320 images fetched**
![hp2](https://user-images.githubusercontent.com/11291849/51395754-e32f6580-1b3d-11e9-8429-4326624418b2.png)

**Planar : With optimisation 45 images fetched**
![hp1](https://user-images.githubusercontent.com/11291849/51395657-92b80800-1b3d-11e9-9b94-afc2dbd30021.png)

** Globe : Without optimisation  340 images fetched**
![hg3](https://user-images.githubusercontent.com/11291849/51398962-17f2eb00-1b45-11e9-8b30-7da01e007b13.png)

** Globe : With optimisation  280 images fetched**
![hg2](https://user-images.githubusercontent.com/11291849/51399039-4b357a00-1b45-11e9-935e-d9e4d61ec9d3.png)



