### PR TITLE
fix(tms): return the correct coordinates for a TMS source

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -125,8 +125,8 @@ class Extent {
                 } else {
                     const size = 360 / nbCol;
                     // convert Y PM to latitude EPSG:4326 degree
-                    const north = Projection.YToWGS84(Yn);
-                    const south = Projection.YToWGS84(Ys);
+                    const north = Projection.y_PMTolatitude(Yn);
+                    const south = Projection.y_PMTolatitude(Ys);
                     // convert column PM to longitude EPSG:4326 degree
                     const west = 180 - size * (nbCol - this.col);
                     const east = west + size;

--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -10,7 +10,7 @@ const quatToAlignLongitude = new THREE.Quaternion();
 const quatToAlignLatitude = new THREE.Quaternion();
 
 function WGS84ToOneSubY(latitude) {
-    return 1.0 - Projection.WGS84ToY(latitude);
+    return 1.0 - Projection.latitudeToY_PM(latitude);
 }
 
 class BuilderEllipsoidTile {
@@ -21,6 +21,7 @@ class BuilderEllipsoidTile {
                 new Coordinates('EPSG:4326', 0, 0),
                 new Coordinates('EPSG:4326', 0, 0)],
             position: new THREE.Vector3(),
+            dimension: new THREE.Vector2(),
         };
     }
     // prepare params
@@ -45,6 +46,7 @@ class BuilderEllipsoidTile {
 
         // let's avoid building too much temp objects
         params.projected = { longitude: 0, latitude: 0 };
+        params.extent.dimensions(this.tmp.dimension);
     }
 
     // get center tile in cartesian 3D
