### PR TITLE
chore(view): remove support of passing a source as an object

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -9,20 +9,6 @@ import { getMaxColorSamplerUnitsCount } from 'Renderer/LayeredMaterial';
 
 import Scheduler from 'Core/Scheduler/Scheduler';
 import Picking from 'Core/Picking';
-import WMTSSource from 'Source/WMTSSource';
-import WMSSource from 'Source/WMSSource';
-import WFSSource from 'Source/WFSSource';
-import TMSSource from 'Source/TMSSource';
-import FileSource from 'Source/FileSource';
-
-const supportedSource = new Map([
-    ['wmts', WMTSSource],
-    ['file', FileSource],
-    ['wfs', WFSSource],
-    ['wms', WMSSource],
-    ['tms', TMSSource],
-    ['xyz', TMSSource],
-]);
 
 export const VIEW_EVENTS = {
     /**
@@ -165,12 +151,6 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
                 providerPreprocessing = Promise.resolve();
             }
         } else if (layer.source) {
-            if (!layer.source.isSource) {
-                console.warn('Deprecation warning: passing a source as an object is deprecated. Instantiate the source before adding it to the layer instead.');
-                const protocol = layer.source.protocol;
-                layer.source = new (supportedSource.get(protocol))(layer.source, layer.projection);
-            }
-
             providerPreprocessing = layer.source.whenReady || providerPreprocessing;
         }
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -144,23 +144,19 @@ function _preprocessLayer(view, layer, provider, parentLayer) {
     }
 
     if (!layer.whenReady) {
-        let providerPreprocessing = Promise.resolve();
         if (provider && provider.preprocessDataLayer) {
-            providerPreprocessing = provider.preprocessDataLayer(layer, view, view.mainLoop.scheduler, parentLayer);
-            if (!(providerPreprocessing && providerPreprocessing.then)) {
-                providerPreprocessing = Promise.resolve();
-            }
-        } else if (layer.source) {
-            providerPreprocessing = layer.source.whenReady || providerPreprocessing;
+            layer.whenReady = provider.preprocessDataLayer(layer, view, view.mainLoop.scheduler, parentLayer);
+        } else if (layer.source && layer.source.whenReady) {
+            layer.whenReady = layer.source.whenReady;
+        } else {
+            layer.whenReady = Promise.resolve();
         }
-
-        // the last promise in the chain must return the layer
-        layer.whenReady = providerPreprocessing.then(() => {
-            layer.ready = true;
-            return layer;
-        });
     }
 
+    layer.whenReady = layer.whenReady.then(() => {
+        layer.ready = true;
+        return layer;
+    });
 
     return layer;
 }


### PR DESCRIPTION
BREAKING CHANGE: Adding a layer to a view, with a source not
instantiated (only as an object) is no longer supported, even in
deprecation mode.
