### PR TITLE
fix(controls): fix ORBIT touch event making North down.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,9 @@ The following people have contributed to iTowns 2.
 * [virtualcitySYSTEMS](https://www.virtualcitysystems.de/)
   * [Ben Kuster](https://github.com/bkuster)
 
+* [Prolexia](http://prolexia.fr/)
+  * [Dorian MOFFROID](https://github.com/dorian-moffroid-prolexia)
+
 The following organizations supported iTowns2 :
 * IGN ( http://www.ign.fr )
 * Oslandia ( http://www.oslandia.com )

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -767,11 +767,15 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
                             state = states.NONE;
                         }
                         break; }
+                    case states.ORBIT:
                     case states.DOLLY: {
-                        const dx = event.touches[0].pageX - event.touches[1].pageX;
-                        const dy = event.touches[0].pageY - event.touches[1].pageY;
+                        const x = event.touches[0].pageX;
+                        const y = event.touches[0].pageY;
+                        const dx = x - event.touches[1].pageX;
+                        const dy = y - event.touches[1].pageY;
                         const distance = Math.sqrt(dx * dx + dy * dy);
                         dollyStart.set(0, distance);
+                        rotateStart.set(x, y);
                         break; }
                     case states.PAN:
                         panStart.set(event.touches[0].pageX, event.touches[0].pageY);


### PR DESCRIPTION
## Description

The globe manipulation with two fingers on a touch screen, for zooming, causes an inversion making the North down and the South up on the screen.

## Your Environment
* Version used: 2.8.0 (but the current code seems have same issue)
* Browser Name and version: Chrome 73
* Operating System and version (desktop or mobile): Desktop Windows 10 with a Touch Screen

## Possible Cause/Fix/Solution

After some code analysis, I found that the `states.ORBIT` state is not referenced in the `onTouchStart` function, and the rotateStart vector is not initialized in the same function but used in the `onTouchMove` function.