@@ -70,12 +72,12 @@ class BuilderEllipsoidTile {
 
     // coord u tile to projected
     uProjecte(u, params) {
-        params.projected.longitude = Projection.UnitaryToLongitudeWGS84(u, params.extent);
+        params.projected.longitude = params.extent.west + u * this.tmp.dimension.x;
     }
 
     // coord v tile to projected
     vProjecte(v, params) {
-        params.projected.latitude = Projection.UnitaryToLatitudeWGS84(v, params.extent);
+        params.projected.latitude = params.extent.south + v * this.tmp.dimension.y;
     }
 
     // Compute uv 1, if isn't defined the uv1 isn't computed

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -157,6 +157,11 @@ class GlobeView extends View {
         if (layer.isColorLayer) {
             const colorLayerCount = this.getLayers(l => l.isColorLayer).length;
             layer.sequence = colorLayerCount;
+            if ((layer.source.isWMTSSource || layer.source.isTMSSource)
+                && layer.source.tileMatrixSet !== 'WGS84G'
+                && layer.source.tileMatrixSet !== 'PM') {
+                throw new Error('Only WGS84G and PM tileMatrixSet are currently supported for WMTS/TMS color layers');
+            }
         } else if (layer.isElevationLayer) {
             if (layer.source.isWMTSSource && layer.source.tileMatrixSet !== 'WGS84G') {
                 throw new Error('Only WGS84G tileMatrixSet is currently supported for WMTS elevation layers');

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -273,7 +273,7 @@ class TiledGeometryLayer extends GeometryLayer {
         let nodeLayer = node.material.getElevationLayer();
 
         for (const e of context.elevationLayers) {
-            const extents = node.getCoordsForSource(e.source);
+            const extents = node.getExtentsForSource(e.source);
             if (!e.frozen && e.ready && e.source.extentsInsideLimit(extents) && (!nodeLayer || nodeLayer.level < 0)) {
                 // no stop subdivision in the case of a loading error
                 if (layerUpdateState[e.id] && layerUpdateState[e.id].inError()) {
@@ -291,7 +291,7 @@ class TiledGeometryLayer extends GeometryLayer {
             if (layerUpdateState[c.id] && layerUpdateState[c.id].inError()) {
                 continue;
             }
-            const extents = node.getCoordsForSource(c.source);
+            const extents = node.getExtentsForSource(c.source);
             nodeLayer = node.material.getLayer(c.id);
             if (c.source.extentsInsideLimit(extents) && (!nodeLayer || nodeLayer.level < 0)) {
                 return false;

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -85,7 +85,7 @@ export default {
             return features;
         }
 
-        const extentsDestination = node.getCoordsForSource(layer.source);
+        const extentsDestination = node.getExtentsForSource(layer.source);
         extentsDestination.forEach((e) => { e.zoom = node.level; });
 
         const extentsSource = [];

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -59,7 +59,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
         return;
     }
 
-    const extentsDestination = node.getCoordsForSource(layer.source);
+    const extentsDestination = node.getExtentsForSource(layer.source);
 
     let nodeLayer = material.getLayer(layer.id);
 
@@ -179,7 +179,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
     // Elevation is currently handled differently from color layers.
     // This is caused by a LayeredMaterial limitation: only 1 elevation texture
     // can be used (where a tile can have N textures x M layers)
-    const extentsDestination = node.getCoordsForSource(layer.source);
+    const extentsDestination = node.getExtentsForSource(layer.source);
     // Init elevation layer, and inherit from parent if possible
     let nodeLayer = material.getElevationLayer();
     if (!nodeLayer) {

--- a/src/Provider/OGCWebServiceHelper.js
+++ b/src/Provider/OGCWebServiceHelper.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import Projection from 'Core/Geographic/Projection';
 import Extent from 'Core/Geographic/Extent';
 import Coordinates from 'Core/Geographic/Coordinates';
 
@@ -11,26 +10,7 @@ const tileDimension = new THREE.Vector2();
 export const SIZE_TEXTURE_TILE = 256;
 export const SIZE_DIAGONAL_TEXTURE = Math.pow(2 * (SIZE_TEXTURE_TILE * SIZE_TEXTURE_TILE), 0.5);
 
-const tileCoord = new Extent('WMTS:WGS84G', 0, 0, 0);
-
 export default {
-    computeTileMatrixSetCoordinates(tile, tileMatrixSet) {
-        tileMatrixSet = tileMatrixSet || 'WGS84G';
-        if (!(tileMatrixSet in tile.wmtsCoords)) {
-            if (tile.wmtsCoords.WGS84G) {
-                const c = tile.wmtsCoords.WGS84G[0];
-                tileCoord.zoom = c.zoom;
-                tileCoord.col = c.col;
-                tileCoord.row = c.row;
-            } else {
-                Projection.WGS84toWMTS(tile.extent, tileCoord);
-                tile.wmtsCoords.WGS84G = [tileCoord.clone()];
-            }
-
-            tile.wmtsCoords[tileMatrixSet] =
-                Projection.getCoordWMTS_WGS84(tileCoord, tile.extent, tileMatrixSet);
-        }
-    },
     // The isInverted parameter is to be set to the correct value, true or false
     // (default being false) if the computation of the coordinates needs to be
     // inverted to match the same scheme as OSM, Google Maps or other system.

--- a/test/unit/layeredmaterial.js
+++ b/test/unit/layeredmaterial.js
@@ -13,7 +13,7 @@ describe('material state vs layer state', function () {
             getLayer: () => nodeLayer,
             visible: true,
         },
-        getCoordsForSource: () => 0,
+        getExtentsForSource: () => 0,
     };
     const layer = {
         id: 'test',

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -13,7 +13,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
     // Misc var to initialize a TileMesh instance
     const geom = new THREE.Geometry();
     geom.OBB = new OBB(new THREE.Vector3(), new THREE.Vector3(1, 1, 1));
-    const extent = new Extent('EPSG:4326', 0, 0, 0, 0);
+    const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
     const material = {};
 
     // Mock scheduler
@@ -32,7 +32,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
 
     const source = new Source({
         url: 'http://',
-        extent: new Extent('EPSG:4326', 0, 0, 0, 0),
+        extent,
     });
 
     const layer = new Layer('foo', {


### PR DESCRIPTION
When using a GlobeView and a TMSSource, the coordinates returned for a
tile were only Pseudo-Mercator; it can be WGS84G now.
