### PR TITLE
Use Feature class in vector tile parser.

### DIFF
--- a/examples/globe_vector_tiles.html
+++ b/examples/globe_vector_tiles.html
@@ -28,12 +28,13 @@
             var viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate iTowns GlobeView*
-            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe, { maxSubdivisionLevel: 13 });
+            var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
 
             // define pole texture
             view.tileLayer.noTextureColor = new itowns.THREE.Color(0x95c1e1);
 
             view.getLayerById('atmosphere').visible = false;
+            view.getLayerById('atmosphere').fog.enable = false;
 
             setupLoadingScreen(viewerDiv, view);
 
@@ -60,10 +61,13 @@
                     }
                 });
 
+                function inter(z) {
+                    return z - (z % 5);
+                }
+
                 function isValidData(data, extentDestination) {
-                    // re-use the same vector tiles by interval 4
-                    var z = extentDestination.zoom - 2;
-                    return extentDestination.zoom, z - z % 4 == data.extent.zoom - 2;
+                    const isValid = inter(extentDestination.zoom) == inter(data.extent.zoom);
+                    return isValid;
                 }
 
                 var mvtSource = new itowns.TMSSource({
@@ -75,8 +79,8 @@
                         url: 'http://www.openstreetmap.org/',
                     },
                     zoom: {
-                        min: 2,
-                        max: 14,
+                        min: 0,
+                        max: 13,
                     },
                     tileMatrixSet: 'PM',
                     projection: 'EPSG:3857',
@@ -86,10 +90,10 @@
                 var mvtLayer = new itowns.ColorLayer('MVT', {
                     isValidData: isValidData,
                     source: mvtSource,
-                    fx: 2.5,
                     style: mapboxStyle,
                     filter: mapboxFilter(supportedLayers),
                     backgroundLayer,
+                    fx: 2.5,
                 });
 
                 return view.addLayer(mvtLayer);
@@ -103,6 +107,11 @@
                     itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
                 }).catch(console.error);
             });
+
+            if (view.isDebugMode) {
+                const d = new debug.Debug(view, menuGlobe.gui);
+                debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
+            }
         </script>
     </body>
 </html>

