### PR TITLE
feat(parser): add a kml parser and modify gpx parser

### DIFF
--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -25,9 +25,6 @@
 
             setupLoadingScreen(viewerDiv, view);
 
-            function addLayerCb(layer) {
-                view.addLayer(layer);
-            }
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
             // object. See Layer* for more info.
@@ -46,15 +43,59 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
+            // update the waypoint
+            var distance, scale;
+            function updatePointScale(renderer, scene, camera) {
+                distance = camera.position.distanceTo(this.geometry.boundingSphere.center);
+                scale = Math.max(2, Math.min(100, distance / renderer.getSize().height));
+                this.scale.set(scale, scale, scale);
+                this.updateMatrixWorld();
+            }
+
+            var waypointGeometry = new itowns.THREE.BoxGeometry(1, 1, 80);
+            var waypointMaterial = new itowns.THREE.MeshBasicMaterial({ color: 0xffffff });
             // Listen for globe full initialisation event
+            var waypoints = [];
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
-                itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx').then(xml => itowns.GpxParser.parse(xml, { crs: view.referenceCrs })).then(function (gpx) {
-                    if (gpx) {
-                        view.scene.add(gpx);
-                        view.controls.setTilt(45, true);
-                    }
-                });
+                itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
+                    .then(gpx => itowns.GpxParser.parse(gpx, {
+                        buildExtent: true,
+                        crsIn: 'EPSG:4326',
+                        crsOut: view.referenceCrs,
+                        mergeFeatures: true,
+                    }))
+                    .then(features => itowns.Feature2Mesh.convert({
+                        color: new itowns.THREE.Color(0xff0000),
+                    })(features))
+                    .then(function (mesh) {
+                        if (mesh) {
+                            mesh.traverse((m) => {
+                                if (m.type == 'Line') {
+                                    m.material.linewidth = 5;
+                                }
+
+                                if (m.type == 'Points') {
+                                    var vertices = m.feature.vertices;
+                                    for (var i = 0; i < vertices.length; i++) {
+                                        var waypoint = new itowns.THREE.Mesh(waypointGeometry, waypointMaterial);
+                                        waypoint.position.set(
+                                            vertices[i * 3],
+                                            vertices[i * 3 + 1],
+                                            vertices[i * 3 + 2]);
+                                        waypoint.lookAt(0, 0, 0);
+                                        waypoint.onBeforeRender = updatePointScale;
+                                        waypoint.updateMatrixWorld();
+                                        waypoints.push(waypoint);
+                                    }
+                                }
+                            });
+                            mesh.add(...waypoints);
+                            mesh.updateMatrixWorld();
+                            view.scene.add(mesh);
+                            view.controls.setTilt(45, true);
+                        }
+                    });
             });
         </script>
     </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9896,12 +9896,6 @@
       "integrity": "sha512-8ufimUVmRLtH+BTpEIbDjdGEKQOVWLMLgGynaKin1KbYTE136ZNOepJ8EgByi0tN43dQ7B1YrKLCJgXGy4bLmw==",
       "dev": true
     },
-    "three.meshline": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/three.meshline/-/three.meshline-1.2.0.tgz",
-      "integrity": "sha512-E7s9xwgjUhQWIvXBMIdCOIvpT1qV9UlntzaaJTWzJvYtvI2ZvVsX8EM8FxoiG5aptXuKbp5osnvcJCCkYOjmBA==",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.101.1",
-    "three.meshline": "^1.2.0"
+    "three": "^0.101.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -79,7 +78,6 @@
     "puppeteer": "^1.12.1",
     "replace-in-file": "^3.4.3",
     "three": "^0.101.1",
-    "three.meshline": "^1.2.0",
     "url-polyfill": "^1.1.3",
     "webpack": "^4.29.1",
     "webpack-cli": "^3.2.1",

--- a/src/Main.js
+++ b/src/Main.js
@@ -60,5 +60,6 @@ export { default as OrientedImageSource } from 'Source/OrientedImageSource';
 // takes the data as the first argument and options as the second.
 export { default as GpxParser } from 'Parser/GpxParser';
 export { default as GeoJsonParser } from 'Parser/GeoJsonParser';
