### PR TITLE
Refactor Extent to Es6  class

### DIFF
--- a/examples/cubic_planar.html
+++ b/examples/cubic_planar.html
@@ -83,7 +83,7 @@
             scale = new itowns.THREE.Vector3(1, 1, 1).divideScalar(extent.dimensions().x);
 
             // Instanciate View
-            view = new itowns.View(extent.crs(), viewerDiv);
+            view = new itowns.View(extent.crs, viewerDiv);
             setupLoadingScreen(viewerDiv, view);
 
             view.mainLoop.gfxEngine.renderer.setClearColor(0x999999);

--- a/examples/globe_vector.html
+++ b/examples/globe_vector.html
@@ -122,7 +122,7 @@
                     return itowns.GeoJsonParser.parse(geojson, {
                         buildExtent: true,
                         crsIn: 'EPSG:4326',
-                        crsOut: view.tileLayer.extent.crs(),
+                        crsOut: view.tileLayer.extent.crs,
                         mergeFeatures: true,
                         withNormal: false,
                         withAltitude: false,

--- a/examples/orthographic.html
+++ b/examples/orthographic.html
@@ -52,7 +52,7 @@
                 // eslint-disable-next-line no-template-curly-in-string
                 url: 'http://c.tile.stamen.com/watercolor/${z}/${x}/${y}.jpg',
                 networkOptions: { crossOrigin: 'anonymous' },
-                extent: [extent.west(), extent.east(), extent.south(), extent.north()],
+                extent,
                 projection: 'EPSG:3857',
                 attribution: {
                     name: 'OpenStreetMap',

--- a/examples/shapefile.html
+++ b/examples/shapefile.html
@@ -47,7 +47,7 @@
             }).then(function _(res) {
                 return itowns.ShapefileParser.parse(res, {
                     buildExtent: true,
-                    crsOut: view.tileLayer.extent.crs(),
+                    crsOut: view.tileLayer.extent.crs,
                 });
             }).then(function _(feature) {
                 var velibSource = new itowns.FileSource({

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -1,5 +1,8 @@
 import * as THREE from 'three';
+import Extent from 'Core/Geographic/Extent';
 import Coordinates from '../Core/Geographic/Coordinates';
+
+const _extent = new Extent('EPSG:4326', [0, 0, 0, 0]);
 
 const pt = new THREE.Vector2();
 
@@ -95,13 +98,13 @@ function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
         px = gStyle.radius * (extentDim.x / 256);
 
         if (feature.type === 'point') {
-            coord.set(extent.crs(), feature.vertices[0], feature.vertices[1]);
+            coord.set(extent.crs, feature.vertices[0], feature.vertices[1]);
             if (extent.isPointInside(coord, px)) {
                 drawPoint(ctx, feature.vertices[0], feature.vertices[1], origin, scale, gStyle);
             }
         } else if (feature.type === 'multipoint') {
             for (var i = 0; i < feature.vertices.length; i += feature.size) {
-                coord.set(extent.crs(), feature.vertices[i], feature.vertices[i + 1]);
+                coord.set(extent.crs, feature.vertices[i], feature.vertices[i + 1]);
                 if (extent.isPointInside(coord, px)) {
                     drawPoint(ctx, feature.vertices[i], feature.vertices[i + 1], origin, scale, gStyle);
                 }
@@ -121,7 +124,7 @@ export default {
         if (collection) {
             // A texture is instancied drawn canvas
             // origin and dimension are used to transform the feature's coordinates to canvas's space
-            const origin = new THREE.Vector2(extent.west(), extent.south());
+            const origin = new THREE.Vector2(extent.west, extent.south);
             const dimension = extent.dimensions();
             const c = document.createElement('canvas');
 
@@ -135,8 +138,7 @@ export default {
             ctx.globalCompositeOperation = style.globalCompositeOperation || 'source-over';
 
             const scale = new THREE.Vector2(ctx.canvas.width / dimension.x, ctx.canvas.width / dimension.y);
-
-            const ex = collection.crs == extent.crs() ? extent : extent.as(collection.crs);
+            const ex = collection.crs == extent.crs ? extent : extent.as(collection.crs, _extent);
             // Draw the canvas
             for (const feature of collection.features) {
                 drawFeature(ctx, feature, origin, scale, ex, style);

--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -45,7 +45,7 @@ export default {
         const level = (parent !== undefined) ? (parent.level + 1) : 0;
 
         const { sharableExtent, quaternion, position } = builder.computeSharableExtent(extent);
-        const south = sharableExtent.south().toFixed(6);
+        const south = sharableExtent.south.toFixed(6);
         const segment = layer.options.segments || 16;
         const key = `${builder.type}_${layer.disableSkirt ? 0 : 1}_${segment}_${level}_${south}`;
 

--- a/src/Converter/textureConverter.js
+++ b/src/Converter/textureConverter.js
@@ -1,5 +1,8 @@
 import * as THREE from 'three';
 import Feature2Texture from 'Converter/Feature2Texture';
+import Extent from 'Core/Geographic/Extent';
+
+const extentTexture = new Extent('EPSG:4326', [0, 0, 0, 0]);
 
 const textureLayer = (texture) => {
     texture.generateMipmaps = false;
@@ -22,7 +25,7 @@ export default {
                 new THREE.Color(layer.backgroundLayer.paint['background-color']) :
                 undefined;
 
-            const extentTexture = extentDestination.as(layer.projection);
+            extentDestination.as(layer.projection, extentTexture);
             texture = Feature2Texture.createTextureFromFeature(data, extentTexture, 256, layer.style, backgroundColor);
             texture.parsedData = data;
             texture.coords = extentDestination;

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -11,6 +11,7 @@ import Ellipsoid from 'Core/Math/Ellipsoid';
 proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
 
 const projectionCache = {};
+const dimension = new THREE.Vector2();
 
 export const ellipsoidSizes = {
     x: 6378137,
@@ -488,20 +489,17 @@ Coordinates.prototype.as = function as(crs, target) {
  * @return {Vector2} normalized offset in extent
  */
 Coordinates.prototype.offsetInExtent = function offsetInExtent(extent, target) {
-    if (this.crs != extent.crs()) {
+    if (this.crs != extent.crs) {
         throw new Error('unsupported mix');
     }
 
-    const dimension = {
-        x: Math.abs(extent.east() - extent.west()),
-        y: Math.abs(extent.north() - extent.south()),
-    };
+    extent.dimensions(dimension);
 
     const x = crsIsGeocentric(this.crs) ? this.x() : this.longitude();
     const y = crsIsGeocentric(this.crs) ? this.y() : this.latitude();
 
-    const originX = (x - extent.west()) / dimension.x;
-    const originY = (extent.north() - y) / dimension.y;
+    const originX = (x - extent.west) / dimension.x;
+    const originY = (extent.north - y) / dimension.y;
 
     target = target || new THREE.Vector2();
     target.set(originX, originY);

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -424,14 +424,16 @@ Extent.prototype.union = function union(extent) {
 const c = new Coordinates('EPSG:4326', 0, 0, 0);
 Extent.prototype.expandByPoint = function expandByPoint(coordinates) {
     const coords = coordinates.crs == this.crs() ? coordinates : coordinates.as(this.crs(), c);
-    const we = coords._values[0];
+    this.expandByValues(coords._values[0], coords._values[1]);
+};
+
+Extent.prototype.expandByValues = function expandByValues(we, sn) {
     if (we < this.west()) {
         this._values[CARDINAL.WEST] = we;
     }
     if (we > this.east()) {
         this._values[CARDINAL.EAST] = we;
     }
-    const sn = coords._values[1];
     if (sn < this.south()) {
         this._values[CARDINAL.SOUTH] = sn;
     }

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -14,48 +14,48 @@ const CARDINAL = {
     NORTH: 3,
 };
 
-/**
- * @class      Extent
- * @param      {string}          crs     projection crs (ex: 'EPSG:4326')
- * @param      {(Array|object|Number)}  values  west, east, south and north values
- */
-function Extent(crs, ...values) {
+function Extent(crs, v0, v1, v2, v3) {
     this._crs = crs;
 
     if (this.isTiledCrs()) {
-        if (values.length == 3) {
-            this.zoom = values[0];
-            this.row = values[1];
-            this.col = values[2];
+        if (v0 !== undefined) {
+            this.zoom = v0;
+            this.row = v1;
+            this.col = v2;
 
             if (this.zoom < 0) {
-                throw new Error(`invlid WTMS values ${values}`);
+                throw new Error('invlid WTMS values');
             }
         } else {
-            throw new Error(`Unsupported constructor args '${values}'`);
+            throw new Error('Unsupported constructor args');
         }
-    } else if (values.length === 2 &&
-        values[0] instanceof Coordinates &&
-        values[1] instanceof Coordinates) {
+    } else if (v0 instanceof Coordinates) {
+        // seem never used
         this._values = new Float64Array(4);
-        this._values[CARDINAL.WEST] = values[0]._values[0];
-        this._values[CARDINAL.EAST] = values[1]._values[0];
-        this._values[CARDINAL.SOUTH] = values[0]._values[1];
-        this._values[CARDINAL.NORTH] = values[1]._values[1];
-    } else if (values.length == 1 && values[0].west != undefined) {
+        this._values[CARDINAL.WEST] = v0._values[0];
+        this._values[CARDINAL.EAST] = v1._values[0];
+        this._values[CARDINAL.SOUTH] = v0._values[1];
+        this._values[CARDINAL.NORTH] = v1._values[1];
+    } else if (v0 && v0.west !== undefined) {
         this._values = new Float64Array(4);
-        this._values[CARDINAL.WEST] = values[0].west;
-        this._values[CARDINAL.EAST] = values[0].east;
-        this._values[CARDINAL.SOUTH] = values[0].south;
-        this._values[CARDINAL.NORTH] = values[0].north;
-    } else if (values.length == 4) {
+        this._values[CARDINAL.WEST] = v0.west;
+        this._values[CARDINAL.EAST] = v0.east;
+        this._values[CARDINAL.SOUTH] = v0.south;
+        this._values[CARDINAL.NORTH] = v0.north;
+    } else if (v0.length == 4) {
         this._values = new Float64Array(4);
         Object.keys(CARDINAL).forEach((key) => {
             const cardinal = CARDINAL[key];
-            this._values[cardinal] = values[cardinal];
+            this._values[cardinal] = v0[cardinal];
         });
+    } else if (v0 !== undefined) {
+        this._values = new Float64Array(4);
+        this._values[CARDINAL.WEST] = v0;
+        this._values[CARDINAL.EAST] = v1;
+        this._values[CARDINAL.SOUTH] = v2;
+        this._values[CARDINAL.NORTH] = v3;
     } else {
-        throw new Error(`Unsupported constructor args '${values}'`);
+        throw new Error('Unsupported constructor args');
     }
 }
 
@@ -63,7 +63,7 @@ Extent.prototype.clone = function clone() {
     if (this.isTiledCrs()) {
         return new Extent(this._crs, this.zoom, this.row, this.col);
     } else {
-        const result = new Extent(this._crs, ...this._values);
+        const result = new Extent(this._crs, this._values[0], this._values[1], this._values[2], this._values[3]);
         return result;
     }
 };
@@ -367,16 +367,16 @@ Extent.prototype.intersect = function intersect(other) {
 };
 
 
-Extent.prototype.set = function set(...values) {
+Extent.prototype.set = function set(v0, v1, v2, v3) {
     if (this.isTiledCrs()) {
-        this.zoom = values[0];
-        this.row = values[1];
-        this.col = values[2];
+        this.zoom = v0;
+        this.row = v1;
+        this.col = v2;
     } else {
-        Object.keys(CARDINAL).forEach((key) => {
-            const cardinal = CARDINAL[key];
-            this._values[cardinal] = values[cardinal];
-        });
+        this._values[CARDINAL.WEST] = v0;
+        this._values[CARDINAL.EAST] = v1;
+        this._values[CARDINAL.SOUTH] = v2;
+        this._values[CARDINAL.NORTH] = v3;
     }
     return this;
 };
@@ -386,7 +386,7 @@ Extent.prototype.copy = function copy(extent) {
     if (this.isTiledCrs()) {
         this.set(extent.zoom, extent.row, extent.col);
     } else {
-        this.set(...extent._values);
+        this.set(extent._values[0], extent._values[1], extent._values[2], extent._values[3]);
     }
     return this;
 };

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -381,6 +381,16 @@ Extent.prototype.set = function set(...values) {
     return this;
 };
 
+Extent.prototype.copy = function copy(extent) {
+    this._crs = extent._crs;
+    if (this.isTiledCrs()) {
+        this.set(extent.zoom, extent.row, extent.col);
+    } else {
+        this.set(...extent._values);
+    }
+    return this;
+};
+
 Extent.prototype.union = function union(extent) {
     if (extent.crs() != this.crs()) {
         throw new Error('unsupported union between 2 diff crs');

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -503,4 +503,24 @@ Extent.prototype.subdivision = function subdivision() {
     return [northWest, northEast, southWest, southEast];
 };
 
+Extent.prototype.copyWithTransform = function copyWithTransform(t, s, toCopy) {
+    if (!toCopy.isTiledCrs()) {
+        this._crs = toCopy._crs;
+        this._values[0] = (toCopy._values[0] - t.x) / s.x;
+        this._values[1] = (toCopy._values[1] - t.x) / s.x;
+        if (this._values[0] > this._values[1]) {
+            const temp = this._values[0];
+            this._values[0] = this._values[1];
+            this._values[1] = temp;
+        }
+        this._values[2] = (toCopy._values[2] - t.y) / s.y;
+        this._values[3] = (toCopy._values[3] - t.y) / s.y;
+        if (this._values[2] > this._values[3]) {
+            const temp = this._values[2];
+            this._values[2] = this._values[3];
+            this._values[3] = temp;
+        }
+    }
+};
+
 export default Extent;

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -14,513 +14,589 @@ const CARDINAL = {
     NORTH: 3,
 };
 
-function Extent(crs, v0, v1, v2, v3) {
-    this._crs = crs;
+const _dim = new THREE.Vector2();
+const _dim2 = new THREE.Vector2();
+const r = { row: 0, col: 0, invDiff: 0 };
 
-    if (this.isTiledCrs()) {
-        if (v0 !== undefined) {
-            this.zoom = v0;
-            this.row = v1;
-            this.col = v2;
+function _rowColfromParent(extent, zoom) {
+    const diffLevel = extent.zoom - zoom;
+    const diff = 2 ** diffLevel;
+    r.invDiff = 1 / diff;
 
-            if (this.zoom < 0) {
-                throw new Error('invlid WTMS values');
-            }
-        } else {
-            throw new Error('Unsupported constructor args');
-        }
-    } else if (v0 instanceof Coordinates) {
-        // seem never used
-        this._values = new Float64Array(4);
-        this._values[CARDINAL.WEST] = v0._values[0];
-        this._values[CARDINAL.EAST] = v1._values[0];
-        this._values[CARDINAL.SOUTH] = v0._values[1];
-        this._values[CARDINAL.NORTH] = v1._values[1];
-    } else if (v0 && v0.west !== undefined) {
-        this._values = new Float64Array(4);
-        this._values[CARDINAL.WEST] = v0.west;
-        this._values[CARDINAL.EAST] = v0.east;
-        this._values[CARDINAL.SOUTH] = v0.south;
-        this._values[CARDINAL.NORTH] = v0.north;
-    } else if (v0.length == 4) {
-        this._values = new Float64Array(4);
-        Object.keys(CARDINAL).forEach((key) => {
-            const cardinal = CARDINAL[key];
-            this._values[cardinal] = v0[cardinal];
-        });
-    } else if (v0 !== undefined) {
-        this._values = new Float64Array(4);
-        this._values[CARDINAL.WEST] = v0;
-        this._values[CARDINAL.EAST] = v1;
-        this._values[CARDINAL.SOUTH] = v2;
-        this._values[CARDINAL.NORTH] = v3;
-    } else {
-        throw new Error('Unsupported constructor args');
-    }
+    r.row = (extent.row - (extent.row % diff)) * r.invDiff;
+    r.col = (extent.col - (extent.col % diff)) * r.invDiff;
+    return r;
 }
 
-Extent.prototype.clone = function clone() {
-    if (this.isTiledCrs()) {
-        return new Extent(this._crs, this.zoom, this.row, this.col);
-    } else {
-        const result = new Extent(this._crs, this._values[0], this._values[1], this._values[2], this._values[3]);
-        return result;
-    }
-};
+let _extent;
 
-Extent.prototype.isTiledCrs = function fnIsTiledCrs() {
-    return this._crs.indexOf('WMTS:') == 0 || this._crs == 'TMS';
-};
+const cardinals = [];
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
+cardinals.push(new Coordinates('EPSG:4326', 0, 0, 0, 0));
 
 // EPSG:3857
 // WGS84 bounds [-180.0, -85.06, 180.0, 85.06] (https://epsg.io/3857)
 // Warning, some tiled source don't exactly match the same bound
 // It should be taken into account
-const coord = new Coordinates('EPSG:4326', 180, 85.06);
-coord.as('EPSG:3857', coord);
+const _c = new Coordinates('EPSG:4326', 180, 85.06);
+_c.as('EPSG:3857', _c);
 // Get bound dimension in 'EPSG:3857'
-const sizeX = coord._values[0] * 2;
-const sizeY = coord._values[1] * 2;
+const sizeX = _c._values[0] * 2;
+const sizeY = _c._values[1] * 2;
 
-Extent.prototype.as = function as(crs) {
-    assertCrsIsValid(crs);
+class Extent {
+    /**
+     * Extent is geographical bounding rectangle defined by 4 limits: west, east, south and north.
+     * If crs is tiled projection (WMTS or TMS), the extent is defined by zoom, row and column.
+     *
+     * @param {String} crs projection of limit values.
+     * @param {number|Array.<number>|Coordinates|Object} v0 west value, zoom value, Array of values [west, east, south and north],
+     * Coordinates of west-south corner or object {west, east, south and north}
+     * @param {number|Coordinates} [v1] east value, row value or Coordinates of east-north corner
+     * @param {number} [v2] south value or column value
+     * @param {number} [v3] north value
+     */
+    constructor(crs, v0, v1, v2, v3) {
+        this.crs = crs;
 
-    if (this.isTiledCrs()) {
-        if (this._crs == 'WMTS:PM' || this._crs == 'TMS') {
-            // Convert this to the requested crs by using 4326 as an intermediate state.
-            const nbCol = 2 ** this.zoom;
-            const nbRow = nbCol;
-            const sizeRow = 1.0 / nbRow;
-            // convert row PM to Y PM
-            const Yn = 1 - sizeRow * (nbRow - this.row);
-            const Ys = Yn + sizeRow;
+        if (this.isTiledCrs()) {
+            if (v0 !== undefined) {
+                this.zoom = v0;
+                this.row = v1;
+                this.col = v2;
 
-            // convert to EPSG:3857
-            if (crs == 'EPSG:3857') {
-                const west = (0.5 - sizeRow * (nbCol - this.col)) * sizeX;
-                const east = west + sizeRow * sizeX;
-                const south = (0.5 - Ys) * sizeY;
-                const north = (0.5 - Yn) * sizeY;
-                return new Extent('EPSG:3857', { west, east, south, north }).as(crs);
-            } else {
-                const size = 360 / nbCol;
-                // convert Y PM to latitude EPSG:4326 degree
-                const north = Projection.YToWGS84(Yn);
-                const south = Projection.YToWGS84(Ys);
-                // convert column PM to longitude EPSG:4326 degree
-                const west = 180 - size * (nbCol - this.col);
-                const east = west + size;
-
-                const extent = new Extent('EPSG:4326', { west, east, south, north });
-                if (crs == 'EPSG:4326') {
-                    return extent;
-                } else {
-                    // convert in new crs
-                    return extent.as(crs);
+                if (this.zoom < 0) {
+                    throw new Error('invlid WTMS values');
                 }
+            } else {
+                throw new Error('Unsupported constructor args');
             }
-        } else if (this._crs == 'WMTS:WGS84G' && crs == 'EPSG:4326') {
-            const nbRow = 2 ** this.zoom;
-            const size = 180 / nbRow;
-            const north = size * (nbRow - this.row) - 90;
-            const south = size * (nbRow - (this.row + 1)) - 90;
-            const west = 180 - size * (2 * nbRow - this.col);
-            const east = 180 - size * (2 * nbRow - (this.col + 1));
-
-            return new Extent(crs, { west, east, south, north });
+        } else if (v0 instanceof Coordinates) {
+            // seem never used
+            this._values = new Float64Array([v0._values[0], v1._values[0], v0._values[1], v1._values[1]]);
+        } else if (v0 && v0.west !== undefined) {
+            this._values = new Float64Array([v0.west, v0.east, v0.south, v0.north]);
+        } else if (v0.length == 4) {
+            this._values = new Float64Array(v0);
+        } else if (v0 !== undefined) {
+            this._values = new Float64Array([v0, v1, v2, v3]);
         } else {
-            throw new Error('Unsupported yet');
+            throw new Error('Unsupported constructor args');
         }
     }
 
-    if (this._crs != crs && !(is4326(this._crs) && is4326(crs))) {
-        // Compute min/max in x/y by projecting 8 cardinal points,
-        // and then taking the min/max of each coordinates.
-        const cardinals = [];
-        const c = this.center();
-        cardinals.push(new Coordinates(this._crs, this.west(), this.north()));
-        cardinals.push(new Coordinates(this._crs, c._values[0], this.north()));
-        cardinals.push(new Coordinates(this._crs, this.east(), this.north()));
-        cardinals.push(new Coordinates(this._crs, this.east(), c._values[1]));
-        cardinals.push(new Coordinates(this._crs, this.east(), this.south()));
-        cardinals.push(new Coordinates(this._crs, c._values[0], this.south()));
-        cardinals.push(new Coordinates(this._crs, this.west(), this.south()));
-        cardinals.push(new Coordinates(this._crs, this.west(), c._values[1]));
-
-        let north = -Infinity;
-        let south = Infinity;
-        let east = -Infinity;
-        let west = Infinity;
-        // loop over the coordinates
-        for (let i = 0; i < cardinals.length; i++) {
-            // convert the coordinate.
-            cardinals[i] = cardinals[i].as(crs);
-            north = Math.max(north, cardinals[i]._values[1]);
-            south = Math.min(south, cardinals[i]._values[1]);
-            east = Math.max(east, cardinals[i]._values[0]);
-            west = Math.min(west, cardinals[i]._values[0]);
-        }
-        return new Extent(crs, { north, south, east, west });
-    }
-
-    return new Extent(crs, {
-        west: this.west(),
-        east: this.east(),
-        north: this.north(),
-        south: this.south(),
-    });
-};
-
-Extent.prototype.offsetToParent = function offsetToParent(other, target = new THREE.Vector4()) {
-    if (this.crs() != other.crs()) {
-        throw new Error('unsupported mix');
-    }
-    if (this.isTiledCrs()) {
-        const diffLevel = this.zoom - other.zoom;
-        const diff = 2 ** diffLevel;
-        const invDiff = 1 / diff;
-
-        const r = (this.row - (this.row % diff)) * invDiff;
-        const c = (this.col - (this.col % diff)) * invDiff;
-
-        return target.set(
-            this.col * invDiff - c,
-            this.row * invDiff - r,
-            invDiff, invDiff);
-    }
-
-    const dimension = {
-        x: Math.abs(other.east() - other.west()),
-        y: Math.abs(other.north() - other.south()),
-    };
-
-    const originX =
-        (this.west() - other.west()) / dimension.x;
-    const originY =
-        (other.north() - this.north()) / dimension.y;
-
-    const scaleX =
-        Math.abs(
-            this.east() - this.west()) / dimension.x;
-
-    const scaleY =
-        Math.abs(
-            this.north() - this.south()) / dimension.y;
-
-    return target.set(originX, originY, scaleX, scaleY);
-};
-
-Extent.prototype.west = function west() {
-    return this._values[CARDINAL.WEST];
-};
-
-Extent.prototype.east = function east() {
-    return this._values[CARDINAL.EAST];
-};
-
-Extent.prototype.north = function north() {
-    return this._values[CARDINAL.NORTH];
-};
-
-Extent.prototype.south = function south() {
-    return this._values[CARDINAL.SOUTH];
-};
-
-Extent.prototype.crs = function crs() {
-    return this._crs;
-};
-
-Extent.prototype.center = function center(target) {
-    if (this.isTiledCrs()) {
-        throw new Error('Invalid operation for WMTS bbox');
-    }
-    let c;
-    if (target) {
-        Coordinates.call(target, this._crs, this._values[0], this._values[2]);
-        c = target;
-    } else {
-        c = new Coordinates(this._crs, this._values[0], this._values[2]);
-    }
-    const dim = this.dimensions();
-    c._values[0] += dim.x * 0.5;
-    c._values[1] += dim.y * 0.5;
-    return c;
-};
-
-/**
- * Returns the dimension of the extent, in a <code>THREE.Vector2</code>.
- *
- * @param {THREE.Vector2} [target] - The target to assign the result in.
- *
- * @return {THREE.Vector2}
- */
-Extent.prototype.dimensions = function dimensions(target) {
-    target = target || new THREE.Vector2();
-    target.x = Math.abs(this.east() - this.west());
-    target.y = Math.abs(this.north() - this.south());
-    return target;
-};
-
-/**
- * Return true if <code>coord</code> is inside the bounding box.
- *
- * @param {Coordinates} coord
- * @param {number} [epsilon=0] - to take into account when comparing to the
- * point.
- *
- * @return {boolean}
- */
-Extent.prototype.isPointInside = function isPointInside(coord, epsilon = 0) {
-    const c = (this.crs() == coord.crs) ? coord : coord.as(this.crs());
-
-    // TODO this ignores altitude
-    if (crsIsGeographic(this.crs())) {
-        return c.longitude() <= this.east() + epsilon &&
-               c.longitude() >= this.west() - epsilon &&
-               c.latitude() <= this.north() + epsilon &&
-               c.latitude() >= this.south() - epsilon;
-    } else {
-        return c.x() <= this.east() + epsilon &&
-               c.x() >= this.west() - epsilon &&
-               c.y() <= this.north() + epsilon &&
-               c.y() >= this.south() - epsilon;
-    }
-};
-
-Extent.prototype.isInside = function isInside(other, epsilon) {
-    if (this.isTiledCrs()) {
-        if (this.zoom == other.zoom) {
-            return this.row == other.row &&
-                this.col == other.col;
-        } else if (this.zoom < other.zoom) {
-            return false;
+    /**
+     * Clone this extent
+     * @return {Extent} cloned extent
+     */
+    clone() {
+        if (this.isTiledCrs()) {
+            return new Extent(this.crs, this.zoom, this.row, this.col);
         } else {
-            const diffLevel = this.zoom - other.zoom;
-            const diff = 2 ** diffLevel;
-            const invDiff = 1 / diff;
-
-            const r = (this.row - (this.row % diff)) * invDiff;
-            const c = (this.col - (this.col % diff)) * invDiff;
-            return r == other.row && c == other.col;
+            return new Extent(this.crs, this._values);
         }
-    } else {
-        const o = other.as(this._crs);
-        epsilon = epsilon == undefined ? reasonnableEpsilonForCRS(this._crs) : epsilon;
-        return this.east() - o.east() <= epsilon &&
-               o.west() - this.west() <= epsilon &&
-               this.north() - o.north() <= epsilon &&
-               o.south() - this.south() <= epsilon;
-    }
-};
-
-Extent.prototype.offsetScale = function offsetScale(bbox) {
-    if (bbox.crs() != this.crs()) {
-        throw new Error('unsupported offscale between 2 diff crs');
     }
 
-    const dimension = {
-        x: Math.abs(this.east() - this.west()),
-        y: Math.abs(this.north() - this.south()),
-    };
-
-    var originX = (bbox.west() - this.west()) / dimension.x;
-    var originY = (bbox.north() - this.north()) / dimension.y;
-
-    var scaleX = Math.abs(bbox.east() - bbox.west()) / dimension.x;
-    var scaleY = Math.abs(bbox.north() - bbox.south()) / dimension.y;
-
-    return new THREE.Vector4(originX, originY, scaleX, scaleY);
-};
-
-/**
- * @documentation: Return true if this bounding box intersect with the bouding box parameter
- * @param {type} bbox
- * @returns {Boolean}
- */
-Extent.prototype.intersectsExtent = function intersectsExtent(bbox) {
-    const other = bbox.crs() == this.crs() ? bbox : bbox.as(this.crs());
-    return !(this.west() >= other.east() ||
-             this.east() <= other.west() ||
-             this.south() >= other.north() ||
-             this.north() <= other.south());
-};
-
-/**
- * @documentation: Return the intersection of this extent with another one
- * @param {type} other
- * @returns {Boolean}
- */
-Extent.prototype.intersect = function intersect(other) {
-    if (!this.intersectsExtent(other)) {
-        return new Extent(this.crs(), 0, 0, 0, 0);
-    }
-    if (other.crs() != this.crs()) {
-        other = other.as(this.crs());
-    }
-    const extent = new Extent(this.crs(),
-        Math.max(this.west(), other.west()),
-        Math.min(this.east(), other.east()),
-        Math.max(this.south(), other.south()),
-        Math.min(this.north(), other.north()));
-
-    return extent;
-};
-
-
-Extent.prototype.set = function set(v0, v1, v2, v3) {
-    if (this.isTiledCrs()) {
-        this.zoom = v0;
-        this.row = v1;
-        this.col = v2;
-    } else {
-        this._values[CARDINAL.WEST] = v0;
-        this._values[CARDINAL.EAST] = v1;
-        this._values[CARDINAL.SOUTH] = v2;
-        this._values[CARDINAL.NORTH] = v3;
-    }
-    return this;
-};
-
-Extent.prototype.copy = function copy(extent) {
-    this._crs = extent._crs;
-    if (this.isTiledCrs()) {
-        this.set(extent.zoom, extent.row, extent.col);
-    } else {
-        this.set(extent._values[0], extent._values[1], extent._values[2], extent._values[3]);
-    }
-    return this;
-};
-
-Extent.prototype.union = function union(extent) {
-    if (extent.crs() != this.crs()) {
-        throw new Error('unsupported union between 2 diff crs');
-    }
-    const west = extent.west();
-    if (west < this.west()) {
-        this._values[CARDINAL.WEST] = west;
+    /**
+     * Return true is tiled Extent (WGS84, PM)
+     * @return {boolean}
+     */
+    isTiledCrs() {
+        return this.crs.indexOf('WMTS:') == 0 || this.crs == 'TMS';
     }
 
-    const east = extent.east();
-    if (east > this.east()) {
-        this._values[CARDINAL.EAST] = east;
+    /**
+     * Convert Extent to the specified projection.
+     * @param {string} crs the projection of destination.
+     * @param {Extent} target copy the destination to target.
+     * @return {Extent}
+     */
+    as(crs, target) {
+        assertCrsIsValid(crs);
+        if (this.isTiledCrs()) {
+            if (this.crs == 'WMTS:PM' || this.crs == 'TMS') {
+                if (!target) {
+                    target = new Extent('EPSG:4326', [0, 0, 0, 0]);
+                }
+                // Convert this to the requested crs by using 4326 as an intermediate state.
+                const nbCol = 2 ** this.zoom;
+                const nbRow = nbCol;
+                const sizeRow = 1.0 / nbRow;
+                // convert row PM to Y PM
+                const Yn = 1 - sizeRow * (nbRow - this.row);
+                const Ys = Yn + sizeRow;
+
+                // convert to EPSG:3857
+                if (crs == 'EPSG:3857') {
+                    const west = (0.5 - sizeRow * (nbCol - this.col)) * sizeX;
+                    const east = west + sizeRow * sizeX;
+                    const south = (0.5 - Ys) * sizeY;
+                    const north = (0.5 - Yn) * sizeY;
+                    target.set(west, east, south, north);
+                    target.crs = 'EPSG:3857';
+                    return target.as(crs, target);
+                } else {
+                    const size = 360 / nbCol;
+                    // convert Y PM to latitude EPSG:4326 degree
+                    const north = Projection.YToWGS84(Yn);
+                    const south = Projection.YToWGS84(Ys);
+                    // convert column PM to longitude EPSG:4326 degree
+                    const west = 180 - size * (nbCol - this.col);
+                    const east = west + size;
+
+                    target.set(west, east, south, north);
+                    target.crs = 'EPSG:4326';
+                    if (crs == 'EPSG:4326') {
+                        return target;
+                    } else {
+                        // convert in new crs
+                        return target.as(crs, target);
+                    }
+                }
+            } else if (this.crs == 'WMTS:WGS84G' && crs == 'EPSG:4326') {
+                if (!target) {
+                    target = new Extent('EPSG:4326', [0, 0, 0, 0]);
+                }
+                const nbRow = 2 ** this.zoom;
+                const size = 180 / nbRow;
+                const north = size * (nbRow - this.row) - 90;
+                const south = size * (nbRow - (this.row + 1)) - 90;
+                const west = 180 - size * (2 * nbRow - this.col);
+                const east = 180 - size * (2 * nbRow - (this.col + 1));
+
+                target.set(west, east, south, north);
+                target.crs = crs;
+                return target;
+            } else {
+                throw new Error('Unsupported yet');
+            }
+        }
+
+        if (!target) {
+            target = new Extent('EPSG:4326', [0, 0, 0, 0]);
+        }
+        if (this.crs != crs && !(is4326(this.crs) && is4326(crs))) {
+            // Compute min/max in x/y by projecting 8 cardinal points,
+            // and then taking the min/max of each coordinates.
+            const center = this.center(_c);
+            cardinals[0].set(this.crs, this.west, this.north);
+            cardinals[1].set(this.crs, center._values[0], this.north);
+            cardinals[2].set(this.crs, this.east, this.north);
+            cardinals[3].set(this.crs, this.east, center._values[1]);
+            cardinals[4].set(this.crs, this.east, this.south);
+            cardinals[5].set(this.crs, center._values[0], this.south);
+            cardinals[6].set(this.crs, this.west, this.south);
+            cardinals[7].set(this.crs, this.west, center._values[1]);
+
+            let north = -Infinity;
+            let south = Infinity;
+            let east = -Infinity;
+            let west = Infinity;
+            // loop over the coordinates
+            for (let i = 0; i < cardinals.length; i++) {
+                // convert the coordinate.
+                cardinals[i].as(crs, _c);
+                north = Math.max(north, _c._values[1]);
+                south = Math.min(south, _c._values[1]);
+                east = Math.max(east, _c._values[0]);
+                west = Math.min(west, _c._values[0]);
+            }
+
+            target.set(west, east, south, north);
+            target.crs = crs;
+            return target;
+        }
+
+        target.crs = crs;
+        target.set(this.west, this.east, this.south, this.north);
+
+        return target;
     }
 
-    const south = extent.south();
-    if (south < this.south()) {
-        this._values[CARDINAL.SOUTH] = south;
+    /**
+     * Return the west value
+     * @return {number}
+     */
+    get west() {
+        return this._values[CARDINAL.WEST];
     }
 
-    const north = extent.north();
-    if (north > this.north()) {
-        this._values[CARDINAL.NORTH] = north;
+    /**
+     * Return the east value
+     * @return {number}
+     */
+    get east() {
+        return this._values[CARDINAL.EAST];
     }
-};
 
-/**
- * expandByPoint perfoms the minimal extension
- * for the point to belong to this Extent object
- * @param {Coordinates} coordinates  The coordinates to belong
- */
-const c = new Coordinates('EPSG:4326', 0, 0, 0);
-Extent.prototype.expandByPoint = function expandByPoint(coordinates) {
-    const coords = coordinates.crs == this.crs() ? coordinates : coordinates.as(this.crs(), c);
-    this.expandByValues(coords._values[0], coords._values[1]);
-};
+    /**
+     * Return the north value
+     * @return {number}
+     */
+    get north() {
+        return this._values[CARDINAL.NORTH];
+    }
 
-Extent.prototype.expandByValues = function expandByValues(we, sn) {
-    if (we < this.west()) {
-        this._values[CARDINAL.WEST] = we;
+    /**
+    * Return the south value
+    * @return {number}
+    */
+    get south() {
+        return this._values[CARDINAL.SOUTH];
     }
-    if (we > this.east()) {
-        this._values[CARDINAL.EAST] = we;
-    }
-    if (sn < this.south()) {
-        this._values[CARDINAL.SOUTH] = sn;
-    }
-    if (sn > this.north()) {
-        this._values[CARDINAL.NORTH] = sn;
-    }
-};
 
-Extent.fromBox3 = function fromBox3(crs, box) {
-    return new Extent(crs, {
-        west: box.min.x,
-        east: box.max.x,
-        south: box.min.y,
-        north: box.max.y,
-    });
-};
+    /**
+     * Return the center of Extent
+     * @param {Coordinates} target copy the center to the target.
+     * @return {Coordinates}
+     */
+    center(target) {
+        if (this.isTiledCrs()) {
+            throw new Error('Invalid operation for WMTS bbox');
+        }
+        this.dimensions(_dim);
+        if (target) {
+            target.set(this.crs, this._values[0] + _dim.x * 0.5, this._values[2] + _dim.y * 0.5);
+        } else {
+            target = new Coordinates(this.crs, this._values[0] + _dim.x * 0.5, this._values[2] + _dim.y * 0.5);
+        }
+        return target;
+    }
 
-Extent.prototype.extentParent = function extentParent(levelParent) {
-    if (this.isTiledCrs()) {
+    /**
+    * Returns the dimension of the extent, in a <code>THREE.Vector2</code>.
+    *
+    * @param {THREE.Vector2} [target] - The target to assign the result in.
+    *
+    * @return {THREE.Vector2}
+    */
+    dimensions(target = new THREE.Vector2()) {
+        target.x = Math.abs(this.east - this.west);
+        target.y = Math.abs(this.north - this.south);
+        return target;
+    }
+
+    /**
+     * Return true if <code>coord</code> is inside the bounding box.
+     *
+     * @param {Coordinates} coord
+     * @param {number} [epsilon=0] - to take into account when comparing to the
+     * point.
+     *
+     * @return {boolean}
+     */
+    isPointInside(coord, epsilon = 0) {
+        const c = (this.crs == coord.crs) ? coord : coord.as(this.crs, _c);
+        // TODO this ignores altitude
+        if (crsIsGeographic(this.crs)) {
+            return c.longitude() <= this.east + epsilon &&
+                   c.longitude() >= this.west - epsilon &&
+                   c.latitude() <= this.north + epsilon &&
+                   c.latitude() >= this.south - epsilon;
+        } else {
+            return c.x() <= this.east + epsilon &&
+                   c.x() >= this.west - epsilon &&
+                   c.y() <= this.north + epsilon &&
+                   c.y() >= this.south - epsilon;
+        }
+    }
+
+    /**
+     * Return true if <code>extent</code> is inside this extent.
+     *
+     * @param {Extent} extent the extent to check
+     * @param {number} epsilon to take into account when comparing to the
+     * point.
+     *
+     * @return {boolean}
+     */
+    isInside(extent, epsilon) {
+        if (this.isTiledCrs()) {
+            if (this.zoom == extent.zoom) {
+                return this.row == extent.row &&
+                    this.col == extent.col;
+            } else if (this.zoom < extent.zoom) {
+                return false;
+            } else {
+                _rowColfromParent(this, extent.zoom);
+                return r.row == extent.row && r.col == extent.col;
+            }
+        } else {
+            extent.as(this.crs, _extent);
+            epsilon = epsilon == undefined ? reasonnableEpsilonForCRS(this.crs) : epsilon;
+            return this.east - _extent.east <= epsilon &&
+                   _extent.west - this.west <= epsilon &&
+                   this.north - _extent.north <= epsilon &&
+                   _extent.south - this.south <= epsilon;
+        }
+    }
+
+    /**
+     * Return the translation and scale to transform this extent to input extent.
+     *
+     * @param {Extent} extent input extent
+     * @param {THREE.Vector4} target copy the result to target.
+     * @return {THREE.Vector4} {x: translation on west-east, y: translation on south-north, z: scale on west-east, w: scale on south-north}
+     */
+    offsetToParent(extent, target = new THREE.Vector4()) {
+        if (this.crs != extent.crs) {
+            throw new Error('unsupported mix');
+        }
+        if (this.isTiledCrs()) {
+            _rowColfromParent(this, extent.zoom);
+            return target.set(
+                this.col * r.invDiff - r.col,
+                this.row * r.invDiff - r.row,
+                r.invDiff, r.invDiff);
+        }
+
+        extent.dimensions(_dim);
+        this.dimensions(_dim2);
+
+        const originX = (this.west - extent.west) / _dim.x;
+        const originY = (extent.north - this.north) / _dim.y;
+
+        const scaleX = _dim2.x / _dim.x;
+        const scaleY = _dim2.y / _dim.y;
+
+        return target.set(originX, originY, scaleX, scaleY);
+    }
+
+    /**
+     * Return parent tiled extent with input level
+     *
+     * @param {number} levelParent level of parent.
+     * @return {Extent}
+     */
+    tiledExtentParent(levelParent) {
         if (levelParent && levelParent < this.zoom) {
-            const diffLevel = this.zoom - levelParent;
-            const diff = 2 ** diffLevel;
-            const invDiff = 1 / diff;
-
-            const r = (this.row - (this.row % diff)) * invDiff;
-            const c = (this.col - (this.col % diff)) * invDiff;
-
-            return new Extent(this.crs(), levelParent, r, c);
+            _rowColfromParent(this, levelParent);
+            return new Extent(this.crs, levelParent, r.row, r.col);
         } else {
             return this;
         }
     }
-};
 
-Extent.prototype.toString = function toString(separator = '') {
-    if (this.isTiledCrs()) {
-        return `${this.zoom}${separator}${this.row}${separator}${this.col}`;
-    } else {
-        return `${this.east()}${separator}${this.north()}${separator}${this.west()}${separator}${this.south()}`;
+    /**
+     * Return true if this bounding box intersect with the bouding box parameter
+     * @param {Extent} extent
+     * @returns {Boolean}
+     */
+    intersectsExtent(extent) {
+        const other = extent.crs == this.crs ? extent : extent.as(this.crs, _extent);
+        return !(this.west >= other.east ||
+                 this.east <= other.west ||
+                 this.south >= other.north ||
+                 this.north <= other.south);
     }
-};
 
-const center = new Coordinates('EPSG:4326', 0, 0, 0);
-/**
- * Subdivide equally an extent from its center to return four extents:
- * north-west, north-east, south-west and south-east.
- *
- * @returns {Extent[]} An array containing the four sections of the extent. The
- * order of the sections is [NW, NE, SW, SE].
- */
-Extent.prototype.subdivision = function subdivision() {
-    this.center(center);
-
-    const northWest = new Extent(this.crs(),
-        this.west(), center._values[0],
-        center._values[1], this.north());
-    const northEast = new Extent(this.crs(),
-        center._values[0], this.east(),
-        center._values[1], this.north());
-    const southWest = new Extent(this.crs(),
-        this.west(), center._values[0],
-        this.south(), center._values[1]);
-    const southEast = new Extent(this.crs(),
-        center._values[0], this.east(),
-        this.south(), center._values[1]);
-
-    return [northWest, northEast, southWest, southEast];
-};
-
-Extent.prototype.copyWithTransform = function copyWithTransform(t, s, toCopy) {
-    if (!toCopy.isTiledCrs()) {
-        this._crs = toCopy._crs;
-        this._values[0] = (toCopy._values[0] - t.x) / s.x;
-        this._values[1] = (toCopy._values[1] - t.x) / s.x;
-        if (this._values[0] > this._values[1]) {
-            const temp = this._values[0];
-            this._values[0] = this._values[1];
-            this._values[1] = temp;
+    /**
+     * Return the intersection of this extent with another one
+     * @param {Extent} extent
+     * @returns {Boolean}
+     */
+    intersect(extent) {
+        if (!this.intersectsExtent(extent)) {
+            return new Extent(this.crs, 0, 0, 0, 0);
         }
-        this._values[2] = (toCopy._values[2] - t.y) / s.y;
-        this._values[3] = (toCopy._values[3] - t.y) / s.y;
-        if (this._values[2] > this._values[3]) {
-            const temp = this._values[2];
-            this._values[2] = this._values[3];
-            this._values[3] = temp;
+        if (extent.crs != this.crs) {
+            extent = extent.as(this.crs, _extent);
+        }
+        return new Extent(this.crs,
+            Math.max(this.west, extent.west),
+            Math.min(this.east, extent.east),
+            Math.max(this.south, extent.south),
+            Math.min(this.north, extent.north));
+    }
+
+    /**
+     * Set west, east, south and north values.
+     * Or if tiled extent, set zoom, row and column values
+     * @param {number} v0 west or zoom value
+     * @param {number} v1 east or row value
+     * @param {number} v2 south or column value
+     * @param {number} v3 north value
+     * @return {Extent}
+     */
+    set(v0, v1, v2, v3) {
+        if (this.isTiledCrs()) {
+            this.zoom = v0;
+            this.row = v1;
+            this.col = v2;
+        } else {
+            this._values[CARDINAL.WEST] = v0;
+            this._values[CARDINAL.EAST] = v1;
+            this._values[CARDINAL.SOUTH] = v2;
+            this._values[CARDINAL.NORTH] = v3;
+        }
+        return this;
+    }
+
+    /**
+     * Copy to this extent to input extent.
+     * @param {Extent} extent
+     * @return {Extent} copied extent
+     */
+    copy(extent) {
+        this.crs = extent.crs;
+        if (this.isTiledCrs()) {
+            this.set(extent.zoom, extent.row, extent.col);
+        } else {
+            this.set(extent._values[0], extent._values[1], extent._values[2], extent._values[3]);
+        }
+        return this;
+    }
+
+    /**
+     * Union this extent with the input extent.
+     * @param {Extent} extent the extent to union.
+     */
+    union(extent) {
+        if (extent.crs != this.crs) {
+            throw new Error('unsupported union between 2 diff crs');
+        }
+        const west = extent.west;
+        if (west < this.west) {
+            this._values[CARDINAL.WEST] = west;
+        }
+
+        const east = extent.east;
+        if (east > this.east) {
+            this._values[CARDINAL.EAST] = east;
+        }
+
+        const south = extent.south;
+        if (south < this.south) {
+            this._values[CARDINAL.SOUTH] = south;
+        }
+
+        const north = extent.north;
+        if (north > this.north) {
+            this._values[CARDINAL.NORTH] = north;
         }
     }
-};
+
+    /**
+     * expandByCoordinates perfoms the minimal extension
+     * for the coordinates to belong to this Extent object
+     * @param {Coordinates} coordinates  The coordinates to belong
+     */
+    expandByCoordinates(coordinates) {
+        const coords = coordinates.crs == this.crs ? coordinates : coordinates.as(this.crs, _c);
+        this.expandByValuesCoordinates(coords._values[0], coords._values[1]);
+    }
+
+    /**
+    * expandByValuesCoordinates perfoms the minimal extension
+    * for the coordinates values to belong to this Extent object
+    * @param {number} we  The coordinate on west-east
+    * @param {number} sn  The coordinate on south-north
+    *
+    */
+    expandByValuesCoordinates(we, sn) {
+        if (we < this.west) {
+            this._values[CARDINAL.WEST] = we;
+        }
+        if (we > this.east) {
+            this._values[CARDINAL.EAST] = we;
+        }
+        if (sn < this.south) {
+            this._values[CARDINAL.SOUTH] = sn;
+        }
+        if (sn > this.north) {
+            this._values[CARDINAL.NORTH] = sn;
+        }
+    }
+
+    /**
+     * Instance Extent with THREE.Box2
+     * @param {string} crs Projection of extent to instancied.
+     * @param {THREE.Box2} box
+     * @return {Extent}
+     */
+    static fromBox3(crs, box) {
+        return new Extent(crs, {
+            west: box.min.x,
+            east: box.max.x,
+            south: box.min.y,
+            north: box.max.y,
+        });
+    }
+
+    /**
+     * Return values of extent in string, separated by the separator input.
+     * @param {string} separator
+     * @return {string}
+     */
+    toString(separator = '') {
+        if (this.isTiledCrs()) {
+            return `${this.zoom}${separator}${this.row}${separator}${this.col}`;
+        } else {
+            return `${this.east}${separator}${this.north}${separator}${this.west}${separator}${this.south}`;
+        }
+    }
+
+    /**
+     * Subdivide equally an extent from its center to return four extents:
+     * north-west, north-east, south-west and south-east.
+     *
+     * @returns {Extent[]} An array containing the four sections of the extent. The
+     * order of the sections is [NW, NE, SW, SE].
+     */
+    subdivision() {
+        this.center(_c);
+
+        const northWest = new Extent(this.crs,
+            this.west, _c._values[0],
+            _c._values[1], this.north);
+        const northEast = new Extent(this.crs,
+            _c._values[0], this.east,
+            _c._values[1], this.north);
+        const southWest = new Extent(this.crs,
+            this.west, _c._values[0],
+            this.south, _c._values[1]);
+        const southEast = new Extent(this.crs,
+            _c._values[0], this.east,
+            this.south, _c._values[1]);
+
+        return [northWest, northEast, southWest, southEast];
+    }
+
+    /**
+     * Apply transform and copy this extent to input.
+     * The <code>transformedCopy</code> doesn't handle
+     * the issue of overflow of geographic limits.
+     * @param {THREE.Vector2} t translation transform
+     * @param {THREE.Vector2} s scale transform
+     * @param {Extent} extent Extent to copy after transformation.
+     */
+    transformedCopy(t, s, extent) {
+        if (!extent.isTiledCrs()) {
+            this.crs = extent.crs;
+            this._values[0] = (extent._values[0] + t.x) * s.x;
+            this._values[1] = (extent._values[1] + t.x) * s.x;
+            if (this._values[0] > this._values[1]) {
+                const temp = this._values[0];
+                this._values[0] = this._values[1];
+                this._values[1] = temp;
+            }
+            this._values[2] = (extent._values[2] + t.y) * s.y;
+            this._values[3] = (extent._values[3] + t.y) * s.y;
+            if (this._values[2] > this._values[3]) {
+                const temp = this._values[2];
+                this._values[2] = this._values[3];
+                this._values[3] = temp;
+            }
+        }
+    }
+}
+
+_extent = new Extent('EPSG:4326', [0, 0, 0, 0]);
 
 export default Extent;

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -70,12 +70,12 @@ const Projection = {
 
     UnitaryToLongitudeWGS84(u, bbox) {
         bbox.dimensions(dim);
-        return bbox.west() + u * dim.x;
+        return bbox.west + u * dim.x;
     },
 
     UnitaryToLatitudeWGS84(v, bbox) {
         bbox.dimensions(dim);
-        return bbox.south() + v * dim.y;
+        return bbox.south + v * dim.y;
     },
 };
 
@@ -87,8 +87,8 @@ function WMTS_WGS84ToWMTS_PM(cWMTS, bbox) {
 
     var sizeRow = 1.0 / nbRow;
 
-    var yMin = Projection.WGS84ToY(WGS84LatitudeClamp(bbox.north()));
-    var yMax = Projection.WGS84ToY(WGS84LatitudeClamp(bbox.south()));
+    var yMin = Projection.WGS84ToY(WGS84LatitudeClamp(bbox.north));
+    var yMax = Projection.WGS84ToY(WGS84LatitudeClamp(bbox.south));
 
     let maxRow;
 

--- a/src/Core/Math/Rectangle.js
+++ b/src/Core/Math/Rectangle.js
@@ -4,10 +4,10 @@
  */
 
 function Rectangle(options) {
-    this._west = options.west() || 0;
-    this._south = options.south() || 0;
-    this._east = options.east() || 0;
-    this._north = options.north() || 0;
+    this._west = options.west || 0;
+    this._south = options.south || 0;
+    this._east = options.east || 0;
+    this._north = options.north || 0;
 }
 
 Rectangle.prototype.getWest = function getWest() {

--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -30,7 +30,7 @@ BuilderEllipsoidTile.prototype.constructor = BuilderEllipsoidTile;
 BuilderEllipsoidTile.prototype.Prepare = function Prepare(params) {
     params.nbRow = 2 ** (params.level + 1.0);
 
-    var st1 = WGS84ToOneSubY(params.extent.south());
+    var st1 = WGS84ToOneSubY(params.extent.south);
 
     if (!isFinite(st1)) { st1 = 0; }
 
@@ -101,13 +101,13 @@ BuilderEllipsoidTile.prototype.computeSharableExtent = function fnComputeSharabl
     // TODO: It should be possible to use equatorial plan symetrie,
     // but we should be reverse UV on tile
     // Common geometry is looking for only on longitude
-    const sizeLongitude = Math.abs(extent.west() - extent.east()) / 2;
-    const sharableExtent = new Extent(extent.crs(), -sizeLongitude, sizeLongitude, extent.south(), extent.north());
+    const sizeLongitude = Math.abs(extent.west - extent.east) / 2;
+    const sharableExtent = new Extent(extent.crs, -sizeLongitude, sizeLongitude, extent.south, extent.north);
 
     // compute rotation to transform tile to position it on ellipsoid
     // this transformation take into account the transformation of the parents
-    const rotLon = THREE.Math.degToRad(extent.west() - sharableExtent.west());
-    const rotLat = THREE.Math.degToRad(90 - extent.center().latitude());
+    const rotLon = THREE.Math.degToRad(extent.west - sharableExtent.west);
+    const rotLat = THREE.Math.degToRad(90 - extent.center(this.tmp.coords[0]).latitude());
     quatToAlignLongitude.setFromAxisAngle(axisZ, rotLon);
     quatToAlignLatitude.setFromAxisAngle(axisY, rotLat);
     quatToAlignLongitude.multiply(quatToAlignLatitude);

--- a/src/Core/Prefab/Planar/PlanarTileBuilder.js
+++ b/src/Core/Prefab/Planar/PlanarTileBuilder.js
@@ -44,12 +44,12 @@ PlanarTileBuilder.prototype.VertexNormal = function VertexNormal() {
 
 // coord u tile to projected
 PlanarTileBuilder.prototype.uProjecte = function uProjecte(u, params) {
-    params.projected.x = params.extent.west() + u * (params.extent.east() - params.extent.west());
+    params.projected.x = params.extent.west + u * (params.extent.east - params.extent.west);
 };
 
 // coord v tile to projected
 PlanarTileBuilder.prototype.vProjecte = function vProjecte(v, params) {
-    params.projected.y = params.extent.south() + v * (params.extent.north() - params.extent.south());
+    params.projected.y = params.extent.south + v * (params.extent.north - params.extent.south);
 };
 
 // get oriented bounding box of tile
@@ -62,7 +62,7 @@ PlanarTileBuilder.prototype.computeSharableExtent = function fnComputeSharableEx
     // compute sharable extent to pool the geometries
     // the geometry in common extent is identical to the existing input
     // with a translation
-    const sharableExtent = new Extent(extent.crs(), 0, Math.abs(extent.west() - extent.east()), 0, Math.abs(extent.north() - extent.south()));
+    const sharableExtent = new Extent(extent.crs, 0, Math.abs(extent.west - extent.east), 0, Math.abs(extent.north - extent.south));
     return {
         sharableExtent,
         quaternion,

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -15,7 +15,7 @@ function PlanarView(viewerDiv, extent, options = {}) {
     THREE.Object3D.DefaultUp.set(0, 0, 1);
 
     // Setup View
-    View.call(this, extent.crs(), viewerDiv, options);
+    View.call(this, extent.crs, viewerDiv, options);
 
     // Configure camera
     const dim = extent.dimensions();

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -67,7 +67,7 @@ class TileMesh extends THREE.Mesh {
         if (source.isWMTSSource) {
             OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, source.tileMatrixSet);
             return this.wmtsCoords[source.tileMatrixSet];
-        } else if (source.isWMSSource && this.extent.crs() != source.projection) {
+        } else if (source.isWMSSource && this.extent.crs != source.projection) {
             if (source.projection == 'EPSG:3857') {
                 const tilematrixset = 'PM';
                 OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, tilematrixset);
@@ -77,20 +77,20 @@ class TileMesh extends THREE.Mesh {
             }
         } else if (source.isTMSSource) {
             // Special globe case: use the P(seudo)M(ercator) coordinates
-            if (is4326(this.extent.crs()) &&
-                    (source.extent.crs() == 'EPSG:3857' || is4326(source.extent.crs()))) {
+            if (is4326(this.extent.crs) &&
+                    (source.extent.crs == 'EPSG:3857' || is4326(source.extent.crs))) {
                 OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, 'PM');
                 return this.wmtsCoords.PM;
             } else {
                 return OGCWebServiceHelper.computeTMSCoordinates(this, source.extent, source.isInverted);
             }
-        } else if (source.extent.crs() == this.extent.crs()) {
+        } else if (source.extent.crs == this.extent.crs) {
             // Currently extent.as() always clone the extent, even if the output
             // crs is the same.
             // So we avoid using it if both crs are the same.
             return [this.extent];
         } else {
-            return [this.extent.as(source.extent.crs())];
+            return [this.extent.as(source.extent.crs)];
         }
     }
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -178,7 +178,7 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
     } else if (layer.source.tileMatrixSet === 'PM' || layer.source.projection == 'EPSG:3857') {
         layer.projection = 'EPSG:3857';
     } else {
-        layer.projection = parentLayer.extent.crs();
+        layer.projection = parentLayer.extent.crs;
     }
 
     if (!layer.whenReady) {

--- a/src/Layer/InfoLayer.js
+++ b/src/Layer/InfoLayer.js
@@ -46,7 +46,7 @@ export class InfoTiledGeometryLayer extends InfoLayer {
             'extent',
             {
                 get: () => {
-                    const extent = new Extent(this.layer.extent.crs(), Infinity, -Infinity, Infinity, -Infinity);
+                    const extent = new Extent(this.layer.extent.crs, Infinity, -Infinity, Infinity, -Infinity);
                     extent.min = +Infinity;
                     extent.max = -Infinity;
                     this.displayed.tiles.forEach((tile) => {

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -61,10 +61,10 @@ function readCoordinates(crsIn, crsOut, coordinates, extent, target, normals, si
 
         // expand extent if present
         if (extent) {
-            if (extent.crs() == crsIn) {
-                extent.expandByPoint(coordIn);
+            if (extent.crs == crsIn) {
+                extent.expandByCoordinates(coordIn);
             } else {
-                extent.expandByPoint(cOut);
+                extent.expandByCoordinates(cOut);
             }
         }
         offset += size;

--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -28,7 +28,7 @@ import GeoJsonParser from 'Parser/GeoJsonParser';
  *     }, {
  *         buildExtent: true,
  *         crsIn: 'EPSG:4326',
- *         crsOut: view.tileLayer.extent.crs(),
+ *         crsOut: view.tileLayer.extent.crs,
  *     });
  * }).then(function _(geojson) {
  *     var source = new FileSource({ parsedData: geojson });

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -78,7 +78,7 @@ function _subdivideNodeAdditive(context, layer, node, cullingTest) {
             node.add(tile);
             tile.updateMatrixWorld();
 
-            const extent = boundingVolumeToExtent(layer.extent.crs(), tile.boundingVolume, tile.matrixWorld);
+            const extent = boundingVolumeToExtent(layer.extent.crs, tile.boundingVolume, tile.matrixWorld);
             tile.traverse((obj) => {
                 obj.extent = extent;
             });

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -2,8 +2,12 @@ import * as THREE from 'three';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import handlingError from 'Process/handlerNodeError';
+import Coordinates from 'Core/Geographic/Coordinates';
 
+const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 const vector = new THREE.Vector3();
+const tmp = new THREE.Vector3();
+
 function applyOffset(obj, offset, quaternion, offsetAltitude = 0) {
     if (obj.geometry) {
         if (obj.geometry.isBufferGeometry) {
@@ -52,7 +56,7 @@ function assignLayer(object, layer) {
 function extentInsideSource(extent, source) {
     return !source.extentInsideLimit(extent) ||
         (source.parsedData &&
-        !source.parsedData.extent.isPointInside(extent.center()));
+        !source.parsedData.extent.isPointInside(extent.center(coord)));
 }
 
 const quaternion = new THREE.Quaternion();
@@ -136,7 +140,7 @@ export default {
                 if (isApplied) {
                     // NOTE: now data source provider use cache on Mesh
                     // TODO move transform in feature2Mesh
-                    const tmp = node.extent.center().as(context.view.referenceCrs).xyz().negate();
+                    node.extent.center(coord).as(context.view.referenceCrs, coord).xyz(tmp).negate();
                     quaternion.setFromRotationMatrix(node.matrixWorld).inverse();
                     // const quaternion = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), node.extent.center().geodesicNormal).inverse();
                     applyOffset(result, tmp, quaternion, result.minAltitude);

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -6,7 +6,7 @@ import handlingError from 'Process/handlerNodeError';
 
 function getSourceExtent(node, extent, targetLevel) {
     if (extent.isTiledCrs()) {
-        return extent.extentParent(targetLevel);
+        return extent.tiledExtentParent(targetLevel);
     } else {
         return node.findAncestorFromLevel(targetLevel).extent;
     }
@@ -159,7 +159,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     return context.scheduler.execute(command).then(
         (result) => {
             // TODO: Handle error : result is undefined in provider. throw error
-            const pitchs = extentsDestination.map((ext, i) => ext.offsetToParent(extentsSource[i]));
+            const pitchs = extentsDestination.map((ext, i) => ext.offsetToParent(extentsSource[i], nodeLayer.offsetScales[i]));
             nodeLayer.setTextures(result, pitchs);
             node.layerUpdateState[layer.id].success();
         },
@@ -246,7 +246,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
         (textures) => {
             const elevation = {
                 texture: textures[0],
-                pitch: extentsDestination[0].offsetToParent(extentsSource[0]),
+                pitch: extentsDestination[0].offsetToParent(extentsSource[0], nodeLayer.offsetScales[0]),
             };
 
             // Do not apply the new texture if its level is < than the current

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -56,7 +56,7 @@ function parseSourceData(data, extSrc, extDest, layer) {
     return parser(data, options).then((parsedFile) => {
         if (source.isFileSource) {
             source.parsedData = parsedFile;
-            if (parsedFile.extent._crs != 'EPSG:4978') {
+            if (parsedFile.extent.crs != 'EPSG:4978') {
                 source.extent = parsedFile.extent || source.extent;
             }
         }

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -1,3 +1,6 @@
+import Extent from 'Core/Geographic/Extent';
+
+const extent = new Extent('EPSG:4326', [0, 0, 0, 0]);
 /**
  * @module URLBuilder
  */
@@ -71,11 +74,11 @@ export default {
      */
     bbox: function bbox(bbox, layer) {
         const precision = layer.projection == 'EPSG:4326' ? 9 : 2;
-        const box = bbox.as(layer.projection);
-        const w = box.west().toFixed(precision);
-        const s = box.south().toFixed(precision);
-        const e = box.east().toFixed(precision);
-        const n = box.north().toFixed(precision);
+        bbox.as(layer.projection, extent);
+        const w = extent.west.toFixed(precision);
+        const s = extent.south.toFixed(precision);
+        const e = extent.east.toFixed(precision);
+        const n = extent.north.toFixed(precision);
 
         let bboxInUnit = layer.axisOrder || 'wsen';
         bboxInUnit = bboxInUnit.replace('w', `${w},`)

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -1,7 +1,10 @@
+import * as THREE from 'three';
 import { CRS_DEFINES, ELEVATION_MODES } from 'Renderer/LayeredMaterial';
 import { checkNodeElevationTextureValidity, insertSignificantValuesFromParent } from 'Parser/XbilParser';
 
 export const EMPTY_TEXTURE_ZOOM = -1;
+
+const pitch = new THREE.Vector4();
 
 function defineLayerProperty(layer, property, initValue, defaultValue) {
     let _value = initValue !== undefined ? initValue : defaultValue;
@@ -110,7 +113,7 @@ class MaterialLayer {
         const parentTexture = parent && parent.textures[0];
         if (dataElevation && parentTexture && !checkNodeElevationTextureValidity(dataElevation, nodatavalue)) {
             const coords = this.textures[0].coords;
-            const pitch = coords.offsetToParent(parentTexture.coords);
+            coords.offsetToParent(parentTexture.coords, pitch);
             insertSignificantValuesFromParent(dataElevation, parentTexture.image.data, nodatavalue, pitch);
         }
     }

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -1,5 +1,9 @@
 import Source from 'Source/Source';
 
+import Extent from 'Core/Geographic/Extent';
+
+const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
+
 /**
  * @classdesc
  * An object defining the source of a single resource to get from a direct
@@ -37,7 +41,7 @@ import Source from 'Source/Source';
  * const kmlLayer = new itowns.ColorLayer('Kml', {
  *     name: 'kml',
  *     transparent: true,
- *     projection: view.tileLayer.extent.crs(),
+ *     projection: view.tileLayer.extent.crs,
  *     source: kmlSource,
  * });
  *
@@ -80,7 +84,7 @@ import Source from 'Source/Source';
  *         return itowns.GeoJsonParser.parse(geojson, {
  *             buildExtent: true,
  *             crsIn: 'EPSG:4326',
- *             crsOut: view.tileLayer.extent.crs(),
+ *             crsOut: view.tileLayer.extent.crs,
  *             mergeFeatures: true,
  *             withNormal: false,
  *             withAltitude: false,
@@ -134,7 +138,7 @@ class FileSource extends Source {
     }
 
     extentInsideLimit(extent) {
-        const localExtent = this.projection == extent.crs() ? extent : extent.as(this.projection);
+        const localExtent = this.projection == extent.crs ? extent : extent.as(this.projection, ext);
         return (extent.zoom == undefined || !(extent.zoom < this.zoom.min || extent.zoom > this.zoom.max)) &&
             this.extent.intersectsExtent(localExtent);
     }

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -146,7 +146,7 @@ class WFSSource extends Source {
     }
 
     urlFromExtent(extent) {
-        return URLBuilder.bbox(extent.as(this.projection), this);
+        return URLBuilder.bbox(extent, this);
     }
 
     extentInsideLimit(extent) {
@@ -156,4 +156,3 @@ class WFSSource extends Source {
 }
 
 export default WFSSource;
-

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -140,7 +140,7 @@ class WMSSource extends Source {
     }
 
     extentInsideLimit(extent) {
-        const localExtent = this.projection == extent.crs() ? extent : extent.as(this.projection);
+        const localExtent = this.projection == extent.crs ? extent : extent.as(this.projection);
         return (extent.zoom == undefined || !(extent.zoom < this.zoom.min || extent.zoom > this.zoom.max)) &&
             this.extent.intersectsExtent(localExtent);
     }

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -123,7 +123,7 @@ class CameraRig extends THREE.Object3D {
 
     setTargetFromCoordinate(view, coord) {
         // clamp altitude to seaLevel
-        coord.as(tileLayer(view).extent.crs(), this.coord);
+        coord.as(tileLayer(view).extent.crs, this.coord);
         const altitude = Math.max(0, this.coord._values[2]);
         this.coord._values[2] = altitude;
         // adjust target's position with clamped altitude
@@ -252,7 +252,7 @@ class CameraRig extends THREE.Object3D {
             if (params.callback) {
                 params.callback(this);
             }
-            targetCoord.set(view.referenceCrs, this.targetWorldPosition).as(tileLayer(view).extent.crs(), this.coord);
+            targetCoord.set(view.referenceCrs, this.targetWorldPosition).as(tileLayer(view).extent.crs, this.coord);
             view.notifyChange(camera);
         };
 

--- a/src/Utils/DEMUtils.js
+++ b/src/Utils/DEMUtils.js
@@ -357,7 +357,7 @@ const temp = {
 };
 
 function _readZ(layer, method, coord, nodes, cache) {
-    const pt = coord.as(layer.extent.crs(), temp.coord1);
+    const pt = coord.as(layer.extent.crs, temp.coord1);
 
     let tileWithValidElevationTexture = null;
     // first check in cache

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -27,9 +27,7 @@ view.getPickingPositionFromDepth = function getPickingPositionFromDepth() {
 view.referenceCrs = 'EPSG:4978';
 view.getLayers = () => [{
     extent: {
-        crs {
-            return 'EPSG:4326';
-        },
+        crs: 'EPSG:4326',
     },
 }];
 view.addFrameRequester = () => {};
@@ -102,4 +100,3 @@ describe('Camera utils unit test', function () {
         });
     });
 });
-

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -27,7 +27,7 @@ view.getPickingPositionFromDepth = function getPickingPositionFromDepth() {
 view.referenceCrs = 'EPSG:4978';
 view.getLayers = () => [{
     extent: {
-        crs() {
+        crs {
             return 'EPSG:4326';
         },
     },

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -126,10 +126,10 @@ describe('Provide in Sources', function () {
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((textures) => {
             assert.equal(textures[0].coords.zoom, zoom);
-            assert.equal(textures[0].coords.west(), tile.extent.west());
-            assert.equal(textures[0].coords.east(), tile.extent.east());
-            assert.equal(textures[0].coords.north(), tile.extent.north());
-            assert.equal(textures[0].coords.south(), tile.extent.south());
+            assert.equal(textures[0].coords.west, tile.extent.west);
+            assert.equal(textures[0].coords.east, tile.extent.east);
+            assert.equal(textures[0].coords.north, tile.extent.north);
+            assert.equal(textures[0].coords.south, tile.extent.south);
         });
     });
     it('should get 4 TileMesh from TileProvider', () => {
@@ -141,10 +141,10 @@ describe('Provide in Sources', function () {
         globelayer.subdivideNode(context, tile);
         TileProvider.executeCommand(context.scheduler.commands[0]).then((tiles) => {
             assert.equal(tiles.length, 4);
-            assert.equal(tiles[0].extent.west(), tile.extent.west());
-            assert.equal(tiles[0].extent.east(), tile.extent.east() * 0.5);
-            assert.equal(tiles[0].extent.north(), tile.extent.north());
-            assert.equal(tiles[0].extent.south(), tile.extent.north() * 0.5);
+            assert.equal(tiles[0].extent.west, tile.extent.west);
+            assert.equal(tiles[0].extent.east, tile.extent.east * 0.5);
+            assert.equal(tiles[0].extent.north, tile.extent.north);
+            assert.equal(tiles[0].extent.south, tile.extent.north * 0.5);
         });
     });
     it('should get 3 meshs with WFS source and DataSourceProvider', () => {

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -3,11 +3,14 @@ import { Box3, Vector3 } from 'three';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 
-describe('Extent constructors', function () {
+describe('Extent', function () {
     const minX = 0;
     const maxX = 10;
     const minY = -1;
     const maxY = 3;
+    const zoom = 5;
+    const row = 22;
+    const col = 10;
 
     it('should build the expected extent using Coordinates', function () {
         const withCoords = new Extent('EPSG:4326',
@@ -38,6 +41,14 @@ describe('Extent constructors', function () {
             maxX,
             minY,
             maxY);
+        assert.equal(minX, withValues.west);
+        assert.equal(maxX, withValues.east);
+        assert.equal(minY, withValues.south);
+        assert.equal(maxY, withValues.north);
+    });
+
+    it('should build the expected extent using Array', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
         assert.equal(minX, withValues.west);
         assert.equal(maxX, withValues.east);
         assert.equal(minY, withValues.south);
@@ -80,5 +91,188 @@ describe('Extent constructors', function () {
         assert.equal(dimensions.x, 25);
         // Height
         assert.equal(dimensions.y, 20);
+    });
+
+    it('should clone extent like expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const clonedExtent = withValues.clone();
+        assert.equal(clonedExtent.west, withValues.west);
+        assert.equal(clonedExtent.east, withValues.east);
+        assert.equal(clonedExtent.south, withValues.south);
+        assert.equal(clonedExtent.north, withValues.north);
+    });
+
+    it('should clone tiled extent like expected', function () {
+        const withValues = new Extent('WMTS:WGS84', zoom, row, col);
+        const clonedExtent = withValues.clone();
+        assert.equal(clonedExtent.zoom, withValues.zoom);
+        assert.equal(clonedExtent.row, withValues.row);
+        assert.equal(clonedExtent.col, withValues.col);
+    });
+
+    it('should isTiledCrs return true if extent is tiled extent', function () {
+        const withValues = new Extent('WMTS:WGS84G', zoom, row, col);
+        assert.ok(withValues.isTiledCrs());
+    });
+
+    it('should convert extent WMTS:WGS84G like expected', function () {
+        const withValues = new Extent('WMTS:WGS84G', 0, 0, 0).as('EPSG:4326');
+        assert.equal(-180, withValues.west);
+        assert.equal(0, withValues.east);
+        assert.equal(-90, withValues.south);
+        assert.equal(90, withValues.north);
+    });
+
+    it('should convert extent WMTS:PM to EPSG:3857 like expected', function () {
+        const withValues = new Extent('WMTS:PM', 0, 0, 0).as('EPSG:3857');
+        assert.equal(-20037508.342789244, withValues.west);
+        assert.equal(20037508.342789244, withValues.east);
+        assert.equal(-20048966.104014594, withValues.south);
+        assert.equal(20048966.104014594, withValues.north);
+    });
+
+    it('should convert extent WMTS:PM to EPSG:4326 like expected', function () {
+        const withValues = new Extent('WMTS:PM', 0, 0, 0).as('EPSG:4326');
+        assert.equal(-180, withValues.west);
+        assert.equal(180, withValues.east);
+        assert.equal(-85.05112877980659, withValues.south);
+        assert.equal(85.0511287798066, withValues.north);
+    });
+
+    it('should convert extent EPSG:4326 like expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]).as('EPSG:3857');
+        // console.log('withValues', withValues.as('EPSG:3857'));
+        assert.equal(0, withValues.west);
+        assert.equal(1113194.9079327357, withValues.east);
+        assert.equal(-111325.14286638597, withValues.south);
+        assert.equal(334111.1714019597, withValues.north);
+    });
+
+    it('should return center of extent expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const center = withValues.center();
+        assert.equal(5, center.longitude());
+        assert.equal(1, center.latitude());
+    });
+    it('should return dimensions of extent expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const dimensions = withValues.dimensions();
+        assert.equal(10, dimensions.x);
+        assert.equal(4, dimensions.y);
+    });
+
+    it('should return true is point is inside extent expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const coord = new Coordinates('EPSG:4326', minX + 1, minY + 2);
+        assert.ok(withValues.isPointInside(coord));
+    });
+
+    it('should return true is extent is inside extent expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const inside = new Extent('EPSG:4326', [minX + 1, maxX - 1, minY + 1, maxY - 1]);
+        assert.ok(withValues.isInside(inside, 1));
+    });
+
+    it('should return expected offset', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const inside = new Extent('EPSG:4326', [minX + 1, maxX - 1, minY + 1, maxY - 1]);
+        const offset = withValues.offsetToParent(inside);
+        assert.equal(offset.x, -0.125);
+        assert.equal(offset.y, -0.5);
+        assert.equal(offset.z, 1.25);
+        assert.equal(offset.w, 2);
+    });
+
+    it('should return expected offset using tiled extent', function () {
+        const withValues = new Extent('WMTS:WGS84G', zoom, row, col);
+        const parent = new Extent('WMTS:WGS84G', zoom - 2, row, col);
+        const offset = withValues.offsetToParent(parent);
+        assert.equal(offset.x, 0.5);
+        assert.equal(offset.y, 0.5);
+        assert.equal(offset.z, 0.25);
+        assert.equal(offset.w, 0.25);
+    });
+
+    it('should return expected tiled extent parent', function () {
+        const withValues = new Extent('WMTS:WGS84G', zoom, row, col);
+        const parent = withValues.tiledExtentParent(zoom - 2);
+        assert.equal(parent.zoom, 3);
+        assert.equal(parent.row, 5);
+        assert.equal(parent.col, 2);
+    });
+
+    it('should return true if intersect other extent', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const inter = new Extent('EPSG:4326', [minX + 1, maxX - 1, maxY - 1, maxY + 2]);
+        assert.ok(withValues.intersectsExtent(inter));
+    });
+
+    it('should intersect like expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const extent = new Extent('EPSG:4326', [minX + 1, maxX - 1, maxY - 1, maxY + 2]);
+        const inter = withValues.intersect(extent);
+        assert.equal(1, inter.west);
+        assert.equal(9, inter.east);
+        assert.equal(2, inter.south);
+        assert.equal(3, inter.north);
+    });
+
+    it('should set values', function () {
+        const withValues = new Extent('EPSG:4326', [0, 0, 0, 0]);
+        withValues.set(minX, maxX, minY, maxY);
+        assert.equal(minX, withValues.west);
+        assert.equal(maxX, withValues.east);
+        assert.equal(minY, withValues.south);
+        assert.equal(maxY, withValues.north);
+    });
+
+    it('should copy extent', function () {
+        const toCopy = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const withValues = new Extent('EPSG:4326', [0, 0, 0, 0]);
+        withValues.copy(toCopy);
+        assert.equal(minX, withValues.west);
+        assert.equal(maxX, withValues.east);
+        assert.equal(minY, withValues.south);
+        assert.equal(maxY, withValues.north);
+    });
+
+    it('should union like expected', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const extent = new Extent('EPSG:4326', [minX + 1, maxX - 1, maxY - 1, maxY + 2]);
+        withValues.union(extent);
+        assert.equal(0, withValues.west);
+        assert.equal(10, withValues.east);
+        assert.equal(-1, withValues.south);
+        assert.equal(5, withValues.north);
+    });
+
+    it('should expand by point', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const coord = new Coordinates('EPSG:4326', maxX + 1, maxY + 2);
+        withValues.expandByCoordinates(coord);
+        assert.equal(0, withValues.west);
+        assert.equal(11, withValues.east);
+        assert.equal(-1, withValues.south);
+        assert.equal(5, withValues.north);
+    });
+
+    it('should convert values to string', function () {
+        const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
+        const tostring = withValues.toString(',');
+        const toValues = tostring.split(',').map(s => Number(s));
+        assert.equal(toValues[0], withValues.east);
+        assert.equal(toValues[1], withValues.north);
+        assert.equal(toValues[2], withValues.west);
+        assert.equal(toValues[3], withValues.south);
+    });
+
+    it('should copy and transform extent', function () {
+        const withValues = new Extent('EPSG:4326', [0, 0, 0, 0]);
+        const extent = new Extent('EPSG:4326', [minX + 1, maxX - 1, maxY - 1, maxY + 2]);
+        withValues.transformedCopy({ x: 1, y: 2 }, { x: 2, y: -2 }, extent);
+        assert.equal(4, withValues.west);
+        assert.equal(20, withValues.east);
+        assert.equal(-14, withValues.south);
+        assert.equal(-8, withValues.north);
     });
 });

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -13,10 +13,10 @@ describe('Extent constructors', function () {
         const withCoords = new Extent('EPSG:4326',
             new Coordinates('EPSG:4326', minX, minY),
             new Coordinates('EPSG:4326', maxX, maxY));
-        assert.equal(minX, withCoords.west());
-        assert.equal(maxX, withCoords.east());
-        assert.equal(minY, withCoords.south());
-        assert.equal(maxY, withCoords.north());
+        assert.equal(minX, withCoords.west);
+        assert.equal(maxX, withCoords.east);
+        assert.equal(minY, withCoords.south);
+        assert.equal(maxY, withCoords.north);
     });
 
     it('should build the expected extent using keywords', function () {
@@ -26,10 +26,10 @@ describe('Extent constructors', function () {
             north: maxY,
             west: minX,
         });
-        assert.equal(minX, withKeywords.west());
-        assert.equal(maxX, withKeywords.east());
-        assert.equal(minY, withKeywords.south());
-        assert.equal(maxY, withKeywords.north());
+        assert.equal(minX, withKeywords.west);
+        assert.equal(maxX, withKeywords.east);
+        assert.equal(minY, withKeywords.south);
+        assert.equal(maxY, withKeywords.north);
     });
 
     it('should build the expected extent using values', function () {
@@ -38,10 +38,10 @@ describe('Extent constructors', function () {
             maxX,
             minY,
             maxY);
-        assert.equal(minX, withValues.west());
-        assert.equal(maxX, withValues.east());
-        assert.equal(minY, withValues.south());
-        assert.equal(maxY, withValues.north());
+        assert.equal(minX, withValues.west);
+        assert.equal(maxX, withValues.east);
+        assert.equal(minY, withValues.south);
+        assert.equal(maxY, withValues.north);
     });
 
     it('should build the expected extent from box3', function () {
@@ -50,10 +50,10 @@ describe('Extent constructors', function () {
             new Vector3(Math.random(), Math.random()));
         const fromBox = Extent.fromBox3('EPSG:4978', box);
 
-        assert.equal(fromBox.west(), box.min.x);
-        assert.equal(fromBox.east(), box.max.x);
-        assert.equal(fromBox.north(), box.max.y);
-        assert.equal(fromBox.south(), box.min.y);
+        assert.equal(fromBox.west, box.min.x);
+        assert.equal(fromBox.east, box.max.x);
+        assert.equal(fromBox.north, box.max.y);
+        assert.equal(fromBox.south, box.min.y);
     });
 
     it('should subdivide the extent in four piece', function () {

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -14,10 +14,10 @@ describe('FeaturesUtils', function () {
         }));
     it('should correctly compute extent geojson', () =>
         promise.then((collection) => {
-            assert.equal(collection.extent.west(), 0.30798339284956455);
-            assert.equal(collection.extent.east(), 2.4722900334745646);
-            assert.equal(collection.extent.south(), 42.91620643817353);
-            assert.equal(collection.extent.north(), 43.72744458647463);
+            assert.equal(collection.extent.west, 0.30798339284956455);
+            assert.equal(collection.extent.east, 2.4722900334745646);
+            assert.equal(collection.extent.south, 42.91620643817353);
+            assert.equal(collection.extent.north, 43.72744458647463);
         }));
     it('should correctly filter point', () =>
         promise.then((collection) => {

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -57,7 +57,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
         source.extentsInsideLimit = () => true;
         source.extentInsideLimit = () => true;
         source.zoom = { min: 0, max: 10 };
-        source.extent = { crs: () => 'EPSG:4326' };
+        source.extent = { crs: 'EPSG:4326' };
     });
 
 

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -156,7 +156,7 @@ function Debug(view, datDebugTool, chartDivContainer) {
             const size = { x: g.width * ratio, y: g.height * ratio };
             debugCamera.aspect = size.x / size.y;
             const camera = view.camera.camera3D;
-            const coord = new Coordinates(view.referenceCrs, camera.position).as(tileLayer.extent._crs);
+            const coord = new Coordinates(view.referenceCrs, camera.position).as(tileLayer.extent.crs);
             const extent = view.tileLayer.info.displayed.extent;
             displayedTilesObb.setFromExtent(extent);
             displayedTilesObbHelper.visible = true;


### PR DESCRIPTION
## Description
* Refactor Extent to Es6  class.
* add functions : `copy`, `expandByValues`, `copyWithTransform`.
* remove spread syntax because transpiled code isn't performing.
* use target copy when possible to avoid instancing.
* add unit tests.

**BREAKING CHANGE:**
`crs()`, `west()`, `east()`, `south()` and`north()` are replaced by getter`crs`, `west`, `east`, `south` and `north`.