### PR TITLE
fix(picking): NaN value when getting the tile under the picking position

### DIFF
--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -43,7 +43,7 @@ function screenCoordsToNodeId(view, tileLayer, viewCoords, radius = 0) {
 
     traversePickingCircle(radius, (x, y) => {
         const idx = (y * 2 * radius + x) * 4;
-        const data = buffer.slice(idx, idx + 4);
+        const data = buffer.slice(idx, (idx + 4) || undefined);
         depthRGBA.fromArray(data).divideScalar(255.0);
         const unpack = unpack1K(depthRGBA, 256 ** 3);
 


### PR DESCRIPTION
When `idx` was given the value `-4`, we got `buffer.slice(-4, 0)` which is not a "valid" call: it results in an empty array. Adding ` || undefined` fix this problem.