### PR TITLE
refactor ColorLayers sequence order 

### DIFF
--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -6,6 +6,7 @@ import convertToTile from 'Converter/convertToTile';
 import CancelledCommandException from 'Core/Scheduler/CancelledCommandException';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import { SIZE_DIAGONAL_TEXTURE } from 'Provider/OGCWebServiceHelper';
+import { ImageryLayers } from 'Layer/Layer';
 
 const subdivisionVector = new THREE.Vector3();
 const boundingSphereCenter = new THREE.Vector3();
@@ -146,6 +147,11 @@ class TiledGeometryLayer extends GeometryLayer {
         if (context.maxElevationLevel == -1) {
             context.maxElevationLevel = Infinity;
         }
+
+        // Prepare ColorLayer sequence order
+        // In this moment, there is only one color layers sequence, because they are attached to tileLayer.
+        // In future, the sequence must be returned by parent geometry layer.
+        context.ColorLayerSequenceOrder = ImageryLayers.getColorLayersIdOrderedBySequence(context.colorLayers);
 
         let commonAncestor;
         for (const source of sources.values()) {

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -1,6 +1,5 @@
 import { chooseNextLevelToFetch } from 'Layer/LayerUpdateStrategy';
 import LayerUpdateState from 'Layer/LayerUpdateState';
-import { ImageryLayers } from 'Layer/Layer';
 import CancelledCommandException from 'Core/Scheduler/CancelledCommandException';
 import { SIZE_TEXTURE_TILE } from 'Provider/OGCWebServiceHelper';
 import { computeMinMaxElevation } from 'Parser/XbilParser';
@@ -93,11 +92,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
             // Create new MaterialLayer
             const tileMT = layer.options.tileMatrixSet || extentsDestination[0].crs();
             nodeLayer = material.addLayer(layer, tileMT);
-
-            // TODO: Sequence must be returned by parent geometry layer
-            const colorLayers = context.view.getLayers(l => l.isColorLayer);
-            const sequence = ImageryLayers.getColorLayersIdOrderedBySequence(colorLayers);
-            material.setSequence(sequence);
+            material.setSequence(context.ColorLayerSequenceOrder);
 
             // Init the new MaterialLayer by parent
             const parentLayer = parent.material && parent.material.getLayer(layer.id);


### PR DESCRIPTION
Compute `ColorLayers` sequence order  only one time, in `tileLayer.preUpdate`.

## Motivation and Context
Avoid to compute sequence order for each visible title.