### PR TITLE
fix(3dtiles): region extent is treated as an OBB

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,9 @@ The following people have contributed to iTowns 2.
   * [Marie Lamure](https://github.com/mlamure)
   * [Vincent Jaillot](https://github.com/jailln)
 
+* [virtualcitySYSTEMS](https://www.virtualcitysystems.de/)
+  * [Ben Kuster](https://github.com/bkuster)
+  
 The following organizations supported iTowns2 :
 * IGN ( http://www.ign.fr )
 * Oslandia ( http://www.oslandia.com )

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -36,11 +36,9 @@ const tmpBox3 = new THREE.Box3();
 const tmpSphere = new THREE.Sphere();
 function boundingVolumeToExtent(crs, volume, transform) {
     if (volume.region) {
-        return new Extent('EPSG:4326',
-            THREE.Math.radToDeg(volume.region[0]),
-            THREE.Math.radToDeg(volume.region[2]),
-            THREE.Math.radToDeg(volume.region[1]),
-            THREE.Math.radToDeg(volume.region[3]));
+        const box = tmpBox3.copy(volume.region.box3D)
+            .applyMatrix4(volume.region.matrixWorld);
+        return Extent.fromBox3(crs, box);
     } else if (volume.box) {
         const box = tmpBox3.copy(volume.box).applyMatrix4(transform);
         return Extent.fromBox3(crs, box);


### PR DESCRIPTION
closes #980 

## Description
Fixes these lines: https://github.com/iTowns/itowns/blob/87bb03e55836311f20142f811e9788ce90971120/src/Process/3dTilesProcessing.js#L38-L44

to handle the regions OBB instead of the original user input.
