### PR TITLE
fix(3dtiles): fix batch table support, for null object.

### DIFF
--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -143,6 +143,10 @@ function createHTMLListFromObject(jsObject) {
         // append property name
         item.appendChild(document.createTextNode(property));
 
+        if (jsObject[property] === null) {
+            jsObject[property] = 'null';
+        }
+
         if (typeof jsObject[property] === 'object') {
             // if property value is an object, then recurse to
             // create a list from it


### PR DESCRIPTION
fix(3dtiles): fix batch table support, for null object.

Before this commit, null object in the input data was raising an error.
To fix it, I've changed null (object) to 'null' (string). So the UI shows, for example: property: null.
