### PR TITLE
fix(process): fix and unify calls to window.setTimeOut

### DIFF
--- a/src/Core/AnimationPlayer.js
+++ b/src/Core/AnimationPlayer.js
@@ -115,7 +115,10 @@ class AnimationPlayer extends THREE.EventDispatcher {
         const promise = new Promise((r) => { this.resolveWait = r; });
         const timew = Math.floor(FRAME_DURATION * waitingFrame);
         window.clearInterval(this.waitTimer);
-        this.waitTimer = window.setTimeout(() => { this.play(animation).then(() => this.resolveWait()); }, timew);
+        const self = this;
+        this.waitTimer = window.setTimeout(() => {
+            self.play(animation).then(() => self.resolveWait());
+        }, timew);
         return promise;
     }
 

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -145,10 +145,9 @@ export default {
                 node.layerUpdateState[layer.id].failure(0, true);
             } else {
                 node.layerUpdateState[layer.id].failure(Date.now());
-                setTimeout(node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
-                    () => {
-                        context.view.notifyChange(layer, false);
-                    });
+                window.setTimeout(context.view.notifyChange,
+                    node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
+                    layer, false);
             }
         });
     },

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -215,9 +215,9 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
                 const definitiveError = node.layerUpdateState[layer.id].errorCount > MAX_RETRY;
                 node.layerUpdateState[layer.id].failure(Date.now(), definitiveError, { targetLevel });
                 if (!definitiveError) {
-                    window.setTimeout(() => {
-                        context.view.notifyChange(node, false);
-                    }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
+                    window.setTimeout(context.view.notifyChange,
+                        node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
+                        node, false);
                 }
             }
         });
@@ -374,9 +374,9 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
                 const definitiveError = node.layerUpdateState[layer.id].errorCount > MAX_RETRY;
                 node.layerUpdateState[layer.id].failure(Date.now(), definitiveError);
                 if (!definitiveError) {
-                    window.setTimeout(() => {
-                        context.view.notifyChange(node, false);
-                    }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
+                    window.setTimeout(context.view.notifyChange,
+                        node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
+                        node, false);
                 }
             }
         });


### PR DESCRIPTION
Noticed in `FeatureProcessing` that a `window.setTimeout` call was not correctly written. Fixed that and took the opportunity to unify all calls to this.