--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -43,7 +43,7 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
 
                 for (p = 0; p < result.length; p++) {
                     visible = true;
-                    if (result[p].type === 'polygon') {
+                    if (result[p].type === itowns.FEATURE_TYPES.POLYGON) {
                         polygon = result[p].geometry;
                         color = polygon.properties.fill || layer.style.fill;
                         stroke = polygon.properties.stroke || layer.style.stroke;
@@ -53,12 +53,12 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                         document.getElementById(name).style['-webkit-text-stroke'] = '1.25px ' + stroke;
                         document.getElementById(name).style.color = color;
                         ++id;
-                    } else if (result[p].type === 'line') {
+                    } else if (result[p].type === itowns.FEATURE_TYPES.LINE) {
                         line = result[p].geometry;
                         color = line.properties.stroke || layer.style.stroke;
                         symb = '<span style=color:' + color + ';>&#9473</span>';
                         tooltip.innerHTML += symb + ' ' + (line.name || layer.name) + '<br />';
-                    } else if (result[p].type === 'point') {
+                    } else if (result[p].type === itowns.FEATURE_TYPES.POINT) {
                         point = result[p].geometry;
                         color = 'white';
                         name = 'point' + id;

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import Earcut from 'earcut';
 import Coordinates from 'Core/Geographic/Coordinates';
+import { FEATURE_TYPES } from 'Core/Feature';
 
 function getProperty(name, options, defaultValue, ...args) {
     const property = options[name];
@@ -389,26 +390,19 @@ function featureToMesh(feature, options) {
 
     var mesh;
     switch (feature.type) {
-        case 'point':
-        case 'multipoint': {
+        case FEATURE_TYPES.POINT:
             mesh = featureToPoint(feature, options);
             break;
-        }
-        case 'line':
-        case 'linestring':
-        case 'multilinestring': {
+        case FEATURE_TYPES.LINE:
             mesh = featureToLine(feature, options);
             break;
-        }
-        case 'polygon':
-        case 'multipolygon': {
+        case FEATURE_TYPES.POLYGON:
             if (options.extrude) {
                 mesh = featureToExtrudedPolygon(feature, options);
             } else {
                 mesh = featureToPolygon(feature, options);
             }
             break;
-        }
         default:
     }
 

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -1,90 +1,95 @@
 import * as THREE from 'three';
+import { FEATURE_TYPES } from 'Core/Feature';
 import Extent from 'Core/Geographic/Extent';
-import Coordinates from '../Core/Geographic/Coordinates';
+import Coordinates from 'Core/Geographic/Coordinates';
 
 const _extent = new Extent('EPSG:4326', [0, 0, 0, 0]);
 
-const pt = new THREE.Vector2();
-
-function _moveTo(ctx, x, y, scale, origin) {
-    pt.x = x - origin.x;
-    pt.y = y - origin.y;
-    pt.multiply(scale);
-    ctx.moveTo(Math.round(pt.x), Math.round(pt.y));
-}
-
-function _lineTo(ctx, x, y, scale, origin) {
-    pt.x = x - origin.x;
-
-    pt.y = y - origin.y;
-    pt.multiply(scale);
-    ctx.lineTo(Math.round(pt.x), Math.round(pt.y));
-}
-
-function drawPolygon(ctx, vertices, indices = [{ offset: 0, count: 1 }], origin, scale, properties, style = {}, size) {
+function drawPolygon(ctx, vertices, indices = [{ offset: 0, count: 1 }], properties, style = {}, size, extent, invCtxScale) {
     if (vertices.length === 0) {
         return;
     }
 
     if (style.length) {
         for (const s of style) {
-            _drawPolygon(ctx, vertices, indices, origin, scale, properties, s, size);
+            _drawPolygon(ctx, vertices, indices, properties, s, size, extent, invCtxScale);
         }
     } else {
-        _drawPolygon(ctx, vertices, indices, origin, scale, properties, style, size);
+        _drawPolygon(ctx, vertices, indices, properties, style, size, extent, invCtxScale);
     }
 }
 
-function _drawPolygon(ctx, vertices, indices, origin, scale, properties = {}, style, size) {
+function _drawPolygon(ctx, vertices, indices, properties = {}, style, size, extent, invCtxScale) {
     // build contour
     ctx.beginPath();
     for (const indice of indices) {
-        const offset = indice.offset * size;
-        const count = offset + indice.count * size;
-        _moveTo(ctx, vertices[offset], vertices[offset + 1], scale, origin);
-        for (let j = offset + size; j < count; j += size) {
-            _lineTo(ctx, vertices[j], vertices[j + 1], scale, origin);
+        if (indice.extent && indice.extent.intersectsExtent(extent)) {
+            const offset = indice.offset * size;
+            const count = offset + indice.count * size;
+            ctx.moveTo(vertices[offset], vertices[offset + 1]);
+            for (let j = offset + size; j < count; j += size) {
+                ctx.lineTo(vertices[j], vertices[j + 1]);
+            }
         }
     }
 
     // draw line polygon
     if (style.stroke || properties.stroke) {
-        ctx.strokeStyle = style.stroke || properties.stroke;
-        ctx.lineWidth = style.strokeWidth || properties['stroke-width'] || 2.0;
-        ctx.globalAlpha = style.strokeOpacity || properties['stroke-opacity'] || 1.0;
+        strokeStyle(style, properties, ctx, invCtxScale);
         ctx.stroke();
     }
 
     // fill polygon
     if (style.fill || properties.fill) {
-        ctx.fillStyle = style.fill || properties.fill;
-        ctx.globalAlpha = style.fillOpacity || properties['fill-opacity'] || 1.0;
+        fillStyle(style, properties, ctx);
         ctx.fill();
     }
 }
 
-function drawPoint(ctx, x, y, origin, scale, style = {}) {
-    pt.x = x - origin.x;
-    pt.y = y - origin.y;
-    pt.multiply(scale);
+function fillStyle(style, properties, ctx) {
+    const fill = style.fill || properties.fill;
+    if (ctx.fillStyle !== fill) {
+        ctx.fillStyle = fill;
+    }
+    const alpha = style.fillOpacity || properties['fill-opacity'] || 1.0;
+    if (alpha !== ctx.globalAlpha && typeof alpha == 'number') {
+        ctx.globalAlpha = alpha;
+    }
+}
 
+function strokeStyle(style, properties, ctx, invCtxScale) {
+    const stroke = style.stroke || properties.stroke;
+    if (ctx.strokeStyle !== stroke) {
+        ctx.strokeStyle = stroke;
+    }
+    const width = Math.round((style.strokeWidth || properties['stroke-width'] || 2.0)) * invCtxScale;
+    if (ctx.lineWidth !== width) {
+        ctx.lineWidth = width;
+    }
+    const alpha = style.strokeOpacity || properties['stroke-opacity'] || 1.0;
+    if (alpha !== ctx.globalAlpha && typeof alpha == 'number') {
+        ctx.globalAlpha = alpha;
+    }
+}
+
+function drawPoint(ctx, x, y, style = {}, invCtxScale) {
     ctx.beginPath();
     const opacity = style.pointOpacity || 1.0;
     if (opacity !== ctx.globalAlpha) {
         ctx.globalAlpha = opacity;
     }
 
-    ctx.arc(Math.round(pt.x), Math.round(pt.y), style.radius, 0, 2 * Math.PI, false);
+    ctx.arc(x, y, style.radius, 0, 2 * Math.PI, false);
     ctx.fillStyle = style.fill || 'white';
     ctx.fill();
-    ctx.lineWidth = style.lineWidth || 1.0;
+    ctx.lineWidth = (style.lineWidth || 1.0) * invCtxScale;
     ctx.strokeStyle = style.stroke || 'red';
     ctx.stroke();
 }
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
-function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
+function drawFeature(ctx, feature, extent, style = {}, invCtxScale) {
     const extentDim = extent.dimensions();
     const scaleRadius = extentDim.x / ctx.canvas.width;
     let gStyle = style;
@@ -98,29 +103,34 @@ function drawFeature(ctx, feature, origin, scale, extent, style = {}) {
                 gStyle = style(properties, feature);
             }
 
-            gStyle.radius = Math.round(gStyle.radius) || 3;
+            gStyle.radius = Math.round(gStyle.radius * invCtxScale) || 3 * invCtxScale;
 
             // cross multiplication to know in the extent system the real size of
             // the point
             px = gStyle.radius * scaleRadius;
 
-            if (feature.type === 'point') {
+            if (feature.type === FEATURE_TYPES.POINT) {
                 for (const indice of geometry.indices) {
                     const offset = indice.offset * feature.size;
                     const count = offset + indice.count * feature.size;
                     for (let j = offset; j < count; j += feature.size) {
                         coord.set(extent.crs, feature.vertices[j], feature.vertices[j + 1]);
                         if (extent.isPointInside(coord, px)) {
-                            drawPoint(ctx, feature.vertices[j], feature.vertices[j + 1], origin, scale, gStyle);
+                            drawPoint(ctx, feature.vertices[j], feature.vertices[j + 1], gStyle, invCtxScale);
                         }
                     }
                 }
             } else {
-                drawPolygon(ctx, feature.vertices, geometry.indices, origin, scale, properties, gStyle, feature.size);
+                drawPolygon(ctx, feature.vertices, geometry.indices, properties, gStyle, feature.size, extent, invCtxScale);
             }
         }
     }
 }
+
+const origin = new THREE.Vector2();
+const dimension = new THREE.Vector2();
+const scale = new THREE.Vector2();
+const extentTransformed = new Extent('EPSG:4326', 0, 0, 0, 0);
 
 export default {
     // backgroundColor is a THREE.Color to specify a color to fill the texture
@@ -131,8 +141,7 @@ export default {
         if (collection) {
             // A texture is instancied drawn canvas
             // origin and dimension are used to transform the feature's coordinates to canvas's space
-            const origin = new THREE.Vector2(extent.west, extent.south);
-            const dimension = extent.dimensions();
+            extent.dimensions(dimension);
             const c = document.createElement('canvas');
 
             c.width = sizeTexture;
@@ -143,12 +152,23 @@ export default {
                 ctx.fillRect(0, 0, sizeTexture, sizeTexture);
             }
             ctx.globalCompositeOperation = style.globalCompositeOperation || 'source-over';
+            ctx.imageSmoothingEnabled = false;
 
-            const scale = new THREE.Vector2(ctx.canvas.width / dimension.x, ctx.canvas.width / dimension.y);
             const ex = collection.crs == extent.crs ? extent : extent.as(collection.crs, _extent);
+            const t = collection.translation;
+            const s = collection.scale;
+            extentTransformed.transformedCopy(t, s, ex);
+
+            scale.set(ctx.canvas.width, ctx.canvas.width).divide(dimension);
+            origin.set(extent.west, extent.south).add(t).multiply(scale).negate();
+            ctx.setTransform(scale.x / s.x, 0, 0, scale.y / s.y, origin.x, origin.y);
+
+            // to scale line width and radius circle
+            const invCtxScale = s.x / scale.x;
+
             // Draw the canvas
             for (const feature of collection.features) {
-                drawFeature(ctx, feature, origin, scale, ex, style);
+                drawFeature(ctx, feature, extentTransformed, style, invCtxScale);
             }
 
             texture = new THREE.CanvasTexture(c);

--- a/src/Main.js
+++ b/src/Main.js
@@ -7,6 +7,7 @@ export { default as Fetcher } from 'Provider/Fetcher';
 export { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
 export { default as View } from 'Core/View';
 export { VIEW_EVENTS } from 'Core/View';
+export { FEATURE_TYPES } from 'Core/Feature';
 export { process3dTilesNode, init3dTilesLayer, $3dTilesCulling, $3dTilesSubdivisionControl, pre3dTilesUpdate } from 'Process/3dTilesProcessing';
 export { $3dTilesExtensions, $3dTilesAbstractExtension } from 'Provider/3dTilesProvider';
 export { default as FeatureProcessing } from 'Process/FeatureProcessing';

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -37,6 +37,7 @@ const toFeature = {
             coord.set(crsIn, pair[0], pair[1], useAlti ? pair[2] : 0);
             geometry.pushCoordinates(coord);
         }
+        geometry.updateExtent();
     },
     default(feature, crsIn, coordsIn, filteringExtent, setAltitude, properties) {
         if (filteringExtent && firstPtIsOut(filteringExtent, coordsIn, crsIn)) {
@@ -109,14 +110,14 @@ function toFeatureType(jsonType) {
 
 const keyProperties = ['type', 'geometry', 'properties'];
 
-function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, featureMerge = {}) {
+function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, featureCollection) {
     if (options.filter && !options.filter(json.properties, json.geometry)) {
         return;
     }
 
     const jsonType = json.geometry.type.toLowerCase();
     const featureType = toFeatureType(jsonType);
-    const feature = options.mergeFeatures ? featureMerge.getFeatureByType(featureType) : new Feature(featureType, crsOut, options);
+    const feature = options.mergeFeatures ? featureCollection.getFeatureByType(featureType) : new Feature(featureType, crsOut, options);
     const geometryCount = feature.geometryCount;
     const coordinates = jsonType != 'point' ? json.geometry.coordinates : [json.geometry.coordinates];
     const setAltitude = !options.overrideAltitudeInToZero && options.withAltitude;

--- a/src/Utils/FeaturesUtils.js
+++ b/src/Utils/FeaturesUtils.js
@@ -1,3 +1,5 @@
+import { FEATURE_TYPES } from 'Core/Feature';
+
 function pointIsOverLine(point, linePoints, epsilon, offset, count, size) {
     const x0 = point._values[0];
     const y0 = point._values[1];
@@ -94,11 +96,11 @@ function pointIsInsidePolygon(point, polygonPoints, offset, count, size) {
 }
 
 function isFeatureSingleGeometryUnderCoordinate(coordinate, type, coordinates, epsilon, offset, count, size) {
-    if ((type == 'line') && pointIsOverLine(coordinate, coordinates, epsilon, offset, count, size)) {
+    if ((type == FEATURE_TYPES.LINE) && pointIsOverLine(coordinate, coordinates, epsilon, offset, count, size)) {
         return true;
-    } else if ((type == 'polygon') && pointIsInsidePolygon(coordinate, coordinates, offset, count, size)) {
+    } else if ((type == FEATURE_TYPES.POLYGON) && pointIsInsidePolygon(coordinate, coordinates, offset, count, size)) {
         return true;
-    } else if (type == 'point') {
+    } else if (type == FEATURE_TYPES.POINT) {
         const closestPoint = getClosestPoint(coordinate, coordinates, epsilon, offset, count, size);
         if (closestPoint) {
             return { coordinates: closestPoint };

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -35,6 +35,7 @@ global.document = {
             stroke: () => { },
             fill: () => { },
             arc: () => { },
+            setTransform: () => { },
             canvas: { width: 256, height: 256 },
         }),
     }),

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -1,7 +1,6 @@
 import assert from 'assert';
-import Feature from 'Core/Feature';
+import Feature, { FEATURE_TYPES } from 'Core/Feature';
 import Coordinates from 'Core/Geographic/Coordinates';
-
 
 const options_A = {
     withNormal: true,
@@ -13,23 +12,23 @@ const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
 describe('Feature', function () {
     it('Should instance Features', function () {
-        const featurePoint = new Feature('point', 'EPSG:4326');
-        const featureLine = new Feature('line', 'EPSG:4326');
-        const featurePolygon = new Feature('polygon', 'EPSG:4326');
-        assert.equal(featurePoint.type, 'point');
-        assert.equal(featureLine.type, 'line');
-        assert.equal(featurePolygon.type, 'polygon');
+        const featurePoint = new Feature(FEATURE_TYPES.POINT, 'EPSG:4326');
+        const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');
+        const featurePolygon = new Feature(FEATURE_TYPES.POLYGON, 'EPSG:4326');
+        assert.equal(featurePoint.type, FEATURE_TYPES.POINT);
+        assert.equal(featureLine.type, FEATURE_TYPES.LINE);
+        assert.equal(featurePolygon.type, FEATURE_TYPES.POLYGON);
     });
 
     it('Should bind FeatureGeometry', function () {
-        const featureLine = new Feature('line', 'EPSG:4326');
+        const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');
         featureLine.bindNewGeometry();
         assert.equal(featureLine.geometryCount, 1);
     });
 
     it('Should instance Features with options', function () {
-        const featureLine_A = new Feature('line', 'EPSG:4326', options_A);
-        const featureLine_B = new Feature('line', 'EPSG:4326');
+        const featureLine_A = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326', options_A);
+        const featureLine_B = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');
 
         assert.equal(featureLine_A.size, 3);
         assert.ok(featureLine_A.normals);
@@ -41,7 +40,7 @@ describe('Feature', function () {
     });
 
     it('Should push Coordinates in Feature Geometry', function () {
-        const featureLine = new Feature('line', 'EPSG:3857', options_A);
+        const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:3857', options_A);
         const geometry = featureLine.bindNewGeometry();
 
         coord.set('EPSG:4326', -10, -10, 0);


### PR DESCRIPTION
feature(parser): parse vector tile in Feature without coordinates conversion.

* Use class Feature in `VectorTileParser` to get directly
  `CollectionFeature` and avoid `geojson` step.

* Add transformation in `CollectionFeature` to avoid coordinates conversion.