### PR TITLE
chore: update THREE to r105.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9040,9 +9040,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.104.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.104.0.tgz",
-      "integrity": "sha512-q617IMBC5k40U2E9UC4/LtmhzTOOLB1jGMIooUL+QrhZ7abiGCSDrKrpCDt9V8RTl6xw+0FYfA1PYsIPKbQOgg==",
+      "version": "0.105.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.105.2.tgz",
+      "integrity": "sha512-L3Al37k4g3hVbgFFS251UVtIc25chhyN0/RvXzR0C+uIBToV6EKDG+MZzEXm9L2miGUVMK27W46/VkP6WUZXMg==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.104.0"
+    "three": "^0.105.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -83,7 +83,7 @@
     "proj4": "^2.5.0",
     "puppeteer": "^1.17.0",
     "replace-in-file": "^4.1.0",
-    "three": "^0.104.0",
+    "three": "^0.105.2",
     "url-polyfill": "^1.1.5",
     "webpack": "^4.32.2",
     "webpack-cli": "^3.3.2",


### PR DESCRIPTION
 ### update THREE to r105.2

- [x] For usability reasons, the default of WebGLRenderer.debug.checkShaderErrors is now false.
- [x] EffectComposer.setSize() now respects the pixel ratio. An instance of EffectComposer can now be resized with the same width and height values like WebGLRenderer.
- [x] Renamed QuickHull to ConvexHull. The file is now located in examples/js/math.
- [x] SimplexNoise and ImprovedNoise are now in the THREE namespace and located in examples/js/math.
- [x] AnimationClipCreator and TimelinerController are now located in examples/js/animation.
- [x] ParametricGeometries is now located in examples/js/geometries.
- [x] hilbert2d and hilbert3D were removed. Please use GeometryUtils.hilbert2D() and GeometryUtils.hilbert3D() instead.

### Interesting features for iTowns:
- Matrix4 
  - Support `.setPosition( x, y, z )`
- Object3D
  - Added `.attach()`


