### PR TITLE
fix(tooltip): display all properties of a feature

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -99,3 +99,26 @@ body {
     border: 2px solid #775555;
     vertical-align: middle;
 }
+
+/* tooltip */
+.tooltip {
+    display: none;
+    background-image: linear-gradient(rgba(80, 80, 80,0.95), rgba(60, 60, 60,0.95));
+    box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
+    margin-top: 20px;
+    margin-left: 20px;
+    padding: 10px;
+    position: absolute;
+    z-index: 1000;
+    color: #CECECE;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 14px;
+    line-height: 18px;
+    text-align: left;
+}
+.tooltip li, .coord {
+    font-size: 12px;
+    padding-left:20px;
+    color: #93B7C0;
+    text-shadow: 0px 1px 0px rgba(200,200,200,.3), 0px -1px 0px rgba(30,30,30,.7);
+}

--- a/examples/globe_vector.html
+++ b/examples/globe_vector.html
@@ -1,30 +1,6 @@
 <html>
     <head>
         <title>Itowns - Globe + color layers from vector data</title>
-
-        <style type="text/css">
-            .tooltip {
-                display: none;
-                background-image: linear-gradient(rgba(80, 80, 80,0.95), rgba(60, 60, 60,0.95));
-                box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
-                margin-top: 20px;
-                margin-left: 20px;
-                padding: 10px;
-                position: absolute;
-                z-index: 1000;
-                color: #CECECE;
-                font-family: 'Open Sans', sans-serif;
-                font-size: 14px;
-                line-height: 18px;
-                text-align: left;
-            }
-            .coord {
-                font-size: 12px;
-                padding-left:20px;
-                color: #93B7C0;
-                text-shadow: 0px 1px 0px rgba(200,200,200,.3), 0px -1px 0px rgba(30,30,30,.7);
-            }
-        </style>
         <meta charset="UTF-8">
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/loading_screen.css">
@@ -33,9 +9,7 @@
         <script src="js/GUI/dat.gui/dat.gui.min.js"></script>
     </head>
     <body>
-        <div id="viewerDiv" class="viewer">
-            <span id="tooltipDiv" class="tooltip"></span>
-        </div>
+        <div id="viewerDiv" class="viewer"></div>
         <script src="js/GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
