### PR TITLE
chore: update to Three r102.1

### DIFF
--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -45,10 +45,12 @@
 
             // update the waypoint
             var distance, scale, point = new itowns.THREE.Vector3();
+            var size = new itowns.THREE.Vector2();
             function updatePointScale(renderer, scene, camera) {
                 point.copy(this.geometry.boundingSphere.center).applyMatrix4(this.matrixWorld);;
                 distance = camera.position.distanceTo(point);
-                scale = Math.max(2, Math.min(100, distance / renderer.getSize().height));
+                renderer.getSize(size);
+                scale = Math.max(2, Math.min(100, distance / size.y));
                 this.scale.set(scale, scale, scale);
                 this.updateMatrixWorld();
             }

--- a/examples/postprocessing.html
+++ b/examples/postprocessing.html
@@ -83,21 +83,15 @@
                 var r = g.renderer;
                 r.setRenderTarget(g.fullSizeRenderTarget);
                 r.clear();
-                r.setViewport(0, 0, g.getWindowSize().x, g.getWindowSize().y);
-                r.render(
-                    view.scene,
-                    view.camera.camera3D, g.fullSizeRenderTarget);
+                r.render(view.scene, view.camera.camera3D);
 
                 quad.material.uniforms.tDiffuse.value = g.fullSizeRenderTarget.texture;
                 quad.material.uniforms.tSize.value.set(
                     g.fullSizeRenderTarget.width, g.fullSizeRenderTarget.height);
 
-                r.setRenderTarget();
+                r.setRenderTarget(null);
                 r.clear();
-                r.setViewport(0, 0, g.getWindowSize().x, g.getWindowSize().y);
-                r.render(
-                    postprocessScene,
-                    cam);
+                r.render(postprocessScene, cam);
             };
 
             itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {

--- a/examples/stereo.html
+++ b/examples/stereo.html
@@ -100,10 +100,11 @@
                 if (effect && effect.dispose) {
                     effect.dispose();
                 }
-
+                var g = view.mainLoop.gfxEngine;
+                var size = g.getWindowSize();
                 effect = null;
                 view.render = null;
-
+                g.renderer.setViewport(0, 0, size.x, size.y);
                 view.notifyChange();
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9550,9 +9550,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.101.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.101.1.tgz",
-      "integrity": "sha512-8ufimUVmRLtH+BTpEIbDjdGEKQOVWLMLgGynaKin1KbYTE136ZNOepJ8EgByi0tN43dQ7B1YrKLCJgXGy4bLmw==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.102.1.tgz",
+      "integrity": "sha512-btHBdww/Es4vdBkB2GjTE9mpj0vy8tgtxkX7ne7uxySXV8zoGxWJv1N88BydxnCqvAfmD4ZUTqPeESO7oDgeOQ==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.101.1"
+    "three": "^0.102.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -77,7 +77,7 @@
     "proj4": "^2.5.0",
     "puppeteer": "^1.12.2",
     "replace-in-file": "^3.4.3",
-    "three": "^0.101.1",
+    "three": "^0.102.1",
     "url-polyfill": "^1.1.3",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -40,7 +40,6 @@ function c3DEngine(rendererOrDiv, options = {}) {
     this.fullSizeRenderTarget.depthTexture.type = THREE.UnsignedShortType;
 
     this.renderView = function renderScene(view) {
-        this.renderer.setViewport(0, 0, this.width, this.height);
         this.renderer.clear();
         this.renderer.render(view.scene, view.camera.camera3D);
     }.bind(this);
@@ -191,7 +190,7 @@ c3DEngine.prototype.renderViewToRenderTarget = function renderViewToRenderTarget
 
     // Don't use setViewport / setScissor on renderer because they would affect
     // on screen rendering as well. Instead set them on the render target.
-    this.fullSizeRenderTarget.viewport.set(0, 0, target.width, target.height);
+    // Example : this.fullSizeRenderTarget.viewport.set(0, 0, target.width, target.height);
     if (zone) {
         this.fullSizeRenderTarget.scissor.set(
             zone.x,
@@ -203,7 +202,7 @@ c3DEngine.prototype.renderViewToRenderTarget = function renderViewToRenderTarget
 
     this.renderer.setRenderTarget(target);
     this.renderer.clear(true, true, false);
-    this.renderer.render(view.scene, view.camera.camera3D, target);
+    this.renderer.render(view.scene, view.camera.camera3D);
     this.renderer.setRenderTarget(current);
 
     this.fullSizeRenderTarget.scissorTest = false;

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -200,14 +200,16 @@ function Debug(view, datDebugTool, chartDivContainer) {
             helper.visible = true;
             helper.updateMatrixWorld(true);
             bClearColor.copy(r.getClearColor());
-            r.setViewport(g.width - size.x, g.height - size.y, size.x, size.y);
-            r.setScissor(g.width - size.x, g.height - size.y, size.x, size.y);
+            r.setViewport(g.width - size.x, 0, size.x, size.y);
+            r.setScissor(g.width - size.x, 0, size.x, size.y);
             r.setScissorTest(true);
             r.setClearColor(0xeeeeee);
             r.clear();
             r.render(view.scene, debugCamera);
             r.setScissorTest(false);
             r.setClearColor(bClearColor);
+            r.setViewport(0, 0, g.width, g.height);
+
             helper.visible = false;
             displayedTilesObbHelper.visible = false;
             if (layerAtmosphere) {


### PR DESCRIPTION
## Description
update to Three r102.1
## migration
- [x] Removed `renderTarget` and `forceClear` parameters from `WebGLRenderer.render()`. Please use `.setRenderTarget() `and `.clear()` instead before you perform the rendering. Be aware that it's now necessary to execute `renderer.setRenderTarget( null )` in order to unset an active render target.

- [x]  Removed .`activeCubeFace` and .`activeMipMapLevel` from `WebGLRenderTargetCube`. They are now parameters of `WebGLRenderer.setRenderTarget().`

- [x] In` WebGLRenderer.setViewport() `and` WebGLRenderer.setScissor()`, (x, y) is the coordinate of the lower left corner of the rectangular region.

- [x] `WebGLRenderer.getSize() `now requires a Vector2 argument.

- [x] `WebGLRenderer.getCurrentViewport()` now requires a Vector4 argument.


Fix #1044 