### PR TITLE
Es6 coordinates

### DIFF
--- a/examples/collada.html
+++ b/examples/collada.html
@@ -57,7 +57,7 @@
             }
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
-            
+
             // ThreeLoader can load each format proposed in ThreeJs examples loaders : https://github.com/mrdoob/three.js/tree/dev/examples/js/loaders
             var promiseCollada = ThreeLoader.load('Collada', 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/models/collada/building.dae')
             .then(collada => {
@@ -67,7 +67,7 @@
                 var coord = new itowns.Coordinates('EPSG:4326', 4.2165, 44.844, 1417);
                 var colladaID = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
 
-                model.position.copy(coord.as(view.referenceCrs).xyz());
+                model.position.copy(coord.as(view.referenceCrs));
                 // align up vector with geodesic normal
                 model.lookAt(model.position.clone().add(coord.geodesicNormal));
                 // user rotate building to align with ortho image

--- a/examples/cubic_planar.html
+++ b/examples/cubic_planar.html
@@ -99,7 +99,7 @@
             for (index = 0; index < wmsLayers.length; index++) {
                 wms = wmsLayers[index];
                 obj = new itowns.THREE.Object3D();
-                offset = extent.center().xyz().negate().applyEuler(cubeTransformations[index].rotation);
+                offset = extent.center().toVector3().negate().applyEuler(cubeTransformations[index].rotation);
                 offset.add(cubeTransformations[index].position.divide(scale));
                 obj.position.copy(offset);
                 obj.rotation.copy(cubeTransformations[index].rotation);

--- a/examples/js/OrientedImageHelper.js
+++ b/examples/js/OrientedImageHelper.js
@@ -4,7 +4,7 @@
 // set object ENH orientation: X to the east, Y (green) to the north, Z (blue) look to the sky.
 function placeObjectFromCoordinate(object, coord) {
     // set object position to the coordinate
-    coord.xyz(object.position);
+    coord.toVector3(object.position);
     // set ENH orientation, looking at the sky (Z axis), so Y axis look to the north..
     object.lookAt(coord.geodesicNormal.clone().add(object.position));
 }
@@ -94,7 +94,7 @@ function setupPictureFromCamera(camera, imageUrl, opacity, distance) {
 // BUT keep the geodesic normal as Up vector
 // eslint-disable-next-line no-unused-vars
 function setupViewCameraLookingAtObject(camera, coord, objectToLookAt) {
-    camera.position.copy(coord.xyz());
+    camera.position.copy(coord);
     camera.up.copy(coord.geodesicNormal);
     camera.lookAt(objectToLookAt.getWorldPosition());
 }

--- a/examples/multiglobe.html
+++ b/examples/multiglobe.html
@@ -120,11 +120,11 @@
                 }
 
                 if (delta > 0) {
-                    geo.setAltitude(geo.altitude() * 0.9);
+                    geo.altitude *= 0.9;
                 } else {
-                    geo.setAltitude(geo.altitude() * 1.1);
+                    geo.altitude *= 1.1;
                 }
-                view.camera.camera3D.position.copy(geo.as('EPSG:4978').xyz());
+                view.camera.camera3D.position.copy(geo.as('EPSG:4978'));
                 view.notifyChange(view.camera.camera3D);
             };
             viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);

--- a/examples/orientation_utils.html
+++ b/examples/orientation_utils.html
@@ -86,7 +86,7 @@
 
             // Load camera calibrations
             var calibrations = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/immersive/exampleParis1/cameraCalibration.json';
-            
+
             // Use the cameraCalibrationParser to create OrientedImageCamera from camera calibration description file.
             promises.push(
                 itowns.Fetcher.json(calibrations, {})
@@ -116,7 +116,7 @@
                     var coord = new itowns.Coordinates(feature.crs, vertices[0], vertices[1], vertices[2]);
 
                     // set model position
-                    model.position.copy(coord.xyz());
+                    model.position.copy(coord);
 
                     // set model orientation (using target parameter)
                     itowns.OrientationUtils.quaternionFromAttitude(feature.geometry[0].properties, coord, true, model.quaternion);
@@ -127,8 +127,8 @@
                     // compute position on the ground
                     coord = coord.as('EPSG:4326');
                     result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, coord, 1, undefined);
-                    coord.setAltitude(result.z);
-                    model.positionOnGround = coord.as(view.referenceCrs).xyz();
+                    coord.altitude = result.z;
+                    model.positionOnGround = coord.as(view.referenceCrs).toVector3();
 
                     // update matrix world and add the model
                     model.updateMatrixWorld();

--- a/examples/orientation_utils_planar.html
+++ b/examples/orientation_utils_planar.html
@@ -100,9 +100,8 @@
                     var coord = new itowns.Coordinates(feature.crs, vertices[0], vertices[1], vertices[2]);
 
                     // set model position to the ground
-                    var position = coord.xyz();
-                    position.z = 0;
-                    model.position.copy(position);
+                    model.position.copy(coord);
+                    model.position.z = 0;
 
                     // set model orientation (quaternion is the target parameter)
                     itowns.OrientationUtils.quaternionFromAttitude(feature.geometry[0].properties, undefined, false, model.quaternion);

--- a/examples/positionGlobe.html
+++ b/examples/positionGlobe.html
@@ -64,10 +64,10 @@
 
                 // position of the mesh
                 var meshCoord = cameraTargetPosition;
-                meshCoord.setAltitude(cameraTargetPosition.altitude() + 30);
+                meshCoord.altitude += 30;
 
                 // position and orientation of the mesh
-                mesh.position.copy(meshCoord.as(view.referenceCrs).xyz());
+                mesh.position.copy(meshCoord.as(view.referenceCrs));
                 mesh.lookAt(new THREE.Vector3(0, 0, 0));
                 mesh.rotateX(Math.PI / 2);
 

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -37,7 +37,7 @@ const xyz = new Coordinates('EPSG:4978', 0, 0, 0);
 const c = new Coordinates('EPSG:4326', 0, 0, 0);
 // Position object on globe
 function positionObject(newPosition, object) {
-    xyz.set('EPSG:4978', newPosition).as('EPSG:4326', c);
+    xyz.setFromVector3(newPosition).as('EPSG:4326', c);
     object.position.copy(newPosition);
     object.lookAt(c.geodesicNormal.add(newPosition));
     object.rotateX(Math.PI * 0.5);
@@ -934,7 +934,7 @@ function GlobeControls(view, targetCoordinate, range, globeRadius, options = {})
         this.camera.layers.enable(layerTHREEjs);
     }
 
-    positionObject(targetCoordinate.as('EPSG:4978').xyz(), cameraTarget);
+    positionObject(targetCoordinate.as('EPSG:4978', xyz), cameraTarget);
 
     this.lookAtCoordinate({
         coord: targetCoordinate,

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -68,7 +68,7 @@ function coordinatesToVertices(ptsIn, normals, target, altitude = 0, extrude = 0
     } else if (Array.isArray(altitude)) {
         fnAltitude = id => altitude[(id - startIn) / 3];
     } else {
-        fnAltitude = id => altitude({}, coord.set(coord.crs, ptsIn[id], ptsIn[id + 1], ptsIn[id + 2]));
+        fnAltitude = id => altitude({}, coord.setFromArray(ptsIn, id));
     }
 
     for (let i = startIn, j = offsetOut; i < endIn; i += 3, j += 3) {
@@ -426,7 +426,8 @@ function featuresToThree(features, options) {
     if (!features || features.length == 0) { return; }
 
     if (features.length == 1) {
-        coord.set(features[0].crs, 0, 0, 0);
+        coord.crs = features[0].crs;
+        coord.setFromValues(0, 0, 0);
         return featureToMesh(features[0], options);
     }
 
@@ -434,7 +435,8 @@ function featuresToThree(features, options) {
     group.minAltitude = Infinity;
 
     for (const feature of features) {
-        coord.set(feature.crs, 0, 0, 0);
+        coord.crs = feature.crs;
+        coord.setFromValues(0, 0, 0);
         const mesh = featureToMesh(feature, options);
         group.add(mesh);
         group.minAltitude = Math.min(mesh.minAltitude, group.minAltitude);

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -106,7 +106,7 @@ function drawFeature(ctx, feature, extent, style, invCtxScale) {
                     const offset = indice.offset * feature.size;
                     const count = offset + indice.count * feature.size;
                     for (let j = offset; j < count; j += feature.size) {
-                        coord.set(extent.crs, feature.vertices[j], feature.vertices[j + 1]);
+                        coord.setFromArray(feature.vertices, j);
                         if (extent.isPointInside(coord, px)) {
                             drawPoint(ctx, feature.vertices[j], feature.vertices[j + 1], geometryStyle, invCtxScale);
                         }
@@ -135,6 +135,8 @@ export default {
             // origin and dimension are used to transform the feature's coordinates to canvas's space
             extent.dimensions(dimension);
             const c = document.createElement('canvas');
+
+            coord.crs = extent.crs;
 
             c.width = sizeTexture;
             c.height = sizeTexture;

--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -27,7 +27,7 @@ function setTileFromTiledLayer(tile, tileLayer) {
         // Computes a point used for horizon culling.
         // If the point is below the horizon,
         // the tile is guaranteed to be below the horizon as well.
-        tile.horizonCullingPoint = tile.extent.center().as('EPSG:4978').xyz();
+        tile.horizonCullingPoint = tile.extent.center().as('EPSG:4978').toVector3();
         tile.extent.dimensions(dimensions).multiplyScalar(THREE.Math.DEG2RAD);
 
         // alpha is maximum angle between two points of tile

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -86,7 +86,7 @@ export class FeatureGeometry {
             coord.geodesicNormal.toArray(this._feature.normals, this._feature._pos);
         }
 
-        this._feature._pushValues(this._feature, coord._values[0], coord._values[1], coord._values[2]);
+        this._feature._pushValues(this._feature, coord.x, coord.y, coord.z);
         // expand extent if present
         if (this._currentExtent) {
             this._currentExtent.expandByCoordinates(coord);

--- a/src/Core/Geographic/CoordStars.js
+++ b/src/Core/Geographic/CoordStars.js
@@ -93,7 +93,7 @@ const CoordStars = {
         var dayMilliSec = 24 * 3600000;
         var longitude = sun.ascension + ((date % dayMilliSec) / dayMilliSec) * -360 + 180; // cause midday
         var coSunCarto = new Coordinates('EPSG:4326', longitude, lat, 50000000)
-            .as('EPSG:4978').xyz();
+            .as('EPSG:4978').toVector3();
 
         return coSunCarto;
     },

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -1,441 +1,280 @@
-/**
- * Generated On: 2015-10-5
- * Class: Coordinates
- * Description: Coordonnées cartographiques
- */
-
 import * as THREE from 'three';
 import proj4 from 'proj4';
-import Ellipsoid from 'Core/Math/Ellipsoid';
 import CRS from 'Core/Geographic/Crs';
+import Ellipsoid from 'Core/Math/Ellipsoid';
 
-const projectionCache = {};
-const dimension = new THREE.Vector2();
+proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
 
 const ellipsoid = new Ellipsoid();
+const vectorPivot = new THREE.Vector3();
+let coordPivot;
 
-function _assertIsGeographic(crs) {
-    if (!CRS.isGeographic(crs)) {
-        throw new Error(`Can't query crs ${crs} long/lat`);
-    }
-}
+const projectionCache = {};
 
-function _assertIsMetric(crs) {
-    if (!CRS.isMetricUnit(crs)) {
-        throw new Error(`Can't query crs ${crs} x/y/z`);
-    }
-}
-
-function instanceProj4(crsIn, crsOut) {
-    if (projectionCache[crsIn]) {
-        const p = projectionCache[crsIn];
-        if (p[crsOut]) {
-            return p[crsOut];
-        }
-    } else {
+function proj4cache(crsIn, crsOut) {
+    if (!projectionCache[crsIn]) {
         projectionCache[crsIn] = {};
     }
-    const p = proj4(crsIn, crsOut);
-    projectionCache[crsIn][crsOut] = p;
-    return p;
+
+    if (!projectionCache[crsIn][crsOut]) {
+        projectionCache[crsIn][crsOut] = proj4(crsIn, crsOut);
+    }
+
+    return projectionCache[crsIn][crsOut];
 }
 
-// Only support explicit conversions
-const cartesian = new THREE.Vector3();
-function _convert(coordsIn, newCrs, target) {
-    target = target || new Coordinates(newCrs, 0, 0);
-    if (newCrs === coordsIn.crs) {
-        return target.copy(coordsIn);
-    } else {
-        if (CRS.is4326(coordsIn.crs) && newCrs === 'EPSG:4978') {
-            ellipsoid.cartographicToCartesian(coordsIn, cartesian);
-            target.set(newCrs, cartesian);
-            target._normal = coordsIn._normal;
-            target._normalNeedsUpdate = false;
-            return target;
+// Internal method, takes a coord and put some proj4 values in it
+function setFromProj4(coord, proj4value, z) {
+    return coord.setFromValues(proj4value[0], proj4value[1], z);
+}
+
+/**
+ * A Coordinates object, defined by a [crs]{@link http://inspire.ec.europa.eu/theme/rs}
+ * and three values. These values are accessible through `x`, `y` and `z`,
+ * although it can also be accessible through `latitude`, `longitude` and
+ * `altitude`. To change a value, prefer the `set()` method below.
+ *
+ * @property {boolean} isCoordinates - Used to checkout whether this coordinates
+ * is a Coordinates. Default is true. You should not change this, as it is used
+ * internally for optimisation.
+ * @property {string} crs - A supported crs by default in
+ * [`proj4js`](https://github.com/proj4js/proj4js#named-projections), or an
+ * added crs to `proj4js` (using `proj4.defs`). Note that `EPSG:4978` is also
+ * supported by default in itowns.
+ * @property {number} x - The first value of the coordinate.
+ * @property {number} y - The second value of the coordinate.
+ * @property {number} z - The third value of the coordinate.
+ * @property {number} latitude - The first value of the coordinate.
+ * @property {number} longitude - The second value of the coordinate.
+ * @property {number} altitude - The third value of the coordinate.
+ * @property {THREE.Vector3} geodesicNormal - The geodesic normal of the
+ * coordinate.
+ *
+ * @example
+ * new Coordinates('EPSG:4978', 20885167, 849862, 23385912); //Geocentric coordinates
+ *
+ * @example
+ * new Coordinates('EPSG:4326', 2.33, 48.24, 24999549); //Geographic coordinates
+ */
+class Coordinates {
+    /**
+     * @constructor
+     *
+     * @param {string} crs - A supported crs (see the `crs` property below).
+     * @param {number|Array<number>|Coordinates|THREE.Vector3} [v0=0] -
+     * x or longitude value, or a more complex one: it can be an array of three
+     * numbers, being x/lon, x/lat, z/alt, or it can be `THREE.Vector3`. It can
+     * also simply be a Coordinates.
+     * @param {number} [v1=0] - y or latitude value.
+     * @param {number} [v2=0] - z or altitude value.
+     */
+    constructor(crs, v0 = 0, v1 = 0, v2 = 0) {
+        this.isCoordinates = true;
+
+        CRS.isValid(crs);
+        this.crs = crs;
+
+        // Storing the coordinates as is, not in arrays, as it is
+        // slower (see https://jsbench.me/40jumfag6g/1)
+        this.x = 0;
+        this.y = 0;
+        this.z = 0;
+
+        // Normal
+        this._normal = new THREE.Vector3();
+
+        if (v0.length > 0) {
+            this.setFromArray(v0);
+        } else if (v0.isVector3 || v0.isCoordinates) {
+            this.setFromVector3(v0);
+        } else {
+            this.setFromValues(v0, v1, v2);
         }
 
-        if (coordsIn.crs === 'EPSG:4978' && CRS.is4326(newCrs)) {
-            ellipsoid.cartesianToCartographic({
-                x: coordsIn._values[0],
-                y: coordsIn._values[1],
-                z: coordsIn._values[2],
-            }, target);
-            return target;
-        }
+        this._normalNeedsUpdate = true;
+    }
 
-        if (coordsIn.crs in proj4.defs && newCrs in proj4.defs) {
-            const val0 = coordsIn._values[0];
-            let val1 = coordsIn._values[1];
-            const crsIn = coordsIn.crs;
+    /**
+     * Set the values of this Coordinates.
+     *
+     * @param {number} [v0=0] - x or longitude value.
+     * @param {number} [v1=0] - y or latitude value.
+     * @param {number} [v2=0] - z or altitude value.
+     *
+     * @return {Coordinates} This Coordinates.
+     */
+    setFromValues(v0 = 0, v1 = 0, v2 = 0) {
+        this.x = v0;
+        this.y = v1;
+        this.z = v2;
 
-            // there is a bug for converting anything from and to 4978 with proj4
-            // https://github.com/proj4js/proj4js/issues/195
-            // the workaround is to use an intermediate projection, like EPSG:4326
-            if (newCrs == 'EPSG:4978') {
-                const p = instanceProj4(crsIn, 'EPSG:4326').forward([val0, val1]);
-                target.set('EPSG:4326', p[0], p[1], coordsIn._values[2]);
-                return target.as('EPSG:4978', target);
-            } else if (coordsIn.crs === 'EPSG:4978') {
-                coordsIn.as('EPSG:4326', target);
-                const p = instanceProj4(target.crs, newCrs).forward([target._values[0], target._values[1]]);
-                target.set(newCrs, p[0], p[1], target._values[2]);
-                return target;
-            } else if (CRS.is4326(crsIn) && newCrs == 'EPSG:3857') {
-                val1 = THREE.Math.clamp(val1, -89.999999, 89.999999);
-                const p = instanceProj4(crsIn, newCrs).forward([val0, val1]);
-                return target.set(newCrs, p[0], p[1], coordsIn._values[2]);
+        this._normalNeedsUpdate = true;
+        return this;
+    }
+
+    /**
+     * Set the values of this Coordinates from an array.
+     *
+     * @param {Array<number>} array - An array of number to assign to the
+     * Coordinates.
+     * @param {number} [offset] - Optional offset into the array.
+     *
+     * @return {Coordinates} This Coordinates.
+     */
+    setFromArray(array, offset = 0) {
+        this.x = array[offset];
+        this.y = array[offset + 1];
+        // special case for as() below, intentionally not mentioned in the
+        // documentation
+        this.z = array[offset + 2];
+
+        this._normalNeedsUpdate = true;
+        return this;
+    }
+
+    /**
+     * Set the values of this Coordinates from a `THREE.Vector3` or an `Object`
+     * having `x/y/z` properties, like a `Coordinates`.
+     *
+     * @param {THREE.Vector3|Coordinates} v0 - The object to read the values
+     * from.
+     *
+     * @return {Coordinates} This Coordinates.
+     */
+    setFromVector3(v0) {
+        this.x = v0.x;
+        this.y = v0.y;
+        this.z = v0.z;
+
+        this._normalNeedsUpdate = true;
+        return this;
+    }
+
+    /**
+     * Returns a new Coordinates with the same values as this one. It will
+     * instantiate a new Coordinates with the same CRS as this one.
+     *
+     * @return {Coordinates} The target with its new coordinates.
+     */
+    clone() {
+        return new Coordinates(this.crs, this);
+    }
+
+    /**
+     * Copies the values of the passed Coordinates to this one. The CRS is
+     * however not copied.
+     *
+     * @param {Coordinates} src - The source to copy from.
+     *
+     * @return {Coordinates} This Coordinates.
+     */
+    copy(src) {
+        return this.setFromVector3(src);
+    }
+
+    get longitude() {
+        return this.x;
+    }
+
+    get latitude() {
+        return this.y;
+    }
+
+    get altitude() {
+        return this.z;
+    }
+
+    set altitude(value) {
+        this.z = value;
+    }
+
+    get geodesicNormal() {
+        if (this._normalNeedsUpdate) {
+            this._normalNeedsUpdate = false;
+
+            if (CRS.is4326(this.crs)) {
+                ellipsoid.geodeticSurfaceNormalCartographic(this, this._normal);
+            } else if (this.crs == 'EPSG:4978') {
+                ellipsoid.geodeticSurfaceNormal(this, this._normal);
             } else {
-                // here is the normal case with proj4
-                const p = instanceProj4(crsIn, newCrs).forward([val0, val1]);
-                return target.set(newCrs, p[0], p[1], coordsIn._values[2]);
+                this._normal.set(0, 0, 1);
             }
         }
 
-        throw new Error(`Cannot convert from crs ${coordsIn.crs} to ${newCrs}`);
+        return this._normal;
     }
-}
 
-/**
- * Build a Coordinates object, given a [crs]{@link
- * http://inspire.ec.europa.eu/theme/rs} and a number of coordinates value.
- * Coordinates can be in geocentric system, geographic system or an instance of
- * [THREE.Vector3]{@link https://threejs.org/docs/#api/math/Vector3}.
- * If crs = 'EPSG:4326', coordinates must be in geographic system.
- * If crs = 'EPSG:4978', coordinates must be in geocentric system.
- * @constructor
- * @param       {string} crs - Geographic or Geocentric coordinates system.
- * @param       {number|THREE.Vector3} coordinates - The globe coordinates to aim to.
- * @param       {number} coordinates.longitude - Geographic Coordinate longitude
- * @param       {number} coordinates.latitude - Geographic Coordinate latitude
- * @param       {number} coordinates.altitude - Geographic Coordinate altiude
- * @param       {number} coordinates.x - Geocentric Coordinate X
- * @param       {number} coordinates.y - Geocentric Coordinate Y
- * @param       {number} coordinates.z - Geocentric Coordinate Z
- * @example
- * new Coordinates('EPSG:4978', 20885167, 849862, 23385912); //Geocentric coordinates
- * // or
- * new Coordinates('EPSG:4326', 2.33, 48.24, 24999549); //Geographic coordinates
- */
-
-function Coordinates(crs, ...coordinates) {
-    this._values = new Float64Array(3);
-    this.set(crs, ...coordinates);
-    this._normalNeedsUpdate = true;
-    this._normal = new THREE.Vector3();
-
-    // this._normal = this._normal || computeGeodesicNormal(this);
-    Object.defineProperty(this, 'geodesicNormal',
-        {
-            configurable: true,
-            get: () => (this._normalNeedsUpdate ? computeGeodesicNormal(this) : this._normal),
-        });
-}
-
-const planarNormal = new THREE.Vector3(0, 0, 1);
-
-function computeGeodesicNormal(coord) {
-    coord._normalNeedsUpdate = false;
-    if (CRS.is4326(coord.crs)) {
-        return ellipsoid.geodeticSurfaceNormalCartographic(coord, coord._normal);
+    /**
+     * Return this Coordinates values into a `THREE.Vector3`.
+     *
+     * @param {THREE.Vector3} [target] - The target to put the values in. If not
+     * specified, a new vector will be created.
+     *
+     * @return {THREE.Vector3}
+     */
+    toVector3(target = new THREE.Vector3()) {
+        return target.copy(this);
     }
-    // In globe mode (EPSG:4978), we compute the normal.
-    if (coord.crs == 'EPSG:4978') {
-        return ellipsoid.geodeticSurfaceNormal(coord, coord._normal);
-    }
-    coord._normal.copy(planarNormal);
-    // In planar mode, normal is the up vector.
-    return planarNormal;
-}
 
-Coordinates.prototype.set = function set(crs, ...coordinates) {
-    CRS.isValid(crs);
-    this.crs = crs;
-
-    if (coordinates.length == 1 && coordinates[0].isVector3) {
-        this._values[0] = coordinates[0].x;
-        this._values[1] = coordinates[0].y;
-        this._values[2] = coordinates[0].z;
-    } else {
-        for (let i = 0; i < coordinates.length && i < 3; i++) {
-            this._values[i] = coordinates[i];
+    /**
+     * Returns coordinates in the wanted [CRS]{@link http://inspire.ec.europa.eu/theme/rs}.
+     *
+     * @param {string} crs - The CRS to convert the Coordinates into.
+     * @param {Coordinates} [target] - The target to put the converted
+     * Coordinates into. If not specified a new one will be created.
+     *
+     * @return {Coordinates} - The resulting Coordinates after the conversion.
+     *
+     * @example
+     * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
+     * const coords = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
+     * const coordinates = coords.as('EPSG:4978'); // Geocentric system
+     *
+     * @example
+     * const position = { x: 20885167, y: 849862, z: 23385912 };
+     * const coords = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
+     * const coordinates = coords.as('EPSG:4326');  // Geographic system
+     *
+     * @example
+     * new Coordinates('EPSG:4326', longitude: 2.33, latitude: 48.24, altitude: 24999549).as('EPSG:4978'); // Geocentric system
+     *
+     * @example
+     * new Coordinates('EPSG:4978', x: 20885167, y: 849862, z: 23385912).as('EPSG:4326'); // Geographic system
+     */
+    as(crs, target = new Coordinates(crs)) {
+        if (this.crs == crs) {
+            target.copy(this);
+            // there is a bug for converting anything from and to 4978 with proj4
+            // https://github.com/proj4js/proj4js/issues/195
+            // the workaround is to use an intermediate projection, like EPSG:4326
+        } else if (crs == 'EPSG:4978') {
+            if (CRS.is4326(this.crs)) {
+                ellipsoid.cartographicToCartesian(this, vectorPivot);
+                target.setFromVector3(vectorPivot);
+            } else {
+                setFromProj4(coordPivot, proj4cache(this.crs, 'EPSG:4326').forward([this.x, this.y]), this.z);
+                coordPivot.as('EPSG:4978', target);
+            }
+        } else if (this.crs == 'EPSG:4978') {
+            if (CRS.is4326(crs)) {
+                ellipsoid.cartesianToCartographic(this, target);
+            } else {
+                this.as('EPSG:4326', coordPivot);
+                setFromProj4(target, proj4cache('EPSG:4326', crs).forward([coordPivot.x, coordPivot.y]), coordPivot.z);
+            }
+        } else if (CRS.is4326(this.crs) && crs == 'EPSG:3857') {
+            this.y = THREE.Math.clamp(this.y, -89.999999, 89.999999);
+            setFromProj4(target, proj4cache(this.crs, crs).forward([this.x, this.y]), this.z);
+        } else {
+            setFromProj4(target, proj4cache(this.crs, crs).forward([this.x, this.y]), this.z);
         }
-        for (let i = coordinates.length; i < 3; i++) {
-            this._values[i] = 0;
-        }
+
+        target.crs = crs;
+
+        return target;
     }
-    this._normalNeedsUpdate = true;
-    return this;
-};
+}
 
-Coordinates.prototype.clone = function clone(target) {
-    let r;
-    if (target) {
-        Coordinates.call(target, this.crs, ...this._values);
-        r = target;
-    } else {
-        r = new Coordinates(this.crs, ...this._values);
-    }
-    if (this._normal) {
-        r._normal.copy(this._normal);
-    }
-    return r;
-};
-
-Coordinates.prototype.copy = function copy(src) {
-    this.set(src.crs, ...src._values);
-    return this;
-};
-
-/**
- * Returns the longitude in geographic coordinates. Coordinates must be in geographic system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coordinates = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * coordinates.longitude(); // Longitude in geographic system
- * // returns 2.33
- *
- * // or
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coords = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * const coordinates = coords.as('EPSG:4326');  // Geographic system
- * coordinates.longitude(); // Longitude in geographic system
- * // returns 2.330201911389028
- *
- * @return     {number} - The longitude of the position.
- */
-
-Coordinates.prototype.longitude = function longitude() {
-    _assertIsGeographic(this.crs);
-    return this._values[0];
-};
-
-/**
- * Returns the latitude in geographic coordinates. Coordinates must be in geographic system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coordinates = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * coordinates.latitude(); // Latitude in geographic system
- * // returns : 48.24
- *
- * // or
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coords = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * const coordinates = coords.as('EPSG:4326');  // Geographic system
- * coordinates.latitude(); // Latitude in geographic system
- * // returns : 48.24830764643365
- *
- * @return     {number} - The latitude of the position.
- */
-
-Coordinates.prototype.latitude = function latitude() {
-    return this._values[1];
-};
-
-/**
- * Returns the altitude in geographic coordinates. Coordinates must be in geographic system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coordinates = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * coordinates.altitude(); // Altitude in geographic system
- * // returns : 24999549
- *
- * // or
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coords = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * const coordinates = coords.as('EPSG:4326');  // Geographic system
- * coordinates.altitude(); // Altitude in geographic system
- * // returns : 24999548.046711832
- *
- * @return     {number} - The altitude of the position.
- */
-
-Coordinates.prototype.altitude = function altitude() {
-    _assertIsGeographic(this.crs);
-    return this._values[2];
-};
-
-/**
- * Set the altiude.
- * @example coordinates.setAltitude(number)
- * @param      {number} - Set the altitude.
- */
-
-Coordinates.prototype.setAltitude = function setAltitude(altitude) {
-    _assertIsGeographic(this.crs);
-    this._values[2] = altitude;
-};
-
-/**
- * Returns the longitude in geocentric coordinates. Coordinates must be in geocentric system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coordinates = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * coordinates.x();  // Geocentric system
- * // returns : 20885167
- *
- * // or
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coords = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * const coordinates = coords.as('EPSG:4978'); // Geocentric system
- * coordinates.x(); // Geocentric system
- * // returns : 20888561.0301258
- *
- * @return     {number} - The longitude of the position.
- */
-
-Coordinates.prototype.x = function x() {
-    _assertIsMetric(this.crs);
-    return this._values[0];
-};
-
-/**
- * Returns the latitude in geocentric coordinates. Coordinates must be in geocentric system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coordinates = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * coordinates.y();  // Geocentric system
- * // returns : 849862
- *
- * // or
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coords = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * const coordinates = coords.as('EPSG:4978'); // Geocentric system
- * coordinates.y(); // Geocentric system
- * // returns : 849926.376770819
- *
- * @return     {number} - The latitude of the position.
- */
-
-Coordinates.prototype.y = function y() {
-    _assertIsMetric(this.crs);
-    return this._values[1];
-};
-
-/**
- * Returns the altitude in geocentric coordinates. Coordinates must be in geocentric system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coordinates = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * coordinates.z();  // Geocentric system
- * // returns : 23385912
- *
- * // or
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coords = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * const coordinates = coords.as('EPSG:4978'); // Geocentric system
- * coordinates.z(); // Geocentric system
- * // returns : 23382883.536591515
- *
- * @return     {number} - The altitude of the position.
- */
-
-Coordinates.prototype.z = function z() {
-    _assertIsMetric(this.crs);
-    return this._values[2];
-};
-
-/**
- * Returns a position in cartesian coordinates. Coordinates must be in geocentric system (can be converted by using {@linkcode as()} ).
- * @example
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coordinates = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * coordinates.xyz();  // Geocentric system
- * // returns : Vector3
- * // x: 20885167
- * // y: 849862
- * // z: 23385912
- *
- * // or
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coords = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * const coordinates = coords.as('EPSG:4978'); // Geocentric system
- * coordinates.xyz(); // Geocentric system
- * // returns : Vector3
- * // x: 20885167
- * // y: 849862
- * // z: 23385912
- *
- * @return     {Position} - position
- */
-
-Coordinates.prototype.xyz = function xyz(target) {
-    _assertIsMetric(this.crs);
-    const v = target || new THREE.Vector3();
-    v.fromArray(this._values);
-    return v;
-};
-
-/**
- * Returns coordinates in the wanted [CRS]{@link http://inspire.ec.europa.eu/theme/rs}.
- * @example
- *
- * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
- * const coords = new Coordinates('EPSG:4326', position.longitude, position.latitude, position.altitude); // Geographic system
- * const coordinates = coords.as('EPSG:4978'); // Geocentric system
- *
- * // or
- *
- * const position = { x: 20885167, y: 849862, z: 23385912 };
- * const coords = new Coordinates('EPSG:4978', position.x, position.y, position.z);  // Geocentric system
- * const coordinates = coords.as('EPSG:4326');  // Geographic system
- *
- * //or
- *
- * new Coordinates('EPSG:4326', longitude: 2.33, latitude: 48.24, altitude: 24999549).as('EPSG:4978'); // Geocentric system
- *
- * // or
- *
- * new Coordinates('EPSG:4978', x: 20885167, y: 849862, z: 23385912).as('EPSG:4326'); // Geographic system
- *
- * @param      {string} - [crs]{@link http://inspire.ec.europa.eu/theme/rs} : Geocentric (ex: 'EPSG:4326') or Geographic (ex: 'EPSG:4978').
- * @return     {Position} - position
- */
-
-Coordinates.prototype.as = function as(crs, target) {
-    if (crs === undefined || CRS.toUnit(crs) === undefined) {
-        throw new Error(`Invalid crs paramater value '${crs}'`);
-    }
-    return _convert(this, crs, target);
-};
-
-/**
- * Returns the normalized offset from top-left in extent of this Coordinates
- * e.g: extent.center().offsetInExtent(extent) would return (0.5, 0.5).
- * @param {Extent} extent
- * @param {Vector2} target optional Vector2 target. If not present a new one will be created
- * @return {Vector2} normalized offset in extent
- */
-Coordinates.prototype.offsetInExtent = function offsetInExtent(extent, target) {
-    if (this.crs != extent.crs) {
-        throw new Error('unsupported mix');
-    }
-
-    extent.dimensions(dimension);
-
-    const x = CRS.isGeographic(this.crs) ? this.longitude() : this.x();
-    const y = CRS.isGeographic(this.crs) ? this.latitude() : this.y();
-
-    const originX = (x - extent.west) / dimension.x;
-    const originY = (extent.north - y) / dimension.y;
-
-    target = target || new THREE.Vector2();
-    target.set(originX, originY);
-    return target;
-};
+coordPivot = new Coordinates('EPSG:4326');
 
 export default Coordinates;

--- a/src/Core/Geographic/Projection.js
+++ b/src/Core/Geographic/Projection.js
@@ -63,8 +63,8 @@ const Projection = {
         var uY = Math.PI / nY;
 
         bbox.center(center);
-        var col = Math.floor((Math.PI + MathExt.degToRad(center.longitude())) / uX);
-        var row = Math.floor(nY - (PI_OV_TWO + MathExt.degToRad(center.latitude())) / uY);
+        var col = Math.floor((Math.PI + MathExt.degToRad(center.longitude)) / uX);
+        var row = Math.floor(nY - (PI_OV_TWO + MathExt.degToRad(center.latitude)) / uY);
         return target.set(zoom, row, col);
     },
 

--- a/src/Core/Math/Ellipsoid.js
+++ b/src/Core/Math/Ellipsoid.js
@@ -19,19 +19,17 @@ class Ellipsoid {
     }
 
     geodeticSurfaceNormal(cartesian, target = new THREE.Vector3()) {
-        return cartesian.xyz(target).multiply(this._invRadiiSquared).normalize();
+        return cartesian.toVector3(target).multiply(this._invRadiiSquared).normalize();
     }
 
     geodeticSurfaceNormalCartographic(coordCarto, target = new THREE.Vector3()) {
-        const longitude = THREE.Math.degToRad(coordCarto.longitude());
-        const latitude = THREE.Math.degToRad(coordCarto.latitude());
+        const longitude = THREE.Math.degToRad(coordCarto.longitude);
+        const latitude = THREE.Math.degToRad(coordCarto.latitude);
         const cosLatitude = Math.cos(latitude);
 
-        const x = cosLatitude * Math.cos(longitude);
-        const y = cosLatitude * Math.sin(longitude);
-        const z = Math.sin(latitude);
-
-        return target.set(x, y, z);
+        return target.set(cosLatitude * Math.cos(longitude),
+            cosLatitude * Math.sin(longitude),
+            Math.sin(latitude));
     }
 
     setSize(size) {
@@ -53,7 +51,7 @@ class Ellipsoid {
 
         target.divideScalar(gamma);
 
-        normal.multiplyScalar(coordCarto.altitude());
+        normal.multiplyScalar(coordCarto.altitude);
 
         return target.add(normal);
     }
@@ -87,10 +85,7 @@ class Ellipsoid {
 
         const h = (rsqXY * Math.cos(phi)) + position.z * Math.sin(phi) - a * Math.sqrt(1 - e * Math.sin(phi) * Math.sin(phi));
 
-        return target.set('EPSG:4326',
-            THREE.Math.radToDeg(theta),
-            THREE.Math.radToDeg(phi),
-            h);
+        return target.setFromValues(THREE.Math.radToDeg(theta), THREE.Math.radToDeg(phi), h);
     }
 
     cartographicToCartesianArray(coordCartoArray) {
@@ -140,10 +135,10 @@ class Ellipsoid {
     }
 
     computeDistance(coordCarto1, coordCarto2) {
-        var longitude1 = THREE.Math.degToRad(coordCarto1.longitude());
-        var latitude1 = THREE.Math.degToRad(coordCarto1.latitude());
-        var longitude2 = THREE.Math.degToRad(coordCarto2.longitude());
-        var latitude2 = THREE.Math.degToRad(coordCarto2.latitude());
+        var longitude1 = THREE.Math.degToRad(coordCarto1.longitude);
+        var latitude1 = THREE.Math.degToRad(coordCarto1.latitude);
+        var longitude2 = THREE.Math.degToRad(coordCarto2.longitude);
+        var latitude2 = THREE.Math.degToRad(coordCarto2.latitude);
 
         var distRad = Math.acos(Math.sin(latitude1) * Math.sin(latitude2) + Math.cos(latitude1) * Math.cos(latitude2) * Math.cos(longitude2 - longitude1));
 

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -119,8 +119,9 @@ class Atmosphere extends GeometryLayer {
 
         const renderer = context.view.mainLoop.gfxEngine.renderer;
         // get altitude camera
-        coordCam.set(context.view.referenceCrs, cameraPosition).as('EPSG:4326', coordGeoCam);
-        const altitude = coordGeoCam.altitude();
+        coordCam.crs = context.view.referenceCrs;
+        coordCam.setFromVector3(cameraPosition).as('EPSG:4326', coordGeoCam);
+        const altitude = coordGeoCam.altitude;
 
         // If the camera altitude is below limitAlti,
         // we interpolate between the sky color and the space color

--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -41,7 +41,7 @@ class BuilderEllipsoidTile {
         // transformation to align tile's normal to z axis
         params.quatNormalToZ = new THREE.Quaternion().setFromAxisAngle(
             axisY,
-            -(Math.PI * 0.5 - THREE.Math.degToRad(params.extent.center().latitude())));
+            -(Math.PI * 0.5 - THREE.Math.degToRad(params.extent.center().latitude)));
 
         // let's avoid building too much temp objects
         params.projected = { longitude: 0, latitude: 0 };
@@ -50,17 +50,16 @@ class BuilderEllipsoidTile {
     // get center tile in cartesian 3D
     center(extent) {
         return extent.center(this.tmp.coords[0])
-            .as('EPSG:4978', this.tmp.coords[1]).xyz();
+            .as('EPSG:4978', this.tmp.coords[1]).toVector3();
     }
 
     // get position 3D cartesian
     vertexPosition(params) {
-        this.tmp.coords[0].set(
-            'EPSG:4326',
+        this.tmp.coords[0].setFromValues(
             params.projected.longitude,
             params.projected.latitude);
 
-        this.tmp.coords[0].as('EPSG:4978', this.tmp.coords[1]).xyz(this.tmp.position);
+        this.tmp.coords[0].as('EPSG:4978', this.tmp.coords[1]).toVector3(this.tmp.position);
         return this.tmp.position;
     }
 
@@ -102,7 +101,7 @@ class BuilderEllipsoidTile {
         // compute rotation to transform tile to position it on ellipsoid
         // this transformation take into account the transformation of the parents
         const rotLon = THREE.Math.degToRad(extent.west - sharableExtent.west);
-        const rotLat = THREE.Math.degToRad(90 - extent.center(this.tmp.coords[0]).latitude());
+        const rotLat = THREE.Math.degToRad(90 - extent.center(this.tmp.coords[0]).latitude);
         quatToAlignLongitude.setFromAxisAngle(axisZ, rotLon);
         quatToAlignLatitude.setFromAxisAngle(axisY, rotLat);
         quatToAlignLongitude.multiply(quatToAlignLatitude);

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -93,7 +93,7 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
 
     // Configure camera
     let positionCamera;
-    if (coordCarto instanceof Coordinates) {
+    if (coordCarto.isCoordinates) {
         positionCamera = coordCarto.as('EPSG:4326');
     } else {
         positionCamera = new Coordinates('EPSG:4326',
@@ -115,13 +115,13 @@ function GlobeView(viewerDiv, coordCarto, options = {}) {
     this.addLayer(tileLayer);
     // Configure controls
     const positionTargetCamera = positionCamera.clone();
-    positionTargetCamera.setAltitude(0);
+    positionTargetCamera.altitude = 0;
 
     if (options.noControls) {
         this.camera.setPosition(positionCamera);
-        this.camera.camera3D.lookAt(positionTargetCamera.as('EPSG:4978').xyz());
+        this.camera.camera3D.lookAt(positionTargetCamera.as('EPSG:4978').toVector3());
     } else {
-        this.controls = new GlobeControls(this, positionTargetCamera, positionCamera.altitude(), ellipsoidSizes.x);
+        this.controls = new GlobeControls(this, positionTargetCamera, positionCamera.altitude, ellipsoidSizes.x);
         this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
     }
 

--- a/src/Core/Prefab/Planar/PlanarTileBuilder.js
+++ b/src/Core/Prefab/Planar/PlanarTileBuilder.js
@@ -25,7 +25,7 @@ class PlanarTileBuilder {
     // get center tile in cartesian 3D
     center(extent) {
         extent.center(this.tmp.coords);
-        center.set(this.tmp.coords.x(), this.tmp.coords.y(), 0);
+        center.set(this.tmp.coords.x, this.tmp.coords.y, 0);
         return center;
     }
 

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -130,8 +130,9 @@ class OrientedImageLayer extends GeometryLayer {
             let i = 0;
             for (const pano of this.panos) {
                 // set position
-                coord.set(pano.crs, pano.vertices[0], pano.vertices[1], pano.vertices[2]);
-                pano.position = coord.xyz();
+                coord.crs = pano.crs;
+                coord.setFromArray(pano.vertices);
+                pano.position = coord.toVector3();
                 // set quaternion
                 pano.quaternion = OrientationUtils.quaternionFromAttitude(pano.geometry[0].properties, coord, isGlobe);
 

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -25,7 +25,8 @@ function readCRS(json) {
 const coord = new Coordinates('EPSG:4978', 0, 0, 0);
 // filter with the first point
 const firstPtIsOut = (extent, aCoords, crs) => {
-    coord.set(crs, aCoords[0][0], aCoords[0][1], 0);
+    coord.crs = crs;
+    coord.setFromArray(aCoords[0]);
     return !extent.isPointInside(coord);
 };
 const toFeature = {
@@ -35,7 +36,8 @@ const toFeature = {
 
         // coordinates is a list of pair [[x1, y1], [x2, y2], ..., [xn, yn]]
         for (const pair of coordinates) {
-            coord.set(crsIn, pair[0], pair[1], useAlti ? pair[2] : 0);
+            coord.crs = crsIn;
+            coord.setFromValues(pair[0], pair[1], useAlti ? pair[2] : 0);
             geometry.pushCoordinates(coord);
         }
         geometry.updateExtent();

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -140,7 +140,7 @@ export default {
                 if (isApplied) {
                     // NOTE: now data source provider use cache on Mesh
                     // TODO move transform in feature2Mesh
-                    node.extent.center(coord).as(context.view.referenceCrs, coord).xyz(tmp).negate();
+                    node.extent.center(coord).as(context.view.referenceCrs, coord).toVector3(tmp).negate();
                     quaternion.setFromRotationMatrix(node.matrixWorld).inverse();
                     // const quaternion = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), node.extent.center().geodesicNormal).inverse();
                     applyOffset(result, tmp, quaternion, result.minAltitude);

--- a/src/Provider/OGCWebServiceHelper.js
+++ b/src/Provider/OGCWebServiceHelper.js
@@ -49,12 +49,12 @@ export default {
         const zoom = Math.floor(Math.log2(tileCount));
 
         // Now that we have computed zoom, we can deduce x and y (or row / column)
-        const x = (c.x() - extent.west) / layerDimension.x;
+        const x = (c.x - extent.west) / layerDimension.x;
         let y;
         if (isInverted) {
-            y = (extent.north - c.y()) / layerDimension.y;
+            y = (extent.north - c.y) / layerDimension.y;
         } else {
-            y = (c.y() - extent.south) / layerDimension.y;
+            y = (c.y - extent.south) / layerDimension.y;
         }
 
         return [new Extent('TMS', zoom, Math.floor(y * tileCount), Math.floor(x * tileCount))];

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -119,7 +119,7 @@ Camera.prototype.position = function position(crs) {
  * @param {Coordinates} position the new position of the camera
  */
 Camera.prototype.setPosition = function setPosition(position) {
-    this.camera3D.position.copy(position.as(this.crs).xyz());
+    this.camera3D.position.copy(position.as(this.crs));
 };
 
 const tmp = {
@@ -224,11 +224,11 @@ Camera.prototype.adjustAltitudeToAvoidCollisionWithLayer = function adjustAltitu
     if (elevationLayer !== undefined) {
         const elevationUnderCamera = DEMUtils.getElevationValueAt(elevationLayer, camLocation);
         if (elevationUnderCamera != undefined) {
-            const difElevation = camLocation.altitude() - (elevationUnderCamera.z + minDistanceCollision);
+            const difElevation = camLocation.altitude - (elevationUnderCamera.z + minDistanceCollision);
             // We move the camera to avoid collisions if too close to terrain
             if (difElevation < 0) {
-                camLocation.setAltitude(elevationUnderCamera.z + minDistanceCollision);
-                view.camera.camera3D.position.copy(camLocation.as(view.referenceCrs).xyz());
+                camLocation.altitude = elevationUnderCamera.z + minDistanceCollision;
+                view.camera.camera3D.position.copy(camLocation.as(view.referenceCrs));
                 view.notifyChange(this.camera3D);
             }
         }

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -140,7 +140,7 @@ class OBB extends THREE.Object3D {
             this.quaternion.copy(quaternion);
             this.updateMatrixWorld(true);
         } else if (!extent.isTiledCrs() && CRS.isMetricUnit(extent.crs)) {
-            extent.center(coord).xyz(this.position);
+            extent.center(coord).toVector3(this.position);
             extent.dimensions(dimension);
             size.set(dimension.x, dimension.y, Math.abs(maxHeight - minHeight));
             this.box3D.setFromCenterAndSize(center, size);

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -124,10 +124,10 @@ class CameraRig extends THREE.Object3D {
     setTargetFromCoordinate(view, coord) {
         // clamp altitude to seaLevel
         coord.as(tileLayer(view).extent.crs, this.coord);
-        const altitude = Math.max(0, this.coord._values[2]);
-        this.coord._values[2] = altitude;
+        const altitude = Math.max(0, this.coord.z);
+        this.coord.z = altitude;
         // adjust target's position with clamped altitude
-        this.coord.as(view.referenceCrs).xyz(targetPosition);
+        this.coord.as(view.referenceCrs).toVector3(targetPosition);
         if (view.referenceCrs == 'EPSG:4978') {
             // ellipsoid geocentric projection
             this.lookAt(targetPosition);
@@ -142,7 +142,7 @@ class CameraRig extends THREE.Object3D {
     }
 
     // set rig's objects transformation from camera's position and target's position
-    setFromPositions(view, cameraPosition, targetPosition) {
+    setFromPositions(view, cameraPosition) {
         this.setTargetFromCoordinate(view, new Coordinates(view.referenceCrs, targetPosition));
         this.target.rotation.set(0, 0, 0);
         this.updateMatrixWorld(true);
@@ -186,7 +186,7 @@ class CameraRig extends THREE.Object3D {
 
     setfromCamera(view, camera) {
         getGroundTargetFromCamera(view, camera, targetPosition);
-        this.setFromPositions(view, camera.position, targetPosition);
+        this.setFromPositions(view, camera.position);
     }
 
     copyObject3D(rig) {
@@ -252,7 +252,8 @@ class CameraRig extends THREE.Object3D {
             if (params.callback) {
                 params.callback(this);
             }
-            targetCoord.set(view.referenceCrs, this.targetWorldPosition).as(tileLayer(view).extent.crs, this.coord);
+            targetCoord.crs = view.referenceCrs;
+            targetCoord.setFromVector3(this.targetWorldPosition).as(tileLayer(view).extent.crs, this.coord);
             view.notifyChange(camera);
         };
 
@@ -472,8 +473,8 @@ export default {
             };
         }
 
-        if (Math.abs(first.coord._values[0] - second.coord._values[0]) > 0.000001 ||
-            Math.abs(first.coord._values[1] - second.coord._values[1]) > 0.000001) {
+        if (Math.abs(first.coord.x - second.coord.x) > 0.000001 ||
+            Math.abs(first.coord.y - second.coord.y) > 0.000001) {
             diff = diff || {};
             diff.coord = {
                 previous: first.coord,

--- a/src/Utils/FeaturesUtils.js
+++ b/src/Utils/FeaturesUtils.js
@@ -1,8 +1,8 @@
 import { FEATURE_TYPES } from 'Core/Feature';
 
 function pointIsOverLine(point, linePoints, epsilon, offset, count, size) {
-    const x0 = point._values[0];
-    const y0 = point._values[1];
+    const x0 = point.x;
+    const y0 = point.y;
     // for each segment of the line (j is i -1)
     for (var i = offset + size, j = offset; i < offset + count; j = i, i += size) {
         /* **********************************************************
@@ -49,8 +49,8 @@ function pointIsOverLine(point, linePoints, epsilon, offset, count, size) {
 }
 
 function getClosestPoint(point, points, epsilon, offset, count, size) {
-    const x0 = point._values[0];
-    const y0 = point._values[1];
+    const x0 = point.x;
+    const y0 = point.y;
     let squaredEpsilon = epsilon * epsilon;
     let closestPoint;
     for (var i = offset; i < offset + count; i += size) {
@@ -71,8 +71,8 @@ function pointIsInsidePolygon(point, polygonPoints, offset, count, size) {
     // ray-casting algorithm based on
     // http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
 
-    const x = point._values[0];
-    const y = point._values[1];
+    const x = point.x;
+    const y = point.y;
 
     let inside = false;
     // in first j is last point of polygon

--- a/test/functional/CameraUtils.js
+++ b/test/functional/CameraUtils.js
@@ -46,8 +46,8 @@ describe('Camera utils with globe example', function _() {
                 view, camera, { coord },
             ).then(final => final.coord);
         }, params);
-        assert.equal(Math.round(result._values[0]), params.longitude);
-        assert.equal(Math.round(result._values[1]), params.latitude);
+        assert.equal(Math.round(result.x), params.longitude);
+        assert.equal(Math.round(result.y), params.latitude);
     });
 
     it('should tilt like expected', async () => {
@@ -89,8 +89,8 @@ describe('Camera utils with globe example', function _() {
         });
         assert.equal(Math.round(result.final.heading), result.params.heading);
         assert.equal(Math.round(result.final.tilt), result.params.tilt);
-        assert.equal(Math.round(result.final.coord._values[0]), result.params.coord._values[0]);
-        assert.equal(Math.round(result.final.coord._values[1]), result.params.coord._values[1]);
+        assert.equal(Math.round(result.final.coord.x), result.params.coord.x);
+        assert.equal(Math.round(result.final.coord.y), result.params.coord.y);
         assert.equal(Math.round(result.final.range / 10000) * 10000, result.params.range);
     });
 
@@ -112,8 +112,8 @@ describe('Camera utils with globe example', function _() {
         });
         assert.equal(Math.round(result.final.heading), result.params.heading);
         assert.equal(Math.round(result.final.tilt), result.params.tilt);
-        assert.equal(Math.round(result.final.coord._values[0]), result.params.coord._values[0]);
-        assert.equal(Math.round(result.final.coord._values[1]), result.params.coord._values[1]);
+        assert.equal(Math.round(result.final.coord.x), result.params.coord.x);
+        assert.equal(Math.round(result.final.coord.y), result.params.coord.y);
         assert.equal(Math.round(result.final.range / 1000) * 1000, result.params.range);
     });
 });

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -66,8 +66,8 @@ describe('GlobeControls with globe example', function _() {
         const coord = result.coord;
         const eps = 0.000001;
 
-        assert.ok(Math.abs(vCoord.longitude - coord._values[0]) < eps);
-        assert.ok(Math.abs(vCoord.latitude - coord._values[1]) < eps);
+        assert.ok(Math.abs(vCoord.longitude - coord.x) < eps);
+        assert.ok(Math.abs(vCoord.latitude - coord.y) < eps);
         assert.ok(Math.abs(tilt - tilts[0]) < eps);
         assert.ok(Math.abs(tilt - tilts[1]) < eps);
         assert.ok(Math.abs(tilt - tilts[2]) < eps);
@@ -113,7 +113,7 @@ describe('GlobeControls with globe example', function _() {
 
         const endCoord = await page.evaluate(() => view.controls.getLookAtCoordinate());
 
-        const diffLongitude = initialPosition.coord._values[0] - endCoord._values[0];
+        const diffLongitude = initialPosition.coord.x - endCoord.x;
         assert.ok(Math.abs(Math.round(diffLongitude)) >= 25);
     });
 

--- a/test/functional/bootstrap.js
+++ b/test/functional/bootstrap.js
@@ -235,9 +235,9 @@ afterEach(async () => {
             // eslint-disable-next-line no-param-reassign
             init.coord = new itowns.Coordinates(
                 init.coord.crs,
-                init.coord._values[0],
-                init.coord._values[1],
-                init.coord._values[2],
+                init.coord.x,
+                init.coord.y,
+                init.coord.z,
             );
             view.controls.lookAtCoordinate(init, false);
             view.notifyChange();

--- a/test/functional/planar.js
+++ b/test/functional/planar.js
@@ -28,7 +28,7 @@ describe('planar', function _() {
 
         // get range with depth buffer and altitude
         await page.evaluate((l) => {
-            const lookat = extent.center().xyz();
+            const lookat = extent.center().toVector3();
 
             view.camera.camera3D.position.copy(lookat);
             view.camera.camera3D.position.z = l;

--- a/test/unit/3dtiles.js
+++ b/test/unit/3dtiles.js
@@ -57,7 +57,7 @@ function tilesetWithSphere(transformMatrix) {
 
 describe('Distance computation using boundingVolume.region', function () {
     const camera = new Camera('EPSG:4978', 100, 100);
-    camera.camera3D.position.copy(new Coordinates('EPSG:4326', 0, 0, 10000).as('EPSG:4978').xyz());
+    camera.camera3D.position.copy(new Coordinates('EPSG:4326', 0, 0, 10000).as('EPSG:4978').toVector3());
     camera.camera3D.updateMatrixWorld(true);
 
     it('should compute distance correctly', function () {
@@ -68,7 +68,7 @@ describe('Distance computation using boundingVolume.region', function () {
 
         computeNodeSSE(camera, tile);
 
-        assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude());
+        assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude);
     });
 
     it('should not be affected by transform', function () {
@@ -81,7 +81,7 @@ describe('Distance computation using boundingVolume.region', function () {
 
         computeNodeSSE(camera, tile);
 
-        assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude());
+        assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude);
     });
 });
 
@@ -90,7 +90,7 @@ describe('Distance computation using boundingVolume.box', function () {
         '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
     const camera = new Camera('EPSG:3946', 100, 100);
-    camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).xyz());
+    camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).toVector3());
     camera.camera3D.updateMatrixWorld(true);
 
     it('should compute distance correctly', function () {
@@ -128,7 +128,7 @@ describe('Distance computation using boundingVolume.sphere', function () {
         '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
     const camera = new Camera('EPSG:3946', 100, 100);
-    camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).xyz());
+    camera.camera3D.position.copy(new Coordinates('EPSG:3946', 0, 0, 100).toVector3());
     camera.camera3D.updateMatrixWorld(true);
 
     it('should compute distance correctly', function () {

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -46,8 +46,8 @@ describe('Camera utils unit test', function () {
         const params = { range, coord };
         CameraUtils.transformCameraToLookAtTarget(view, camera, params).then((result) => {
             assert.ok(equalToFixed(result.range, params.range, 1));
-            assert.ok(equalToFixed(result.coord.longitude(), params.coord.longitude(), 4));
-            assert.ok(equalToFixed(result.coord.latitude(), params.coord.latitude(), 4));
+            assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
+            assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
         });
     });
     it('should set range like expected', function () {
@@ -59,10 +59,10 @@ describe('Camera utils unit test', function () {
     });
     it('should look at coordinate like expected', function () {
         const params = { coord: coord.clone() };
-        params.coord.set(coord.crs, params.coord.longitude() + 1, params.coord.latitude() + 1, 0);
+        params.coord.setFromValues(params.coord.longitude + 1, params.coord.latitude + 1, 0);
         CameraUtils.transformCameraToLookAtTarget(view, camera, params).then((result) => {
-            assert.ok(equalToFixed(result.coord.longitude(), params.coord.longitude(), 4));
-            assert.ok(equalToFixed(result.coord.latitude(), params.coord.latitude(), 4));
+            assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
+            assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
         });
     });
     it('should tilt like expected', function () {
@@ -79,24 +79,24 @@ describe('Camera utils unit test', function () {
     });
     it('should heading, tilt, range and coordinate like expected', function () {
         const params = { heading: 17, tilt: 80, range: 20000, coord: coord.clone() };
-        params.coord.set(coord.crs, params.coord.longitude() + 5, params.coord.latitude() + 5, 0);
+        params.coord.setFromValues(params.coord.longitude + 5, params.coord.latitude + 5, 0);
         CameraUtils.transformCameraToLookAtTarget(view, camera, params).then((result) => {
             assert.ok(equalToFixed(result.heading, params.heading, 4));
             assert.ok(equalToFixed(result.tilt, params.tilt, 4));
             assert.ok(equalToFixed(result.range, params.range, 1));
-            assert.ok(equalToFixed(result.coord.longitude(), params.coord.longitude(), 4));
-            assert.ok(equalToFixed(result.coord.latitude(), params.coord.latitude(), 4));
+            assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
+            assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
         });
     });
     it('should heading, tilt, range and coordinate like expected with animation (200ms)', function () {
         const params = { heading: 17, tilt: 80, range: 20000, coord: coord.clone(), time: 200 };
-        params.coord.set(coord.crs, params.coord.longitude() + 3, params.coord.latitude() + 4, 0);
+        params.coord.setFromValues(params.coord.longitude + 3, params.coord.latitude + 4, 0);
         CameraUtils.animateCameraToLookAtTarget(view, camera, params).then((result) => {
             assert.ok(equalToFixed(result.heading, params.heading, 4));
             assert.ok(equalToFixed(result.tilt, params.tilt, 4));
             assert.ok(equalToFixed(result.range, params.range, 1));
-            assert.ok(equalToFixed(result.coord.longitude(), params.coord.longitude(), 4));
-            assert.ok(equalToFixed(result.coord.latitude(), params.coord.latitude(), 4));
+            assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
+            assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
         });
     });
 });

--- a/test/unit/camera.js
+++ b/test/unit/camera.js
@@ -23,8 +23,8 @@ describe('camera', function () {
         const coordinates = new Coordinates('EPSG:4326', 40, 52, 2002);
         camera.setPosition(coordinates);
         const resultCoordinates = camera.position('EPSG:4326');
-        assert.ok(resultCoordinates.longitude() == coordinates.longitude());
-        assert.ok(resultCoordinates.latitude().toFixed(8) == coordinates.latitude());
-        assert.ok(resultCoordinates.altitude().toFixed(8) == coordinates.altitude());
+        assert.ok(resultCoordinates.longitude == coordinates.longitude);
+        assert.ok(resultCoordinates.latitude.toFixed(8) == coordinates.latitude);
+        assert.ok(resultCoordinates.altitude.toFixed(8) == coordinates.altitude);
     });
 });

--- a/test/unit/coordinate.js
+++ b/test/unit/coordinate.js
@@ -5,26 +5,26 @@ import Coordinates from 'Core/Geographic/Coordinates';
 // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
-// Asster two float number are equals, with 5 digits precision.
+// Assert two float number are equals, with 5 digits precision.
 function assertFloatEqual(float1, float2, precision = 5) {
     assert.equal(Number(float1).toFixed(precision), Number(float2).toFixed(precision));
 }
 
-// Assert two coordinates obects are equals.
+// Assert two coordinates objects are equals.
 function assertCoordEqual(coord1, coord2) {
     assert.equal(coord1.crs, coord2.crs);
-    assertFloatEqual(coord1._values[0], coord2._values[0]);
-    assertFloatEqual(coord1._values[1], coord2._values[1]);
-    assertFloatEqual(coord1._values[2], coord2._values[2]);
+    assertFloatEqual(coord1.x, coord2.x);
+    assertFloatEqual(coord1.y, coord2.y);
+    assertFloatEqual(coord1.z, coord2.z);
 }
 
-describe('Coordinate conversions', function () {
+describe('Coordinates', function () {
     it('should correctly convert from EPSG:4326 to EPSG:4978', function () {
         var coord1 = new Coordinates('EPSG:4326', 15.0, 12.0);
         var coord2 = coord1.as('EPSG:4978');
         // verify value for x and y.
-        assertFloatEqual(6027050.95, coord2.x(), 2);
-        assertFloatEqual(1614943.43, coord2.y(), 2);
+        assertFloatEqual(6027050.95, coord2.x, 2);
+        assertFloatEqual(1614943.43, coord2.y, 2);
     });
     it('should correctly convert from EPSG:4326 to EPSG:4978 and back to EPSG:4326', function () {
         var coord1 = new Coordinates('EPSG:4326', 15.0, 12.0);
@@ -32,14 +32,14 @@ describe('Coordinate conversions', function () {
         var coord3 = coord2.as('EPSG:4326');
         assertCoordEqual(coord1, coord3);
     });
-    it('should correctly convert from EPSG:3946 (Lyon WFS bus example) to EPSG:4978 (Globe) and back to EPSG:3946', function () {
+    it('should correctly convert from EPSG:3946 to EPSG:4978 and back to EPSG:3946', function () {
         var coord1 = new Coordinates('EPSG:3946', 1500000, 5100000, 12);
         var coord2 = coord1.as('EPSG:4978');
         var coord3 = coord2.as('EPSG:3946');
         assertCoordEqual(coord1, coord3);
     });
     // This case happend in iTowns when we convert the tile extent (4326) to a target WFS server (EPSG:3946 for example) to request Lyon bus line in WFS.
-    it('should correctly convert from EPSG:4326 (tiles extent) to EPSG:3946 (Lyon WFS) and back to EPSG:4326 (degrees)', function () {
+    it('should correctly convert from EPSG:4326 to EPSG:3946 and back to EPSG:4326', function () {
         // geographic example for EPSG 4326 in degrees
         var longIn = 4.82212;
         var latIn = 45.723722;
@@ -48,17 +48,15 @@ describe('Coordinate conversions', function () {
         // convert coordinate in EPSG:3946
         var coord2 = coord1.as('EPSG:3946');
         // verify intermediate values
-        assertFloatEqual(1841825.45, coord2.x(), 2);
-        assertFloatEqual(5170916.93, coord2.y(), 2);
+        assertFloatEqual(1841825.45, coord2.x, 2);
+        assertFloatEqual(5170916.93, coord2.y, 2);
         // and convert back to EPSG:4626 standard in degree.
         var coord3 = coord2.as('EPSG:4326');
         // verify coordinates
-        assertFloatEqual(longIn, coord3.longitude());
-        assertFloatEqual(latIn, coord3.latitude());
+        assertFloatEqual(longIn, coord3.longitude);
+        assertFloatEqual(latIn, coord3.latitude);
     });
-});
 
-describe('Coordinate surface normale property', function () {
     it('should correctly compute a surface normal ', function () {
         const coord0 = new Coordinates('EPSG:4326', 15.0, 12.0).as('EPSG:4978');
         const normal0 = coord0.geodesicNormal;

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -163,8 +163,8 @@ describe('Extent', function () {
     it('should return center of extent expected', function () {
         const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);
         const center = withValues.center();
-        assert.equal(5, center.longitude());
-        assert.equal(1, center.latitude());
+        assert.equal(5, center.longitude);
+        assert.equal(1, center.latitude);
     });
     it('should return dimensions of extent expected', function () {
         const withValues = new Extent('EPSG:4326', [minX, maxX, minY, maxY]);

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -43,9 +43,9 @@ describe('Feature', function () {
         const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:3857', options_A);
         const geometry = featureLine.bindNewGeometry();
 
-        coord.set('EPSG:4326', -10, -10, 0);
+        coord.setFromValues(-10, -10, 0);
         geometry.pushCoordinates(coord);
-        coord.set('EPSG:4326', 10, 10, 0);
+        coord.setFromValues(10, 10, 0);
         geometry.pushCoordinates(coord);
         geometry.closeSubGeometry(2);
 

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -168,9 +168,9 @@ function Debug(view, datDebugTool, chartDivContainer) {
             // console.log('distance', distance, distance + bbox.getBoundingSphere(sphere).radius * 2);
 
             // Compute position camera debug
-            const altitudeCameraDebug = 1.5 * coord._values[2];
-            coord._values[2] = altitudeCameraDebug;
-            coord.as(view.referenceCrs).xyz(debugCamera.position);
+            const altitudeCameraDebug = 1.5 * coord.z;
+            coord.z = altitudeCameraDebug;
+            coord.as(view.referenceCrs).toVector3(debugCamera.position);
             // Compute recoil camera
             camera.worldToLocal(debugCamera.position);
             debugCamera.position.z += altitudeCameraDebug;


### PR DESCRIPTION
The long awaited refactor of Coordinates to ES6 class, along with some 
optimisations in it. Now the CRS is no longer checked everywhere when 
converting a coordinate, or accessing properties fro example. It is only
checked when the Coordinates is created. This is a debatable choice, but
I can assure you that we used to check the CRS way too much for nothing.
I also got rid of the `Float64Array` containing the values, in profit of more
direct properties (see this benchmark https://jsbench.me/40jumfag6g/1).
Otherwise it is quite the same as before.

BREAKING CHANGE:
* `x()`, `y()`, `z()`, `latitude()`, `longitude()` and `altitude()` have
been replaced by getters of the same names
* `setAltitude()` has been replaced by a setter on `altitude`
* the validity of a CRS is no longer check when doing conversion using
`as()`, so it needs to be checked beforehand if needed