### PR TITLE
refacto/feat: create a layer/source from data loaded by the user

### DIFF
--- a/examples/globe_geojson_to3D.html
+++ b/examples/globe_geojson_to3D.html
@@ -68,7 +68,7 @@
                 projection: 'EPSG:4326',
                 format: 'application/json',
                 zoom: { min: 7, max: 7 },
-            }, view.referenceCrs);
+            });
 
             view.addLayer(ariege).then(function menue(layer) {
                 var gui = debug.GeometryDebug

--- a/examples/globe_vector.html
+++ b/examples/globe_vector.html
@@ -13,8 +13,7 @@
                 position: absolute;
                 z-index: 1000;
                 color: #CECECE;
-                font-family: 'Open Sans',
-                sans-serif;
+                font-family: 'Open Sans', sans-serif;
                 font-size: 14px;
                 line-height: 18px;
                 text-align: left;
@@ -63,7 +62,10 @@
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
                 config.source = new itowns.WMTSSource(config.source);
                 var layer = new itowns.ColorLayer('Ortho', config);
-                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(layer).then(function _() {
+                    menuGlobe.addLayerGUI.bind(menuGlobe);
+                    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
+                });
             });
             // Add two elevation layers.
             // These will deform iTowns globe geometry to represent terrain elevation.
@@ -75,53 +77,80 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
+            var promises = [];
+
+            // Fetch, Parse and Convert by iTowns
             var kmlSource = new itowns.FileSource({
-                    url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
-                    projection: 'EPSG:4326',
-                }, view.tileLayer.extent.crs());
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
+                projection: 'EPSG:4326',
+                fetcher: itowns.Fetcher.xml,
+                parser: itowns.KMLParser.parse,
+            });
 
             var kmlLayer = new itowns.ColorLayer('Kml', {
                 name: 'kml',
                 transparent: true,
                 source: kmlSource,
             });
-            view.addLayer(kmlLayer);
 
-            var gpxSource = new itowns.FileSource({
-                    url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx',
-                    projection: 'EPSG:4326',
-                }, view.tileLayer.extent.crs());
+            promises.push(view.addLayer(kmlLayer));
 
-            var gpxLayer = new itowns.ColorLayer('Gpx', {
-                name: 'Ultra 2009',
-                transparent: true,
-                source: gpxSource,
-            });
-            view.addLayer(gpxLayer);
+            // Parse and Convert by iTowns
+            promises.push(itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
+                .then(function _(gpx) {
+                    var gpxSource = new itowns.FileSource({
+                        fetchedData: gpx,
+                        projection: 'EPSG:4326',
+                        parser: itowns.GpxParser.parse,
+                    });
 
-            var ariegeSource = new itowns.FileSource({
-                    url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
-                    projection: 'EPSG:4326',
-                }, view.tileLayer.extent.crs());
+                    var gpxLayer = new itowns.ColorLayer('Gpx', {
+                        name: 'Ultra 2009',
+                        transparent: true,
+                        source: gpxSource,
+                        style: {
+                            stroke: 'red'
+                        },
+                    });
 
-            var ariegeLayer = new itowns.ColorLayer('ariege', {
-                name: 'ariege',
-                transparent: true,
-                style: {
-                    fill: 'orange',
-                    fillOpacity: 0.5,
-                    stroke: 'white',
-                },
-                source: ariegeSource,
-            });
-            view.addLayer(ariegeLayer);
+                    return view.addLayer(gpxLayer);
+                }));
+
+            // Convert by iTowns
+            promises.push(itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson')
+                .then(function _(geojson) {
+                    return itowns.GeoJsonParser.parse(geojson, {
+                        buildExtent: true,
+                        crsIn: 'EPSG:4326',
+                        crsOut: view.tileLayer.extent.crs(),
+                        mergeFeatures: true,
+                        withNormal: false,
+                        withAltitude: false,
+                    });
+                }).then(function _(parsedData) {
+                    var ariegeSource = new itowns.FileSource({
+                        parsedData,
+                    });
+
+                    var ariegeLayer = new itowns.ColorLayer('ariege', {
+                        name: 'ariege',
+                        transparent: true,
+                        style: {
+                            fill: 'orange',
+                            fillOpacity: 0.5,
+                            stroke: 'white',
+                        },
+                        source: ariegeSource,
+                    });
+
+                    return view.addLayer(ariegeLayer);
+                }));
 
             // Listen for globe full initialisation event
