### PR TITLE
fix(core): wrong Z min and max  to compute tile's obb

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -339,7 +339,10 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
                     elevation.min = layer.colorTextureElevationMinZ;
                     elevation.max = layer.colorTextureElevationMaxZ;
                 } else {
-                    const { min, max } = computeMinMaxElevation(elevation.texture.image.data);
+                    const { min, max } = computeMinMaxElevation(elevation.texture.image.data,
+                        SIZE_TEXTURE_TILE,
+                        SIZE_TEXTURE_TILE,
+                        elevation.pitch);
                     elevation.min = !min ? 0 : min;
                     elevation.max = !max ? 0 : max;
                 }

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -254,12 +254,17 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
         // extract min-max from the texture (too few information), we instead chose
         // to use parent's min-max.
         const useMinMaxFromParent = extentsDestination[0].zoom - nodeLayer.zoom > 6;
-        if (nodeLayer.textures[0] && !useMinMaxFromParent) {
-            const { min, max } =  computeMinMaxElevation(
-                nodeLayer.textures[0].image.data,
-                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-                nodeLayer.offsetScales[0]);
-            node.setBBoxZ(min, max);
+        if (nodeLayer.textures[0]) {
+            if (!useMinMaxFromParent) {
+                const { min, max } =  computeMinMaxElevation(
+                    nodeLayer.textures[0].image.data,
+                    SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                    nodeLayer.offsetScales[0]);
+                node.setBBoxZ(min, max);
+            } else {
+                // TODO: to verify we don't pass here,
+                // To follow issue, see #1011 https://github.com/iTowns/itowns/issues/1011
+            }
         }
 
         if (nodeLayer.level >= layer.source.zoom.min) {


### PR DESCRIPTION
fix(core): wrong Z min and max  to compute tile's obb
because the offset/pitch was it was not taken into account

fix #844