### PR TITLE
Refactor Debug layer and Atmosphere

### DIFF
--- a/examples/globe_travel.html
+++ b/examples/globe_travel.html
@@ -41,7 +41,8 @@
             var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             var time = 50000;
             var pathTravel = [];
-            view.setRealisticLightingOn(true);
+            const atmosphere = view.getLayerById('atmosphere');
+            atmosphere.setRealisticOn(value);
 
             pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 2.0889, 42.809), range: 100000, time: time * 0.2 });
             pathTravel.push({ range: 13932, time: time * 0.2, tilt: 7.59, heading: -110.9 });

--- a/examples/globe_vector_tiles.html
+++ b/examples/globe_vector_tiles.html
@@ -33,7 +33,7 @@
             // define pole texture
             view.tileLayer.noTextureColor = new itowns.THREE.Color(0x95c1e1);
 
-            view.atmosphere.visible = false;
+            view.getLayerById('atmosphere').visible = false;
 
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/immersive_paris.html
+++ b/examples/immersive_paris.html
@@ -53,7 +53,7 @@
             view.camera.camera3D.updateProjectionMatrix();
 
             // disable atmosphere
-            view.atmosphere.visible = false;
+            view.getLayerById('atmosphere').visible = false;
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js

--- a/index.html
+++ b/index.html
@@ -61,7 +61,11 @@ and open the template in the editor.
             itowns.Fetcher.json('examples/layers/JSONLayers/IGN_MNT_HIGHRES.json')
                 .then(createWMTSSourceFromConfig).then(addElevationLayerFromConfig);
 
