### PR TITLE
chore(build): swap functional and unit testing in npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\" \"docs/*.js\"",
     "doc": "jsdoc --readme docs/HOMEPAGE.md -c docs/config.json",
     "doclint": "npm run doc -- -t templates/silent",
-    "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-functional && npm run test-with-coverage",
+    "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-with-coverage && npm run test-functional",
     "test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --require @babel/register test/unit",
     "test-functional": "mocha -t 60000 --recursive test/functional",
     "test-with-coverage": "nyc -n src -r html cross-env npm run test-unit",


### PR DESCRIPTION
It will liberate quicker Travis as unit testing is quicker than functional testing (in case unit testing fails).