-            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function _() {
-                // eslint-disable-next-line no-console
-                console.info('Globe initialized');
-                itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
-                new ToolTip(view, document.getElementById('viewerDiv'), document.getElementById('tooltipDiv'));
+            view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function _() {
+                Promise.all(promises).then(new ToolTip(view,
+                    document.getElementById('viewerDiv'),
+                    document.getElementById('tooltipDiv')));
             });
         </script>
     </body>

--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -35,6 +35,9 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
             // convert degree precision
             for (i = 0; i < layers.length; i++) {
                 layer = layers[i];
+
+                if (!layer.source.parsedData) { continue; }
+
                 result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(
                     geoCoord, layer.source.parsedData, precision);
 

--- a/examples/planar_vector.html
+++ b/examples/planar_vector.html
@@ -93,24 +93,28 @@
                     projection: 'EPSG:4326',
                     extent: extent,
                     zoom: { min: 0, max: 6 },
-                }, view.tileLayer.extent.crs());
+                    fetcher: itowns.Fetcher.xml,
+                    parser: itowns.KMLParser.parse,
+                });
             var kmlLayer = new itowns.ColorLayer('Kml', {
                 transparent: true,
                 source: kmlSource,
             });
             view.addLayer(kmlLayer);
 
-            var kmlSource = new itowns.FileSource({
+            var gpxSource = new itowns.FileSource({
                     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/lyon.gpx',
                     projection: 'EPSG:4326',
                     zoom: { min: 0, max: 6 },
-                }, view.tileLayer.extent.crs());
+                    fetcher: itowns.Fetcher.xml,
+                    parser: itowns.GpxParser.parse,
+                });
             var gpxLayer = new itowns.ColorLayer('Gpx', {
                 transparent: true,
                 style: {
                     stroke: 'blue',
                 },
-                source: kmlSource,
+                source: gpxSource,
             });
             view.addLayer(gpxLayer);
 
@@ -119,7 +123,9 @@
                     projection: 'EPSG:3946',
                     extent: extent,
                     zoom: { min: 0, max: 6 },
