### PR TITLE
fix(process): stop update for a FileSource + ColorLayer

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -161,7 +161,11 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
             // TODO: Handle error : result is undefined in provider. throw error
             const pitchs = extentsDestination.map((ext, i) => ext.offsetToParent(extentsSource[i], nodeLayer.offsetScales[i]));
             nodeLayer.setTextures(result, pitchs);
-            node.layerUpdateState[layer.id].success();
+            if (layer.source.isFileSource) {
+                node.layerUpdateState[layer.id].noMoreUpdatePossible();
+            } else {
+                node.layerUpdateState[layer.id].success();
+            }
         },
         err => handlingError(err, node, layer, targetLevel, context.view));
 }


### PR DESCRIPTION
A FileSource is not tiled, and so it wasn't stopping when updating the
same a tiled source (in ColorLayer mode). So once the source is loaded,
it doesn't call `success()` but `noMoreUpdatePossible()` (for FileSource
only).

Note: I don't know if it is the correct fix, but it seems to be the only thing that could solve my problems.