### PR TITLE
fix(controls): smart zoom in the right direction

### DIFF
--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -457,7 +457,10 @@ function PlanarControls(view, options = {}) {
         // camera position at the end of the travel
         const moveTarget = new THREE.Vector3();
 
-        moveTarget.copy(pointUnderCursor).add(dir.multiplyScalar(-targetHeight * 2));
+        moveTarget.copy(pointUnderCursor);
+        if (this.enableRotation) {
+            moveTarget.add(dir.multiplyScalar(-targetHeight * 2));
+        }
         moveTarget.z = pointUnderCursor.z + targetHeight;
 
         // initiate the travel


### PR DESCRIPTION
When the rotation is disable on the control, don't apply some factor to
the movement to do.

Fixes #835
