### PR TITLE
chore: update THREE to v103

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10081,9 +10081,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.102.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.102.1.tgz",
-      "integrity": "sha512-btHBdww/Es4vdBkB2GjTE9mpj0vy8tgtxkX7ne7uxySXV8zoGxWJv1N88BydxnCqvAfmD4ZUTqPeESO7oDgeOQ==",
+      "version": "0.103.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.103.0.tgz",
+      "integrity": "sha512-4WKRHTMt96sp+lX+Hx/eHtN9CWFyejDqr1ikgxZUJIkKEHVglSE7FY8n81NC6yWXqVSjUIQQppaxsoUe26Zi9g==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.102.1"
+    "three": "^0.103.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -77,7 +77,7 @@
     "proj4": "^2.5.0",
     "puppeteer": "^1.14.0",
     "replace-in-file": "^3.4.4",
-    "three": "^0.102.1",
+    "three": "^0.103.0",
     "url-polyfill": "^1.1.5",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0",


### PR DESCRIPTION
## Description
update THREE to v103

- [x] The npm script npm run editor was removed. The editor is now a Progressive Web App (PWA).
- [x] The callback parameter of SVGLoader.onLoad() is now an object (data) containing the root node of the SVG document and an array of ShapePath objects. Also, all paths are returned now (not only the ones with fill color)
- [x] Removed .allocTextureUnit(), .setTexture2D(), .setTexture() and .setTextureCube() from WebGLRenderer. These methods were never intended to be part of WebGLRenderer's public API and are now private (as a part of WebGLTexture).
