### PR TITLE
fix(examples): remove UTIF package and use it from a CDN

### DIFF
--- a/examples/tiff.html
+++ b/examples/tiff.html
@@ -11,7 +11,7 @@
     <body>
         <div id="viewerDiv"></div>
         <script src="js/GUI/GuiTools.js"></script>
-        <script src="../node_modules/utif/UTIF.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/utif@3.1.0/UTIF.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/loading_screen.js"></script>
         <script src="js/TIFFParser.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9428,15 +9428,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "utif": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utif/-/utif-3.0.0.tgz",
-      "integrity": "sha512-rAdBSYyqIbU7hFV38pibD9kyYBuzshrWa2jNhE/17YWe8DqI0/JSDBcL3GN48DvG04JC2ecG4Xu0XcQZnEGLdg==",
-      "dev": true,
-      "requires": {
-        "pako": "^1.0.5"
-      }
-    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "replace-in-file": "^4.1.0",
     "three": "^0.105.2",
     "url-polyfill": "^1.1.5",
-    "utif": "^3.0.0",
     "webpack": "^4.32.2",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.5.1",


### PR DESCRIPTION
The current example is not working, I forgot that npm packages weren't installed in Github 