### PR TITLE
chore: fix 'npm ci' when it prints npm version.

### DIFF
--- a/config/prepare.js
+++ b/config/prepare.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+const { execSync } = require('child_process');
 
 // Verify Puppeteer configuration
 const pupSkip = process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD;
@@ -21,9 +22,7 @@ if (nodeMajorVersion < minNodeMajorVersion) {
     console.log(chalk.green('Node.js version :', process.versions.node));
 }
 
-const regex = new RegExp(/npm\/([^ ]+)/g);
-const npmVersion = regex.exec(process.env.npm_config_user_agent)[1];
-
+const npmVersion = execSync('npm --version');
 if (npmVersion) {
     console.log(chalk.green('Npm version :', npmVersion), '\n');
 }


### PR DESCRIPTION
chore: fix 'npm ci' when it prints npm version.

## Description
Before this commit, there was an error on Travis with node 11.10 (because in prepare.js, process.env.npm_config_user_agent was not defined),
Now, it get the npm version executing 'npm --version'.

## Motivation and Context
New PR doesn't work on Travis with Node 11.10