+export { default as KMLParser } from 'Parser/KMLParser';
 export { default as CameraCalibrationParser } from 'Parser/CameraCalibrationParser';
 export { default as BatchTableHierarchyExtensionParser } from 'Parser/BatchTableHierarchyExtensionParser';

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -289,6 +289,23 @@ function readFeatures(crsIn, crsOut, features, filteringExtent, options) {
 }
 
 /**
+ * @typedef {Object} geojsonParserOptions
+ * @property {string} crsOut - The CRS to convert the input coordinates
+ * to.
+ * @property {string} crsIn - Override the data CRS.
+ * @property {Extent} [filteringExtent] - Optional filter to reject
+ * features outside of this extent.
+ * @property {boolean} [buildExtent=false] - If true the geometry will
+ * have an extent property containing the area covered by the geom
+ * @property {function} [filter] - Filter function to remove features
+ * @property {boolean} [mergeFeatures=true] - If true all geometries are merged by type and multi-type
+ * @property {boolean} [withNormal=true] - If true each coordinate normal is computed
+ * @property {boolean} [withAltitude=true] - If true each coordinate altitude is kept
+ * @property {boolean} [overrideAltitudeInToZero=false] - If true, the altitude of the source data isn't taken into account for 3D geometry convertions.
+ * the altitude will be override to 0. This can be useful if you don't have a DEM or provide a new one when converting (with Layer.convert).
+ */
+
+/**
  * The GeoJsonParser module provide a [parse]{@link module:GeoJsonParser.parse}
  * method that takes a GeoJSON in and gives an object formatted for iTowns
  * containing all necessary informations to display this GeoJSON.
@@ -357,20 +374,7 @@ export default {
      * module:GeoJsonParser~FeatureCollection}.
      *
      * @param {string} json - The GeoJSON file content to parse.
-     * @param {Object} options - Options controlling the parsing.
-     * @param {string} options.crsOut - The CRS to convert the input coordinates
-     * to.
-     * @param {string} options.crsIn - Override the data CRS.
-     * @param {Extent} [options.filteringExtent] - Optional filter to reject
-     * features outside of this extent.
-     * @param {boolean} [options.buildExtent=false] - If true the geometry will
-     * have an extent property containing the area covered by the geom
-     * @param {function} [options.filter] - Filter function to remove features
-     * @param {boolean} [options.mergeFeatures=true] - If true all geometries are merged by type and multi-type
-     * @param {boolean} [options.withNormal=true] - If true each coordinate normal is computed
-     * @param {boolean} [options.withAltitude=true] - If true each coordinate altitude is kept
-     * @param {boolean} [options.overrideAltitudeInToZero=false] - If true, the altitude of the source data isn't taken into account for 3D geometry convertions.
-     * the altitude will be override to 0. This can be useful if you don't have a DEM or provide a new one when converting (with Layer.convert).
+     * @param {geojsonParserOptions} options - Options controlling the parsing.
      *
      * @return {Promise} A promise resolving with a [FeatureCollection]{@link
      * module:GeoJsonParser~FeatureCollection}.

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -1,191 +1,25 @@
-/**
- * Generated On: 2016-07-07
- * Class: GpxParser
- * Description: Parse Gpx file to get [lat, lon, alt]
- */
-
-import * as THREE from 'three';
-import Line from 'three.meshline';
-import Coordinates from 'Core/Geographic/Coordinates';
-
-function _gpxToWayPointsArray(gpxXML) {
-    return gpxXML.getElementsByTagName('wpt');
-}
-
-function _gGpxToWTrackPointsArray(gpxXML) {
-    return gpxXML.getElementsByTagName('trkpt');
-}
-
-function _gGpxToWTrackSegmentsArray(gpxXML) {
-    return gpxXML.getElementsByTagName('trkseg');
-}
-
-function _gpxPtToCartesian(pt, crs) {
-    var longitude = Number(pt.attributes.lon.nodeValue);
-    var latitude = Number(pt.attributes.lat.nodeValue);
-    // TODO: get elevation with terrain
-    const elem = pt.getElementsByTagName('ele')[0];
-    const elevation = elem ? Number(elem.childNodes[0].nodeValue) : 0;
-
-    return new Coordinates('EPSG:4326', longitude, latitude, elevation).as(crs).xyz();
-}
-
-const geometryPoint = new THREE.BoxGeometry(1, 1, 80);
-const materialPoint = new THREE.MeshBasicMaterial({ color: 0xffffff });
-const positionCamera = new THREE.Vector3();
-
-function getDistance(object, camera) {
-    const point = object.geometry.boundingSphere.center.clone().applyMatrix4(object.matrixWorld);
-    positionCamera.setFromMatrixPosition(camera.matrixWorld);
-    return positionCamera.distanceTo(point);
-}
-
-function updatePointScale(renderer, scene, camera) {
-    const distance = getDistance(this, camera);
-    const scale = Math.max(2, Math.min(100, distance / renderer.getSize().height));
-    this.scale.set(scale, scale, scale);
-    this.updateMatrixWorld();
-}
-
-function _gpxToWayPointsMesh(gpxXML, crs) {
-    var wayPts = _gpxToWayPointsArray(gpxXML);
-
-    if (wayPts.length) {
-        const points = new THREE.Group();
-
-        gpxXML.center = gpxXML.center || _gpxPtToCartesian(wayPts[0], crs);
-
-        const lookAt = gpxXML.center.clone().negate();
-
-        for (const wayPt of wayPts) {
-            const position = _gpxPtToCartesian(wayPt, crs).sub(gpxXML.center);
-            // use Pin to make it more visible
-            const mesh = new THREE.Mesh(geometryPoint, materialPoint);
-            mesh.position.copy(position);
-            mesh.lookAt(lookAt);
-
-            // Scale pin in function of distance
-            mesh.onBeforeRender = updatePointScale;
-
-            points.add(mesh);
-        }
-        return points;
-    } else {
-        return null;
-    }
-}
-
-function updatePath(renderer, scene, camera) {
-    const distance = getDistance(this, camera);
-    this.material.depthTest = distance < this.geometry.boundingSphere.radius * 2;
-    const size = renderer.getSize();
-    this.material.uniforms.resolution.value.set(size.width, size.height);
-}
-
-function _gpxToWTrackPointsMesh(gpxXML, options) {
-    var trackSegs = _gGpxToWTrackSegmentsArray(gpxXML);
-    var masterObject = new THREE.Object3D();
-
-    if (trackSegs.length) {
-        for (const trackSeg of trackSegs) {
-            var trackPts = _gGpxToWTrackPointsArray(trackSeg);
-
-            if (trackPts.length) {
-                gpxXML.center = gpxXML.center || _gpxPtToCartesian(trackPts[0], options.crs);
-
-                var geometry = new THREE.Geometry();
-
-                for (const trackPt of trackPts) {
-                    const point = _gpxPtToCartesian(trackPt, options.crs).sub(gpxXML.center);
-                    geometry.vertices.push(point);
-                }
-
-                var line = new Line.MeshLine();
-                line.setGeometry(geometry);
-                // Due to limitations in the ANGLE layer,
-                // with the WebGL renderer on Windows platforms
-                // lineWidth will always be 1 regardless of the set value
-                // Use MeshLine to fix it
-                var material = new Line.MeshLineMaterial({
-                    lineWidth: options.lineWidth || 12,
-                    sizeAttenuation: 0,
-                    color: new THREE.Color(0xFF0000),
-                });
-
-                const pathMesh = new THREE.Mesh(line.geometry, material);
-                // update size screen uniform
-                // update depth test for visibilty path, because of the proximity of the terrain and gpx mesh
-                pathMesh.onBeforeRender = updatePath;
-                masterObject.add(pathMesh);
-            }
-        }
-        return masterObject;
-    } else {
-        return null;
-    }
-}
-
-function _gpxToMesh(gpxXML, options = {}) {
-    if (!gpxXML) {
-        return undefined;
-    }
-
-    if (options.enablePin == undefined) {
-        options.enablePin = true;
-    }
-
-    var gpxMesh = new THREE.Object3D();
-
-    // Getting the track points
-    var trackPts = _gpxToWTrackPointsMesh(gpxXML, options);
-
-    if (trackPts) {
-        gpxMesh.add(trackPts);
-    }
-
-    if (options.enablePin) {
-        // Getting the waypoint points
-        var wayPts = _gpxToWayPointsMesh(gpxXML, options.crs);
-
-        if (wayPts) {
-            gpxMesh.add(wayPts);
-        }
-    }
-
-    gpxMesh.position.copy(gpxXML.center);
-    gpxMesh.updateMatrixWorld();
-    // gpxMesh is static data, it doens't need matrix update
-    gpxMesh.matrixAutoUpdate = false;
-
-    return gpxMesh;
-}
+import togeojson from '@mapbox/togeojson';
+import GeoJsonParser from 'Parser/GeoJsonParser';
 
 /**
+ * The GpxParser module provides a [parse]{@link module:GpxParser.parse}
+ * method that takes a GPX in and gives an object formatted for iTowns
+ * containing all necessary informations to display this GPX.
+ *
  * @module GpxParser
  */
 export default {
     /**
-     * Parse gpx file and convert to THREE.Mesh
-     * @param {string} xml - the gpx file or xml.
-     * @param {Object=} options - additional properties.
-     * @param {string} options.crs - the default CRS of Three.js coordinates. Should be a cartesian CRS.
-     * @param {boolean=} [options.enablePin=true] - draw pin for way points.
-     * @param {NetworkOptions=} options.networkOptions - options for fetching resources over network.
-     * @param {number=} [options.lineWidth=12] - set line width to track line.
-     * @return {THREE.Mesh} - a promise that resolves with a Three.js Mesh (see {@link https://threejs.org/docs/#api/objects/Mesh}).
-     * @example
-     * // How to add a gpx object
-     * itowns.GpxParser.parse(file, { crs: viewer.referenceCrs }).then((gpx) => {
-     *      if (gpx) {
-     *         viewer.scene.add(gpx);
-     *         viewer.notifyChange();
-     *      }
-     * });
+     * Parse a GPX file content and return a [FeatureCollection]{@link
+     * module:GeoJsonParser~FeatureCollection}.
+     *
+     * @param {XMLDocument} gpx - The GPX file content to parse.
+     * @param {geojsonParserOptions} options - Options controlling the parsing.
+     *
+     * @return {Promise} A promise resolving with a [FeatureCollection]{@link
+     * module:GeoJsonParser~FeatureCollection}.
      */
-    parse(xml, options = {}) {
-        if (!(xml instanceof XMLDocument)) {
-            xml = new window.DOMParser().parseFromString(xml, 'text/xml');
-        }
-        return Promise.resolve(_gpxToMesh(xml, options));
+    parse(gpx, options) {
+        return GeoJsonParser.parse(togeojson.gpx(gpx), options);
     },
 };

--- a/src/Parser/KMLParser.js
+++ b/src/Parser/KMLParser.js
@@ -1,0 +1,25 @@
+import togeojson from '@mapbox/togeojson';
+import GeoJsonParser from 'Parser/GeoJsonParser';
+
+/**
+ * The KMLParser module provides a [parse]{@link module:KMLParser.parse}
+ * method that takes a KML in and gives an object formatted for iTowns
+ * containing all necessary informations to display this KML.
+ *
+ * @module KMLParser
+ */
+export default {
+    /**
+     * Parse a KML file content and return a [FeatureCollection]{@link
+     * module:GeoJsonParser~FeatureCollection}.
+     *
+     * @param {XMLDocument} kml - The KML file content to parse.
+     * @param {geojsonParserOptions} options - Options controlling the parsing.
+     *
+     * @return {Promise} A promise resolving with a [FeatureCollection]{@link
+     * module:GeoJsonParser~FeatureCollection}.
+     */
+    parse(kml, options) {
+        return GeoJsonParser.parse(togeojson.kml(kml), options);
+    },
+};


### PR DESCRIPTION
## Description

- I added a very tiny KML parser (almost the same as the one we used to have some time ago)
- I modified the GPX parser to be very simple like the KML one
- Both parsers use `togeojson`
- The `gpx.html` example has been rewritten to generate some meshes, as the new GPX parser doesn't generate it now

## Motivation and Context

I'm doing this now, because I'm making `FileSource` simpler, and making `DataSourceProvider` malleable. This will be cover in my next PR (coming very soon).