### PR TITLE
fix(core): handle the case where the Mesh.material is an array

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ The following people have contributed to iTowns 2.
   * [Emmanuel Schmück](https://github.com/EmmanuelSchmuck/)
   * [Marie Lamure](https://github.com/mlamure)
   * [Vincent Jaillot](https://github.com/jailln)
+  * [Valentin Rigolle](https://github.com/Crejak)
 
 * [virtualcitySYSTEMS](https://www.virtualcitysystems.de/)
   * [Ben Kuster](https://github.com/bkuster)

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -9,7 +9,13 @@ function disposeMesh(obj) {
             obj.geometry.dispose();
         }
         if (obj.material) {
-            obj.material.dispose();
+            if (Array.isArray(obj.material)) {
+                for (const material of obj.material) {
+                    material.dispose();
+                }
+            } else {
+                obj.material.dispose();
+            }
         }
     }
 }

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -182,7 +182,13 @@ export default {
                         mesh.frustumCulled = false;
                         if (mesh.material) {
                             if (options.overrideMaterials) {
-                                mesh.material.dispose();
+                                if (Array.isArray(mesh.material)) {
+                                    for (const material of mesh.material) {
+                                        material.dispose();
+                                    }
+                                } else {
+                                    mesh.material.dispose();
+                                }
                                 if (typeof (options.overrideMaterials) === 'object' &&
                                     options.overrideMaterials.isMaterial) {
                                     mesh.material = options.overrideMaterials.clone();

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -212,7 +212,15 @@ function _cleanupObject3D(n) {
     }
     // free resources
     if (n.material) {
-        n.material.dispose();
+        // material can be either a THREE.Material object, or an array of
+        // THREE.Material objects
+        if (Array.isArray(n.material)) {
+            for (const material of n.material) {
+                material.dispose();
+            }
+        } else {
+            n.material.dispose();
+        }
     }
     if (n.geometry) {
         n.geometry.dispose();

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -18,7 +18,13 @@ export default {
                 // obj.geometry = null;
             }
             if (obj.material) {
-                obj.material.dispose();
+                if (Array.isArray(obj.material)) {
+                    for (const material of obj.material) {
+                        material.dispose();
+                    }
+                } else {
+                    obj.material.dispose();
+                }
                 // obj.material = null;
             }
         }

--- a/src/Process/PointCloudProcessing.js
+++ b/src/Process/PointCloudProcessing.js
@@ -291,7 +291,13 @@ export default {
                 // remove from group
                 layer.group.children.splice(i, 1);
 
-                obj.material.dispose();
+                if (Array.isArray(obj.material)) {
+                    for (const material of obj.material) {
+                        material.dispose();
+                    }
+                } else {
+                    obj.material.dispose();
+                }
                 obj.geometry.dispose();
                 obj.material = null;
                 obj.geometry = null;
@@ -300,7 +306,13 @@ export default {
                 if (__DEBUG__) {
                     if (obj.boxHelper) {
                         obj.boxHelper.removeMe = true;
-                        obj.boxHelper.material.dispose();
+                        if (Array.isArray(obj.boxHelper.material)) {
+                            for (const material of obj.boxHelper.material) {
+                                material.dispose();
+                            }
+                        } else {
+                            obj.boxHelper.material.dispose();
+                        }
                         obj.boxHelper.geometry.dispose();
                     }
                 }

--- a/utils/debug/OBBHelper.js
+++ b/utils/debug/OBBHelper.js
@@ -69,7 +69,13 @@ class OBBHelper extends THREE.LineSegments {
         this.material.dispose();
         this.geometry.dispose();
         if (this.textMesh) {
-            this.textMesh.material.dispose();
+            if (Array.isArray(this.textMesh.material)) {
+                for (const material of this.textMesh.material) {
+                    material.dispose();
+                }
+            } else {
+                this.textMesh.material.dispose();
+            }
             this.textMesh.geometry.dispose();
             delete this.textMesh;
         }

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -163,6 +163,10 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
                                 if (c.layer === sb_layer_id) {
                                     if (c.dispose) {
                                         c.dispose();
+                                    } else if (Array.isArray(c.material)) {
+                                        for (const material of c.material) {
+                                            material.dispose();
+                                        }
                                     } else {
                                         c.material.dispose();
                                     }


### PR DESCRIPTION
When disposing the material of a Mesh, the type of the attribute
was not checked and was assumed to be an instance of `Material`.
The case where `material` is an array has now been handled.

## Description

As specified in the [THREE.js documentation](https://threejs.org/docs/index.html#api/en/objects/Mesh) for the Mesh object, the `material` attribute can either be "a single or an array of Material". In iTowns, only the first case was handled. This is easily fixed by adding an condition on the object type (by calling `Array.isArray`) to check wether the `material` attribute is an array.

## Motivation and Context

We found out the problem when trying to color a 3DTiles object using the `groups` attribute of the mesh. When using groups, THREE.js require that the mesh uses an array of materials instead of a single one. This causes a bug where the application crashes at a `material.dispose()` call in `3DTilesProcessing` when a tile unloads.