-            menuGlobe.addGUI('RealisticLighting', false, view.setRealisticLightingOn.bind(view));
+            const atmosphere = view.getLayerById('atmosphere');
+            menuGlobe.addGUI('RealisticLighting', false, function (v) {
+                atmosphere.setRealisticOn(v);
+                view.notifyChange(atmosphere);
+            });
 
             // eslint-disable-next-line prefer-arrow-callback
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function m() {

--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -74,9 +74,6 @@ export default {
 
         tile.add(tile.obb);
 
-        tile.material.lightingEnable = layer.lighting.enable;
-        tile.material.lightPosition = layer.lighting.position;
-
         if (layer.diffuse) {
             tile.material.diffuse = layer.diffuse;
         }

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -6,7 +6,9 @@
 
 
 import * as THREE from 'three';
-import { ellipsoidSizes } from 'Core/Geographic/Coordinates';
+import GeometryLayer from 'Layer/GeometryLayer';
+import { C, ellipsoidSizes } from 'Core/Geographic/Coordinates';
+import CoordStars from 'Core/Geographic/CoordStars';
 import Sky from './SkyShader';
 import skyFS from './Shaders/skyFS.glsl';
 import skyVS from './Shaders/skyVS.glsl';
@@ -15,186 +17,223 @@ import groundVS from './Shaders/groundVS.glsl';
 import GlowFS from './Shaders/GlowFS.glsl';
 import GlowVS from './Shaders/GlowVS.glsl';
 
-export const LIGHTING_POSITION = new THREE.Vector3(1, 0, 0);
+const LIGHTING_POSITION = new THREE.Vector3(1, 0, 0);
+const v = new THREE.Vector3();
 
-function Atmosphere() {
+const coordCam = new C.EPSG_4326();
+const coordGeoCam = new C.EPSG_4326();
+const skyBaseColor = new THREE.Color(0x93d5f8);
+const colorSky = new THREE.Color();
+const spaceColor = new THREE.Color(0x030508);
+const limitAlti = 600000;
+const mfogDistance = ellipsoidSizes.x * 160.0;
+
+class Atmosphere extends GeometryLayer {
+    constructor(id = 'atmosphere', options = {}) {
+        super(id, new THREE.Object3D(), options);
+
+        const material = new THREE.ShaderMaterial({
+            uniforms: {
+                atmoIN: {
+                    type: 'i',
+                    value: 0,
+                },
+                screenSize: {
+                    type: 'v2',
+                    value: new THREE.Vector2(window.innerWidth, window.innerHeight),
+                }, // Should be updated on screen resize...
+            },
+            vertexShader: GlowVS,
+            fragmentShader: GlowFS,
+            side: THREE.BackSide,
+            blending: THREE.AdditiveBlending,
+            transparent: true,
+            wireframe: false,
+        });
+
+        const sphereGeometry = new THREE.SphereGeometry(1, 64, 64);
+        const basicAtmosphereOut = new THREE.Mesh(sphereGeometry, material);
+        basicAtmosphereOut.scale.copy(ellipsoidSizes).multiplyScalar(1.14);
+
+        this.basicAtmosphere = new THREE.Object3D();
+        this.realisticAtmosphere = new THREE.Object3D();
+        this.realisticAtmosphere.visible = false;
+        this.object3d.add(this.basicAtmosphere);
+        this.object3d.add(this.realisticAtmosphere);
+
+        this.basicAtmosphere.add(basicAtmosphereOut);
+
+        var materialAtmoIn = new THREE.ShaderMaterial({
+            uniforms: {
+                atmoIN: {
+                    type: 'i',
+                    value: 1,
+                },
+                screenSize: {
+                    type: 'v2',
+                    value: new THREE.Vector2(window.innerWidth, window.innerHeight),
+                }, // Should be updated on screen resize...
+            },
+            vertexShader: GlowVS,
+            fragmentShader: GlowFS,
+            side: THREE.FrontSide,
+            blending: THREE.AdditiveBlending,
+            transparent: true,
+            depthWrite: false,
+        });
+
+        const basicAtmosphereIn = new THREE.Mesh(sphereGeometry, materialAtmoIn);
+        basicAtmosphereIn.scale.copy(ellipsoidSizes).multiplyScalar(1.002);
+
+        this.basicAtmosphere.add(basicAtmosphereIn);
+        this.realisticLightingPosition = { x: -0.5, y: 0.0, z: 1.0 };
+
+        this.fog = {
+            enable: true,
+            distance: mfogDistance,
+        };
+
+        this.object3d.updateMatrixWorld();
+    }
+
+    update(context, layer, node) {
+        // update uniforms
+        node.material.fogDistance = this.fog.distance;
+        node.material.lightingEnabled = this.realisticAtmosphere.visible;
+        node.material.lightPosition = this.realisticLightingPosition;
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    preUpdate(context, srcs) {
+        const cameraPosition = context.view.camera.camera3D.position;
+        if (this.fog.enable) {
+            v.setFromMatrixPosition(context.view.tileLayer.object3d.matrixWorld);
+            const len = v.distanceTo(cameraPosition);
+            // Compute fog distance, this function makes it possible to have a shorter distance
+            // when the camera approaches the ground
+            this.fog.distance = mfogDistance * ((len - ellipsoidSizes.x * 0.99) * 0.25 / ellipsoidSizes.x) ** 1.5;
+        } else {
+            this.fog.distance = 10e10;
+        }
+
+        const renderer = context.view.mainLoop.gfxEngine.renderer;
+        // get altitude camera
+        coordCam.set(context.view.referenceCrs, cameraPosition).as('EPSG:4326', coordGeoCam);
+        const altitude = coordGeoCam.altitude();
+
+        // If the camera altitude is below limitAlti,
+        // we interpolate between the sky color and the space color
+        if (altitude < limitAlti) {
+            const t = (limitAlti - altitude) / limitAlti;
+            colorSky.copy(spaceColor).lerp(skyBaseColor, t);
+            renderer.setClearColor(colorSky, renderer.getClearAlpha());
+        } else {
+            renderer.setClearColor(spaceColor, renderer.getClearAlpha());
+        }
+    }
+
     // default to non-realistic lightning
-    this.realistic = false;
+    _initRealisticLighning() {
+        // Atmosphere Shader From Space (Atmospheric scattering)
+        // http://stainlessbeer.weebly.com/planets-9-atmospheric-scattering.html
+        const atmosphere = {
+            Kr: 0.0025,
+            Km: 0.0010,
+            ESun: 20.0,
+            g: -0.950,
+            innerRadius: 6400000,
+            outerRadius: 6700000,
+            wavelength: [0.650, 0.570, 0.475],
+            scaleDepth: 0.25,
+            mieScaleDepth: 0.1,
+        };
+        const uniformsAtmosphere = {
+            v3LightPosition: { value: LIGHTING_POSITION.clone().normalize() },
+            v3InvWavelength: { value: new THREE.Vector3(1 / atmosphere.wavelength[0] ** 4, 1 / atmosphere.wavelength[1] ** 4, 1 / atmosphere.wavelength[2] ** 4) },
+            fCameraHeight: { value: 0.0 },
+            fCameraHeight2: { value: 0.0 },
+            fInnerRadius: { value: atmosphere.innerRadius },
+            fInnerRadius2: { value: atmosphere.innerRadius * atmosphere.innerRadius },
+            fOuterRadius: { value: atmosphere.outerRadius },
+            fOuterRadius2: { value: atmosphere.outerRadius * atmosphere.outerRadius },
+            fKrESun: { value: atmosphere.Kr * atmosphere.ESun },
+            fKmESun: { value: atmosphere.Km * atmosphere.ESun },
+            fKr4PI: { value: atmosphere.Kr * 4.0 * Math.PI },
+            fKm4PI: { value: atmosphere.Km * 4.0 * Math.PI },
+            fScale: { value: 1 / (atmosphere.outerRadius - atmosphere.innerRadius) },
+            fScaleDepth: { value: atmosphere.scaleDepth },
+            fScaleOverScaleDepth: { value: 1 / (atmosphere.outerRadius - atmosphere.innerRadius) / atmosphere.scaleDepth },
+            g: { value: atmosphere.g },
+            g2: { value: atmosphere.g * atmosphere.g },
+            nSamples: { value: 3 },
+            fSamples: { value: 3.0 },
+            tDisplacement: { value: new THREE.Texture() },
+            tSkyboxDiffuse: { value: new THREE.Texture() },
+            fNightScale: { value: 1.0 },
+        };
 
-    this.uniformsOut = {
-        atmoIN: {
-            type: 'i',
-            value: 0,
-        },
-        screenSize: {
-            type: 'v2',
-            value: new THREE.Vector2(window.innerWidth, window.innerHeight),
-        }, // Should be updated on screen resize...
-    };
-
-    var material = new THREE.ShaderMaterial({
-        uniforms: this.uniformsOut,
-        vertexShader: GlowVS,
-        fragmentShader: GlowFS,
-        side: THREE.BackSide,
-        blending: THREE.AdditiveBlending,
-        transparent: true,
-        wireframe: false,
-    });
-
-    var geometry = (new THREE.SphereGeometry(1.14, 64, 64)).scale(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z);
-
-    THREE.Mesh.call(this, geometry, material);
-
-    this.uniformsIn = {
-        atmoIN: {
-            type: 'i',
-            value: 1,
-        },
-        screenSize: {
-            type: 'v2',
-            value: new THREE.Vector2(window.innerWidth, window.innerHeight),
-        }, // Should be updated on screen resize...
-    };
-
-    var materialAtmoIn = new THREE.ShaderMaterial({
-        uniforms: this.uniformsIn,
-        vertexShader: GlowVS,
-        fragmentShader: GlowFS,
-        side: THREE.FrontSide,
-        blending: THREE.AdditiveBlending,
-        transparent: true,
-        depthWrite: false,
-    });
-
-    this.atmosphereIN = new THREE.Mesh((new THREE.SphereGeometry(1.002, 64, 64)).scale(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z), materialAtmoIn);
-
-    this.add(this.atmosphereIN);
-}
-
-Atmosphere.prototype = Object.create(THREE.Mesh.prototype);
-Atmosphere.prototype.constructor = Atmosphere;
-
-Atmosphere.prototype._initRealisticLighning = function _initRealisticLighning() {
-    var atmosphere = {
-        Kr: 0.0025,
-        Km: 0.0010,
-        ESun: 20.0,
-        g: -0.950,
-        innerRadius: 6400000,
-        outerRadius: 6700000,
-        wavelength: [0.650, 0.570, 0.475],
-        scaleDepth: 0.25,
-        mieScaleDepth: 0.1,
-    };
-
-    var uniformsSky = {
-        v3LightPosition: { value: LIGHTING_POSITION.clone().normalize() },
-        v3InvWavelength: { value: new THREE.Vector3(1 / atmosphere.wavelength[0] ** 4, 1 / atmosphere.wavelength[1] ** 4, 1 / atmosphere.wavelength[2] ** 4) },
-        fCameraHeight: { value: 0.0 },
-        fCameraHeight2: { value: 0.0 },
-        fInnerRadius: { value: atmosphere.innerRadius },
-        fInnerRadius2: { value: atmosphere.innerRadius * atmosphere.innerRadius },
-        fOuterRadius: { value: atmosphere.outerRadius },
-        fOuterRadius2: { value: atmosphere.outerRadius * atmosphere.outerRadius },
-        fKrESun: { value: atmosphere.Kr * atmosphere.ESun },
-        fKmESun: { value: atmosphere.Km * atmosphere.ESun },
-        fKr4PI: { value: atmosphere.Kr * 4.0 * Math.PI },
-        fKm4PI: { value: atmosphere.Km * 4.0 * Math.PI },
-        fScale: { value: 1 / (atmosphere.outerRadius - atmosphere.innerRadius) },
-        fScaleDepth: { value: atmosphere.scaleDepth },
-        fScaleOverScaleDepth: { value: 1 / (atmosphere.outerRadius - atmosphere.innerRadius) / atmosphere.scaleDepth },
-        g: { value: atmosphere.g },
-        g2: { value: atmosphere.g * atmosphere.g },
-        nSamples: { value: 3 },
-        fSamples: { value: 3.0 },
-        tDisplacement: { value: new THREE.Texture() },
-        tSkyboxDiffuse: { value: new THREE.Texture() },
-        fNightScale: { value: 1.0 },
-    };
-
-    this.ground = {
-        geometry: new THREE.SphereGeometry(atmosphere.innerRadius, 50, 50),
-        material: new THREE.ShaderMaterial({
-            uniforms: uniformsSky,
+        const geometryAtmosphereIn = new THREE.SphereGeometry(atmosphere.innerRadius, 50, 50);
+        const materialAtmosphereIn = new THREE.ShaderMaterial({
+            uniforms: uniformsAtmosphere,
             vertexShader: groundVS,
             fragmentShader: groundFS,
             blending: THREE.AdditiveBlending,
             transparent: true,
             depthTest: false,
             depthWrite: false,
-        }),
-    };
+        });
+        const ground = new THREE.Mesh(geometryAtmosphereIn, materialAtmosphereIn);
 
-    this.ground.mesh = new THREE.Mesh(this.ground.geometry, this.ground.material);
-
-    this.sky = {
-        geometry: new THREE.SphereGeometry(atmosphere.outerRadius, 196, 196),
-        material: new THREE.ShaderMaterial({
-            uniforms: uniformsSky,
+        const geometryAtmosphereOut = new THREE.SphereGeometry(atmosphere.outerRadius, 196, 196);
+        const materialAtmosphereOut = new THREE.ShaderMaterial({
+            uniforms: uniformsAtmosphere,
             vertexShader: skyVS,
             fragmentShader: skyFS,
-        }),
-    };
+            transparent: true,
+            side: THREE.BackSide,
+        });
+        const sky = new THREE.Mesh(geometryAtmosphereOut, materialAtmosphereOut);
 
-    this.sky.mesh = new THREE.Mesh(this.sky.geometry, this.sky.material);
-    this.sky.material.side = THREE.BackSide;
-    this.sky.material.transparent = true;
+        const skyDome = new Sky();
+        skyDome.frustumCulled = false;
 
-    this.ground.mesh.visible = false;
-    this.sky.mesh.visible = false;
-
-    this.skyDome = new Sky();
-    this.skyDome.mesh.frustumCulled = false;
-    this.skyDome.mesh.material.transparent = true;
-    this.skyDome.mesh.visible = false;
-    this.skyDome.mesh.material.depthWrite = false;
-
-    this.ground.mesh.layers.mask = this.layers.mask;
-    this.sky.mesh.layers.mask = this.layers.mask;
-    this.skyDome.mesh.layers.mask = this.layers.mask;
-    this.add(this.ground.mesh);
-    this.add(this.sky.mesh);
-    this.add(this.skyDome.mesh);
-
-    var effectController = {
-        turbidity: 10,
-        reileigh: 2,
-        mieCoefficient: 0.005,
-        mieDirectionalG: 0.8,
-        luminance: 1,
-        inclination: 0.49, // elevation / inclination
-        azimuth: 0.25, // Facing front,
-        sun: !true,
-    };
-
-    var uniforms = this.skyDome.uniforms;
-    uniforms.turbidity.value = effectController.turbidity;
-    uniforms.reileigh.value = effectController.reileigh;
-    uniforms.luminance.value = effectController.luminance;
-    uniforms.mieCoefficient.value = effectController.mieCoefficient;
-    uniforms.mieDirectionalG.value = effectController.mieDirectionalG;
-    uniforms.up.value = new THREE.Vector3(); // no more necessary, estimate normal from cam..
-};
-
-Atmosphere.prototype.setRealisticOn = function setRealisticOn(bool) {
-    if (bool && !this.sky) {
-        this._initRealisticLighning();
+        ground.layers.mask = this.object3d.layers.mask;
+        sky.layers.mask = this.object3d.layers.mask;
+        skyDome.layers.mask = this.object3d.layers.mask;
+        this.realisticAtmosphere.add(ground);
+        this.realisticAtmosphere.add(sky);
+        this.realisticAtmosphere.add(skyDome);
+        const effectController = {
+            turbidity: 10,
+            reileigh: 2,
+            mieCoefficient: 0.005,
+            mieDirectionalG: 0.8,
+            luminance: 1,
+            inclination: 0.49, // elevation / inclination
+            azimuth: 0.25, // Facing front,
+            sun: !true,
+        };
+        skyDome.material.uniforms.turbidity.value = effectController.turbidity;
+        skyDome.material.uniforms.reileigh.value = effectController.reileigh;
+        skyDome.material.uniforms.luminance.value = effectController.luminance;
+        skyDome.material.uniforms.mieCoefficient.value = effectController.mieCoefficient;
+        skyDome.material.uniforms.mieDirectionalG.value = effectController.mieDirectionalG;
+        skyDome.material.uniforms.up.value = new THREE.Vector3(); // no more necessary, estimate normal from cam..
     }
-    this.realistic = bool;
-    this.material.visible = !this.realistic;
-    this.atmosphereIN.visible = !this.realistic;
-    this.ground.mesh.visible = this.realistic;
-    this.sky.mesh.visible = this.realistic;
-    this.skyDome.mesh.visible = this.realistic;
-};
 
-Atmosphere.prototype.updateLightingPos = function updateLightingPos(pos) {
-    if (this.realistic) {
-        this.ground.material.uniforms.v3LightPosition.value = pos.clone().normalize();
-        this.sky.material.uniforms.v3LightPosition.value = pos.clone().normalize();
-        this.skyDome.uniforms.sunPosition.value.copy(pos);
+    setRealisticOn(bool) {
+        if (bool && !this.sky) {
+            this._initRealisticLighning();
+        }
+
+        this.basicAtmosphere.visible = !bool;
+        this.realisticAtmosphere.visible = bool;
+
+        if (bool) {
+            this.realisticLightingPosition = CoordStars.getSunPositionInScene(new Date().getTime(), 48.85, 2.35).normalize();
+            this.realisticAtmosphere.children.forEach((obj => obj.material.uniforms.v3LightPosition.value.copy(this.realisticLightingPosition)));
+        }
     }
-};
+}
 
 export default Atmosphere;

--- a/src/Core/Prefab/Globe/SkyShader.js
+++ b/src/Core/Prefab/Globe/SkyShader.js
@@ -40,7 +40,7 @@ var skyShader = {
             type: 'f',
             value: 0.8,
         },
-        sunPosition: {
+        v3LightPosition: {
             type: 'v3',
             value: new THREE.Vector3(),
         },
@@ -69,7 +69,7 @@ var skyShader = {
     fragmentShader: [
 
         'uniform sampler2D skySampler;',
-        'uniform vec3 sunPosition;',
+        'uniform vec3 v3LightPosition;',
         'uniform vec3 up;',
         'varying vec3 vWorldPosition;',
 
@@ -179,11 +179,11 @@ var skyShader = {
         '{',
         'vec3 up2 = normalize(cameraPosition.xyz);',
 
-        'float sunfade = 1.0-clamp(1.0-exp((sunPosition.y/450000.0)),0.0,1.0);',
+        'float sunfade = 1.0-clamp(1.0-exp((v3LightPosition.y/450000.0)),0.0,1.0);',
 
         'float reileighCoefficient = reileigh - (1.0* (1.0-sunfade));',
 
-        'vec3 sunDirection = normalize(sunPosition);',
+        'vec3 sunDirection = normalize(v3LightPosition);',
 
         'float sunE = sunIntensity(dot(sunDirection, up2));',
 
@@ -261,25 +261,22 @@ var skyShader = {
 
 };
 
-function Sky() {
-    var skyUniforms = THREE.UniformsUtils.clone(skyShader.uniforms);
+class Sky extends THREE.Mesh {
+    constructor() {
+        var skyUniforms = THREE.UniformsUtils.clone(skyShader.uniforms);
 
-    var skyMat = new THREE.ShaderMaterial({
-        fragmentShader: skyShader.fragmentShader,
-        vertexShader: skyShader.vertexShader,
-        uniforms: skyUniforms,
-        side: THREE.BackSide,
-    });
+        var skyMat = new THREE.ShaderMaterial({
+            fragmentShader: skyShader.fragmentShader,
+            vertexShader: skyShader.vertexShader,
+            uniforms: skyUniforms,
+            side: THREE.BackSide,
+            transparent: true,
+            depthWrite: false,
+        });
 
-    var skyGeo = new THREE.SphereBufferGeometry(40000, 32, 15);
-    var skyMesh = new THREE.Mesh(skyGeo, skyMat);
-
-
-    // Expose variables
-    this.mesh = skyMesh;
-    this.uniforms = skyUniforms;
+        var skyGeo = new THREE.SphereBufferGeometry(40000, 32, 15);
+        super(skyGeo, skyMat);
+    }
 }
-// Sky.prototype = Object.create(THREE.EventDispatcher.prototype);
-Sky.prototype.constructor = Sky;
 
 export default Sky;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -7,7 +7,6 @@ import RenderMode from 'Renderer/RenderMode';
 
 import { getMaxColorSamplerUnitsCount } from 'Renderer/LayeredMaterial';
 
-import Layer from 'Layer/Layer';
 import ColorLayer from 'Layer/ColorLayer';
 import ElevationLayer from 'Layer/ElevationLayer';
 import GeometryLayer from 'Layer/GeometryLayer';

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -133,10 +133,9 @@ function _createLayerFromConfig(config) {
             return new ColorLayer(config.id, config);
         case 'elevation':
             return new ElevationLayer(config.id, config);
-        case 'geometry':
-            return new GeometryLayer(config.id, new THREE.Group(), config);
+        case 'geometry' :
         case 'debug':
-            return new Layer(config.id, 'debug', config);
+            return new GeometryLayer(config.id, new THREE.Group(), config);
         default:
             throw new Error(`Unknown layer type ${config.type}: please
                 specify a valid one`);
@@ -169,8 +168,8 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
         }
     }
 
-    if (layer.isGeometryLayer || layer.type == 'debug') {
-        if (parentLayer || layer.type == 'debug') {
+    if (layer.isGeometryLayer) {
+        if (parentLayer) {
             // layer.threejsLayer *must* be assigned before preprocessing,
             // because TileProvider.preprocessDataLayer function uses it.
             layer.threejsLayer = view.mainLoop.gfxEngine.getUniqueThreejsLayer();

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -116,7 +116,7 @@ class GeometryLayer extends Layer {
         });
 
         this.attachedLayers = [];
-        this.visible = true;
+        this.visible = config.visible == undefined ? true : config.visible;
 
         // Attached layers expect to receive the visual representation of a
         // layer (= THREE object with a material).  So if a layer's update

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -49,10 +49,6 @@ class TiledGeometryLayer extends GeometryLayer {
         this.isTiledGeometryLayer = true;
 
         this.protocol = 'tile';
-        this.lighting = {
-            enable: false,
-            position: { x: -0.5, y: 0.0, z: 1.0 },
-        };
 
         this.sseSubdivisionThreshold = this.sseSubdivisionThreshold || 1.0;
 
@@ -229,11 +225,6 @@ class TiledGeometryLayer extends GeometryLayer {
             }
 
             if (node.material.visible) {
-                // update uniforms
-                if (context.view.fogDistance != undefined) {
-                    node.material.fogDistance = context.view.fogDistance;
-                }
-
                 if (!requestChildrenUpdate) {
                     return ObjectRemovalHelper.removeChildren(this, node);
                 }

--- a/test/functional/3dtiles.js
+++ b/test/functional/3dtiles.js
@@ -36,8 +36,13 @@ describe('3dtiles', function _() {
 
     it('should remove GeometryLayer', async () => {
         const countGeometryLayerStart = await page.evaluate(() => view.getLayers(l => l.isGeometryLayer).length);
+        const attachedGeometricLayerCount = await page.evaluate(() => {
+            const attachedLayers = view.getLayerById('3d-tiles-discrete-lod').attachedLayers.filter(l => l.isGeometryLayer);
+            return attachedLayers.length;
+        });
         await page.evaluate(() => view.removeLayer('3d-tiles-discrete-lod'));
         const countGeometryLayerEnd = await page.evaluate(() => view.getLayers(l => l.isGeometryLayer).length);
-        assert.ok(countGeometryLayerStart - countGeometryLayerEnd === 1);
+        // the attached GeometryLayers are, also, removed.
+        assert.equal(countGeometryLayerStart - countGeometryLayerEnd, 1 + attachedGeometricLayerCount);
     });
 });

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import View from 'Core/View';
-import Layer from 'Layer/Layer';
+import GeometryLayer from 'Layer/GeometryLayer';
 import GeometryDebug from './GeometryDebug';
 import OBBHelper from './OBBHelper';
 
@@ -97,7 +97,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) 
         }
     };
 
-    const obbLayer = new Layer(obb_layer_id, 'debug', {
+    const obbLayer = new GeometryLayer(obb_layer_id, new THREE.Object3D(), {
         update: debugIdUpdate,
         visible: false,
     });

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -128,7 +128,8 @@ function Debug(view, datDebugTool, chartDivContainer) {
     debugCamera.updateProjectionMatrix();
     const g = view.mainLoop.gfxEngine;
     const r = g.renderer;
-    let fogDistance = view.fogDistance;
+    const layerAtmosphere = view.getLayerById('atmosphere');
+    let fogDistance = layerAtmosphere.fog.distance;
     helper.visible = false;
     view.scene.add(helper);
 
@@ -186,8 +187,8 @@ function Debug(view, datDebugTool, chartDivContainer) {
             }
 
             debugCamera.updateProjectionMatrix();
-            if (view.atmosphere) {
-                view.atmosphere.visible = false;
+            if (layerAtmosphere) {
+                layerAtmosphere.object3d.visible = false;
             }
             fogDistance = 10e10;
             for (const obj of tileLayer.level0Nodes) {
@@ -206,10 +207,10 @@ function Debug(view, datDebugTool, chartDivContainer) {
             r.setClearColor(bClearColor);
             helper.visible = false;
             displayedTilesObbHelper.visible = false;
-            if (view.atmosphere) {
-                view.atmosphere.visible = true;
+            if (layerAtmosphere) {
+                layerAtmosphere.object3d.visible = true;
             }
-            fogDistance = view.fogDistance;
+            fogDistance = layerAtmosphere.fog.distance;
             for (const obj of tileLayer.level0Nodes) {
                 obj.traverseVisible(updateFogDistance);
             }

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import TWEEN from '@tweenjs/tween.js';
 import View from 'Core/View';
-import Layer from 'Layer/Layer';
+import GeometryLayer from 'Layer/GeometryLayer';
 import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import TileObjectChart from './charts/TileObjectChart';
@@ -193,7 +193,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
         }
     }
 
-    const obbLayer = new Layer(obb_layer_id, 'debug', {
+    const obbLayer = new GeometryLayer(obb_layer_id, new THREE.Object3D(), {
         update: debugIdUpdate,
         visible: false,
     });
@@ -204,7 +204,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
         });
     });
 
-    const sbLayer = new Layer(sb_layer_id, 'debug', {
+    const sbLayer = new GeometryLayer(sb_layer_id, new THREE.Object3D(), {
         update: debugIdUpdate,
         visible: false,
     });

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -18,26 +18,7 @@ function applyToNodeFirstMaterial(view, root, layer, cb) {
     view.notifyChange();
 }
 
-let _showInfo;
-let showOutline;
 let selectedNode;
-let selectedId;
-
-function selectTile(node) {
-    if (node.material) {
-        const selected = node.id === selectedId;
-        node.material.overlayAlpha = selected ? 0.5 : 0;
-        node.material.showOutline = selected ? true : showOutline;
-        if (selected) {
-            selectedNode = node;
-            if (_showInfo) {
-                // eslint-disable-next-line no-console
-                console.info(node);
-            }
-        }
-    }
-}
-
 /**
  * Select tile
  *
@@ -48,17 +29,24 @@ function selectTile(node) {
  * @return     {TileMesh} Selected tile.
  */
 function selectTileAt(view, mouseOrEvt, showInfo = true) {
-    const picked = view.tileLayer.pickObjectsAt(view, mouseOrEvt);
-    selectedId = picked.length ? picked[0].object.id : undefined;
-    selectedNode = undefined;
-    _showInfo = showInfo;
-    showOutline = view.tileLayer.showOutline;
-
-    for (const n of view.tileLayer.level0Nodes) {
-        n.traverse(selectTile);
+    if (selectedNode) {
+        selectedNode.material.overlayAlpha = 0;
+        selectedNode.material.showOutline = view.tileLayer.showOutline;
+        view.notifyChange(selectedNode);
     }
 
-    view.notifyChange();
+    const picked = view.tileLayer.pickObjectsAt(view, mouseOrEvt);
+    selectedNode = picked.length ? picked[0].object : undefined;
+
+    if (selectedNode) {
+        if (showInfo) {
+            // eslint-disable-next-line no-console
+            console.info(selectedNode);
+        }
+        selectedNode.material.overlayAlpha = 0.5;
+        selectedNode.material.showOutline = true;
+        view.notifyChange(selectedNode);
+    }
     return selectedNode;
 }
 


### PR DESCRIPTION
## Description

1. Stop to use deprecated `layer.type == 'debug'` and replace them by `GeometryLayer`.
2. Convert `Atmosphere` to `GeometryLayer` and move atmospheric processing in `Atmosphere.update`

## Motivation 
The itowns architecture is more structured, there are no longer atmospheric processing in `GlobeView`, and specific `layer.type == 'debug'`. 

