### PR TITLE
refacto(crs): create a CRS module

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -21,6 +21,7 @@
 
             "Geographic": [
                 "Coordinates",
+                "CRS",
                 "Extent",
                 "OrientationUtils",
                 "OBB"

--- a/src/Core/Geographic/Crs.js
+++ b/src/Core/Geographic/Crs.js
@@ -1,0 +1,122 @@
+import proj4 from 'proj4';
+
+proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
+
+const UNIT = {
+    DEGREE: 1,
+    METER: 2,
+};
+
+function is4326(crs) {
+    return crs.indexOf('EPSG:4326') == 0;
+}
+
+function _unitFromProj4Unit(projunit) {
+    if (projunit === 'degrees') {
+        return UNIT.DEGREE;
+    } else if (projunit === 'm') {
+        return UNIT.METER;
+    } else {
+        return undefined;
+    }
+}
+
+function toUnit(crs) {
+    switch (crs) {
+        case 'EPSG:4326' : return UNIT.DEGREE;
+        case 'EPSG:4978' : return UNIT.METER;
+        default: {
+            const p = proj4.defs(crs);
+            if (!p) {
+                return undefined;
+            }
+            return _unitFromProj4Unit(p.units);
+        }
+    }
+}
+
+function toUnitWithError(crs) {
+    const u = toUnit(crs);
+    if (crs === undefined || u === undefined) {
+        throw new Error(`Invalid crs parameter value '${crs}'`);
+    }
+    return u;
+}
+
+/**
+ * This module provides basic methods to manipulate a CRS (as a string).
+ *
+ * @module CRS
+ */
+export default {
+    /**
+     * Units that can be used for a CRS.
+     *
+     * @enum {number}
+     */
+    UNIT,
+
+    /**
+     * Assert that the CRS is valid one.
+     *
+     * @param {string} crs - The CRS to validate.
+     *
+     * @throws {Error} if the CRS is not valid.
+     */
+    isValid(crs) {
+        toUnitWithError(crs);
+    },
+
+    /**
+     * Assert that the CRS is geographic.
+     *
+     * @param {string} crs - The CRS to validate.
+     * @return {boolean}
+     * @throws {Error} if the CRS is not valid.
+     */
+    isGeographic(crs) {
+        return (toUnitWithError(crs) == UNIT.DEGREE);
+    },
+
+    /**
+     * Assert that the CRS is using metric units.
+     *
+     * @param {string} crs - The CRS to validate.
+     * @return {boolean}
+     * @throws {Error} if the CRS is not valid.
+     */
+    isMetricUnit(crs) {
+        return (toUnit(crs) == UNIT.METER);
+    },
+
+    /**
+     * Get the unit to use with the CRS.
+     *
+     * @param {string} crs - The CRS to get the unit from.
+     * @return {number} Either <code>UNIT.METER</code>, <code>UNIT.DEGREE</code>
+     * or <code>undefined</code>.
+     */
+    toUnit,
+
+    /**
+     * Is the CRS EPSG:4326 ?
+     *
+     * @param {string} crs - The CRS to test.
+     * @return {boolean}
+     */
+    is4326,
+
+    /**
+     * Give a reasonnable epsilon to use with this CRS.
+     *
+     * @param {string} crs - The CRS to use.
+     * @return {number} 0.01 if the CRS is EPSG:4326, 0.001 otherwise.
+     */
+    reasonnableEpsilon(crs) {
+        if (is4326(crs)) {
+            return 0.01;
+        } else {
+            return 0.001;
+        }
+    },
+};

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
-import Coordinates, { crsIsGeographic, assertCrsIsValid, reasonnableEpsilonForCRS, is4326 } from 'Core/Geographic/Coordinates';
+import Coordinates from 'Core/Geographic/Coordinates';
+import CRS from 'Core/Geographic/Crs';
 import Projection from 'Core/Geographic/Projection';
 
 /**
@@ -115,7 +116,7 @@ class Extent {
      * @return {Extent}
      */
     as(crs, target) {
-        assertCrsIsValid(crs);
+        CRS.isValid(crs);
         if (this.isTiledCrs()) {
             if (this.crs == 'WMTS:PM' || this.crs == 'TMS') {
                 if (!target) {
@@ -178,7 +179,7 @@ class Extent {
         if (!target) {
             target = new Extent('EPSG:4326', [0, 0, 0, 0]);
         }
-        if (this.crs != crs && !(is4326(this.crs) && is4326(crs))) {
+        if (this.crs != crs && !(CRS.is4326(this.crs) && CRS.is4326(crs))) {
             // Compute min/max in x/y by projecting 8 cardinal points,
             // and then taking the min/max of each coordinates.
             const center = this.center(_c);
@@ -291,7 +292,7 @@ class Extent {
     isPointInside(coord, epsilon = 0) {
         const c = (this.crs == coord.crs) ? coord : coord.as(this.crs, _c);
         // TODO this ignores altitude
-        if (crsIsGeographic(this.crs)) {
+        if (CRS.isGeographic(this.crs)) {
             return c.longitude() <= this.east + epsilon &&
                    c.longitude() >= this.west - epsilon &&
                    c.latitude() <= this.north + epsilon &&
@@ -326,7 +327,7 @@ class Extent {
             }
         } else {
             extent.as(this.crs, _extent);
-            epsilon = epsilon == undefined ? reasonnableEpsilonForCRS(this.crs) : epsilon;
+            epsilon = epsilon == undefined ? CRS.reasonnableEpsilon(this.crs) : epsilon;
             return this.east - _extent.east <= epsilon &&
                    _extent.west - this.west <= epsilon &&
                    this.north - _extent.north <= epsilon &&

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import OGCWebServiceHelper from 'Provider/OGCWebServiceHelper';
-import { is4326 } from 'Core/Geographic/Coordinates';
+import CRS from 'Core/Geographic/Crs';
 
 /**
  * A TileMesh is a THREE.Mesh with a geometricError and an OBB
@@ -77,8 +77,8 @@ class TileMesh extends THREE.Mesh {
             }
         } else if (source.isTMSSource) {
             // Special globe case: use the P(seudo)M(ercator) coordinates
-            if (is4326(this.extent.crs) &&
-                    (source.extent.crs == 'EPSG:3857' || is4326(source.extent.crs))) {
+            if (CRS.is4326(this.extent.crs) &&
+                    (source.extent.crs == 'EPSG:3857' || CRS.is4326(source.extent.crs))) {
                 OGCWebServiceHelper.computeTileMatrixSetCoordinates(this, 'PM');
                 return this.wmtsCoords.PM;
             } else {

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,5 +1,8 @@
-export { default as Coordinates, UNIT, ellipsoidSizes } from 'Core/Geographic/Coordinates';
+// Geographic tools
 export { default as Extent } from 'Core/Geographic/Extent';
+export { default as Coordinates, ellipsoidSizes } from 'Core/Geographic/Coordinates';
+export { default as CRS } from 'Core/Geographic/Crs';
+
 export { default as Ellipsoid } from 'Core/Math/Ellipsoid';
 export { default as GlobeView, GLOBE_VIEW_EVENTS, createGlobeLayer } from 'Core/Prefab/GlobeView';
 export { default as PlanarView, createPlanarLayer } from 'Core/Prefab/PlanarView';

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
 import TileGeometry from 'Core/TileGeometry';
 import BuilderEllipsoidTile from 'Core/Prefab/Globe/BuilderEllipsoidTile';
-import Coordinates, { crsIsGeocentric } from 'Core/Geographic/Coordinates';
+import Coordinates from 'Core/Geographic/Coordinates';
+import CRS from 'Core/Geographic/Crs';
 
 // get oriented bounding box of tile
 const builder = new BuilderEllipsoidTile();
@@ -138,7 +139,7 @@ class OBB extends THREE.Object3D {
             this.position.copy(position);
             this.quaternion.copy(quaternion);
             this.updateMatrixWorld(true);
-        } else if (!extent.isTiledCrs() && crsIsGeocentric(extent.crs)) {
+        } else if (!extent.isTiledCrs() && CRS.isMetricUnit(extent.crs)) {
             extent.center(coord).xyz(this.position);
             extent.dimensions(dimension);
             size.set(dimension.x, dimension.y, Math.abs(maxHeight - minHeight));

--- a/test/unit/crs.js
+++ b/test/unit/crs.js
@@ -1,0 +1,48 @@
+import assert from 'assert';
+import proj4 from 'proj4';
+import CRS from 'Core/Geographic/Crs';
+
+proj4.defs('EPSG:7133', '+proj=longlat +ellps=GRS80 +no_defs +units=degrees');
+proj4.defs('EPSG:INVALID', '+no_defs');
+
+describe('CRS assertions', function () {
+    it('should assert that the CRS is valid', function () {
+        assert.doesNotThrow(() => CRS.isValid('EPSG:4326'));
+        assert.doesNotThrow(() => CRS.isValid('EPSG:7133'));
+        assert.doesNotThrow(() => CRS.isValid('EPSG:4978'));
+        assert.doesNotThrow(() => CRS.isValid('EPSG:3857'));
+        assert.throws(() => CRS.isValid('EPSG:INVALID'));
+        assert.throws(() => CRS.isValid('INVALID'));
+    });
+
+    it('should assert that the CRS is geographic', function () {
+        assert.ok(CRS.isGeographic('EPSG:4326'));
+        assert.ok(CRS.isGeographic('EPSG:7133'));
+        assert.ok(!CRS.isGeographic('EPSG:4978'));
+        assert.ok(!CRS.isGeographic('EPSG:3857'));
+    });
+
+    it('should assert that the CRS is using meter unit', function () {
+        assert.ok(!CRS.isMetricUnit('EPSG:4326'));
+        assert.ok(!CRS.isMetricUnit('EPSG:7133'));
+        assert.ok(CRS.isMetricUnit('EPSG:4978'));
+        assert.ok(CRS.isMetricUnit('EPSG:3857'));
+    });
+
+    it('should get the correct unit for this CRS', function () {
+        assert.strictEqual(CRS.toUnit('EPSG:4326'), CRS.UNIT.DEGREE);
+        assert.strictEqual(CRS.toUnit('EPSG:7133'), CRS.UNIT.DEGREE);
+        assert.strictEqual(CRS.toUnit('EPSG:4978'), CRS.UNIT.METER);
+        assert.strictEqual(CRS.toUnit('EPSG:3857'), CRS.UNIT.METER);
+    });
+
+    it('should check if the CRS is EPSG:4326', function () {
+        assert.ok(CRS.is4326('EPSG:4326'));
+        assert.ok(!CRS.is4326('EPSG:3857'));
+    });
+
+    it('should return a reasonnable epsilon', function () {
+        assert.strictEqual(CRS.reasonnableEpsilon('EPSG:4326'), 0.01);
+        assert.strictEqual(CRS.reasonnableEpsilon('EPSG:3857'), 0.001);
+    });
+});


### PR DESCRIPTION
All methods exported from Coordinates have been moved to a single CRS
module, to simplify readability of Coordinates file.