### PR TITLE
chore: update THREE to r106.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9073,9 +9073,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.105.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.105.2.tgz",
-      "integrity": "sha512-L3Al37k4g3hVbgFFS251UVtIc25chhyN0/RvXzR0C+uIBToV6EKDG+MZzEXm9L2miGUVMK27W46/VkP6WUZXMg==",
+      "version": "0.106.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.106.2.tgz",
+      "integrity": "sha512-4Tlx43uoxnIaZFW2Bzkd1rXsatvVHEWAZJy8LuE+s6Q8c66ogNnhfq1bHiBKPAnXP230LD11H/ScIZc2LZMviA==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.5.0",
-    "three": "^0.105.2"
+    "three": "^0.106.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -84,7 +84,7 @@
     "proj4": "^2.5.0",
     "puppeteer": "^1.18.1",
     "replace-in-file": "^4.1.0",
-    "three": "^0.105.2",
+    "three": "^0.106.2",
     "url-polyfill": "^1.1.5",
     "webpack": "^4.35.2",
     "webpack-cli": "^3.3.5",

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -91,12 +91,14 @@ class CameraRig extends THREE.Object3D {
         // sea level's worldPoistion
         this.targetWorldPosition = new THREE.Vector3();
         this.removeAll = () => {};
+
+        this._onChangeCallback = null;
     }
 
     // apply rig.camera's transformation to camera
     applyTransformToCamera(view, camera) {
         if (this.proxy) {
-            camera.quaternion._onChange(() => {});
+            camera.quaternion._onChange(this._onChangeCallback);
             this.camera.matrixWorld.decompose(this.proxy.position, camera.quaternion, camera.scale);
             camera.quaternion._onChange(() => this.removeProxy(view, camera));
         } else {
@@ -108,6 +110,7 @@ class CameraRig extends THREE.Object3D {
         if (!this.proxy && view && camera) {
             this.proxy = { position: new THREE.Vector3() };
             Object.keys(camera.position).forEach(key => proxyProperty(view, camera, this, key));
+            this._onChangeCallback = camera.quaternion._onChangeCallback;
             camera.quaternion._onChange(() => this.removeProxy(view, camera));
         }
     }
@@ -116,7 +119,7 @@ class CameraRig extends THREE.Object3D {
         this.stop(view);
         if (this.proxy && view && camera) {
             Object.keys(camera.position).forEach(key => Object.defineProperty(camera.position, key, { value: this.proxy.position[key], writable: true }));
-            camera.quaternion._onChange(() => {});
+            camera.quaternion._onChange(this._onChangeCallback);
             this.proxy = null;
         }
     }

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -96,9 +96,9 @@ class CameraRig extends THREE.Object3D {
     // apply rig.camera's transformation to camera
     applyTransformToCamera(view, camera) {
         if (this.proxy) {
-            camera.quaternion.onChange(() => {});
+            camera.quaternion._onChange(() => {});
             this.camera.matrixWorld.decompose(this.proxy.position, camera.quaternion, camera.scale);
-            camera.quaternion.onChange(() => this.removeProxy(view, camera));
+            camera.quaternion._onChange(() => this.removeProxy(view, camera));
         } else {
             this.camera.matrixWorld.decompose(camera.position, camera.quaternion, camera.scale);
         }
@@ -108,7 +108,7 @@ class CameraRig extends THREE.Object3D {
         if (!this.proxy && view && camera) {
             this.proxy = { position: new THREE.Vector3() };
             Object.keys(camera.position).forEach(key => proxyProperty(view, camera, this, key));
-            camera.quaternion.onChange(() => this.removeProxy(view, camera));
+            camera.quaternion._onChange(() => this.removeProxy(view, camera));
         }
     }
 
@@ -116,7 +116,7 @@ class CameraRig extends THREE.Object3D {
         this.stop(view);
         if (this.proxy && view && camera) {
             Object.keys(camera.position).forEach(key => Object.defineProperty(camera.position, key, { value: this.proxy.position[key], writable: true }));
-            camera.quaternion.onChange(() => {});
+            camera.quaternion._onChange(() => {});
             this.proxy = null;
         }
     }


### PR DESCRIPTION

- [x] All examples now use ES6 modules.
- [x] VRMLLoader has a new implementation. It's necessary now to include chevrotain.min.js into your code. Check out the official example for more details.
- [x] The optional update arg has been removed from the public API of the following methods: Euler.setFromRotationMatrix( m, order ), Euler.setFromQuaternion( q, order ), and Quaternion.setFromEuler( e ).
- [x] GPUParticleSystem has been removed.
- [x] DracoExporter has been renamed to DRACOExporter.
- [x] Objects of type LOD are now updated automatically by WebGLRenderer. Set LOD.autoUpdate to false if you want to perform the update by yourself.
- [x] MTL related functions like .loadMtl() have been removed from OBJLoader2. Please use MTLLoader and MtlObjBridge as shown in basic obj2 example.

