### PR TITLE
refactor(core): use class Es6 for Builder tile and add factory of Tile.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
     'new-cap': 'off',
     'no-continue': 'off',
     'no-console': [ 'warn', { allow: ['warn', 'error'] } ],
+    'class-methods-use-this' : 'off',
   },
   "globals": {
     "__DEBUG__": false

--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -6,122 +6,118 @@ import Extent from 'Core/Geographic/Extent';
 
 const axisZ = new THREE.Vector3(0, 0, 1);
 const axisY = new THREE.Vector3(0, 1, 0);
+const quatToAlignLongitude = new THREE.Quaternion();
+const quatToAlignLatitude = new THREE.Quaternion();
 
 function WGS84ToOneSubY(latitude) {
     return 1.0 - Projection.WGS84ToY(latitude);
 }
 
-function BuilderEllipsoidTile() {
-    this.tmp = {
-        coords: [
-            new Coordinates('EPSG:4326', 0, 0),
-            new Coordinates('EPSG:4326', 0, 0)],
-        position: new THREE.Vector3(),
-    };
+class BuilderEllipsoidTile {
+    constructor() {
+        this.type = 'e';
+        this.tmp = {
+            coords: [
+                new Coordinates('EPSG:4326', 0, 0),
+                new Coordinates('EPSG:4326', 0, 0)],
+            position: new THREE.Vector3(),
+        };
+    }
+    // prepare params
+    // init projected object -> params.projected
+    prepare(params) {
+        params.nbRow = 2 ** (params.level + 1.0);
 
-    this.type = 'e';
+        var st1 = WGS84ToOneSubY(params.extent.south);
+
+        if (!isFinite(st1)) { st1 = 0; }
+
+        var sizeTexture = 1.0 / params.nbRow;
+
+        var start = (st1 % (sizeTexture));
+
+        params.deltaUV1 = (st1 - start) * params.nbRow;
+
+        // transformation to align tile's normal to z axis
+        params.quatNormalToZ = new THREE.Quaternion().setFromAxisAngle(
+            axisY,
+            -(Math.PI * 0.5 - THREE.Math.degToRad(params.extent.center().latitude())));
+
+        // let's avoid building too much temp objects
+        params.projected = { longitude: 0, latitude: 0 };
+    }
+
+    // get center tile in cartesian 3D
+    center(extent) {
+        return extent.center(this.tmp.coords[0])
+            .as('EPSG:4978', this.tmp.coords[1]).xyz();
+    }
+
+    // get position 3D cartesian
+    vertexPosition(params) {
+        this.tmp.coords[0].set(
+            'EPSG:4326',
+            params.projected.longitude,
+            params.projected.latitude);
+
+        this.tmp.coords[0].as('EPSG:4978', this.tmp.coords[1]).xyz(this.tmp.position);
+        return this.tmp.position;
+    }
+
+    // get normal for last vertex
+    vertexNormal() {
+        return this.tmp.coords[1].geodesicNormal;
+    }
+
+    // coord u tile to projected
+    uProjecte(u, params) {
+        params.projected.longitude = Projection.UnitaryToLongitudeWGS84(u, params.extent);
+    }
+
+    // coord v tile to projected
+    vProjecte(v, params) {
+        params.projected.latitude = Projection.UnitaryToLatitudeWGS84(v, params.extent);
+    }
+
+    // Compute uv 1, if isn't defined the uv1 isn't computed
+    getUV_PM(params) {
+        var t = WGS84ToOneSubY(params.projected.latitude) * params.nbRow;
+
+        if (!isFinite(t)) { t = 0; }
+
+        return t - params.deltaUV1;
+    }
+
+    computeSharableExtent(extent) {
+        // Compute sharable extent to pool the geometries
+        // the geometry in common extent is identical to the existing input
+        // with a transformation (translation, rotation)
+
+        // TODO: It should be possible to use equatorial plan symetrie,
+        // but we should be reverse UV on tile
+        // Common geometry is looking for only on longitude
+        const sizeLongitude = Math.abs(extent.west - extent.east) / 2;
+        const sharableExtent = new Extent(extent.crs, -sizeLongitude, sizeLongitude, extent.south, extent.north);
+
+        // compute rotation to transform tile to position it on ellipsoid
+        // this transformation take into account the transformation of the parents
+        const rotLon = THREE.Math.degToRad(extent.west - sharableExtent.west);
+        const rotLat = THREE.Math.degToRad(90 - extent.center(this.tmp.coords[0]).latitude());
+        quatToAlignLongitude.setFromAxisAngle(axisZ, rotLon);
+        quatToAlignLatitude.setFromAxisAngle(axisY, rotLat);
+        quatToAlignLongitude.multiply(quatToAlignLatitude);
+
+        return {
+            sharableExtent,
+            quaternion: quatToAlignLongitude.clone(),
+            position: this.center(extent),
+        };
+    }
+
+    // use for region for adaptation boundingVolume
+    OBB(boundingBox) {
+        return new OBB(boundingBox.min, boundingBox.max);
+    }
 }
-
-BuilderEllipsoidTile.prototype.constructor = BuilderEllipsoidTile;
-
-// prepare params
-// init projected object -> params.projected
-
-BuilderEllipsoidTile.prototype.Prepare = function Prepare(params) {
-    params.nbRow = 2 ** (params.level + 1.0);
-
-    var st1 = WGS84ToOneSubY(params.extent.south);
-
-    if (!isFinite(st1)) { st1 = 0; }
-
-    var sizeTexture = 1.0 / params.nbRow;
-
-    var start = (st1 % (sizeTexture));
-
-    params.deltaUV1 = (st1 - start) * params.nbRow;
-
-    // transformation to align tile's normal to z axis
-    params.quatNormalToZ = new THREE.Quaternion().setFromAxisAngle(
-        axisY,
-        -(Math.PI * 0.5 - THREE.Math.degToRad(params.extent.center().latitude())));
-
-    // let's avoid building too much temp objects
-    params.projected = { longitude: 0, latitude: 0 };
-};
-
-// get center tile in cartesian 3D
-BuilderEllipsoidTile.prototype.Center = function Center(extent) {
-    return extent.center(this.tmp.coords[0])
-        .as('EPSG:4978', this.tmp.coords[1]).xyz();
-};
-
-// get position 3D cartesian
-BuilderEllipsoidTile.prototype.VertexPosition = function VertexPosition(params) {
-    this.tmp.coords[0].set(
-        'EPSG:4326',
-        params.projected.longitude,
-        params.projected.latitude);
-
-    this.tmp.coords[0].as('EPSG:4978', this.tmp.coords[1]).xyz(this.tmp.position);
-    return this.tmp.position;
-};
-
-// get normal for last vertex
-BuilderEllipsoidTile.prototype.VertexNormal = function VertexNormal() {
-    return this.tmp.coords[1].geodesicNormal;
-};
-
-// coord u tile to projected
-BuilderEllipsoidTile.prototype.uProjecte = function uProjecte(u, params) {
-    params.projected.longitude = Projection.UnitaryToLongitudeWGS84(u, params.extent);
-};
-
-// coord v tile to projected
-BuilderEllipsoidTile.prototype.vProjecte = function vProjecte(v, params) {
-    params.projected.latitude = Projection.UnitaryToLatitudeWGS84(v, params.extent);
-};
-
-// Compute uv 1, if isn't defined the uv1 isn't computed
-BuilderEllipsoidTile.prototype.getUV_PM = function getUV_PM(params) {
-    var t = WGS84ToOneSubY(params.projected.latitude) * params.nbRow;
-
-    if (!isFinite(t)) { t = 0; }
-
-    return t - params.deltaUV1;
-};
-
-const quatToAlignLongitude = new THREE.Quaternion();
-const quatToAlignLatitude = new THREE.Quaternion();
-
-BuilderEllipsoidTile.prototype.computeSharableExtent = function fnComputeSharableExtent(extent) {
-    // Compute sharable extent to pool the geometries
-    // the geometry in common extent is identical to the existing input
-    // with a transformation (translation, rotation)
-
-    // TODO: It should be possible to use equatorial plan symetrie,
-    // but we should be reverse UV on tile
-    // Common geometry is looking for only on longitude
-    const sizeLongitude = Math.abs(extent.west - extent.east) / 2;
-    const sharableExtent = new Extent(extent.crs, -sizeLongitude, sizeLongitude, extent.south, extent.north);
-
-    // compute rotation to transform tile to position it on ellipsoid
-    // this transformation take into account the transformation of the parents
-    const rotLon = THREE.Math.degToRad(extent.west - sharableExtent.west);
-    const rotLat = THREE.Math.degToRad(90 - extent.center(this.tmp.coords[0]).latitude());
-    quatToAlignLongitude.setFromAxisAngle(axisZ, rotLon);
-    quatToAlignLatitude.setFromAxisAngle(axisY, rotLat);
-    quatToAlignLongitude.multiply(quatToAlignLatitude);
-
-    return {
-        sharableExtent,
-        quaternion: quatToAlignLongitude.clone(),
-        position: this.Center(extent),
-    };
-};
-
-// use for region for adaptation boundingVolume
-BuilderEllipsoidTile.prototype.OBB = function OBBFn(boundingBox) {
-    return new OBB(boundingBox.min, boundingBox.max);
-};
 
 export default BuilderEllipsoidTile;

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -92,7 +92,6 @@ class GlobeLayer extends TiledGeometryLayer {
         return super.preUpdate(context, changeSources);
     }
 
-    // eslint-disable-next-line class-methods-use-this
     countColorLayersTextures(...layers) {
         let occupancy = 0;
         for (const layer of layers) {
@@ -104,7 +103,6 @@ class GlobeLayer extends TiledGeometryLayer {
         return occupancy;
     }
 
-    // eslint-disable-next-line
     culling(node, camera) {
         if (super.culling(node, camera)) {
             return true;

--- a/src/Core/Prefab/Panorama/Constants.js
+++ b/src/Core/Prefab/Panorama/Constants.js
@@ -1,4 +1,0 @@
-export default {
-    CYLINDRICAL: 1,
-    SPHERICAL: 2,
-};

--- a/src/Core/Prefab/Planar/PlanarTileBuilder.js
+++ b/src/Core/Prefab/Planar/PlanarTileBuilder.js
@@ -3,71 +3,69 @@ import OBB from 'Renderer/OBB';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 
-function PlanarTileBuilder() {
-    this.tmp = {
-        coords: new Coordinates('EPSG:4326', 0, 0),
-        position: new THREE.Vector3(),
-        normal: new THREE.Vector3(0, 0, 1),
-    };
-
-    this.type = 'p';
-}
-
-PlanarTileBuilder.prototype.constructor = PlanarTileBuilder;
-
-// prepare params
-// init projected object -> params.projected
-PlanarTileBuilder.prototype.Prepare = function Prepare(params) {
-    params.nbRow = 2 ** (params.zoom + 1.0);
-    params.projected = new THREE.Vector3();
-};
-
-
-// get center tile in cartesian 3D
-const center = new THREE.Vector3();
-PlanarTileBuilder.prototype.Center = function Center(extent) {
-    extent.center(this.tmp.coords);
-    center.set(this.tmp.coords.x(), this.tmp.coords.y(), 0);
-    return center;
-};
-
-// get position 3D cartesian
-PlanarTileBuilder.prototype.VertexPosition = function VertexPosition(params) {
-    this.tmp.position.set(params.projected.x, params.projected.y, 0);
-    return this.tmp.position;
-};
-
-// get normal for last vertex
-PlanarTileBuilder.prototype.VertexNormal = function VertexNormal() {
-    return this.tmp.normal;
-};
-
-// coord u tile to projected
-PlanarTileBuilder.prototype.uProjecte = function uProjecte(u, params) {
-    params.projected.x = params.extent.west + u * (params.extent.east - params.extent.west);
-};
-
-// coord v tile to projected
-PlanarTileBuilder.prototype.vProjecte = function vProjecte(v, params) {
-    params.projected.y = params.extent.south + v * (params.extent.north - params.extent.south);
-};
-
-// get oriented bounding box of tile
-PlanarTileBuilder.prototype.OBB = function OBBFn(boundingBox) {
-    return new OBB(boundingBox.min, boundingBox.max);
-};
-
 const quaternion = new THREE.Quaternion();
-PlanarTileBuilder.prototype.computeSharableExtent = function fnComputeSharableExtent(extent) {
-    // compute sharable extent to pool the geometries
-    // the geometry in common extent is identical to the existing input
-    // with a translation
-    const sharableExtent = new Extent(extent.crs, 0, Math.abs(extent.west - extent.east), 0, Math.abs(extent.north - extent.south));
-    return {
-        sharableExtent,
-        quaternion,
-        position: this.Center(extent).clone(),
-    };
-};
+const center = new THREE.Vector3();
+
+class PlanarTileBuilder {
+    constructor() {
+        this.type = 'p';
+        this.tmp = {
+            coords: new Coordinates('EPSG:4326', 0, 0),
+            position: new THREE.Vector3(),
+            normal: new THREE.Vector3(0, 0, 1),
+        };
+    }
+    // prepare params
+    // init projected object -> params.projected
+    prepare(params) {
+        params.nbRow = 2 ** (params.zoom + 1.0);
+        params.projected = new THREE.Vector3();
+    }
+
+    // get center tile in cartesian 3D
+    center(extent) {
+        extent.center(this.tmp.coords);
+        center.set(this.tmp.coords.x(), this.tmp.coords.y(), 0);
+        return center;
+    }
+
+    // get position 3D cartesian
+    vertexPosition(params) {
+        this.tmp.position.set(params.projected.x, params.projected.y, 0);
+        return this.tmp.position;
+    }
+
+    // get normal for last vertex
+    vertexNormal() {
+        return this.tmp.normal;
+    }
+
+    // coord u tile to projected
+    uProjecte(u, params) {
+        params.projected.x = params.extent.west + u * (params.extent.east - params.extent.west);
+    }
+
+    // coord v tile to projected
+    vProjecte(v, params) {
+        params.projected.y = params.extent.south + v * (params.extent.north - params.extent.south);
+    }
+
+    // get oriented bounding box of tile
+    OBB(boundingBox) {
+        return new OBB(boundingBox.min, boundingBox.max);
+    }
+
+    computeSharableExtent(extent) {
+        // compute sharable extent to pool the geometries
+        // the geometry in common extent is identical to the existing input
+        // with a translation
+        const sharableExtent = new Extent(extent.crs, 0, Math.abs(extent.west - extent.east), 0, Math.abs(extent.north - extent.south));
+        return {
+            sharableExtent,
+            quaternion,
+            position: this.center(extent).clone(),
+        };
+    }
+}
 
 export default PlanarTileBuilder;

--- a/src/Core/Prefab/TileBuilder.js
+++ b/src/Core/Prefab/TileBuilder.js
@@ -1,0 +1,59 @@
+import * as THREE from 'three';
+import TileGeometry from 'Core/TileGeometry';
+import Cache from 'Core/Scheduler/Cache';
+import computeBuffers from 'Core/Prefab/computeBufferTileGeometry';
+
+const cacheBuffer = new Map();
+export default function newTileGeometry(builder, params) {
+    const { sharableExtent, quaternion, position } = builder.computeSharableExtent(params.extent);
+    const south = sharableExtent.south.toFixed(6);
+    const bufferKey = `${builder.type}_${params.disableSkirt ? 0 : 1}_${params.segment}`;
+    const geometryKey = `${bufferKey}_${params.level}_${south}`;
+    let promiseGeometry = Cache.get(geometryKey);
+
+    // build geometry if doesn't exist
+    if (!promiseGeometry) {
+        let resolve;
+        promiseGeometry = new Promise((r) => { resolve = r; });
+        Cache.set(geometryKey, promiseGeometry);
+
+        params.extent = sharableExtent;
+        params.center = builder.center(params.extent).clone();
+        // Read previously cached values (index and uv.wgs84 only depend on the # of triangles)
+        let cachedBuffers = cacheBuffer.get(bufferKey);
+        params.buildIndexAndWGS84 = !cachedBuffers;
+        params.builder = builder;
+        return Promise.resolve(computeBuffers(params)).then((buffers) => {
+            if (!cachedBuffers) {
+                cachedBuffers = {};
+                cachedBuffers.index = new THREE.BufferAttribute(buffers.index, 1);
+                cachedBuffers.uvwgs84 = new THREE.BufferAttribute(buffers.uv.wgs84, 2);
+
+                // Update cacheBuffer
+                cacheBuffer.set(bufferKey, cachedBuffers);
+            }
+
+            buffers.index = cachedBuffers.index;
+            buffers.uv.wgs84 = cachedBuffers.uvwgs84;
+            buffers.position = new THREE.BufferAttribute(buffers.position, 3);
+            buffers.normal = new THREE.BufferAttribute(buffers.normal, 3);
+            buffers.uv.pm = new THREE.BufferAttribute(buffers.uv.pm, 1);
+
+            const geometry = new TileGeometry(params, buffers);
+            geometry.OBB = builder.OBB(geometry.boundingBox);
+
+            geometry._count = 0;
+            geometry.dispose = () => {
+                geometry._count--;
+                if (geometry._count == 0) {
+                    THREE.BufferGeometry.prototype.dispose.call(geometry);
+                    Cache.delete(bufferKey);
+                }
+            };
+            resolve(geometry);
+            return { geometry, quaternion, position };
+        });
+    }
+
+    return promiseGeometry.then(geometry => ({ geometry, quaternion, position }));
+}

--- a/src/Core/Prefab/computeBufferTileGeometry.js
+++ b/src/Core/Prefab/computeBufferTileGeometry.js
@@ -1,0 +1,217 @@
+import * as THREE from 'three';
+
+export default function computeBuffers(params) {
+    // Create output buffers.
+    const outBuffers = {
+        index: null,
+        position: null,
+        normal: null,
+        // 2 UV set per tile: wgs84 and pm
+        //    - wgs84: 1 texture per tile because tiles are using wgs84 projection
+        //    - pm: use multiple textures per tile.
+        //      +-------------------------+
+        //      |                         |
+        //      |     Texture 0           |
+        //      +-------------------------+
+        //      |                         |
+        //      |     Texture 1           |
+        //      +-------------------------+
+        //      |                         |
+        //      |     Texture 2           |
+        //      +-------------------------+
+        //        * u = wgs84.u
+        //        * v = textureid + v in builder texture
+        uv: {
+            wgs84: null,
+            pm: null,
+        },
+    };
+
+    const builder = params.builder;
+
+    const nSeg = params.segment;
+    // segments count :
+    // Tile : (nSeg + 1) * (nSeg + 1)
+    // Skirt : 8 * (nSeg - 1)
+    const nVertex = (nSeg + 1) * (nSeg + 1) + (params.disableSkirt ? 0 : 4 * nSeg);
+    const triangles = (nSeg) * (nSeg) * 2 + (params.disableSkirt ? 0 : 4 * nSeg * 2);
+
+    outBuffers.position = new Float32Array(nVertex * 3);
+    outBuffers.normal = new Float32Array(nVertex * 3);
+    outBuffers.uv.pm = new Float32Array(nVertex);
+
+    if (params.buildIndexAndWGS84) {
+        outBuffers.index = new Uint32Array(triangles * 3);
+        outBuffers.uv.wgs84 = new Float32Array(nVertex * 2);
+    }
+
+    const widthSegments = Math.max(2, Math.floor(nSeg) || 2);
+    const heightSegments = Math.max(2, Math.floor(nSeg) || 2);
+
+    let idVertex = 0;
+    const vertices = [];
+    let skirt = [];
+    const skirtEnd = [];
+
+    builder.prepare(params);
+
+    let UV_WGS84 = function UV_WGS84() { };
+    let UV_PM = function UV_PM() { };
+
+    // Define UV computation functions if needed
+    if (params.buildIndexAndWGS84) {
+        UV_WGS84 = function UV_WGS84(out, id, u, v) {
+            out.uv.wgs84[id * 2 + 0] = u;
+            out.uv.wgs84[id * 2 + 1] = v;
+        };
+    }
+    if (builder.getUV_PM) {
+        UV_PM = function UV_PM(out, id, u) {
+            out.uv.pm[id] = u;
+        };
+    }
+
+    for (let y = 0; y <= heightSegments; y++) {
+        const verticesRow = [];
+        const v = y / heightSegments;
+
+        builder.vProjecte(v, params);
+
+        const uv_pm = builder.getUV_PM ? builder.getUV_PM(params) : undefined;
+
+        for (let x = 0; x <= widthSegments; x++) {
+            const u = x / widthSegments;
+            const id_m3 = idVertex * 3;
+
+            builder.uProjecte(u, params);
+
+            const vertex = builder.vertexPosition(params, params.projected);
+            const normal = builder.vertexNormal(params);
+
+            // move geometry to center world
+            vertex.sub(params.center);
+
+            // align normal to z axis
+            if (params.quatNormalToZ) {
+                vertex.applyQuaternion(params.quatNormalToZ);
+                normal.applyQuaternion(params.quatNormalToZ);
+            }
+
+            vertex.toArray(outBuffers.position, id_m3);
+            normal.toArray(outBuffers.normal, id_m3);
+
+            UV_WGS84(outBuffers, idVertex, u, v);
+            UV_PM(outBuffers, idVertex, uv_pm);
+
+            if (!params.disableSkirt) {
+                if (y !== 0 && y !== heightSegments) {
+                    if (x === widthSegments) {
+                        skirt.push(idVertex);
+                    } else if (x === 0) {
+                        skirtEnd.push(idVertex);
+                    }
+                }
+            }
+
+            verticesRow.push(idVertex);
+
+            idVertex++;
+        }
+
+        vertices.push(verticesRow);
+
+        if (y === 0) {
+            skirt = skirt.concat(verticesRow);
+        } else if (y === heightSegments) {
+            skirt = skirt.concat(verticesRow.slice().reverse());
+        }
+    }
+
+    if (!params.disableSkirt) {
+        skirt = skirt.concat(skirtEnd.reverse());
+    }
+
+    function bufferize(va, vb, vc, idVertex) {
+        outBuffers.index[idVertex + 0] = va;
+        outBuffers.index[idVertex + 1] = vb;
+        outBuffers.index[idVertex + 2] = vc;
+        return idVertex + 3;
+    }
+
+    let idVertex2 = 0;
+
+    if (params.buildIndexAndWGS84) {
+        for (let y = 0; y < heightSegments; y++) {
+            for (let x = 0; x < widthSegments; x++) {
+                const v1 = vertices[y][x + 1];
+                const v2 = vertices[y][x];
+                const v3 = vertices[y + 1][x];
+                const v4 = vertices[y + 1][x + 1];
+
+                idVertex2 = bufferize(v4, v2, v1, idVertex2);
+                idVertex2 = bufferize(v4, v3, v2, idVertex2);
+            }
+        }
+    }
+
+    const iStart = idVertex;
+
+    // TODO: WARNING beware skirt's size influences performance
+    // The size of the skirt is now a ratio of the size of the tile.
+    // To be perfect it should depend on the real elevation delta but too heavy to compute
+    if (!params.disableSkirt) {
+        // We compute the actual size of tile segment to use later for the skirt.
+        const segmentSize = new THREE.Vector3().fromArray(outBuffers.position).distanceTo(
+            new THREE.Vector3().fromArray(outBuffers.position, 3));
+
+        let buildIndexSkirt = function buildIndexSkirt() { };
+        let buildUVSkirt = function buildUVSkirt() { };
+
+        if (params.buildIndexAndWGS84) {
+            buildIndexSkirt = function buildIndexSkirt(id, v1, v2, v3, v4) {
+                id = bufferize(v1, v2, v3, id);
+                id = bufferize(v1, v3, v4, id);
+                return id;
+            };
+
+            buildUVSkirt = function buildUVSkirt(id) {
+                outBuffers.uv.wgs84[idVertex * 2 + 0] = outBuffers.uv.wgs84[id * 2 + 0];
+                outBuffers.uv.wgs84[idVertex * 2 + 1] = outBuffers.uv.wgs84[id * 2 + 1];
+            };
+        }
+
+        for (let i = 0; i < skirt.length; i++) {
+            const id = skirt[i];
+            const id_m3 = idVertex * 3;
+            const id2_m3 = id * 3;
+
+            outBuffers.position[id_m3 + 0] = outBuffers.position[id2_m3 + 0]
+                - outBuffers.normal[id2_m3 + 0] * segmentSize;
+            outBuffers.position[id_m3 + 1] = outBuffers.position[id2_m3 + 1]
+                - outBuffers.normal[id2_m3 + 1] * segmentSize;
+            outBuffers.position[id_m3 + 2] = outBuffers.position[id2_m3 + 2]
+                - outBuffers.normal[id2_m3 + 2] * segmentSize;
+
+            outBuffers.normal[id_m3 + 0] = outBuffers.normal[id2_m3 + 0];
+            outBuffers.normal[id_m3 + 1] = outBuffers.normal[id2_m3 + 1];
+            outBuffers.normal[id_m3 + 2] = outBuffers.normal[id2_m3 + 2];
+
+            buildUVSkirt(id);
+
+            outBuffers.uv.pm[idVertex] = outBuffers.uv.pm[id];
+
+            const idf = (i + 1) % skirt.length;
+
+            const v1 = id;
+            const v2 = idVertex;
+            const v3 = (idf === 0) ? iStart : idVertex + 1;
+            const v4 = skirt[idf];
+
+            idVertex2 = buildIndexSkirt(idVertex2, v1, v2, v3, v4);
+
+            idVertex++;
+        }
+    }
+
+    return outBuffers;
+}

--- a/src/Core/TileGeometry.js
+++ b/src/Core/TileGeometry.js
@@ -1,261 +1,33 @@
 import * as THREE from 'three';
+import computeBuffers from 'Core/Prefab/computeBufferTileGeometry';
 
-const cache = new Map();
-
-function Buffers() {
-    this.index = null;
-    this.position = null;
-    this.normal = null;
-    // 2 UV set per tile: wgs84 and pm
-    //    - wgs84: 1 texture per tile because tiles are using wgs84 projection
-    //    - pm: use multiple textures per tile.
-    //      +-------------------------+
-    //      |                         |
-    //      |     Texture 0           |
-    //      +-------------------------+
-    //      |                         |
-    //      |     Texture 1           |
-    //      +-------------------------+
-    //      |                         |
-    //      |     Texture 2           |
-    //      +-------------------------+
-    //        * u = wgs84.u
-    //        * v = textureid + v in this texture
-    this.uv = {
-        wgs84: null,
-        pm: null,
-    };
+function defaultBuffers(params) {
+    params.buildIndexAndWGS84 = true;
+    params.center = params.builder.center(params.extent).clone();
+    const buffers = computeBuffers(params);
+    buffers.index = new THREE.BufferAttribute(buffers.index, 1);
+    buffers.uv.wgs84 = new THREE.BufferAttribute(buffers.uv.wgs84, 2);
+    buffers.position = new THREE.BufferAttribute(buffers.position, 3);
+    buffers.normal = new THREE.BufferAttribute(buffers.normal, 3);
+    buffers.uv.pm = new THREE.BufferAttribute(buffers.uv.pm, 1);
+    return buffers;
 }
 
-function TileGeometry(params, builder) {
-    // Constructor
-    THREE.BufferGeometry.call(this);
+class TileGeometry extends THREE.BufferGeometry {
+    constructor(params, buffers = defaultBuffers(params)) {
+        super();
+        this.center = params.center;
+        this.extent = params.extent;
 
-    this.center = builder.Center(params.extent).clone();
-    this.extent = params.extent;
+        this.setIndex(buffers.index);
+        this.addAttribute('uv_wgs84', buffers.uv.wgs84);
+        this.addAttribute('position', buffers.position);
+        this.addAttribute('normal', buffers.normal);
+        this.addAttribute('uv_pm', buffers.uv.pm);
 
-    const bufferAttribs = this.computeBuffers(params, builder);
-
-    this.setIndex(bufferAttribs.index);
-    this.addAttribute('position', bufferAttribs.position);
-    this.addAttribute('normal', bufferAttribs.normal);
-    this.addAttribute('uv_wgs84', bufferAttribs.uv.wgs84);
-    this.addAttribute('uv_pm', bufferAttribs.uv.pm);
-
-    this.computeBoundingBox();
-    this.OBB = builder.OBB(this.boundingBox);
+        this.computeBoundingBox();
+        this.OBB = {};
+    }
 }
-
-
-TileGeometry.prototype = Object.create(THREE.BufferGeometry.prototype);
-
-TileGeometry.prototype.constructor = TileGeometry;
-
-TileGeometry.prototype.computeBuffers = function computeBuffers(params, builder) {
-    // Create output buffers.
-    const outBuffers = new Buffers();
-
-    const nSeg = params.segment;
-    // segments count :
-    // Tile : (nSeg + 1) * (nSeg + 1)
-    // Skirt : 8 * (nSeg - 1)
-    const nVertex = (nSeg + 1) * (nSeg + 1) + (params.disableSkirt ? 0 : 4 * nSeg);
-    const triangles = (nSeg) * (nSeg) * 2 + (params.disableSkirt ? 0 : 4 * nSeg * 2);
-
-    outBuffers.position = new THREE.BufferAttribute(new Float32Array(nVertex * 3), 3);
-    outBuffers.normal = new THREE.BufferAttribute(new Float32Array(nVertex * 3), 3);
-    outBuffers.uv.pm = new THREE.BufferAttribute(new Float32Array(nVertex), 1);
-
-    // Read previously cached values (index and uv.wgs84 only depend on the # of triangles)
-    const cacheKey = `${builder.type}_${params.disableSkirt ? 0 : 1}_${params.segment}`;
-    const cachedBuffers = cache.get(cacheKey);
-    const mustBuildIndexAndWGS84 = !cachedBuffers;
-    if (cachedBuffers) {
-        outBuffers.index = cachedBuffers.index;
-        outBuffers.uv.wgs84 = cachedBuffers.uvwgs84;
-    } else {
-        outBuffers.index = new THREE.BufferAttribute(
-            new Uint32Array(triangles * 3), 1);
-        outBuffers.uv.wgs84 = new THREE.BufferAttribute(
-            new Float32Array(nVertex * 2), 2);
-
-        // Update cache
-        cache.set(cacheKey, {
-            index: outBuffers.index,
-            uvwgs84: outBuffers.uv.wgs84,
-        });
-    }
-
-    var widthSegments = Math.max(2, Math.floor(nSeg) || 2);
-    var heightSegments = Math.max(2, Math.floor(nSeg) || 2);
-
-    var idVertex = 0;
-    const vertices = [];
-    let skirt = [];
-    const skirtEnd = [];
-
-    builder.Prepare(params);
-
-    var UV_WGS84 = function UV_WGS84() {};
-    var UV_PM = function UV_PM() {};
-
-    // Define UV computation functions if needed
-    if (mustBuildIndexAndWGS84) {
-        UV_WGS84 = function UV_WGS84(out, id, u, v) {
-            out.uv.wgs84.array[id * 2 + 0] = u;
-            out.uv.wgs84.array[id * 2 + 1] = v;
-        };
-    }
-    if (builder.getUV_PM) {
-        UV_PM = function UV_PM(out, id, u) {
-            out.uv.pm.array[id] = u;
-        };
-    }
-
-    for (let y = 0; y <= heightSegments; y++) {
-        var verticesRow = [];
-
-        const v = y / heightSegments;
-
-        builder.vProjecte(v, params);
-
-        var uv_pm = builder.getUV_PM ? builder.getUV_PM(params) : undefined;
-
-        for (let x = 0; x <= widthSegments; x++) {
-            const u = x / widthSegments;
-            const id_m3 = idVertex * 3;
-
-            builder.uProjecte(u, params);
-
-            const vertex = builder.VertexPosition(params, params.projected);
-            const normal = builder.VertexNormal(params);
-
-            // move geometry to center world
-            vertex.sub(this.center);
-
-            // align normal to z axis
-            if (params.quatNormalToZ) {
-                vertex.applyQuaternion(params.quatNormalToZ);
-                normal.applyQuaternion(params.quatNormalToZ);
-            }
-
-            vertex.toArray(outBuffers.position.array, id_m3);
-            normal.toArray(outBuffers.normal.array, id_m3);
-
-            UV_WGS84(outBuffers, idVertex, u, v);
-            UV_PM(outBuffers, idVertex, uv_pm);
-
-            if (!params.disableSkirt) {
-                if (y !== 0 && y !== heightSegments) {
-                    if (x === widthSegments) {
-                        skirt.push(idVertex);
-                    } else if (x === 0) {
-                        skirtEnd.push(idVertex);
-                    }
-                }
-            }
-
-            verticesRow.push(idVertex);
-
-            idVertex++;
-        }
-
-        vertices.push(verticesRow);
-
-        if (y === 0) {
-            skirt = skirt.concat(verticesRow);
-        } else if (y === heightSegments) {
-            skirt = skirt.concat(verticesRow.slice().reverse());
-        }
-    }
-
-    if (!params.disableSkirt) {
-        skirt = skirt.concat(skirtEnd.reverse());
-    }
-
-    function bufferize(va, vb, vc, idVertex) {
-        outBuffers.index.array[idVertex + 0] = va;
-        outBuffers.index.array[idVertex + 1] = vb;
-        outBuffers.index.array[idVertex + 2] = vc;
-        return idVertex + 3;
-    }
-
-    let idVertex2 = 0;
-
-    if (mustBuildIndexAndWGS84) {
-        for (let y = 0; y < heightSegments; y++) {
-            for (let x = 0; x < widthSegments; x++) {
-                const v1 = vertices[y][x + 1];
-                const v2 = vertices[y][x];
-                const v3 = vertices[y + 1][x];
-                const v4 = vertices[y + 1][x + 1];
-
-                idVertex2 = bufferize(v4, v2, v1, idVertex2);
-                idVertex2 = bufferize(v4, v3, v2, idVertex2);
-            }
-        }
-    }
-
-    const iStart = idVertex;
-
-    // TODO: WARNING beware skirt's size influences performance
-    // The size of the skirt is now a ratio of the size of the tile.
-    // To be perfect it should depend on the real elevation delta but too heavy to compute
-    if (!params.disableSkirt) {
-        // We compute the actual size of tile segment to use later for the skirt.
-        const segmentSize = new THREE.Vector3().fromArray(outBuffers.position.array).distanceTo(
-            new THREE.Vector3().fromArray(outBuffers.position.array, 3));
-
-        var buildIndexSkirt = function buildIndexSkirt() {};
-        var buildUVSkirt = function buildUVSkirt() {};
-
-        if (mustBuildIndexAndWGS84) {
-            buildIndexSkirt = function buildIndexSkirt(id, v1, v2, v3, v4) {
-                id = bufferize(v1, v2, v3, id);
-                id = bufferize(v1, v3, v4, id);
-                return id;
-            };
-
-            buildUVSkirt = function buildUVSkirt(id) {
-                outBuffers.uv.wgs84.array[idVertex * 2 + 0] = outBuffers.uv.wgs84.array[id * 2 + 0];
-                outBuffers.uv.wgs84.array[idVertex * 2 + 1] = outBuffers.uv.wgs84.array[id * 2 + 1];
-            };
-        }
-
-        for (let i = 0; i < skirt.length; i++) {
-            const id = skirt[i];
-            const id_m3 = idVertex * 3;
-            const id2_m3 = id * 3;
-
-            outBuffers.position.array[id_m3 + 0] = outBuffers.position.array[id2_m3 + 0]
-                - outBuffers.normal.array[id2_m3 + 0] * segmentSize;
-            outBuffers.position.array[id_m3 + 1] = outBuffers.position.array[id2_m3 + 1]
-                - outBuffers.normal.array[id2_m3 + 1] * segmentSize;
-            outBuffers.position.array[id_m3 + 2] = outBuffers.position.array[id2_m3 + 2]
-                - outBuffers.normal.array[id2_m3 + 2] * segmentSize;
-
-            outBuffers.normal.array[id_m3 + 0] = outBuffers.normal.array[id2_m3 + 0];
-            outBuffers.normal.array[id_m3 + 1] = outBuffers.normal.array[id2_m3 + 1];
-            outBuffers.normal.array[id_m3 + 2] = outBuffers.normal.array[id2_m3 + 2];
-
-            buildUVSkirt(id);
-
-            outBuffers.uv.pm.array[idVertex] = outBuffers.uv.pm.array[id];
-
-            const idf = (i + 1) % skirt.length;
-
-            const v1 = id;
-            const v2 = idVertex;
-            const v3 = (idf === 0) ? iStart : idVertex + 1;
-            const v4 = skirt[idf];
-
-            idVertex2 = buildIndexSkirt(idVertex2, v1, v2, v3, v4);
-
-            idVertex++;
-        }
-    }
-
-    return outBuffers;
-};
 
 export default TileGeometry;

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -248,7 +248,6 @@ class TiledGeometryLayer extends GeometryLayer {
         return convertToTile.convert(requester, extent, this);
     }
 
-    // eslint-disable-next-line class-methods-use-this
     countColorLayersTextures(...layers) {
         return layers.length;
     }

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -128,11 +128,11 @@ class OBB extends THREE.Object3D {
                 level: 0,
                 segment,
                 disableSkirt: true,
+                builder,
             };
 
-            // Calling geometry.dispose() is not needed since this geometry never gets rendered
-            const geometry = new TileGeometry(paramsGeometry, builder);
-            this.copy(geometry.OBB);
+            const geometry = new TileGeometry(paramsGeometry);
+            this.copy(builder.OBB(geometry.boundingBox));
 
             this.updateZ(minHeight, maxHeight);
             this.position.copy(position);

--- a/test/unit/obb.js
+++ b/test/unit/obb.js
@@ -2,9 +2,9 @@ import * as THREE from 'three';
 import proj4 from 'proj4';
 import assert from 'assert';
 import Extent from 'Core/Geographic/Extent';
-import BuilderEllipsoidTile from 'Core/Prefab/Globe/BuilderEllipsoidTile';
 import PlanarTileBuilder from 'Core/Prefab/Planar/PlanarTileBuilder';
-import TileGeometry from 'Core/TileGeometry';
+import BuilderEllipsoidTile from 'Core/Prefab/Globe/BuilderEllipsoidTile';
+import newTileGeometry from 'Core/Prefab/TileBuilder';
 import OBB from 'Renderer/OBB';
 
 const max = new THREE.Vector3(10, 10, 10);
@@ -38,22 +38,32 @@ function assertVerticesAreInOBB(builder, extent) {
         disableSkirt: true,
     };
 
-    const geom = new TileGeometry(params, builder);
-    const inverse = new THREE.Matrix4().getInverse(geom.OBB.matrix);
+    newTileGeometry(builder, params).then((result) => {
+        const geom = result.geometry;
+        const inverse = new THREE.Matrix4().getInverse(geom.OBB.matrix);
 
-    let failing = 0;
-    const vec = new THREE.Vector3();
-    for (let i = 0; i < geom.attributes.position.count; i++) {
-        vec.fromArray(geom.attributes.position.array, 3 * i);
+        let failing = 0;
+        const vec = new THREE.Vector3();
+        for (let i = 0; i < geom.attributes.position.count; i++) {
+            vec.fromArray(geom.attributes.position.array, 3 * i);
 
-        vec.applyMatrix4(inverse);
-        if (!geom.OBB.box3D.containsPoint(vec)) {
-            failing++;
+            vec.applyMatrix4(inverse);
+            if (!geom.OBB.box3D.containsPoint(vec)) {
+                failing++;
+            }
         }
-    }
-    assert.equal(geom.attributes.position.count - failing, geom.attributes.position.count, 'All points should be inside OBB');
+        assert.equal(geom.attributes.position.count - failing, geom.attributes.position.count, 'All points should be inside OBB');
+    });
 }
 
+describe('Planar tiles OBB computation', function () {
+    const builder = new PlanarTileBuilder();
+
+    it('should compute OBB correctly', function () {
+        const extent = new Extent('EPSG:3946', -100, 100, -50, 50);
+        assertVerticesAreInOBB(builder, extent);
+    });
+});
 describe('Ellipsoid tiles OBB computation', function () {
     const builder = new BuilderEllipsoidTile();
 
@@ -64,15 +74,6 @@ describe('Ellipsoid tiles OBB computation', function () {
 
     it('should compute globe-level 2 OBB correctly', function () {
         const extent = new Extent('EPSG:4326', 0, 45, -45, 0);
-        assertVerticesAreInOBB(builder, extent);
-    });
-});
-
-describe('Planar tiles OBB computation', function () {
-    const builder = new PlanarTileBuilder();
-
-    it('should compute OBB correctly', function () {
-        const extent = new Extent('EPSG:3946', -100, 100, -50, 50);
         assertVerticesAreInOBB(builder, extent);
     });
 });


### PR DESCRIPTION
## Description
* add a new class `TileBuilder`, it extends ellipsoid and planar tile builders.
* use Class es6 for geometry `TileBuilder`.
* move buffer and geometry tile cache in `TileBuilder`.
* Use `TileBuilder` like a factory of tile with `builder.newTileGeometry`.

## Motivation
Prepare to introduce **worker** in **iTowns**.