@@ -143,7 +117,7 @@
                         transparent: true,
                         style: {
                             fill: {
-                              color: 'orange',  
+                              color: 'orange',
                               opacity: 0.5,
                             },
                             stroke: {
@@ -158,9 +132,7 @@
 
             // Listen for globe full initialisation event
             view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function _() {
-                Promise.all(promises).then(new ToolTip(view,
-                    document.getElementById('viewerDiv'),
-                    document.getElementById('tooltipDiv')));
+                Promise.all(promises).then(new ToolTip(view));
             });
         </script>
     </body>

--- a/examples/js/FeatureToolTip.js
+++ b/examples/js/FeatureToolTip.js
@@ -1,9 +1,33 @@
-/* global itowns, document */
-// eslint-disable-next-line no-unused-vars
-function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
-    var mouseDown = 0;
-    var layers = viewer.getLayers(function _(l) { return l.source && l.source.isFileSource; });
+/* global itowns */
+/**
+ * A tooltip that can display some useful information about a feature when
+ * hovering it. Only works for layers using FileSource.
+ *
+ * @param {View} viewer - The view to bind the tooltip to.
+ * @param {Object} options - Options to have more custom content displayed.
+ * @param {number} [options.precisionPx=5] - The precision of the picking.
+ * @param {function} [options.format] - A function that takes the name of the
+ * property currently being processed and its value, and gives the appropriate
+ * HTML output to it. If this method is specified, no others properties other
+ * than the ones handled in it will be displayed.
+ * @param {Array<string>} [options.filter] - An array of properties to filter.
+ * @param {boolean} [options.filterAll=true] - Filter all the properties.
+ * Default to true.
+ *
+ * @example
+ * view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function() {
+ *      new ToolTip(view);
+ * });
+ */
+function ToolTip(viewer, options) {
+    var opts = options || { filterAll: true };
+    opts.filter = opts.filter == undefined ? [] : opts.filter;
 
+    var tooltip = document.createElement('div');
+    tooltip.className = 'tooltip';
+    viewer.mainLoop.gfxEngine.renderer.domElement.parentElement.appendChild(tooltip);
+
+    var mouseDown = 0;
     document.body.onmousedown = function onmousedown() {
         ++mouseDown;
     };
@@ -11,29 +35,28 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
         --mouseDown;
     };
 
+    var layer;
+    var result;
+    var feature;
+    var symb;
+    var style;
+    var fill;
+    var stroke;
+    var content;
+    var prop;
+    var layers = viewer.getLayers(function _(l) { return l.source && l.source.isFileSource; });
     function buildToolTip(geoCoord, e) {
         var visible = false;
-        var precision = viewer.controls.pixelsToDegrees(precisionPx || 5);
         var i = 0;
         var p = 0;
-        var id = 0;
-        var layer;
-        var result;
-        var polygon;
-        var color;
-        var stroke;
-        var name;
-        var symb;
-        var label;
-        var line;
-        var point;
-        var style;
+        var precision = viewer.controls.pixelsToDegrees(opts.precisionPx || 5);
 
         tooltip.innerHTML = '';
         tooltip.style.display = 'none';
         if (geoCoord) {
             visible = false;
-            // convert degree precision
+
+            // Pick on each layer, and display them all in the tooltip
             for (i = 0; i < layers.length; i++) {
                 layer = layers[i];
 
@@ -42,39 +65,64 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
                 result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(geoCoord, layer.source.parsedData, precision);
 
                 for (p = 0; p < result.length; p++) {
+                    content = '';
                     visible = true;
+
+                    feature = result[p].geometry;
+                    style = layer.style.isStyle ? layer.style : feature.properties.style;
+                    fill = style.fill.color;
+                    stroke = '1.25px ' + style.stroke.color;
+
                     if (result[p].type === itowns.FEATURE_TYPES.POLYGON) {
-                        polygon = result[p].geometry;
-                        style = layer.style.isStyle ? layer.style : polygon.properties.style;
-                        color = style.fill.color;
-                        stroke = style.stroke.color;
-                        name = 'polygon' + id;
-                        symb = '<span id=' + name + ' >&#9724</span>';
-                        tooltip.innerHTML += symb + ' ' + (polygon.properties.name || polygon.properties.nom || polygon.properties.description || layer.name) + '<br />';
-                        document.getElementById(name).style['-webkit-text-stroke'] = '1.25px ' + stroke;
-                        document.getElementById(name).style.color = color;
-                        ++id;
+                        symb = '&#9724';
                     } else if (result[p].type === itowns.FEATURE_TYPES.LINE) {
-                        line = result[p].geometry;
-                        style = layer.style.isStyle ? layer.style : line.properties.style;
-                        color = style.stroke.color;
-                        symb = '<span style=color:' + color + ';>&#9473</span>';
-                        tooltip.innerHTML += symb + ' ' + (line.name || layer.name) + '<br />';
+                        symb = '&#9473';
+                        fill = style.stroke.color;
+                        stroke = '0px';
                     } else if (result[p].type === itowns.FEATURE_TYPES.POINT) {
-                        point = result[p].geometry;
-                        style = layer.style.isStyle ? layer.style : point.properties.style;
-                        color = style.point.color;
-                        name = 'point' + id;
-                        symb = '<span id=' + name + ' style=color:' + color + ';>&#9679</span>';
-                        label = point.properties.name || point.properties.description || layer.name;
-                        tooltip.innerHTML += '<div>' + symb + ' ' + label + '<br></div>';
-                        tooltip.innerHTML += '<span class=coord>long ' + result[p].coordinates[0].toFixed(4) + '<br /></span>';
-                        tooltip.innerHTML += '<span class=coord>lati &nbsp; ' + result[p].coordinates[1].toFixed(4) + '<br /></span>';
-                        document.getElementById(name).style['-webkit-text-stroke'] = '1px ' + style.point.line;
-                        ++id;
+                        symb = '&#9679';
                     }
+
+                    content += '<div>';
+                    content += '<span style="color: ' + fill + '; -webkit-text-stroke: ' + stroke + '">';
+                    content += symb + ' ';
+                    content += '</span>';
+                    content += (feature.properties.name || feature.properties.nom || feature.properties.description || layer.name);
+
+                    if (result[p].type === itowns.FEATURE_TYPES.POINT) {
+                        content += '<br/><span class="coord">long ' + result[p].coordinates[0].toFixed(4) + '</span>';
+                        content += '<br/><span class="coord">lat ' + result[p].coordinates[1].toFixed(4) + '</span>';
+                    }
+
+                    if (feature.properties && !opts.filterAll) {
+                        if (opts.format) {
+                            for (prop in feature.properties) {
+                                if (!opts.filter.includes(prop) && prop != 'style' && prop != 'name' && prop != 'nom' && prop != 'description') {
+                                    opts.format(prop, feature.properties[prop]);
+                                }
+                            }
+                        } else {
+                            content += '<ul>';
+                            for (prop in feature.properties) {
+                                if (!opts.filter.includes(prop) && prop != 'style' && prop != 'name' && prop != 'nom' && prop != 'description') {
+                                    content += '<li>' + prop + ': ' + feature.properties[prop] + '</li>';
+                                }
+                            }
+
+                            if (content.endsWith('<ul>')) {
+                                content = content.replace('<ul>', '');
+                            } else {
+                                content += '</ul>';
+                            }
+                        }
+                    }
+
+                    content += '</div>';
+
+                    tooltip.innerHTML += content;
                 }
             }
+
             if (visible) {
                 tooltip.style.left = viewer.eventToViewCoords(e).x + 'px';
                 tooltip.style.top = viewer.eventToViewCoords(e).y + 'px';
@@ -92,10 +140,10 @@ function ToolTip(viewer, viewerDiv, tooltip, precisionPx) {
         }
     }
 
-    function pickPosition(e) {
-        buildToolTip(viewer.controls.pickGeoPosition(viewer.eventToViewCoords(e)), e);
-    }
-
     document.addEventListener('mousemove', readPosition, false);
-    document.addEventListener('mousedown', pickPosition, false);
+    document.addEventListener('mousedown', readPosition, false);
+}
+
+if (typeof module != 'undefined' && module.exports) {
+    module.exports = ToolTip;
 }

--- a/examples/shapefile.html
+++ b/examples/shapefile.html
@@ -13,17 +13,14 @@
         <script src="js/GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
+        <script src="js/FeatureToolTip.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
             // Define initial camera position
             var positionOnGlobe = { longitude: 2.351323, latitude: 48.856712, altitude: 25000 };
-            var miniView;
-            var minDistance = 10000000;
-            var maxDistance = 30000000;
 
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             var viewerDiv = document.getElementById('viewerDiv');
-            var miniDiv = document.getElementById('miniDiv');
 
             // Instanciate iTowns GlobeView*
             var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
@@ -63,6 +60,8 @@
                     }});
 
                 view.addLayer(velibLayer);
+
+                new ToolTip(view, { filterAll: false });
             });
         </script>
     </body>


### PR DESCRIPTION
Before, only a few selected properties of a feature were displayed in
FeatureToolTip. Now, everything is displayed.
In the same time, a quick cleaning has been done, and the FeatureToolTip
has been added to the shapefile example.
