### PR TITLE
chore(example): update jsonlayers url to https

### DIFF
--- a/examples/globe_wfs_color.html
+++ b/examples/globe_wfs_color.html
@@ -58,7 +58,7 @@
             }
 
             var wfsBuildingSource = new itowns.WFSSource({
-                url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
+                url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
                 zoom: { max: 20, min: 13 },

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -186,6 +186,7 @@
                     meshes.push(mesh);
                 },
                 filter: acceptFeature,
+                overrideAltitudeInToZero: true,
                 source: wfsBuildingSource
             });
             view.addLayer(wfsBuildingLayer);

--- a/examples/globe_wfs_extruded.html
+++ b/examples/globe_wfs_extruded.html
@@ -159,7 +159,7 @@
             view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
 
             var wfsBuildingSource = new itowns.WFSSource({
-                url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
+                url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
                 projection: 'EPSG:4326',

--- a/examples/immersive_paris.html
+++ b/examples/immersive_paris.html
@@ -51,7 +51,7 @@
             // open camera fov
             view.camera.camera3D.fov = 75;
             view.camera.camera3D.updateProjectionMatrix();
-            
+
             // disable atmosphere
             view.atmosphere.visible = false;
 
@@ -93,7 +93,7 @@
             // Url of a a JSON file with calibration for all cameras. see [CameraCalibrationParser]{@link module:CameraCalibrationParser.parse}
             // in this example, we have the ladybug, it's a set of 6 cameras
             var calibrationUrl = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/immersive/exampleParis1/cameraCalibration.json';
-            
+
             // Fetch the two files
             var promises = [];
             var networkOptions = {crossOrigin: ''};
@@ -124,7 +124,7 @@
 
                     // prepare WFS source for the buildings
                     var wfsBuildingSource = new itowns.WFSSource({
-                        url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
+                        url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                         version: '2.0.0',
                         typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
                         projection: 'EPSG:4326',
@@ -163,7 +163,7 @@
 
             // Listen for globe full initialisation event
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
-                
+
                 // eslint-disable-next-line no-console
                 console.info('Globe initialized');
 
@@ -171,7 +171,7 @@
                 view.controls.setCameraToCurrentPosition();
                 view.notifyChange(view.camera.camera3D);
             });
-            
+
         </script>
     </body>
 </html>

--- a/examples/layers/JSONLayers/IGN_MNT.json
+++ b/examples/layers/JSONLayers/IGN_MNT.json
@@ -8,7 +8,7 @@
         }
     },
     "source": {
-        "url":        "http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "format": "image/x-bil;bits=32",
         "attribution" : {
             "name":"IGN",

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -8,7 +8,7 @@
 		}
 	},
 	"source": {
-		"url":        "http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+		"url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
 		"format": "image/x-bil;bits=32",
 		"attribution" : {
 			"name":"IGN",

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -1,7 +1,7 @@
 {
     "id":   "Ortho",
     "source": {
-        "url": "http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "networkOptions": {
             "crossOrigin": "anonymous"
         },

--- a/examples/layers/JSONLayers/OrthosCRS.json
+++ b/examples/layers/JSONLayers/OrthosCRS.json
@@ -2,7 +2,7 @@
     "id":         "OrthoCRS",
     "fx" :        1.0,
     "source": {
-        "url":        "http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "format": "image/jpeg",
         "name": "ORTHOIMAGERY.ORTHOPHOTOS.CRS84",
         "attribution" : {

--- a/examples/layers/JSONLayers/ScanEX.json
+++ b/examples/layers/JSONLayers/ScanEX.json
@@ -2,7 +2,7 @@
     "id":         "ScanEX",
     "fx" :        2.5,
     "source": {
-        "url":        "http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "format": "image/jpeg",
         "name": "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD",
         "attribution" : {

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -10,7 +10,7 @@
     },
     "source": {
         "format": "image/x-bil;bits=32",
-        "url":        "http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "name": "ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3",
         "tileMatrixSet": "WGS84G",
         "tileMatrixSetLimits": {

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -167,7 +167,7 @@
             view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
 
             var wfsBuildingSource = new itowns.WFSSource({
-                url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
+                url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
                 projection: 'EPSG:4326',

--- a/examples/wfs.html
+++ b/examples/wfs.html
@@ -193,6 +193,7 @@
                     meshes.push(mesh);
                 },
                 filter: acceptFeature,
+                overrideAltitudeInToZero: true,
                 projection: 'EPSG:3946',
                 source: wfsBuildingSource,
             });

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -39,6 +39,7 @@ function FetchAndConvertSourceData(url, layer, extentSource, extentDestination) 
         // TODO FIXME: error in filtering vector tile
         // filteringExtent: extentDestination.as(layer.projection),
         filteringExtent: layer.isGeometryLayer ? extentDestination : undefined,
+        overrideAltitudeInToZero: layer.overrideAltitudeInToZero,
         filter: layer.filter,
         isInverted: source.isInverted,
         mergeFeatures: layer.mergeFeatures === undefined ? true : layer.mergeFeatures,

--- a/test/examples/layersColorVisible.js
+++ b/test/examples/layersColorVisible.js
@@ -18,9 +18,11 @@ describe('layersColorVisible', function _() {
 
     it('should display correct color layer', async () => {
         // test displayed tile
-        const layer = await page.evaluate(() => view.tileLayer.info.displayed.layers[0].id);
-        const count = await page.evaluate(() => view.tileLayer.info.displayed.layers.filter(l => l.isColorLayer).length);
-        assert.equal(count, 1);
-        assert.equal(layer, 'Ortho');
+        result = await page.evaluate(() => {
+            const layers = view.tileLayer.info.displayed.layers.filter(l => l.isColorLayer);
+            return { count: layers.length, id: layers[0].id };
+        });
+        assert.equal(result.count, 1);
+        assert.equal(result.id, 'Ortho');
     });
 });


### PR DESCRIPTION
Some sources aren't working at the moment, because we are fetching them in http instead of https. This PR fixes that.