### PR TITLE
fix(provider): remove the caching exception causing jittering

### DIFF
--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -56,7 +56,7 @@ function parseSourceData(data, extSrc, extDest, layer) {
     return parser(data, options).then((parsedFile) => {
         if (source.isFileSource) {
             source.parsedData = parsedFile;
-            if (parsedFile.extent.crs != 'EPSG:4978') {
+            if (parsedFile.extent && parsedFile.extent.crs != 'EPSG:4978') {
                 source.extent = parsedFile.extent || source.extent;
             }
         }
@@ -102,10 +102,7 @@ export default {
             const validedParsedData = isValidData(parsedData[i], extDest, layer.isValidData) || source.parsedData;
 
             // Tag to Cache data
-            let tag = `${source.uid}-${extSource.toString('-')}`;
-            if (layer.isGeometryLayer && source.isFileSource) {
-                tag = `${source.uid}`;
-            }
+            const tag = `${source.uid}-${extSource.toString('-')}`;
 
             // Get converted source data, in cache
             let convertedSourceData = Cache.get(tag);


### PR DESCRIPTION
The fact, for a FileSource and a GeometryLayer at the same time, of
having a simpler Cache key (only the uid instead of uid + extent) was
making some cases jitter. The condition linked to this has been removed.
