### PR TITLE
fix(process): bad calling of window.setTimeout

### DIFF
--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -145,9 +145,9 @@ export default {
                 node.layerUpdateState[layer.id].failure(0, true);
             } else {
                 node.layerUpdateState[layer.id].failure(Date.now());
-                window.setTimeout(context.view.notifyChange,
-                    node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
-                    layer, false);
+                window.setTimeout(() => {
+                    context.view.notifyChange(layer, false);
+                }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
             }
         });
     },

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -215,9 +215,9 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
                 const definitiveError = node.layerUpdateState[layer.id].errorCount > MAX_RETRY;
                 node.layerUpdateState[layer.id].failure(Date.now(), definitiveError, { targetLevel });
                 if (!definitiveError) {
-                    window.setTimeout(context.view.notifyChange,
-                        node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
-                        node, false);
+                    window.setTimeout(() => {
+                        context.view.notifyChange(node, false);
+                    }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
                 }
             }
         });
@@ -374,9 +374,9 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
                 const definitiveError = node.layerUpdateState[layer.id].errorCount > MAX_RETRY;
                 node.layerUpdateState[layer.id].failure(Date.now(), definitiveError);
                 if (!definitiveError) {
-                    window.setTimeout(context.view.notifyChange,
-                        node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000,
-                        node, false);
+                    window.setTimeout(() => {
+                        context.view.notifyChange(node, false);
+                    }, node.layerUpdateState[layer.id].secondsUntilNextTry() * 1000);
                 }
             }
         });


### PR DESCRIPTION
window.setTimeout was badly called, and the result was that
`this` was window instead of the correct view.

Fixes a problem added in #1038 