### PR TITLE
doc: add the support of quotes to write code strings in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,10 @@ tutorials.
 ### API reference
 
 The API reference is written in the source of itowns, using
-[JSDoc](http://usejsdoc.org/). This is a classic documentation, explaining all
-exposed methods and classes in itowns, and some internal others.
+[JSDoc](http://usejsdoc.org/), along with support for the
+[Markdown](https://commonmark.org/help/) syntax. This is a
+classic documentation, explaining all exposed methods and classes in itowns, and
+some internal others.
 
 When documenting something, don't forget to check the presence of your file
 inside `docs/config.json`.

--- a/docs/config.json
+++ b/docs/config.json
@@ -103,5 +103,6 @@
     "source": {
         "include": [ "src" ],
         "exclude": [ "src/ThreeExtended" ]
-    }
+    },
+    "plugins": ["plugins/markdown"]
 }

--- a/docs/static/styles/itowns.css
+++ b/docs/static/styles/itowns.css
@@ -163,3 +163,7 @@ p, ul, ol {
     max-width: 780px;
     text-align: justify;
 }
+
+.params p {
+    display: inline;
+}

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -31,8 +31,8 @@ const vectorZero = new THREE.Vector3();
  *
  * @typedef {Object} PlanarControls~PlanarControlsOptions
  *
- * @property {boolean} [enableRotation=true] Enable the rotation with the
- * <code>CTRL + Left mouse button</code> and in animations, like the smart zoom.
+ * @property {boolean} [enableRotation=true] Enable the rotation with the `CTRL
+ * + Left mouse button` and in animations, like the smart zoom.
  * @property {number} [rotateSpeed=2.0] Rotate speed.
  * @property {number} [maxPanSpeed=15] Pan speed when close to maxAltitude.
  * @property {number} [minPanSpeed=0.05] Pan speed when close to the ground.
@@ -44,11 +44,11 @@ const vectorZero = new THREE.Vector3();
  * @property {number} [maxAltitude=12000] Maximum altitude reachable when panning.
  * @property {number} [groundLevel=200] Minimum altitude reachable when panning.
  * @property {number} [autoTravelTimeMin=1.5] Minimum duration for animated
- * travels with the <code>auto</code> parameter.
+ * travels with the `auto` parameter.
  * @property {number} [autoTravelTimeMax=4]  Maximum duration for animated
- * travels with the <code>auto</code> parameter.
+ * travels with the `auto` parameter.
  * @property {number} [autoTravelTimeDist=20000] Maximum travel distance for
- * animated travel with the <code>auto</code> parameter.
+ * animated travel with the `auto` parameter.
  * @property {number} [smartZoomHeightMin=75] Minimum height above ground
  * reachable after a smart zoom.
  * @property {number} [smartZoomHeightMax=500] Maximum height above ground
@@ -470,11 +470,10 @@ function PlanarControls(view, options = {}) {
      *
      * @param {THREE.Vector3} targetPos - The target position of the camera
      * (reached at the end).
-     * @param {number} travelTime - Set to <code>auto</code>, or set to a
-     * duration in seconds. If set to <code>auto</code> : travel time will be
-     * set to a duration between <code>autoTravelTimeMin</code> and
-     * <code>autoTravelTimeMax</code> according to the distance and the angular
-     * difference between start and finish.
+     * @param {number} travelTime - Set to `auto`, or set to a duration in
+     * seconds. If set to `auto` : travel time will be set to a duration between
+     * `autoTravelTimeMin` and `autoTravelTimeMax` according to the distance and
+     * the angular difference between start and finish.
      * @param {(string|THREE.Vector3|THREE.Quaternion)} targetOrientation -
      * Define the target rotation of the camera:
      * <ul>

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -17,14 +17,12 @@ const defaultNormal = new THREE.Vector3(0, 0, 1);
 /**
  * @property {Extent} extent - The 2D extent containing all the points
  * composing the geometry.
- * @property {Object[]} indices - Contains the indices
- * that define the geometry. Objects stored in this array have two
- * properties, an <code>offset</code> and a <code>count</code>. The offset
- * is related to the overall number of vertices in the Feature.
+ * @property {Object[]} indices - Contains the indices that define the geometry.
+ * Objects stored in this array have two properties, an `offset` and a `count`.
+ * The offset is related to the overall number of vertices in the Feature.
  *
  * @property {Object} properties - Properties of the geometry. It can be
- * anything specified in the GeoJSON under the <code>properties</code>
- * property.
+ * anything specified in the GeoJSON under the `properties` property.
  */
 class FeatureGeometry {
     /**
@@ -55,9 +53,9 @@ class FeatureGeometry {
     }
 
     /**
-     * After you have pushed new the coordinates of sub geometry without <code>startSubGeometry</code>,
-     * this function close sub geometry. The sub geometry stored in indices,
-     * see constructor for more information.
+     * After you have pushed new the coordinates of sub geometry without
+     * `startSubGeometry`, this function close sub geometry. The sub geometry
+     * stored in indices, see constructor for more information.
      * @param {number} count count of vertices
      */
     closeSubGeometry(count) {
@@ -158,8 +156,8 @@ export const FEATURE_TYPES = {
  * This class improves and simplifies the construction and conversion of geographic data structures.
  * It's an intermediary structure between geomatic formats and THREE objects.
  *
- * @property {string} type - Geometry type, can be <code>point</code>, <code>line</code>,
- * or <code>polygon</code> or
+ * @property {string} type - Geometry type, can be `point`, `line`, or
+ * `polygon`.
  * @property {number[]} vertices - All the vertices of the Feature.
  * @property {number[]} normals - All the normals of the Feature.
  * @property {number} size - the number of values of the array that should be associated with a coordinates.
@@ -250,8 +248,8 @@ export class FeatureCollection {
     }
 
     /**
-     * Update FeatureCollection extent with <code>extent</code> or
-     * all features extent if <code>extent</code> is <code>undefined</code>.
+     * Update FeatureCollection extent with `extent` or all features extent if
+     * `extent` is `undefined`.
      * @param {Extent} extent
      */
     updateExtent(extent) {
@@ -271,7 +269,7 @@ export class FeatureCollection {
     }
 
     /**
-     * Push the <code>feature</code> in FeatureCollection.
+     * Push the `feature` in FeatureCollection.
      * @param {Feature} feature
      */
     pushFeature(feature) {
@@ -280,8 +278,8 @@ export class FeatureCollection {
     }
 
     /**
-     * Returns the Feature by type if <code>mergeFeatures</code> is <code>true</code>
-     * or returns the new instance of typed Feature.
+     * Returns the Feature by type if `mergeFeatures` is `true` or returns the
+     * new instance of typed Feature.
      *
      * @param {string} type the type requested
      * @returns {Feature}

--- a/src/Core/Geographic/Crs.js
+++ b/src/Core/Geographic/Crs.js
@@ -93,8 +93,7 @@ export default {
      * Get the unit to use with the CRS.
      *
      * @param {string} crs - The CRS to get the unit from.
-     * @return {number} Either <code>UNIT.METER</code>, <code>UNIT.DEGREE</code>
-     * or <code>undefined</code>.
+     * @return {number} Either `UNIT.METER`, `UNIT.DEGREE` or `undefined`.
      */
     toUnit,
 

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -219,7 +219,7 @@ class Extent {
     }
 
     /**
-    * Returns the dimension of the extent, in a <code>THREE.Vector2</code>.
+    * Returns the dimension of the extent, in a `THREE.Vector2`.
     *
     * @param {THREE.Vector2} [target] - The target to assign the result in.
     *
@@ -232,7 +232,7 @@ class Extent {
     }
 
     /**
-     * Return true if <code>coord</code> is inside the bounding box.
+     * Return true if `coord` is inside the bounding box.
      *
      * @param {Coordinates} coord
      * @param {number} [epsilon=0] - to take into account when comparing to the
@@ -257,7 +257,7 @@ class Extent {
     }
 
     /**
-     * Return true if <code>extent</code> is inside this extent.
+     * Return true if `extent` is inside this extent.
      *
      * @param {Extent} extent the extent to check
      * @param {number} epsilon to take into account when comparing to the
@@ -549,9 +549,8 @@ class Extent {
     }
 
     /**
-     * Apply transform and copy this extent to input.
-     * The <code>transformedCopy</code> doesn't handle
-     * the issue of overflow of geographic limits.
+     * Apply transform and copy this extent to input.  The `transformedCopy`
+     * doesn't handle the issue of overflow of geographic limits.
      * @param {THREE.Vector2} t translation transform
      * @param {THREE.Vector2} s scale transform
      * @param {Extent} extent Extent to copy after transformation.

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -32,13 +32,12 @@ class GlobeLayer extends TiledGeometryLayer {
      * {@link View} that already has a layer going by that id.
      * @param {THREE.Object3d} [object3d=THREE.Group] - The object3d used to
      * contain the geometry of the TiledGeometryLayer. It is usually a
-     * <code>THREE.Group</code>, but it can be anything inheriting from a
-     * <code>THREE.Object3d</code>.
+     * `THREE.Group`, but it can be anything inheriting from a `THREE.Object3d`.
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      * @param {number} [config.minSubdivisionLevel=2] - Minimum subdivision
      * level for this tiled layer.
      * @param {number} [config.maxSubdivisionLevel=18] - Maximum subdivision
@@ -48,8 +47,7 @@ class GlobeLayer extends TiledGeometryLayer {
      * @param {number} [config.maxDeltaElevationLevel=4] - Maximum delta between
      * two elevations tile.
      *
-     * @throws {Error} <code>object3d</code> must be a valid
-     * <code>THREE.Object3d</code>.
+     * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
     constructor(id, object3d, config = {}) {
         // Configure tiles

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -22,20 +22,18 @@ class PlanarLayer extends TiledGeometryLayer {
      * @param {Extent} extent - The extent to define the layer within.
      * @param {THREE.Object3d} [object3d=THREE.Group] - The object3d used to
      * contain the geometry of the TiledGeometryLayer. It is usually a
-     * <code>THREE.Group</code>, but it can be anything inheriting from a
-     * <code>THREE.Object3d</code>.
+     * `THREE.Group`, but it can be anything inheriting from a `THREE.Object3d`.
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      * @param {number} [config.maxSubdivisionLevel=5] - Maximum subdivision
      * level for this tiled layer.
      * @param {number} [config.maxDeltaElevationLevel=4] - Maximum delta between
      * two elevations tile.
      *
-     * @throws {Error} <code>object3d</code> must be a valid
-     * <code>THREE.Object3d</code>.
+     * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
     constructor(id, extent, object3d, config = {}) {
         super(id, object3d || new THREE.Group(), [extent], new PlanarTileBuilder(), config);

--- a/src/Core/Scheduler/Cache.js
+++ b/src/Core/Scheduler/Cache.js
@@ -30,8 +30,7 @@ const Cache = {
      * @typedef {Object} POLICIES
      *
      * @property {number} INFINITE - The entry is never flushed, except when the
-     * <code>all</code> flag is set to <code>true</code> when calling {@link
-     * Cache.flush}.
+     * `all` flag is set to `true` when calling {@link Cache.flush}.
      * @property {number} TEXTURE - Shortcut for texture resources. Time is 15 minutes.
      * @property {number} ELEVATION - Shortcut for elevation resources. Time is 15
      * minutes.
@@ -116,20 +115,19 @@ const Cache = {
      * Flush the cache: entries that have been present for too long since the
      * last time they were used, are removed from the cache. By default, the
      * time is the current time, but the interval can be reduced by doing
-     * something like <code>Cache.flush(Date.now() - reductionTime)</code>. If
-     * you want to clear the whole cache, use {@link Cache.clear} instead.
+     * something like `Cache.flush(Date.now() - reductionTime)`. If you want to
+     * clear the whole cache, use {@link Cache.clear} instead.
      *
      * @name module:Cache.flush
      * @function
      *
      * @param {number} [time]
      *
-     * @return {Object} Statistics about the flush: <code>before</code>
-     * gives the number of entries before flushing, <code>after</code> the
-     * number after flushing, <code>hit</code> the number of total successful
-     * hit on resources in the cache, and </code>miss</code> the number of
-     * failed hit. The hit and miss are based since the last flush, and are
-     * reset on every flush.
+     * @return {Object} Statistics about the flush: `before` gives the number of
+     * entries before flushing, `after` the number after flushing, `hit` the
+     * number of total successful hit on resources in the cache, and `miss` the
+     * number of failed hit. The hit and miss are based since the last flush,
+     * and are reset on every flush.
      */
     flush: (time = Date.now()) => {
         const before = data.size;

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -219,9 +219,8 @@ Scheduler.prototype.execute = function execute(command) {
  * tiles, given the current position of the camera on the map. For simple layers
  * like a GPX trace, it gets the data once.
  * <br><br>
- * It passes a <code>command</code> object as a parameter, with the
- * <code>view</code> and the <code>layer</code> always present. The other
- * parameters are optional.
+ * It passes a `command` object as a parameter, with the `view` and the `layer`
+ * always present. The other parameters are optional.
  *
  * @function
  * @name Provider#executeCommand
@@ -252,8 +251,8 @@ Scheduler.prototype.execute = function execute(command) {
  * current provider will be overwritten by the given provider.
  *
  * @param {string} protocol - The name of the protocol to add. This is the
- * <code>protocol</code> parameter put inside the configuration when adding a
- * layer. The capitalization of the name is not taken into account here.
+ * `protocol` parameter put inside the configuration when adding a layer. The
+ * capitalization of the name is not taken into account here.
  * @param {Provider} provider - The provider to link to the protocol, that must
  * respect the {@link Provider} interface description.
  *

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -387,25 +387,25 @@ View.prototype.getParentLayer = function getParentLayer(layer) {
  * @function
  *
  * @description
- * Method that will be called each time the <code>MainLoop</code> updates. This
- * function will be given as parameter the delta (in ms) between this update and
- * the previous one, and whether or not we just started to render again. This
- * update is considered as the "next" update if <code>view.notifyChange</code>
- * was called during a precedent update. If <code>view.notifyChange</code> has
- * been called by something else (other micro/macrotask, UI events etc...), then
- * this update is considered as being the "first". It can also receive optional
- * arguments, depending on the attach point of this function.  Currently only
- * <code>BEFORE_LAYER_UPDATE / AFTER_LAYER_UPDATE</code> attach points provide
- * an additional argument: the layer being updated.
+ * Method that will be called each time the `MainLoop` updates. This function
+ * will be given as parameter the delta (in ms) between this update and the
+ * previous one, and whether or not we just started to render again. This update
+ * is considered as the "next" update if `view.notifyChange` was called during a
+ * precedent update. If `view.notifyChange` has been called by something else
+ * (other micro/macrotask, UI events etc...), then this update is considered as
+ * being the "first". It can also receive optional arguments, depending on the
+ * attach point of this function. Currently only `BEFORE_LAYER_UPDATE /
+ * AFTER_LAYER_UPDATE` attach points provide an additional argument: the layer
+ * being updated.
  * <br><br>
  *
- * This means that if a <code>frameRequester</code> function wants to animate something, it
- * should keep on calling <code>view.notifyChange</code> until its task is done.
+ * This means that if a `frameRequester` function wants to animate something, it
+ * should keep on calling `view.notifyChange` until its task is done.
  * <br><br>
  *
- * Implementors of <code>frameRequester</code> should keep in mind that this
- * function will be potentially called at each frame, thus care should be given
- * about performance.
+ * Implementors of `frameRequester` should keep in mind that this function will
+ * be potentially called at each frame, thus care should be given about
+ * performance.
  * <br><br>
  *
  * Typical frameRequesters are controls, module wanting to animate moves or UI

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -35,9 +35,9 @@ class ColorLayer extends Layer {
      * {@link View} that already has a layer going by that id.
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      * @param {WMTSSource|WMSSource|WFSSource|TMSSource|FileSource} [config.source] -
      * Description and options of the source.
      *

--- a/src/Layer/ElevationLayer.js
+++ b/src/Layer/ElevationLayer.js
@@ -20,9 +20,9 @@ class ElevationLayer extends Layer {
      * {@link View} that already has a layer going by that id.
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      * @param {WMTSSource|WMSSource|WFSSource|TMSSource|FileSource} [config.source] -
      * Description and options of the source.
      *

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -43,18 +43,17 @@ class GeometryLayer extends Layer {
      * not mandatory, but an error will be emitted if this layer is added a
      * {@link View} that already has a layer going by that id.
      * @param {THREE.Object3d} object3d - The object3d used to contain the
-     * geometry of the GeometryLayer. It is usually a <code>THREE.Group</code>,
-     * but it can be anything inheriting from a <code>THREE.Object3d</code>.
+     * geometry of the GeometryLayer. It is usually a `THREE.Group`, but it can
+     * be anything inheriting from a `THREE.Object3d`.
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      * @param {WMTSSource|WMSSource|WFSSource|TMSSource|FileSource} [config.source] -
      * Description and options of the source.
      *
-     * @throws {Error} <code>object3d</code> must be a valid
-     * <code>THREE.Object3d</code>.
+     * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      *
      * @example
      * // Create a GeometryLayer
@@ -147,10 +146,10 @@ class GeometryLayer extends Layer {
 
     /**
      * Attach another layer to this one. Layers attached to a GeometryLayer will
-     * be available in <code>geometryLayer.attachedLayers</code>.
+     * be available in `geometryLayer.attachedLayers`.
      *
-     * @param {Layer} layer - The layer to attach, that must have an
-     * <code>update</code> method.
+     * @param {Layer} layer - The layer to attach, that must have an `update`
+     * method.
      */
     attach(layer) {
         if (!layer.update) {
@@ -203,7 +202,7 @@ class GeometryLayer extends Layer {
      *
      * @param {View} view - The view instance.
      * @param {Object} coordinates - The coordinates to pick in the view. It
-     * should have at least <code>x</code> and <code>y</code> properties.
+     * should have at least `x` and `y` properties.
      * @param {number} radius - Radius of the picking circle.
      *
      * @return {Array} An array containing all targets picked under the
@@ -214,11 +213,11 @@ class GeometryLayer extends Layer {
     }
 
     /**
-     * Change the opacity of an object, according to the value of the
-     * <code>opacity</code> property of this layer.
+     * Change the opacity of an object, according to the value of the `opacity`
+     * property of this layer.
      *
      * @param {Object} object - The object to change the opacity from. It is
-     * usually a <code>THREE.Object3d</code> or an implementation of it.
+     * usually a `THREE.Object3d` or an implementation of it.
      */
     changeOpacity(object) {
         if (object.material) {

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -21,9 +21,9 @@ class Layer extends THREE.EventDispatcher {
      * {@link View} that already has a layer going by that id.
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      *
      * @example
      * // Add and create a new Layer
@@ -76,10 +76,9 @@ class Layer extends THREE.EventDispatcher {
      * executed when the property changes.
      * <br><br>
      * When changing the property, it also emits an event, named following this
-     * convention: <code>${propertyName}-property-changed</code>, with
-     * <code>${propertyName}</code> being replaced by the name of the property.
-     * For example, if the added property name is <code>frozen</code>, it will
-     * emit a <code>frozen-property-changed</code>.
+     * convention: `${propertyName}-property-changed`, with `${propertyName}`
+     * being replaced by the name of the property.  For example, if the added
+     * property name is `frozen`, it will emit a `frozen-property-changed`.
      * <br><br>
      * @example <caption>The emitted event has some properties assigned to it</caption>
      * event = {

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -28,21 +28,19 @@ class TiledGeometryLayer extends GeometryLayer {
      * not mandatory, but an error will be emitted if this layer is added a
      * {@link View} that already has a layer going by that id.
      * @param {THREE.Object3d} object3d - The object3d used to contain the
-     * geometry of the TiledGeometryLayer. It is usually a
-     * <code>THREE.Group</code>, but it can be anything inheriting from a
-     * <code>THREE.Object3d</code>.
+     * geometry of the TiledGeometryLayer. It is usually a `THREE.Group`, but it
+     * can be anything inheriting from a `THREE.Object3d`.
      * @param {Array} schemeTile - extents Array of root tiles
      * @param {Object} builder - builder geometry object
      * @param {Object} [config] - Optional configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements <code>name, protocol, extent</code>, these
-     * elements will be available using <code>layer.name</code> or something
-     * else depending on the property name.
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
      * @param {WMTSSource|WMSSource|WFSSource|TMSSource|FileSource} [config.source] -
      * Description and options of the source.
      *
-     * @throws {Error} <code>object3d</code> must be a valid
-     * <code>THREE.Object3d</code>.
+     * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
     constructor(id, object3d, schemeTile, builder, config) {
         super(id, object3d, config);
@@ -86,7 +84,7 @@ class TiledGeometryLayer extends GeometryLayer {
      *
      * @param {View} view - The view instance.
      * @param {Object} coordinates - The coordinates to pick in the view. It
-     * should have at least <code>x</code> and <code>y</code> properties.
+     * should have at least `x` and `y` properties.
      * @param {number} radius - Radius of the picking circle.
      *
      * @return {Array} An array containing all targets picked under the
@@ -99,23 +97,21 @@ class TiledGeometryLayer extends GeometryLayer {
     /**
      * Does pre-update work on the context:
      * <ul>
-     *  <li>update the <code>colorLayers</code> and
-     *  <code>elevationLayers</code></li>
-     *  <li>update the <code>maxElevationLevel</code></li>
+     *  <li>update the `colorLayers` and `elevationLayers`</li>
+     *  <li>update the `maxElevationLevel`</li>
      * </ul>
      *
      * Once this work is done, it returns a list of nodes to update. Depending
-     * on the origin of <code>sources</code>, it can return a few things:
+     * on the origin of `sources`, it can return a few things:
      * <ul>
-     *  <li>if <code>sources</code> is empty, it returns the first node of the
-     *  layer (stored as <code>level0Nodes</code>), which will trigger the
-     *  update of the whole tree</li>
+     *  <li>if `sources` is empty, it returns the first node of the layer
+     *  (stored as `level0Nodes`), which will trigger the update of the whole
+     *  tree</li>
      *  <li>if the update is triggered by a camera move, the whole tree is
      *  returned too</li>
-     *  <li>if <code>source.layer</code> is this layer, it means that
-     *  <code>source</code> is a node; a common ancestor will be found if there
-     *  are multiple sources, with the default common ancestor being the first
-     *  source itself</li>
+     *  <li>if `source.layer` is this layer, it means that `source` is a node; a
+     *  common ancestor will be found if there are multiple sources, with the
+     *  default common ancestor being the first source itself</li>
      *  <li>else it returns the whole tree</li>
      * </ul>
      *

--- a/src/Provider/Fetcher.js
+++ b/src/Provider/Fetcher.js
@@ -32,8 +32,8 @@ export default {
      * Wrapper over fetch to get some text.
      *
      * @param {string} url - The URL of the resources to fetch.
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
      *
      * @return {Promise<string>} Promise containing the text.
@@ -49,8 +49,8 @@ export default {
      * Little wrapper over fetch to get some JSON.
      *
      * @param {string} url - The URL of the resources to fetch.
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
      *
      * @return {Promise<Object>} Promise containing the JSON object.
@@ -66,8 +66,8 @@ export default {
      * Wrapper over fetch to get some XML.
      *
      * @param {string} url - The URL of the resources to fetch.
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
      *
      * @return {Promise<Document>} Promise containing the XML Document.
@@ -83,11 +83,11 @@ export default {
      * Wrapper around {@link THREE.TextureLoader}.
      *
      * @param {string} url - The URL of the resources to fetch.
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
-     * Note that THREE.js docs mentions <code>withCredentials</code>, but it is
-     * not actually used in {@link THREE.TextureLoader}.
+     * Note that THREE.js docs mentions `withCredentials`, but it is not
+     * actually used in {@link THREE.TextureLoader}.
      *
      * @return {Promise<THREE.Texture>} Promise containing the {@link
      * THREE.Texture}.
@@ -111,8 +111,8 @@ export default {
      * Wrapper over fetch to get some ArrayBuffer.
      *
      * @param {string} url - The URL of the resources to fetch.
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
      *
      * @return {Promise<ArrayBuffer>} Promise containing the ArrayBuffer.
@@ -123,8 +123,8 @@ export default {
      * Wrapper over fetch to get some {@link THREE.DataTexture}.
      *
      * @param {string} url - The URL of the resources to fetch.
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
      *
      * @return {Promise<THREE.DataTexture>} Promise containing the DataTexture.
@@ -142,13 +142,12 @@ export default {
      * different extensions.
      *
      * @param {string} baseUrl - The shared URL of the resources to fetch.
-     * @param {Object} extensions - An object containing arrays. The keys of each
-     * of this array are available fetch type, such as <code>text</code>,
-     * <code>json</code> or even <code>arrayBuffer</code>. The arrays contains
-     * the extensions to append after the <code>baseUrl</code> (see example
-     * below).
-     * @param {Object} options - Fetch options (passed directly to
-     * <code>fetch()</code>), see [the syntax for more information]{@link
+     * @param {Object} extensions - An object containing arrays. The keys of
+     * each of this array are available fetch type, such as `text`, `json` or
+     * even `arrayBuffer`. The arrays contains the extensions to append after
+     * the `baseUrl` (see example below).
+     * @param {Object} options - Fetch options (passed directly to `fetch()`),
+     * see [the syntax for more information]{@link
      * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
      *
      * @return {Promise[]} An array of promises, containing all the files,

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -11,12 +11,9 @@ export default {
      * The layer object needs to have an url property, which should have some
      * specific strings that will be replaced by coordinates.
      * <ul>
-     * <li><code>${x}</code> or <code>%COL</code> will be replaced by
-     * <code>coords.col</code></li>
-     * <li><code>${y}</code> or <code>%ROW</code> will be replaced by
-     * <code>coords.row</code></li>
-     * <li><code>${z}</code> or <code>%TILEMATRIX</code> will be replaced by
-     * <code>coords.zoom</code></li>
+     * <li>`${x}` or `%COL` will be replaced by `coords.col`</li>
+     * <li>`${y}` or `%ROW` will be replaced by `coords.row`</li>
+     * <li>`${z}` or `%TILEMATRIX` will be replaced by `coords.zoom`</li>
      * </ul>
      *
      * @example
@@ -50,13 +47,12 @@ export default {
      * Builds an URL knowing the bounding box and the layer to query.
      * <br><br>
      * The layer object needs to have an url property, which should have the
-     * string <code>%bbox</code> in it. This string will be replaced by the four
-     * cardinal points composing the bounding box.
+     * string `%bbox` in it. This string will be replaced by the four cardinal
+     * points composing the bounding box.
      * <br><br>
-     * Order of the points can be specified in the <code>axisOrder</code>
-     * property in layer, using the letters <code>w, s, e, n</code> respectively
-     * for <code>WEST, SOUTH, EAST, NORTH</code>. The default order is
-     * <code>wsen</code>.
+     * Order of the points can be specified in the `axisOrder` property in
+     * layer, using the letters `w, s, e, n` respectively for `WEST, SOUTH,
+     * EAST, NORTH`. The default order is `wsen`.
      *
      * @example
      * extent = new Extent('EPSG:4326', 12, 14, 35, 46);

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -10,12 +10,11 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
  * access. It inherits from {@link Source}. There is multiple ways of adding a
  * resource here:
  * <ul>
- *  <li>add the file like any other sources, using the <code>url</code>
+ *  <li>add the file like any other sources, using the `url` property.</li>
+ *  <li>fetch the file, and give the data to the source using the `fetchedData`
  *  property.</li>
- *  <li>fetch the file, and give the data to the source using the
- *  <code>fetchedData</code> property.</li>
  *  <li>fetch the file, parse it and git the parsed data to the source using the
- *  <code>parsedData</code> property.</li>
+ *  `parsedData` property.</li>
  * </ul>
  * See the examples below for real use cases.
  *
@@ -101,9 +100,9 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
 class FileSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * FileSource and {@link Source}. Only <code>projection</code> is mandatory,
-     * but if it presents in <code>parsedData</code> under the property
-     * <code>projection</code> or <code>crs</code>, it is fine.
+     * FileSource and {@link Source}. Only `projection` is mandatory, but if it
+     * presents in `parsedData` under the property `projection` or `crs`, it is
+     * fine.
      * @param {string} crsOut - The projection of the output data after parsing.
      *
      * @constructor

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -8,7 +8,7 @@ let uid = 0;
  * set source.
  *
  * To extend a Source, it is necessary to implement two functions:
- * <code>urlFromExtent</code> and <code>extentInsideLimit</code>.
+ * `urlFromExtent` and `extentInsideLimit`.
  *
  * @property {boolean} isSource - Used to checkout whether this source is a
  * Source. Default is true. You should not change this, as it is used internally
@@ -19,24 +19,23 @@ let uid = 0;
  * @property {string} format - The format of the resources that are fetched.
  * @property {function} fetcher - The method used to fetch the resources from
  * the source. iTowns provides some methods in {@link Fetcher}, but it can be
- * specified a custom one. This method should return a <code>Promise</code>
- * containing the fetched resource. If this property is set, it overrides the
- * chosen fetcher method with <code>format</code>.
+ * specified a custom one. This method should return a `Promise` containing the
+ * fetched resource. If this property is set, it overrides the chosen fetcher
+ * method with `format`.
  * @property {Object} networkOptions - Fetch options (passed directly to
- * <code>fetch()</code>), see [the syntax for more information]{@link
+ * `fetch()`), see [the syntax for more information]{@link
  * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
- * By default, set to <code>{ crossOrigin: 'anonymous' }</code>.
+ * By default, set to `{ crossOrigin: 'anonymous' }`.
  * @property {string} projection - The projection of the resources.
  * @property {string} attribution - The intellectual property rights for the
  * resources.
  * @property {Extent} extent - The extent of the resources.
  * @property {function} parser - The method used to parse the resources attached
- * to the layer. iTowns provides some parsers, visible in the
- * <code>Parser/</code> folder. If the method is custom, it should return a
- * <code>Promise</code> containing the parsed resource. If this property is set,
- * it overrides the default selected parser method with
- * <code>source.format</code>. If <code>source.format</code> is also empty, no
- * parsing action is done.
+ * to the layer. iTowns provides some parsers, visible in the `Parser/` folder.
+ * If the method is custom, it should return a `Promise` containing the parsed
+ * resource. If this property is set, it overrides the default selected parser
+ * method with `source.format`. If `source.format` is also empty, no parsing
+ * action is done.
  * <br><br>
  * When calling this method, two parameters are passed:
  * <ul>
@@ -48,27 +47,27 @@ let uid = 0;
  *
  * The properties of the second parameter are:
  * <ul>
- *  <li><code>buildExtent : boolean</code> - True if the layer does not inherit
- *  from {@link GeometryLayer}.</li>
- *  <li><code>crsIn : string</code> - The projection of the source.</li>
- *  <li><code>crsOut : string</code> - The projection of the layer.</li>
- *  <li><code>filteringExtent : Extent</code> - If the layer inherits from
- *  {@link GeometryLayer}, it is set to the extent of destination, otherwise it
- *  is undefined.</li>
- *  <li><code>filter : function</code> - Property of the layer.</li>
- *  <li><code>mergeFeatures : boolean (default true)</code> - Property of the
- *  layer, default to true.</li>
- *  <li><code>withNormal : boolean</code> - True if the layer inherits from
- *  {@link GeometryLayer}.</li>
- *  <li><code>withAltitude : boolean</code> - True if the layer inherits from
- *  {@link GeometryLayer}.</li>
- *  <li><code>isInverted : string</code> - Property of the source.</li>
+ *  <li>`buildExtent : boolean` - True if the layer does not inherit from {@link
+ *  GeometryLayer}.</li>
+ *  <li>`crsIn : string` - The projection of the source.</li>
+ *  <li>`crsOut : string` - The projection of the layer.</li>
+ *  <li>`filteringExtent : Extent` - If the layer inherits from {@link
+ *  GeometryLayer}, it is set to the extent of destination, otherwise it is
+ *  undefined.</li>
+ *  <li>`filter : function` - Property of the layer.</li>
+ *  <li>`mergeFeatures : boolean (default true)` - Property of the layer,
+ *  default to true.</li>
+ *  <li>`withNormal : boolean` - True if the layer inherits from {@link
+ *  GeometryLayer}.</li>
+ *  <li>`withAltitude : boolean` - True if the layer inherits from {@link
+ *  GeometryLayer}.</li>
+ *  <li>`isInverted : string` - Property of the source.</li>
  * </ul>
  */
 class Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * Source. Only the <code>url</code> property is mandatory.
+     * Source. Only the `url` property is mandatory.
      *
      * @constructor
      */

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -51,7 +51,7 @@ import Extent from 'Core/Geographic/Extent';
 class TMSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * TMSSource and {@link Source}. Only <code>url</code> is mandatory.
+     * TMSSource and {@link Source}. Only `url` is mandatory.
      *
      * @constructor
      */

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -25,9 +25,9 @@ import URLBuilder from 'Provider/URLBuilder';
  * @property {Object} vendorSpecific - An object containing vendor specific
  * parameters. See for example a [list of these parameters for GeoServer]{@link
  * https://docs.geoserver.org/latest/en/user/services/wfs/vendor.html}. This
- * object is read simply with the <code>key</code> being the name of the
- * parameter and <code>value</code> being the value of the parameter. If used,
- * this property should be set in the constructor parameters.
+ * object is read simply with the `key` being the name of the parameter and
+ * `value` being the value of the parameter. If used, this property should be
+ * set in the constructor parameters.
  *
  * @example
  * // Add color layer with WFS source
@@ -91,8 +91,8 @@ import URLBuilder from 'Provider/URLBuilder';
 class WFSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * WFSSource and {@link Source}. <code>url</code>, <code>typeName</code> and
-     * <code>projection</code> are mandatory.
+     * WFSSource and {@link Source}. `url`, `typeName` and `projection` are
+     * mandatory.
      *
      * @constructor
      */

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -36,9 +36,9 @@ import URLBuilder from 'Provider/URLBuilder';
  * @property {Object} vendorSpecific - An object containing vendor specific
  * parameters. See for example a [list of these parameters for GeoServer]{@link
  * https://docs.geoserver.org/latest/en/user/services/wms/vendor.html}. This
- * object is read simply with the <code>key</code> being the name of the
- * parameter and <code>value</code> being the value of the parameter. If used,
- * this property should be set in the constructor parameters.
+ * object is read simply with the `key` being the name of the parameter and
+ * `value` being the value of the parameter. If used, this property should be
+ * set in the constructor parameters.
  *
  * @example
  * // Create the source
@@ -68,8 +68,8 @@ import URLBuilder from 'Provider/URLBuilder';
 class WMSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of
-     * WMSSource and {@link Source}. <code>url</code>, <code>name</code>,
-     * <code>extent</code> and <code>projection</code> are mandatory.
+     * WMSSource and {@link Source}. `url`, `name`, `extent` and `projection`
+     * are mandatory.
      *
      * @constructor
      */

--- a/src/Source/WMTSSource.js
+++ b/src/Source/WMTSSource.js
@@ -19,14 +19,13 @@ import URLBuilder from 'Provider/URLBuilder';
  * @property {string} style - The style to query on the WMTS server. Default
  * value is 'normal'.
  * @property {string} projection - The projection in which to fetch the data. If
- * not specified, it is deduced from <code>tileMatrixSet</code>. Default value
- * is 'EPSG:3857'.
+ * not specified, it is deduced from `tileMatrixSet`. Default value is
+ * 'EPSG:3857'.
  * @property {string} tileMatrixSet - Tile matrix set of the layer, used in the
  * generation of the url. Default value is 'WGS84'.
- * @property {Object} tileMatrixSetLimits - Limits of the tile matrix
- * set. Each limit has for key its level number, and their properties are the
- * <code>minTileRow</code>, <code>maxTileRow</code>, <code>minTileCol</code> and
- * <code>maxTileCol</code>.
+ * @property {Object} tileMatrixSetLimits - Limits of the tile matrix set. Each
+ * limit has for key its level number, and their properties are the
+ * `minTileRow`, `maxTileRow`, `minTileCol` and `maxTileCol`.
  * @property {number} tileMatrixSetLimits.minTileRow - Minimum row for tiles at
  * the specified level.
  * @property {number} tileMatrixSetLimits.maxTileRow - Maximum row for tiles at
@@ -62,8 +61,7 @@ import URLBuilder from 'Provider/URLBuilder';
 class WMTSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * WMTSSource and {@link Source}. Only <code>url</code> and
-     * <code>name</code> are mandatory.
+     * WMTSSource and {@link Source}. Only `url` and `name` are mandatory.
      *
      * @constructor
      */


### PR DESCRIPTION
We can use `` instead of `<code></code>` to encapsulate some code when
writing documentation.

No changes done in the content, I only realigned all impacted documentation.