### PR TITLE
fix(examples): wrong altitude for buildings in immersive paris example.

### DIFF
--- a/examples/immersive_paris.html
+++ b/examples/immersive_paris.html
@@ -130,7 +130,7 @@
                         projection: 'EPSG:4326',
                         ipr: 'IGN',
                         format: 'application/json',
-                        zoom: { min: 14, max: 14 },
+                        zoom: { min: 15, max: 15 },
                         extent: {
                             west: 2.334,
                             east: 2.335,
@@ -148,7 +148,8 @@
 
                         // when a building is created, it get the projective texture mapping, from oriented image layer.
                         onMeshCreated: (mesh) => mesh.traverse(object => object.material = orientedImageLayer.material),
-                        source: wfsBuildingSource
+                        source: wfsBuildingSource,
+                        overrideAltitudeInToZero: true,
                     });
 
                     // add the created building layer


### PR DESCRIPTION
Add option overrideAltitudeInToZero in wfs
