### PR TITLE
refacto(three): remove all instanceof THREE.*

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -257,7 +257,7 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
     this._mouseToPan = function _mouseToPan(deltaX, deltaY) {
         const gfx = view.mainLoop.gfxEngine;
         state = states.PAN;
-        if (this.camera instanceof THREE.PerspectiveCamera) {
+        if (this.camera.isPerspectiveCamera) {
             let targetDistance = this.camera.position.distanceTo(this.getCameraTargetPosition());
             // half of the fov is center to top of screen
             targetDistance *= 2 * Math.tan(THREE.Math.degToRad(this.camera.fov * 0.5));
@@ -265,7 +265,7 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
             // we actually don't use screenWidth, since perspective camera is fixed to screen height
             this.panLeft(deltaX * targetDistance / gfx.width * this.camera.aspect);
             this.panUp(deltaY * targetDistance / gfx.height);
-        } else if (this.camera instanceof THREE.OrthographicCamera) {
+        } else if (this.camera.isOrthographicCamera) {
             // orthographic
             this.panLeft(deltaX * (this.camera.right - this.camera.left) / gfx.width);
             this.panUp(deltaY * (this.camera.top - this.camera.bottom) / gfx.height);
@@ -277,9 +277,9 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
             dollyScale = this.getDollyScale();
         }
 
-        if (this.camera instanceof THREE.PerspectiveCamera) {
+        if (this.camera.isPerspectiveCamera) {
             orbitScale /= dollyScale;
-        } else if (this.camera instanceof THREE.OrthographicCamera) {
+        } else if (this.camera.isOrthographicCamera) {
             this.camera.zoom = THREE.Math.clamp(this.camera.zoom * dollyScale, this.minZoom, this.maxZoom);
             this.camera.updateProjectionMatrix();
             view.notifyChange(this.camera);
@@ -291,9 +291,9 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
             dollyScale = this.getDollyScale();
         }
 
-        if (this.camera instanceof THREE.PerspectiveCamera) {
+        if (this.camera.isPerspectiveCamera) {
             orbitScale *= dollyScale;
-        } else if (this.camera instanceof THREE.OrthographicCamera) {
+        } else if (this.camera.isOrthographicCamera) {
             this.camera.zoom = THREE.Math.clamp(this.camera.zoom / dollyScale, this.minZoom, this.maxZoom);
             this.camera.updateProjectionMatrix();
             view.notifyChange(this.camera);

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -498,7 +498,7 @@ function PlanarControls(view, options = {}) {
         // update cursor
         this.updateMouseCursorType();
 
-        travelUseRotation = this.enableRotation && (targetOrientation instanceof THREE.Quaternion || targetOrientation instanceof THREE.Vector3);
+        travelUseRotation = this.enableRotation && (targetOrientation.isQuaternion || targetOrientation.isVector3);
         travelUseSmooth = useSmooth;
 
         // start position (current camera position)
@@ -510,9 +510,9 @@ function PlanarControls(view, options = {}) {
         // setup the end rotation :
 
         // case where targetOrientation is a quaternion
-        if (targetOrientation instanceof THREE.Quaternion) {
+        if (targetOrientation.isQuaternion) {
             travelEndRot.copy(targetOrientation);
-        } else if (targetOrientation instanceof THREE.Vector3) {
+        } else if (targetOrientation.isVector3) {
             // case where targetOrientation is a vector3
             if (targetPos === targetOrientation) {
                 this.camera.lookAt(targetOrientation);

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -219,7 +219,7 @@ Coordinates.prototype.set = function set(crs, ...coordinates) {
     _crsToUnitWithError(crs);
     this.crs = crs;
 
-    if (coordinates.length == 1 && coordinates[0] instanceof THREE.Vector3) {
+    if (coordinates.length == 1 && coordinates[0].isVector3) {
         this._values[0] = coordinates[0].x;
         this._values[1] = coordinates[0].y;
         this._values[2] = coordinates[0].z;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -632,7 +632,7 @@ View.prototype.pickObjectsAt = function pickObjectsAt(mouseOrEvt, radius, ...whe
                     }
                 }
             }
-        } else if (source instanceof THREE.Object3D) {
+        } else if (source.isObject3D) {
             Picking.pickObjectsAt(
                 this,
                 mouse,

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -7,7 +7,7 @@ import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 const vector = new THREE.Vector3();
 function applyOffset(obj, offset, quaternion, offsetAltitude = 0) {
     if (obj.geometry) {
-        if (obj.geometry instanceof THREE.BufferGeometry) {
+        if (obj.geometry.isBufferGeometry) {
             const count = obj.geometry.attributes.position.count * 3;
             for (let i = 0; i < count; i += 3) {
                 vector.fromArray(obj.geometry.attributes.position.array, i);

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -1,4 +1,3 @@
-import * as THREE from 'three';
 import { CRS_DEFINES, ELEVATION_MODES } from 'Renderer/LayeredMaterial';
 import { checkNodeElevationTextureValidity, insertSignificantValuesFromParent } from 'Parser/XbilParser';
 
@@ -119,7 +118,7 @@ class MaterialLayer {
     dispose() {
         // TODO: WARNING  verify if textures to dispose aren't attached with ancestor
         for (const texture of this.textures) {
-            if (texture instanceof THREE.Texture) {
+            if (texture.isTexture) {
                 texture.dispose();
             }
         }

--- a/src/Utils/DEMUtils.js
+++ b/src/Utils/DEMUtils.js
@@ -114,7 +114,7 @@ export default {
                 }
                 geometry.verticesNeedUpdate = true;
                 return success;
-            } else if (geometry instanceof THREE.BufferGeometry) {
+            } else if (geometry.isBufferGeometry) {
                 if (options.cache) {
                     options.cache.length = geometry.attributes.position.count;
                 }


### PR DESCRIPTION
As we seem to transpile THREE in the build of iTowns, using instanceof
for checking THREE objects makes the usage of an external THREE instance
limited to the one in the build. This is a first step to maybe the
removal of THREE from our build.
