### PR TITLE
Debugging code

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -24,6 +24,10 @@ See the [node website](https://nodejs.org) to install node and npm.
    * You can then require `src/Main.js` in your code
 * Test and lint changes: see test, lint and test-examples npm script
 
+## Debuging
+* `babel-inline-import-loader` prevents the source map debug in browser.
+   if you want launch server and debug with the original source map, run : `npm run debug`.
+
 ## Testing
 
 In order to run the tests, [puppeteer](https://github.com/GoogleChrome/puppeteer)

--- a/CODING.md
+++ b/CODING.md
@@ -24,9 +24,10 @@ See the [node website](https://nodejs.org) to install node and npm.
    * You can then require `src/Main.js` in your code
 * Test and lint changes: see test, lint and test-examples npm script
 
-## Debuging
+## Debugging
 * `babel-inline-import-loader` prevents the source map debug in browser.
    if you want launch server and debug with the original source map, run : `npm run debug`.
+* To debug iTowns package on your side project. You can link iTowns package with `npm link ../path/iTowns/` in project folder and auto-transpile to `lib/` when iTowns sources are modified with command `npm run watch` in iTowns folder.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "webpack -p",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
+    "debug": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot --env.noInline=true",
     "prepublishOnly": "npm run build && npm run transpile",
     "prepare": "node ./config/prepare.js && node ./config/replace.config.js"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
     "debug": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot --env.noInline=true",
     "prepublishOnly": "npm run build && npm run transpile",
-    "prepare": "node ./config/prepare.js && node ./config/replace.config.js"
+    "prepare": "node ./config/prepare.js && node ./config/replace.config.js",
+    "watch": "cross-env BABEL_DISABLE_CACHE=1 babel --watch src --out-dir lib"
   },
   "nyc": {
     "exclude": "**/*ThreeExtended"

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -119,6 +119,7 @@ function c3DEngine(rendererOrDiv, options = {}) {
     this.renderer.setClearColor(0x030508);
     this.renderer.autoClear = false;
     this.renderer.sortObjects = true;
+    this.renderer.debug.checkShaderErrors = __DEBUG__;
 
     if (!renderer) {
         this.renderer.setPixelRatio(viewerDiv.devicePixelRatio);

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -52,6 +52,7 @@ const renderer = {
     capabilities: {
         logarithmicDepthBuffer: true,
     },
+    debug: {},
     setClearColor: () => {},
     getRenderTarget: () => { },
     setRenderTarget: () => {},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,49 +36,54 @@ const include = [
     path.resolve(__dirname, 'utils'),
 ];
 
-module.exports = {
-    context: path.resolve(__dirname),
-    resolve: {
-        modules: [path.resolve(__dirname, 'src'), 'node_modules'],
-    },
-    entry: {
-        itowns: ['@babel/polyfill', 'url-polyfill', 'whatwg-fetch', './src/MainBundle.js'],
-        debug: ['./utils/debug/Main.js'],
-    },
-    devtool: 'source-map',
-    output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: '[name].js',
-        library: '[name]',
-        libraryTarget: 'umd',
-        umdNamedDefine: true,
-    },
-    optimization: {
-        runtimeChunk: {
-            name: 'itowns',
+module.exports = (env) => {
+    const babelLoaderOptions = [];
+    if (!(env && env.noInline)) {
+        babelLoaderOptions.push('babel-inline-import-loader');
+    }
+    babelLoaderOptions.push({
+        loader: 'babel-loader',
+        options: babelConf,
+    });
+    return {
+        context: path.resolve(__dirname),
+        resolve: {
+            modules: [path.resolve(__dirname, 'src'), 'node_modules'],
         },
-    },
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                enforce: 'pre',
-                include,
-                loader: 'eslint-loader',
+        entry: {
+            itowns: ['@babel/polyfill', 'url-polyfill', 'whatwg-fetch', './src/MainBundle.js'],
+            debug: ['./utils/debug/Main.js'],
+        },
+        devtool: 'source-map',
+        output: {
+            path: path.resolve(__dirname, 'dist'),
+            filename: '[name].js',
+            library: '[name]',
+            libraryTarget: 'umd',
+            umdNamedDefine: true,
+        },
+        optimization: {
+            runtimeChunk: {
+                name: 'itowns',
             },
-            {
-                test: /\.js$/,
-                include,
-                use: [
-                    'babel-inline-import-loader',
-                    {
-                        loader: 'babel-loader',
-                        options: babelConf,
-                    }],
-            },
-        ],
-    },
-    devServer: {
-        publicPath: '/dist/',
-    },
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.js$/,
+                    enforce: 'pre',
+                    include,
+                    loader: 'eslint-loader',
+                },
+                {
+                    test: /\.js$/,
+                    include,
+                    use: babelLoaderOptions,
+                },
+            ],
+        },
+        devServer: {
+            publicPath: '/dist/',
+        },
+    };
 };


### PR DESCRIPTION
* chore: option to disable babel-inline-import-loader.
`npm run startDebug` => launch server and debug with no transpiled source map. fix #934
* add shader debugging in developing mode
* add command to auto transpile iTowns

* `babel-inline-import-loader` prevents the source map debug in browser.
   if you want launch server and debug with the original source map, run : `npm run startDebug`.
* To debug iTowns package on your side project. You can link iTowns package with `npm link ../path/iTowns/` in project folder and auto-transpile when iTowns sources are modified with command `npm run watch` in iTowns folder.


## Motivation and Context
* babel-inline-import-loader prevents the source map debug in browser.
* since three v104  shader debugging are disabled by default

