### PR TITLE
Controls add key to previous pano

### DIFF
--- a/examples/immersive_paris.html
+++ b/examples/immersive_paris.html
@@ -13,6 +13,7 @@
            <p>Key bindings</p>
            <ul>
              <li>Z: camera move to next panoramic</li>
+             <li>S: camera move to previous panoramic</li>
             </ul>
         </div>
         <div id="viewerDiv"></div>
@@ -112,6 +113,7 @@
                     calibration: calibration,
                     projection: view.referenceCrs,
                     onPanoChanged: (e) => {
+                        view.controls.setPreviousPosition(e.previousPanoPosition);
                         view.controls.setCurrentPosition(e.currentPanoPosition);
                         view.controls.setNextPosition(e.nextPanoPosition);
                     }

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -20,7 +20,12 @@ function moveCameraExp(root, progress) {
  * </ul>
  * <ul> Bindings added
  * <li><b> keys Z : </b> Move camera to the next position </li>
+ * <li><b> keys S : </b> Move camera to the previous position </li>
+ * <li><b> keys A : </b> Set camera to current position </li>
  * </ul>
+ * @property {number} keyGoToNextPosition key code to go to next position, default to 90 for key Z
+ * @property {number} keyGoToPreviousPosition key code to go to previous position, default to 83 for key S
+ * @property {number} keySetCameraToCurrentPosition key code set camera to current position, default to 65 for key  A
  * @extends FirstPersonControls
  */
 class StreetControls extends FirstPersonControls {
@@ -55,11 +60,8 @@ class StreetControls extends FirstPersonControls {
         this.currentPosition = undefined;
         this.nextPosition = undefined;
 
-        // store key binding to go to next position, default to Z
         this.keyGoToNextPosition = 90;
-        // store key binding to go to previous position, default to S
         this.keyGoToPreviousPosition = 83;
-        // store key binding to set camera to current position, default to A
         this.keySetCameraToCurrentPosition = 65;
     }
 

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -54,6 +54,13 @@ class StreetControls extends FirstPersonControls {
         this.previousPosition = undefined;
         this.currentPosition = undefined;
         this.nextPosition = undefined;
+
+        // store key binding to go to next position, default to Z
+        this.keyGoToNextPosition = 90;
+        // store key binding to go to previous position, default to S
+        this.keyGoToPreviousPosition = 83;
+        // store key binding to set camera to current position, default to A
+        this.keySetCameraToCurrentPosition = 65;
     }
 
     setCurrentPosition(newCurrentPosition) {
@@ -113,16 +120,16 @@ class StreetControls extends FirstPersonControls {
     onKeyDown(e) {
         super.onKeyDown(e);
 
-        // key Z to move to next position
-        if (e.keyCode == 90) {
+        // key to move to next position (default to Z)
+        if (e.keyCode == this.keyGoToNextPosition) {
             this.moveCameraTo(this.nextPosition);
         }
-        // key S to move to previous position
-        if (e.keyCode == 83) {
+        // key to move to previous position (default to S)
+        if (e.keyCode == this.keyGoToPreviousPosition) {
             this.moveCameraTo(this.previousPosition);
         }
-        // key A to set to camera to current position looking at next position
-        if (e.keyCode == 65) {
+        // key to set to camera to current position looking at next position (default to A)
+        if (e.keyCode == this.keySetCameraToCurrentPosition) {
             this.setCameraToCurrentPosition();
             this.view.notifyChange(this.view.camera.camera3D);
         }

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -51,6 +51,7 @@ class StreetControls extends FirstPersonControls {
         this.player.addEventListener('animation-frame', this.updateView.bind(this));
 
         // twos positions used by this control : current and next
+        this.previousPosition = undefined;
         this.currentPosition = undefined;
         this.nextPosition = undefined;
     }
@@ -61,6 +62,10 @@ class StreetControls extends FirstPersonControls {
 
     setNextPosition(newNextPosition) {
         this.nextPosition = newNextPosition;
+    }
+
+    setPreviousPosition(newPreviousPosition) {
+        this.previousPosition = newPreviousPosition;
     }
 
     /**
@@ -93,15 +98,33 @@ class StreetControls extends FirstPersonControls {
      * @param { THREE.Vector3 }  positionTo  Destination of the movement.
      */
     moveCameraTo(positionTo) {
+        if (!positionTo) {
+            return;
+        }
         this.positionFrom.copy(this.camera.position);
         this.positionTo = positionTo;
         this.player.play(this.animationMoveCamera);
     }
 
+    moveCameraToCurrentPosition() {
+        this.moveCameraTo(this.currentPosition);
+    }
+
     onKeyDown(e) {
         super.onKeyDown(e);
+
+        // key Z to move to next position
         if (e.keyCode == 90) {
             this.moveCameraTo(this.nextPosition);
+        }
+        // key S to move to previous position
+        if (e.keyCode == 83) {
+            this.moveCameraTo(this.previousPosition);
+        }
+        // key A to set to camera to current position looking at next position
+        if (e.keyCode == 65) {
+            this.setCameraToCurrentPosition();
+            this.view.notifyChange(this.view.camera.camera3D);
         }
     }
 

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -27,6 +27,7 @@ function updatePano(context, camera, layer) {
 
         // callback to indicate current pano has changed
         layer.onPanoChanged({
+            previousPanoPosition: layer.getPreviousPano() ? layer.getPreviousPano().position : undefined,
             currentPanoPosition: layer.getCurrentPano().position,
             nextPanoPosition: layer.getNextPano().position,
         });
@@ -104,7 +105,9 @@ class OrientedImageLayer extends GeometryLayer {
 
         this.background = config.background || createBackground(config.backgroundDistance);
 
-        this.object3d.add(this.background);
+        if (this.background) {
+            this.object3d.add(this.background);
+        }
 
         // currentPano is the current point, means it's the closest from the camera
         this.currentPano = undefined;
@@ -170,6 +173,11 @@ class OrientedImageLayer extends GeometryLayer {
 
     getCurrentPano() {
         return this.currentPano;
+    }
+
+    getPreviousPano() {
+        var index = (this.currentPano.index - 1) % this.panos.length;
+        return this.panos[index];
     }
 }
 


### PR DESCRIPTION
## Description
Immersive: Add the possibility to go backward with key S

- Street controls : Add key binding to previsous pano
- Oriented Image Layer : 
  - Add the previsous pano position in the callback
  - Also, manage case wise no background object
- Immersive example updated