-                }, view.tileLayer.extent.crs());
+                    fetcher: itowns.Fetcher.json,
+                    parser: itowns.GeoJsonParser.parse,
+                });
             var geoLayer = new itowns.ColorLayer('geo', {
                 transparent: true,
                 source: geoSource,

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -191,11 +191,6 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
                 providerPreprocessing = Promise.resolve();
             }
         } else if (layer.source) {
-            // TODO: move to dataSourceProvider
-            // Tempory fix, because sourceFile loads data in his constructor
-            // while it should be loaded in the provider
-            layer.source.toTexture = !layer.isGeometryLayer;
-
             if (!layer.source.isSource) {
                 console.warn('Deprecation warning: passing a source as an object is deprecated. Instantiate the source before adding it to the layer instead.');
                 const protocol = layer.source.protocol;

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -33,9 +33,10 @@ function updatePano(context, camera, layer) {
         });
 
         // prepare informations about the needed textures
-        const imagesInfo = layer.cameras.map(cam =>  ({
+        const imagesInfo = layer.cameras.map(cam => ({
             cameraId: cam.name,
             panoId: newPano.id,
+            toString: (separator = '') => (`${cam.name}${separator}${newPano.id}`),
         }));
 
         const command = {

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -1,71 +1,70 @@
-import togeojson from '@mapbox/togeojson';
 import Source from 'Source/Source';
-import Fetcher from 'Provider/Fetcher';
-import Extent from 'Core/Geographic/Extent';
-import GeoJsonParser from 'Parser/GeoJsonParser';
-
-function getExtentFromGpxFile(file) {
-    const bound = file.getElementsByTagName('bounds')[0];
-    if (bound) {
-        const west = bound.getAttribute('minlon');
-        const east = bound.getAttribute('maxlon');
-        const south = bound.getAttribute('minlat');
-        const north = bound.getAttribute('maxlat');
-        return new Extent('EPSG:4326', west, east, south, north);
-    }
-    return new Extent('EPSG:4326', -180, 180, -90, 90);
-}
-
-// TODO move and refacto
-function fileParser(text) {
-    let parsedFile;
-    const trimmedText = text.trim();
-    // We test the start of the string to choose a parser
-    if (trimmedText.startsWith('<')) {
-        // if it's an xml file, then it can be kml or gpx
-        const parser = new DOMParser();
-        const file = parser.parseFromString(text, 'application/xml');
-        if (file.documentElement.tagName.toLowerCase() === 'kml') {
-            parsedFile = togeojson.kml(file);
-        } else if (file.documentElement.tagName.toLowerCase() === 'gpx') {
-            parsedFile = togeojson.gpx(file);
-            const line = parsedFile.features.find(e => e.geometry.type == 'LineString');
-            line.properties.stroke = 'red';
-            parsedFile.extent = getExtentFromGpxFile(file);
-        } else if (file.documentElement.tagName.toLowerCase() === 'parsererror') {
-            throw new Error('Error parsing XML document');
-        } else {
-            throw new Error('Unsupported xml file, only valid KML and GPX are supported, but no <gpx> or <kml> tag found.');
-        }
-    } else if (trimmedText.startsWith('{') || trimmedText.startsWith('[')) {
-        parsedFile = JSON.parse(text);
-        if (parsedFile.type !== 'Feature' && parsedFile.type !== 'FeatureCollection') {
-            throw new Error('This json is not a GeoJSON');
-        }
-    } else {
-        throw new Error('Unsupported file: only well-formed KML, GPX or GeoJSON are supported');
-    }
-
-    return parsedFile;
-}
 
 /**
  * @classdesc
  * An object defining the source of a single resource to get from a direct
- * access. It inherits from {@link Source}.
- *
- * A source of this type can only load three types of files: Geojson, GPX and
- * KML.
+ * access. It inherits from {@link Source}. There is multiple ways of adding a
+ * resource here:
+ * <ul>
+ *  <li>add the file like any other sources, using the <code>url</code>
+ *  property.</li>
+ *  <li>fetch the file, and give the data to the source using the
+ *  <code>fetchedData</code> property.</li>
+ *  <li>fetch the file, parse it and git the parsed data to the source using the
+ *  <code>parsedData</code> property.</li>
+ * </ul>
+ * See the examples below for real use cases.
  *
  * @extends Source
  *
  * @property {boolean} isFileSource - Used to checkout whether this source is a
  * FileSource. Default is true. You should not change this, as it is used
  * internally for optimisation.
- * @property {Array} parsedData - Once the file has been loaded and parsed using
- * the GeoJsonParser, the resulting data is stored in this property.
+ * @property {*} fetchedData - Once the file has been loaded, the resulting data
+ * is stored in this property.
+ * @property {*} parsedData - Once the file has been loaded and parsed, the
+ * resulting data is stored in this property.
  *
- * @example
+ * @example <caption>Simple: create a source, a layer, and let iTowns taking
+ * care of everything.</caption>
+ * const kmlSource = new itowns.FileSource({
+ *     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
+ *     projection: 'EPSG:4326',
+ *     fetcher: itowns.Fetcher.xml,
+ *     parser: itowns.KMLParser.parse,
+ * });
+ *
+ * const kmlLayer = new itowns.ColorLayer('Kml', {
+ *     name: 'kml',
+ *     transparent: true,
+ *     projection: view.tileLayer.extent.crs(),
+ *     source: kmlSource,
+ * });
+ *
+ * view.addLayer(kmlLayer);
+ *
+ * @example <caption>Advanced: fetch some data, create a source, a layer, and
+ * let iTowns do the parsing and converting.</caption>
+ * // Parse and Convert by iTowns
+ * itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
+ *     .then(function _(gpx) {
+ *         const gpxSource = new itowns.FileSource({
+ *             data: gpx,
+ *             projection: 'EPSG:4326',
+ *             parser: itowns.GpxParser.parse,
+ *         });
+ *
+ *         const gpxLayer = new itowns.ColorLayer('Gpx', {
+ *             name: 'Ultra 2009',
+ *             transparent: true,
+ *             source: gpxSource,
+ *         });
+ *
+ *         return view.addLayer(gpxLayer);
+ *     });
+ *
+ * @example <caption>More advanced: create a layer, fetch some data, parse the
+ * data, append a source to the layer and add the layer to iTowns.</caption>
  * // Create a layer
  * const ariege = new itowns.GeometryLayer('ariege', new itowns.THREE.Group());
  *
@@ -76,77 +75,68 @@ function fileParser(text) {
  *     extrude: () => 5000,
  * });
  *
- * // Create and append the source
- * ariege.source = new itowns.FileSource({
- *     url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
- *     projection: 'EPSG:4326',
- *     format: 'application/json',
- *     zoom: { min: 7, max: 7 },
- * });
+ * itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson')
+ *     .then(function _(geojson) {
+ *         return itowns.GeoJsonParser.parse(geojson, {
+ *             buildExtent: true,
+ *             crsIn: 'EPSG:4326',
+ *             crsOut: view.tileLayer.extent.crs(),
+ *             mergeFeatures: true,
+ *             withNormal: false,
+ *             withAltitude: false,
+ *         });
+ *     }).then(function _(parsedData) {
+ *         ariege.source = new itowns.FileSource({
+ *             projection: 'EPSG:4326',
+ *             parsedData,
+ *         });
  *
- * view.addLayer(ariege);
- *
- * @example
- * // Create the source
- * const gpxSource = new itowns.FileSource({
- *     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx',
- *     projection: 'EPSG:4326',
- * });
- *
- * // Create the layer
- * const gpxLayer = new itowns.ColorLayer('Gpx', {
- *     name: 'Ultra 2009',
- *     transparent: true,
- *     source: gpxSource,
- * });
- *
- * // Add the layer
- * view.addLayer(gpxLayer);
+ *         return view.addLayer(ariegeLayer);
+ *     });
  */
 class FileSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * FileSource and {@link Source}. Only <code>url</code> and
-     * <code>projection</code> are mandatory.
+     * FileSource and {@link Source}. Only <code>projection</code> is mandatory,
+     * but if it presents in <code>parsedData</code> under the property
+     * <code>projection</code> or <code>crs</code>, it is fine.
      * @param {string} crsOut - The projection of the output data after parsing.
      *
      * @constructor
      */
-    constructor(source, crsOut) {
+    constructor(source) {
         if (!source.projection) {
-            throw new Error('source.projection is required in FileSource');
+            if (source.parsedData && (source.parsedData.crs || source.parsedData.projection)) {
+                source.projection = source.parsedData.crs || source.parsedData.projection;
+            } else {
+                throw new Error('source.projection is required in FileSource');
+            }
         }
+
+        if (!source.url && !source.fetchedData && !source.parsedData) {
+            throw new Error(`url, fetchedData and parsedData are not set in
+                FileSource; at least one needs to be present`);
+        }
+
+        // the fake url is for when we use the fetchedData or parsedData mode
+        source.url = source.url || 'fake-file-url';
         super(source);
 
         this.isFileSource = true;
-        this.url = source.url;
-        this.parsedData = [];
-        this.zoom = source.zoom || { min: 5, max: 21 };
-        const options = {
-            buildExtent: true,
-            crsIn: this.projection,
-            crsOut,
-            withNormal: !source.toTexture,
-            withAltitude: !source.toTexture,
-            mergeFeatures: true,
-        };
 
-        this.whenReady = Fetcher.text(this.url, source.networkOptions).then(fileParser).then(parsedFile =>
-            GeoJsonParser.parse(parsedFile, options).then((feature) => {
-                feature.style = parsedFile.style;
-                this.parsedData = feature;
-            }));
+        this.fetchedData = source.fetchedData;
+        this.parsedData = source.parsedData;
+        this.zoom = source.zoom || { min: 5, max: 21 };
     }
 
-    urlFromExtent(extent) {
-        return `${this.url},${extent.crs()}`;
+    urlFromExtent() {
+        return this.url;
     }
 
     extentInsideLimit(extent) {
-        const dataExtent = this.parsedData.extent;
         const localExtent = this.projection == extent.crs() ? extent : extent.as(this.projection);
         return (extent.zoom == undefined || !(extent.zoom < this.zoom.min || extent.zoom > this.zoom.max)) &&
-            dataExtent.intersectsExtent(localExtent);
+            this.extent.intersectsExtent(localExtent);
     }
 }
 

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -1,5 +1,7 @@
 import Extent from 'Core/Geographic/Extent';
 
+let uid = 0;
+
 /**
  * @classdesc
  * Sources are object containing informations on how to fetch resources, from a
@@ -11,6 +13,8 @@ import Extent from 'Core/Geographic/Extent';
  * @property {boolean} isSource - Used to checkout whether this source is a
  * Source. Default is true. You should not change this, as it is used internally
  * for optimisation.
+ * @property {number} uid - Unique uid mainly used to store data linked to this
+ * source into Cache.
  * @property {string} url - The url of the resources that are fetched.
  * @property {string} format - The format of the resources that are fetched.
  * @property {function} fetcher - The method used to fetch the resources from
@@ -74,6 +78,8 @@ class Source {
         if (!source.url) {
             throw new Error('New Source: url is required');
         }
+
+        this.uid = uid++;
 
         this.url = source.url;
         this.format = source.format;

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -65,7 +65,6 @@ describe('Provide in Sources', function () {
     featureLayer.source = new WFSSource({
         url: 'http://',
         typeName: 'name',
-        protocol: 'wms',
         format: 'application/json',
         extent: [-90, 90, -45, 45],
         projection: 'EPSG:4326',
@@ -86,7 +85,6 @@ describe('Provide in Sources', function () {
         colorlayer.source = new WMTSSource({
             url: 'http://',
             name: 'name',
-            protocol: 'wmts',
             format: 'image/png',
             tileMatrixSet: 'WGS84G',
             zoom: {
@@ -112,7 +110,6 @@ describe('Provide in Sources', function () {
         colorlayer.source = new WMSSource({
             url: 'http://',
             name: 'name',
-            protocol: 'wms',
             format: 'image/png',
             extent: [-90, 90, -45, 45],
             projection: 'EPSG:4326',

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -92,16 +92,43 @@ describe('Source', function () {
         assert.ok(source.extentInsideLimit(extent));
         assert.ok(source.extentsInsideLimit([extent, extent]));
     });
-    it('Should instance and use FileSource', function () {
+    it('Should instance and use FileSource with url', function () {
         Fetcher.text = function () { return geojson.promise; };
         const source = new FileSource({
             url: '..',
             projection: 'EPSG:4326',
-        }, 'EPSG:4326');
+        });
 
         const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
-        source.whenReady.then(() => assert.equal(source.parsedData.features[0].geometry.length, 3));
         assert.ok(source.urlFromExtent(extent));
+        assert.ok(!source.fetchedData);
+        assert.ok(!source.parsedData);
+        assert.ok(source.isFileSource);
+    });
+    it('Should instance and use FileSource with fetchedData', function () {
+        Fetcher.text = function () { return geojson.promise; };
+        const source = new FileSource({
+            fetchedData: { foo: 'bar' },
+            projection: 'EPSG:4326',
+        });
+
+        const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
+        assert.ok(source.urlFromExtent(extent).startsWith('fake-file-url'));
+        assert.ok(source.fetchedData);
+        assert.ok(!source.parsedData);
+        assert.ok(source.isFileSource);
+    });
+    it('Should instance and use FileSource with parsedData', function () {
+        Fetcher.text = function () { return geojson.promise; };
+        const source = new FileSource({
+            parsedData: { foo: 'bar' },
+            projection: 'EPSG:4326',
+        });
+
+        const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
+        assert.ok(source.urlFromExtent(extent).startsWith('fake-file-url'));
+        assert.ok(!source.fetchedData);
+        assert.ok(source.parsedData);
         assert.ok(source.isFileSource);
     });
     it('Should instance and use StaticSource', function () {


### PR DESCRIPTION
## Description

Main goal of the PR: create a Layer/Source directly from data loaded 
by the user. To achieve this, it is mainly `DataSourceProvider` and
`FileSource` that have been rewritten. So now we have three way of 
receiving data:
- by fetching it, parsing it and converting it in the provider
- by giving fetched data to the layer and parsing it and converting it
  in the provider
- by giving parsed data to the layer and converting it in the provider

And thus FileSource can be simplified drastically and extended to
receive ANY type of data, not only geojson, kml and gpx (see #1032)

Documentation and examples have been updated, and I tried to not 
introduce breaking changes, but I may have miss some.

## Motivation and Context

People have asked about it in issue (#892), offline and I need this 
working for another thing. It is also the occasion to clean `FileSource` 
and `DataSourceProvider` that were too messy imho.


## Problems

I still got two problems, that maybe someone can help with:
- the first one is visible in example `globe_vector`, the GPX path and 
the geojson texture seems to overlap, but I don't understand why
- in example `globe_geojson_to3D`, I can't seem to make it work too

NOTE: this PR needs #1032 to be merged first