### PR TITLE
Fix #1215 (Meridian convergence looks good but seems to be applied in reverse)

### DIFF
--- a/test/unit/orientationUtils.js
+++ b/test/unit/orientationUtils.js
@@ -131,7 +131,7 @@ describe('OrientationUtils.quaternionFromCRSToCRS', function () {
 describe('OrientationUtils.quaternionFromCRSToCRS', function () {
     it('should compute the identity quaternion from EPSG:4978 to itself', function () {
         var coord = new Coordinates('EPSG:4978', 0, 0, 0); // local frame is a geocent frame
-        var actual = OrientationUtils.quaternionFromCRSToCRS('EPSG:4978', 'EPSG:4978')(coord);
+        var actual = OrientationUtils.quaternionFromCRSToCRS('EPSG:4978', 'EPSG:4978', coord);
 
         var expected = new THREE.Quaternion();
         assertQuatEqual(expected, actual);
@@ -153,11 +153,11 @@ const RAD2DEG = THREE.Math.RAD2DEG;
 const axis = new THREE.Vector3().set(0, 0, 1);
 
 // https://geodesie.ign.fr/contenu/fichiers/documentation/algorithmes/alg0060.pdf
-describe('OrientationUtils.quaternionToLCC', function () {
+describe('OrientationUtils.quaternionFromLCCToEnu', function () {
     it('should compute the correct meridian convergence 1/2', function () {
         var coord = new Coordinates('EPSG:4326', 0.0523598776 * RAD2DEG, 0.8796459430 * RAD2DEG);
         var proj = { lat0: Math.asin(0.7604059656), long0: 0.0407923443 };
-        var actual = OrientationUtils.quaternionToLCC(proj)(coord);
+        var actual = OrientationUtils.quaternionFromLCCToEnu(proj, coord);
         var expected = new THREE.Quaternion();
         expected.setFromAxisAngle(axis, -0.008796);
         assertQuatEqual(expected, actual, 7);
@@ -166,7 +166,7 @@ describe('OrientationUtils.quaternionToLCC', function () {
     it('should compute the correct meridian convergence 2/2', function () {
         var coord = new Coordinates('EPSG:4326', 0.1570796327 * RAD2DEG, 0.7330382858 * RAD2DEG);
         var proj = { lat0: Math.asin(0.6712679323), long0: 0.0407923443 };
-        var actual = OrientationUtils.quaternionToLCC(proj)(coord);
+        var actual = OrientationUtils.quaternionFromLCCToEnu(proj)(coord);
         var expected = new THREE.Quaternion();
         expected.setFromAxisAngle(axis, -0.07806);
         assertQuatEqual(expected, actual, 7);
@@ -174,11 +174,11 @@ describe('OrientationUtils.quaternionToLCC', function () {
 });
 
 // https://geodesie.ign.fr/contenu/fichiers/documentation/algorithmes/alg0061.pdf
-describe('OrientationUtils.quaternionToTMerc', function () {
+describe('OrientationUtils.quaternionFromTMercToEnu', function () {
     it('should compute the correct meridian convergence 1/3', function () {
         var coord = new Coordinates('EPSG:4326', -0.0785398163 * RAD2DEG, 0.8552113335 * RAD2DEG);
         var proj = { e: 0.0818191910, long0: -0.0523598776 };
-        var actual = OrientationUtils.quaternionToTMerc(proj)(coord);
+        var actual = OrientationUtils.quaternionFromTMercToEnu(proj, coord);
         var expected = new THREE.Quaternion();
         expected.setFromAxisAngle(axis, 0.01976);
         assertQuatEqual(expected, actual, 6);
@@ -187,7 +187,7 @@ describe('OrientationUtils.quaternionToTMerc', function () {
     it('should compute the correct meridian convergence 2/3', function () {
         var coord = new Coordinates('EPSG:4326', 0.0523598776 * RAD2DEG, 0.837758041 * RAD2DEG);
         var proj = { e: 0.0818191910, long0: 0.0523598776 };
-        var actual = OrientationUtils.quaternionToTMerc(proj)(coord);
+        var actual = OrientationUtils.quaternionFromTMercToEnu(proj)(coord);
         var expected = new THREE.Quaternion();
         expected.setFromAxisAngle(axis, 0);
         assertQuatEqual(expected, actual, 6);
@@ -196,7 +196,7 @@ describe('OrientationUtils.quaternionToTMerc', function () {
     it('should compute the correct meridian convergence 3/3', function () {
         var coord = new Coordinates('EPSG:4326', 0.2094395102 * RAD2DEG, 0.872664626 * RAD2DEG);
         var proj = { e: 0.0818191910, long0: 0.1570796327 };
-        var actual = OrientationUtils.quaternionToTMerc(proj)(coord);
+        var actual = OrientationUtils.quaternionFromTMercToEnu(proj)(coord);
         var expected = new THREE.Quaternion();
         expected.setFromAxisAngle(axis, -0.040125);
         assertQuatEqual(expected, actual, 6);


### PR DESCRIPTION
this PR :
- fixes #1215
- generalizes the use of  ```quaternionFrom[*]``` and ```quaternionTo[*]``` functions. By being explicit, I expect less bugs in client code.
- reintroduces currying : similar to [proj4](http://proj4js.org/) where ```proj4(fromProjection[, toProjection, coordinates])``` returns a function when `coordinates` is undefined. This way, ```crs2crs=OrientationUtils.quaternionFromCRSToCRS('EPSG:4978', 'EPSG:4978')``` may do some precomputing and be stored to be applied later to many coordinates. These two lines are equivalent : 
```
OrientationUtils.quaternionFromCRSToCRS('EPSG:4978', 'EPSG:4978')(coord)
OrientationUtils.quaternionFromCRSToCRS('EPSG:4978', 'EPSG:4978', coord)
```

