### PR TITLE
fix(elevation): add a removed line from the elevation shader

### DIFF
--- a/examples/layers/JSONLayers/GeoidMNT.json
+++ b/examples/layers/JSONLayers/GeoidMNT.json
@@ -4,6 +4,7 @@
     "updateStrategy": {
         "type": 0
     },
+    "zmin": -12000,
     "source": {
         "url": "https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/geoid/geoid/bil/%TILEMATRIX/geoid_%COL_%ROW.bil",
         "format": "image/x-bil;bits=32",

--- a/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
+++ b/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
@@ -33,6 +33,7 @@
     float getElevation(vec2 uv, sampler2D texture, vec4 offsetScale, Layer layer) {
         uv = uv * offsetScale.zw + offsetScale.xy;
         float d = getElevationMode(uv, texture, layer.mode);
+        if (d < layer.zmin || d > layer.zmax) d = 0.;
         return d * layer.scale + layer.bias;
     }
 #endif


### PR DESCRIPTION
The minimum z of an elevation layer was no longer respected, and it was
causing visual artefacts.
