### PR TITLE
chore(docs): remove console.log

### DIFF
--- a/docs/tmpl/method.tmpl
+++ b/docs/tmpl/method.tmpl
@@ -31,7 +31,6 @@
                 <h4>Returns</h4>
                 <?js method.returns.forEach(function(value) { ?>
                     <?js= value.description.replace(/^[-\s]*/, '') ?>
-                    <?js console.log(method.memberof, method.name, value); ?>
                 <?js });
             }
      } ?>


### PR DESCRIPTION
There was a `console.log` that remained from ancient times.