### PR TITLE
fix(geographic): return the correct center of an extent

### DIFF
--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -104,9 +104,9 @@ class Coordinates {
      * @return {Coordinates} This Coordinates.
      */
     setFromValues(v0 = 0, v1 = 0, v2 = 0) {
-        this.x = v0;
-        this.y = v1;
-        this.z = v2;
+        this.x = v0 == undefined ? 0 : v0;
+        this.y = v1 == undefined ? 0 : v1;
+        this.z = v2 == undefined ? 0 : v2;
 
         this._normalNeedsUpdate = true;
         return this;
@@ -122,14 +122,7 @@ class Coordinates {
      * @return {Coordinates} This Coordinates.
      */
     setFromArray(array, offset = 0) {
-        this.x = array[offset];
-        this.y = array[offset + 1];
-        // special case for as() below, intentionally not mentioned in the
-        // documentation
-        this.z = array[offset + 2];
-
-        this._normalNeedsUpdate = true;
-        return this;
+        return this.setFromValues(array[offset], array[offset + 1], array[offset + 2]);
     }
 
     /**
@@ -142,12 +135,7 @@ class Coordinates {
      * @return {Coordinates} This Coordinates.
      */
     setFromVector3(v0) {
-        this.x = v0.x;
-        this.y = v0.y;
-        this.z = v0.z;
-
-        this._normalNeedsUpdate = true;
-        return this;
+        return this.setFromValues(v0.x, v0.y, v0.z);
     }
 
     /**

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -220,7 +220,7 @@ class Extent {
         this.dimensions(_dim);
 
         target.crs = this.crs;
-        target.setFromValues(this.west + _dim.x * 0.5, this.south + _dim.y * 0.5, target.z);
+        target.setFromValues(this.west + _dim.x * 0.5, this.south + _dim.y * 0.5);
 
         return target;
     }


### PR DESCRIPTION
The altitude is not taken in account here, as it was before the
refactoring to ES6 Coordinates. `undefined` cases have also been handled
better, and all `set` methods of `Coordinates` redirect to
`setFromValues`.

Fixes #1150 