### PR TITLE
Improve Street controls 1

### DIFF
--- a/examples/immersive_paris.html
+++ b/examples/immersive_paris.html
@@ -45,7 +45,7 @@
             });
 
             // limit camera far, to increase performance
-            view.camera.camera3D.far = 100;
+            view.camera.camera3D.far = 10000;
             view.camera.camera3D.near = 0.1;
 
             // open camera fov
@@ -107,7 +107,7 @@
                 // Create oriented image layer
                 var olayer = new itowns.OrientedImageLayer('demo_orientedImage', {
                     // Radius in meter of the sphere used as a background.
-                    backgroundDistance: 80,
+                    backgroundDistance: 1200,
                     source: orientedImageSource,
                     orientation: orientation,
                     calibration: calibration,
@@ -140,7 +140,7 @@
                     });
 
                     // create geometry layer for the buildings
-                    var wfsBuildingLayer = new itowns.GeometryLayer('WFS Building', new itowns.THREE.Group(), {
+                    var wfsBuildingLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
                         update: itowns.FeatureProcessing.update,
                         convert: itowns.Feature2Mesh.convert({
                             altitude: altitudeBuildings,
@@ -152,8 +152,11 @@
                         overrideAltitudeInToZero: true,
                     });
 
-                    // add the created building layer
-                    view.addLayer(wfsBuildingLayer);
+                    // add the created building layer, and debug UI
+                    view.addLayer(wfsBuildingLayer).then(function addDebugUI(buildingLayer) {
+                        var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, buildingLayer);
+                        debug.GeometryDebug.addWireFrameCheckbox(gui, view, buildingLayer);
+                    });
                 });
 
             });
@@ -161,6 +164,9 @@
             /* global itowns, document, GuiTools, view, promises */
             var menuGlobe = new GuiTools('menuDiv');
             menuGlobe.view = view;
+
+            var d = new debug.Debug(view, menuGlobe.gui);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
             // Listen for globe full initialisation event
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
@@ -171,6 +177,7 @@
                 // set camera to current panoramic
                 view.controls.setCameraToCurrentPosition();
                 view.notifyChange(view.camera.camera3D);
+
             });
 
         </script>

--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -52,7 +52,7 @@ export default {
         // TODO semble ne pas etre necessaire
         tile.layers.set(layer.threejsLayer);
 
-        if (parent && parent instanceof TileMesh) {
+        if (parent && parent.isTileMesh) {
             // get parent extent transformation
             const pTrans = builder.computeSharableExtent(parent.extent);
             // place relative to his parent

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import TileMesh from 'Core/TileMesh';
 import RenderMode from 'Renderer/RenderMode';
 import { unpack1K } from 'Renderer/LayeredMaterial';
 
@@ -120,7 +119,7 @@ export default {
         const _ids = screenCoordsToNodeId(_view, layer, viewCoords, radius);
 
         const extractResult = (node) => {
-            if (_ids.includes(node.id) && node instanceof TileMesh) {
+            if (_ids.includes(node.id) && node.isTileMesh) {
                 results.push({
                     object: node,
                     layer,

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -34,6 +34,7 @@ class TileMesh extends THREE.Mesh {
         this.rotationAutoUpdate = false;
 
         this.layerUpdateState = {};
+        this.isTileMesh = true;
     }
 
     /**

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -612,6 +612,10 @@ View.prototype.pickObjectsAt = function pickObjectsAt(mouseOrEvt, radius, ...whe
             const layer = (typeof (source) === 'string') ?
                 this.getLayerById(source) :
                 source;
+            if (!layer || !layer.ready) {
+                console.warn('view.pickObjectAt : layer is not ready : ', source);
+                continue;
+            }
 
             const parentLayer = this.getParentLayer(layer);
             if (!parentLayer) {

--- a/src/Renderer/OrientedImageCamera.js
+++ b/src/Renderer/OrientedImageCamera.js
@@ -15,7 +15,7 @@ class OrientedImageCamera extends THREE.PerspectiveCamera {
      * @param {number} skew - shear transform parameter (default: 0)
      * @param {number} aspect - aspect ratio of the camera (default: size.x/size.y).
      */
-    constructor(size = 1024, focal = 1024, center, near = 0.1, far = 1000, skew, aspect) {
+    constructor(size = 1024, focal = 1024, center, near = 0.1, far = 10000, skew, aspect) {
         size = size.isVector2 ? size : new THREE.Vector2(size, size);
         aspect = aspect || size.x / size.y;
         super(undefined, aspect, near, far);

--- a/src/Renderer/OrientedImageMaterial.js
+++ b/src/Renderer/OrientedImageMaterial.js
@@ -50,7 +50,7 @@ class OrientedImageMaterial extends THREE.RawShaderMaterial {
     constructor(cameras, options = {}) {
         options.side = options.side !== undefined ? options.side : THREE.DoubleSide;
         options.transparent = options.transparent !== undefined ? options.transparent : true;
-        options.opacity = options.opacity !== undefined ? options.opacity : 0.1;
+        options.opacity = options.opacity !== undefined ? options.opacity : 1;
         super(options);
 
         this.defines.NUM_TEXTURES = cameras.length;
@@ -91,6 +91,7 @@ class OrientedImageMaterial extends THREE.RawShaderMaterial {
             this.group.add(camera);
         }
 
+        this.uniforms.opacity = new THREE.Uniform(this.opacity);
         this.uniforms.projectiveTextureAlphaBorder = new THREE.Uniform(this.alphaBorder);
         this.uniforms.projectiveTextureDistortion = new THREE.Uniform(distortion);
         this.uniforms.projectiveTextureMatrix = new THREE.Uniform(textureMatrix);

--- a/src/Renderer/Shader/Chunk/projective_texturing_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/projective_texturing_pars_fragment.glsl
@@ -1,6 +1,7 @@
 uniform sampler2D projectiveTexture[NUM_TEXTURES];
 varying vec4      projectiveTextureCoords[NUM_TEXTURES];
 uniform float     projectiveTextureAlphaBorder;
+uniform float     opacity;
 
 struct Distortion {
     vec2 size;

--- a/src/Renderer/Shader/ProjectiveTextureFS.glsl
+++ b/src/Renderer/Shader/ProjectiveTextureFS.glsl
@@ -14,6 +14,6 @@ void main(void)
     }
 
     if (color.a > 0.0) color /= color.a;
-    color.a = 1.;
+    color.a = opacity;
     gl_FragColor = color;
 }


### PR DESCRIPTION
## Description
improve StreetControls : add click and go, surface helpers, click and look at, tweens animations :
- Mouse click on ground detection, and associated callback, that go to the clicked position
- Mouse click on other object (not ground), and associated callback, that makes camera look at the position
- Surfaces as helpers for the end user :
  - Circle displayed when user moves the mouse on the ground
  - Rectangle displayed when user moves the mouse on other objects (like walls of a building)
- Tweens animations :
  - camera can move to another position smoothly
  - camera can look at a position smoothly in an animation

## Motivation and Context
User should have a good experience using immersive example

## Screenshots (if appropriate)
![helper_wall](https://user-images.githubusercontent.com/15127065/51912450-acc2d780-23d4-11e9-861f-1fcf81813d58.png)
![helper_ground](https://user-images.githubusercontent.com/15127065/51912459-b3e9e580-23d4-11e9-864b-198c81cb57cd.png)
