### PR TITLE
feat(view): add a pickFeaturesAt method in View

### DIFF
--- a/examples/effects_stereo.html
+++ b/examples/effects_stereo.html
@@ -174,11 +174,11 @@
             debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
 
             function updateScaleWidget() {
-                var value = view.controls.pixelsToMeters(200);
+                var value = view.getPixelsToMeters(200);
                 value = Math.floor(value);
                 var digit = Math.pow(10, value.toString().length - 1);
                 value = Math.round(value / digit) * digit;
-                var pix = view.controls.metersToPixels(value);
+                var pix = view.getMetersToPixels(value);
                 var unit = 'm';
                 if (value >= 1000) {
                     value /= 1000;

--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -1,150 +1,229 @@
 /* global itowns */
 /**
  * A tooltip that can display some useful information about a feature when
- * hovering it. Only works for layers using FileSource.
+ * hovering it.
  *
- * @param {View} viewer - The view to bind the tooltip to.
- * @param {Object} options - Options to have more custom content displayed.
- * @param {number} [options.precisionPx=5] - The precision of the picking.
- * @param {function} [options.format] - A function that takes the name of the
- * property currently being processed and its value, and gives the appropriate
- * HTML output to it. If this method is specified, no others properties other
- * than the ones handled in it will be displayed.
- * @param {Array<string>} [options.filter] - An array of properties to filter.
- * @param {boolean} [options.filterAll=true] - Filter all the properties.
- * Default to true.
- *
- * @class FeatureToolTip
+ * @module FeatureToolTip
  *
  * @example
- * view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function() {
- *      new FeatureToolTip(view);
- * });
+ * // Initialize the FeatureToolTip
+ * FeatureToolTip.init(viewerDiv, view);
+ *
+ * // Add layers
+ * var wfsSource = new itowns.WFSSource(...);
+ * var wfsLayer = new itowns.ColorLayer(wfsSource...);
+ * view.addLayer(wfsLayer);
+ *
+ * var fileSource = new itowns.FileSource(...);
+ * var fileLayer = new itowns.GeometryLayer(fileSource...);
+ * view.addLayer(fileLayer);
+ *
+ * FeatureToolTip.addLayer(wfsLayer);
+ * FeatureToolTip.addLayer(fileLayer);
  */
-function FeatureToolTip(viewer, options) {
-    var opts = options || { filterAll: true };
-    opts.filter = opts.filter == undefined ? [] : opts.filter;
-
-    var tooltip = document.createElement('div');
-    tooltip.className = 'tooltip';
-    viewer.mainLoop.gfxEngine.renderer.domElement.parentElement.appendChild(tooltip);
+var FeatureToolTip = (function _() {
+    var tooltip;
+    var view;
+    var layers = [];
+    var layersId = [];
 
     var mouseDown = 0;
-    document.body.onmousedown = function onmousedown() {
+    document.body.addEventListener('mousedown', function _() {
         ++mouseDown;
-    };
-    document.body.onmouseup = function onmouseup() {
+    }, false);
+    document.body.addEventListener('mouseup', function _() {
         --mouseDown;
-    };
+    }, false);
 
-    var layer;
-    var result;
-    var feature;
-    var symb;
-    var style;
-    var fill;
-    var stroke;
-    var content;
-    var prop;
-    var layers = viewer.getLayers(function _(l) { return l.source && l.source.isFileSource; });
-    function buildToolTip(geoCoord, e) {
-        var visible = false;
-        var i = 0;
-        var p = 0;
-        var precision = viewer.controls.pixelsToDegrees(opts.precisionPx || 5);
-
+    function moveToolTip(event) {
         tooltip.innerHTML = '';
         tooltip.style.display = 'none';
-        if (geoCoord) {
-            visible = false;
 
-            // Pick on each layer, and display them all in the tooltip
-            for (i = 0; i < layers.length; i++) {
-                layer = layers[i];
+        var features = view.pickFeaturesAt(event, 3, layersId);
 
-                if (!layer.source.parsedData) { continue; }
+        var layer;
+        for (var layerId in features) {
+            if (features[layerId].length == 0) {
+                continue;
+            }
 
-                result = itowns.FeaturesUtils.filterFeaturesUnderCoordinate(geoCoord, layer.source.parsedData, precision);
+            layer = layers[layersId.indexOf(layerId)];
+            if (typeof layer.options.filterGeometries == 'function') {
+                features[layerId] = layer.options.filterGeometries(features[layerId], layer.layer) || [];
+            }
+            tooltip.innerHTML += fillToolTip(features[layerId], layer.layer, layer.options);
+        }
 
-                for (p = 0; p < result.length; p++) {
-                    content = '';
-                    visible = true;
+        if (tooltip.innerHTML != '') {
+            tooltip.style.display = 'block';
+            tooltip.style.left = view.eventToViewCoords(event).x + 'px';
+            tooltip.style.top = view.eventToViewCoords(event).y + 'px';
+        }
+    }
 
-                    feature = result[p].geometry;
-                    style = layer.style.isStyle ? layer.style : feature.properties.style;
-                    fill = style.fill.color;
-                    stroke = '1.25px ' + style.stroke.color;
+    function fillToolTip(features, layer, options) {
+        var content = '';
+        var feature;
+        var geometry;
+        var style;
+        var fill;
+        var stroke;
+        var symb = '';
+        var prop;
 
-                    if (result[p].type === itowns.FEATURE_TYPES.POLYGON) {
-                        symb = '&#9724';
-                    } else if (result[p].type === itowns.FEATURE_TYPES.LINE) {
-                        symb = '&#9473';
-                        fill = style.stroke.color;
-                        stroke = '0px';
-                    } else if (result[p].type === itowns.FEATURE_TYPES.POINT) {
-                        symb = '&#9679';
+        for (var p = 0; p < features.length; p++) {
+            feature = features[p];
+
+            geometry = feature.geometry;
+            style = (layer.style && layer.style.isStyle) ? layer.style : geometry.properties.style;
+            fill = style.fill.color;
+            stroke = '1.25px ' + style.stroke.color;
+
+            if (feature.type === itowns.FEATURE_TYPES.POLYGON) {
+                symb = '&#9724';
+            } else if (feature.type === itowns.FEATURE_TYPES.LINE) {
+                symb = '&#9473';
+                fill = style.stroke.color;
+                stroke = '0px';
+            } else if (feature.type === itowns.FEATURE_TYPES.POINT) {
+                symb = '&#9679';
+            }
+
+            content += '<div>';
+            content += '<span style="color: ' + fill + '; -webkit-text-stroke: ' + stroke + '">';
+            content += symb + ' ';
+            content += '</span>';
+            content += (geometry.properties.name || geometry.properties.nom || geometry.properties.description || layer.name || '');
+
+            if (feature.type === itowns.FEATURE_TYPES.POINT) {
+                content += '<br/><span class="coord">long ' + feature.coordinates[0].toFixed(4) + '</span>';
+                content += '<br/><span class="coord">lat ' + feature.coordinates[1].toFixed(4) + '</span>';
+            }
+
+            if (geometry.properties && !options.filterAllProperties) {
+                if (options.format) {
+                    for (prop in geometry.properties) {
+                        if (!options.filterProperties.includes(prop)) {
+                            content += options.format(prop, geometry.properties[prop]) || '';
+                        }
                     }
-
-                    content += '<div>';
-                    content += '<span style="color: ' + fill + '; -webkit-text-stroke: ' + stroke + '">';
-                    content += symb + ' ';
-                    content += '</span>';
-                    content += (feature.properties.name || feature.properties.nom || feature.properties.description || layer.name);
-
-                    if (result[p].type === itowns.FEATURE_TYPES.POINT) {
-                        content += '<br/><span class="coord">long ' + result[p].coordinates[0].toFixed(4) + '</span>';
-                        content += '<br/><span class="coord">lat ' + result[p].coordinates[1].toFixed(4) + '</span>';
-                    }
-
-                    if (feature.properties && !opts.filterAll) {
-                        if (opts.format) {
-                            for (prop in feature.properties) {
-                                if (!opts.filter.includes(prop) && prop != 'style' && prop != 'name' && prop != 'nom' && prop != 'description') {
-                                    opts.format(prop, feature.properties[prop]);
-                                }
-                            }
-                        } else {
-                            content += '<ul>';
-                            for (prop in feature.properties) {
-                                if (!opts.filter.includes(prop) && prop != 'style' && prop != 'name' && prop != 'nom' && prop != 'description') {
-                                    content += '<li>' + prop + ': ' + feature.properties[prop] + '</li>';
-                                }
-                            }
-
-                            if (content.endsWith('<ul>')) {
-                                content = content.replace('<ul>', '');
-                            } else {
-                                content += '</ul>';
-                            }
+                } else {
+                    content += '<ul>';
+                    for (prop in geometry.properties) {
+                        if (!options.filterProperties.includes(prop)) {
+                            content += '<li>' + prop + ': ' + geometry.properties[prop] + '</li>';
                         }
                     }
 
-                    content += '</div>';
-
-                    tooltip.innerHTML += content;
+                    if (content.endsWith('<ul>')) {
+                        content = content.replace('<ul>', '');
+                    } else {
+                        content += '</ul>';
+                    }
                 }
             }
 
-            if (visible) {
-                tooltip.style.left = viewer.eventToViewCoords(e).x + 'px';
-                tooltip.style.top = viewer.eventToViewCoords(e).y + 'px';
-                tooltip.style.display = 'block';
+            content += '</div>';
+        }
+
+        return content;
+    }
+
+    return {
+        /**
+         * Initialize the `FeatureToolTip` plugin for a specific view.
+         *
+         * @param {Element} viewerDiv - The element containing the viewer.
+         * @param {View} viewer - The view to bind the tooltip to.
+         *
+         * @example
+         * const viewerDiv = document.getElementById('viewerDiv');
+         * const view = new GlobeView(viewerDiv, { longitude: 4, latitude: 45, altitude: 3000 });
+         *
+         * FeatureToolTip.init(viewerDiv, view);
+         *
+         * @memberof module:FeatureToolTip
+         */
+        init: function _(viewerDiv, viewer) {
+            // HTML element
+            tooltip = document.createElement('div');
+            tooltip.className = 'tooltip';
+            viewerDiv.appendChild(tooltip);
+
+            // View binding
+            view = viewer;
+
+            // Mouse movement listening
+            function onMouseMove(event) {
+                if (!mouseDown) {
+                    moveToolTip(event);
+                } else {
+                    tooltip.style.left = view.eventToViewCoords(event).x + 'px';
+                    tooltip.style.top = view.eventToViewCoords(event).y + 'px';
+                }
             }
-        }
-    }
 
-    function readPosition(e) {
-        if (!mouseDown) {
-            buildToolTip(viewer.controls.pickGeoPosition(viewer.eventToViewCoords(e)), e);
-        } else {
-            tooltip.style.left = viewer.eventToViewCoords(e).x + 'px';
-            tooltip.style.top = viewer.eventToViewCoords(e).y + 'px';
-        }
-    }
+            document.addEventListener('mousemove', onMouseMove, false);
+            document.addEventListener('mousedown', onMouseMove, false);
+        },
 
-    document.addEventListener('mousemove', readPosition, false);
-    document.addEventListener('mousedown', readPosition, false);
-}
+        /**
+         * Add a layer to be picked by the tooltip.
+         *
+         * @param {Layer} layer - The layer to add.
+         * @param {Object} options - Options to have more custom content displayed.
+         * @param {function} [options.filterGeometries] - A callback to filter
+         * geometries following a criteria, like an id found on FeatureGeometry
+         * properties.  This is useful to remove duplicates, for example when a
+         * feature is present on multiple tiles at the same time (see the
+         * example below).  This function takes two parameters: a list of
+         * features (usually a `Array<Feature>`) and the `Layer` associated to
+         * these features.
+         * @param {function} [options.format] - A function that takes the name
+         * of the property currently being processed and its value, and gives
+         * the appropriate HTML output to it. If this method is specified, no
+         * others properties other than the ones handled in it will be
+         * displayed.
+         * @param {Array<string>} [options.filterProperties] - An array of
+         * properties to filter.
+         * @param {boolean} [options.filterAllProperties=true] - Filter all the
+         * properties, and don't display anything besides the name of the layer
+         * the feature is attached to.
+         *
+         * @return {Layer} The added layer.
+         *
+         * @example
+         * FeatureToolTip.addLayer(wfsLayer, {
+         *      filterProperties: ['uuid', 'notes', 'classification'],
+         *      filterGeometries: (features, layer) => {
+         *          const idList = [];
+         *          return features.filter((f) => {
+         *              if (!idList.includes(f.geometry.properties.id)) {
+         *                  idList.push(f.geometry.properties.id);
+         *                  return f;
+         *              }
+         *          });
+         *      }
+         * });
+         *
+         * @memberof module:FeatureToolTip
+         */
+        addLayer: function _(layer, options) {
+            if (!layer.isLayer) {
+                return layer;
+            }
+
+            var opts = options || { filterAllProperties: true };
+            opts.filterProperties = opts.filterProperties == undefined ? [] : opts.filterProperties;
+            opts.filterProperties.concat(['name', 'nom', 'style', 'description']);
+
+            layers.push({ layer: layer, options: opts });
+            layersId.push(layer.id);
+
+            return layer;
+        },
+    };
+}());
 
 if (typeof module != 'undefined' && module.exports) {
     module.exports = FeatureToolTip;

--- a/examples/plugins_vrt.html
+++ b/examples/plugins_vrt.html
@@ -27,7 +27,9 @@
             // Instanciate iTowns GlobeView*
             var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             var menuGlobe = new GuiTools('menuDiv', view);
+
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -62,9 +64,9 @@
                         }
                     }});
 
-                view.addLayer(velibLayer);
-
-                new FeatureToolTip(view, { filterAll: false });
+                return view.addLayer(velibLayer);
+            }).then(function _(layer) {
+                FeatureToolTip.addLayer(layer, { filterAllProperties: false });
             });
         </script>
     </body>

--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -30,6 +30,7 @@
             var menuGlobe = new GuiTools('menuDiv', view);
 
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -52,7 +53,6 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
-            var promises = [];
             var optionsGeoJsonParser = {
                         buildExtent: true,
                         crsIn: 'EPSG:4326',
@@ -63,7 +63,7 @@
             };
 
             // Convert by iTowns
-            promises.push(itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson')
+            itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson')
                 .then(function _(geojson) {
                     return itowns.GeoJsonParser.parse(geojson, optionsGeoJsonParser);
                 }).then(function _(parsedData) {
@@ -86,10 +86,10 @@
                         source: ariegeSource,
                     });
 
-                    return view.addLayer(ariegeLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
-                }));
+                    return view.addLayer(ariegeLayer);
+                }).then(FeatureToolTip.addLayer);
 
-            promises.push(itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/66-pyrenees-orientales/departement-66-pyrenees-orientales.geojson')
+            itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/66-pyrenees-orientales/departement-66-pyrenees-orientales.geojson')
                 .then(function _(geojson) {
                     return itowns.GeoJsonParser.parse(geojson, optionsGeoJsonParser);
                 }).then(function _(parsedData) {
@@ -113,14 +113,9 @@
                             source: pyoSource,
                         });
 
-                        return view.addLayer(pyoLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
-                    });
-                }));
-
-            // Listen for globe full initialisation event
-            view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function _() {
-                Promise.all(promises).then(new FeatureToolTip(view));
-            });
+                        return view.addLayer(pyoLayer);
+                    }).then(FeatureToolTip.addLayer);
+                });
 
             debug.createTileDebugUI(menuGlobe.gui, view);
         </script>

--- a/examples/source_file_gpx_raster.html
+++ b/examples/source_file_gpx_raster.html
@@ -30,6 +30,7 @@
             var menuGlobe = new GuiTools('menuDiv', view);
 
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -52,10 +53,8 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
-            var promises = [];
-
             // Parse and Convert by iTowns
-            promises.push(itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
+            itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
                 .then(function _(gpx) {
                     var gpxSource = new itowns.FileSource({
                         fetchedData: gpx,
@@ -78,13 +77,8 @@
                         },
                     });
 
-                    return view.addLayer(gpxLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
-                }));
-
-            // Listen for globe full initialisation event
-            view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function _() {
-                Promise.all(promises).then(new FeatureToolTip(view));
-            });
+                    return view.addLayer(gpxLayer);
+                }).then(FeatureToolTip.addLayer);
 
             debug.createTileDebugUI(menuGlobe.gui, view);
         </script>

--- a/examples/source_file_kml_raster.html
+++ b/examples/source_file_kml_raster.html
@@ -30,6 +30,7 @@
             var menuGlobe = new GuiTools('menuDiv', view);
 
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -52,8 +53,6 @@
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
-            var promises = [];
-
             // Fetch, Parse and Convert by iTowns
             var kmlSource = new itowns.FileSource({
                 url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
@@ -68,14 +67,9 @@
                 source: kmlSource,
             });
 
-            promises.push(view.addLayer(kmlLayer));
-
-            // Listen for globe full initialisation event
-            view.addEventListener(itowns.VIEW_EVENTS.LAYERS_INITIALIZED, function _() {
-                Promise.all(promises).then(new FeatureToolTip(view));
-            });
-
             debug.createTileDebugUI(menuGlobe.gui, view);
+
+            view.addLayer(kmlLayer).then(FeatureToolTip.addLayer);
         </script>
     </body>
 </html>

--- a/examples/source_file_shapefile.html
+++ b/examples/source_file_shapefile.html
@@ -25,7 +25,9 @@
             // Instanciate iTowns GlobeView*
             var view = new itowns.GlobeView(viewerDiv, positionOnGlobe);
             var menuGlobe = new GuiTools('menuDiv', view);
+
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -59,10 +61,11 @@
                         }
                     }});
 
-                view.addLayer(velibLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
-
-                new FeatureToolTip(view, { filterAll: false });
                 debug.createTileDebugUI(menuGlobe.gui, view);
+
+                return view.addLayer(velibLayer);
+            }).then(function _(layer) {
+                FeatureToolTip.addLayer(layer, { filterAllProperties: false });
             });
         </script>
     </body>

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -14,12 +14,8 @@
         <script src="js/GUI/GuiTools.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="js/plugins/FeatureToolTip.js"></script>
         <script src="../dist/debug.js"></script>
-        <div id="description">
-            <p><b>Building Information</b></p>
-            <ul id="info">
-            </ul>
-        </div>
         <script type="text/javascript">
             /* global itowns,document,GuiTools, window, debug, setupLoadingScreen */
             // Define initial camera position
@@ -33,6 +29,7 @@
             var menuGlobe = new GuiTools('menuDiv', view);
             var d = new debug.Debug(view, menuGlobe.gui);
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view, { filterAll: false });
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -89,6 +86,17 @@
                 source: wfsBuildingSource,
             });
             view.addLayer(wfsBuildingLayer);
+            FeatureToolTip.addLayer(wfsBuildingLayer, {
+                filterGeometries: function _(features, layer) {
+                    var idList = [];
+                    return features.filter(function _(f) {
+                        if (!idList.includes(f.geometry.properties.id)) {
+                            idList.push(f.geometry.properties.id);
+                            return f;
+                        }
+                    });
+                }
+            });
 
             // Listen for globe full initialisation event
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {

--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -16,6 +16,7 @@
         <script src="../dist/itowns.js"></script>
         <script src="../dist/debug.js"></script>
         <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="js/plugins/FeatureToolTip.js"></script>
         <script>
             // # Planar view with one single layer of vector tile
 
@@ -48,6 +49,7 @@
             // Turn in the right angle
             itowns.CameraUtils.transformCameraToLookAtTarget(view, view.camera.camera3D, { tilt: 90 });
             setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
 
             var count = 0;
 
@@ -99,7 +101,24 @@
                     projection: 'EPSG:3857',
                 });
 
-                view.addLayer(mvtLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(mvtLayer).then(function _(layer) {
+                    FeatureToolTip.addLayer(layer, {
+                        filterGeometries: function _(geometries) {
+                            var uniqueClasses = [];
+                            return geometries.filter(function _(g) {
+                                if (g.geometry.properties.class && !uniqueClasses.includes(g.geometry.properties.class)) {
+                                    uniqueClasses.push(g.geometry.properties.class);
+                                    return true;
+                                }
+                            });
+                        },
+                        filterAllProperties: false,
+                        format: function _(n, p) {
+                            if (p !== undefined && n == 'class') return p;
+                        }
+                    });
+                    return layer;
+                }).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             });
 
             // Request redraw

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -90,11 +90,11 @@
             var divScaleWidget = document.getElementById('divScaleWidget');
 
             function updateScaleWidget() {
-                var value = view.controls.pixelsToMeters(200);
+                var value = view.getPixelsToMeters(200);
                 value = Math.floor(value);
                 var digit = Math.pow(10, value.toString().length - 1);
                 value = Math.round(value / digit) * digit;
-                var pix = view.controls.metersToPixels(value);
+                var pix = view.getMetersToPixels(value);
                 var unit = 'm';
                 if (value >= 1000) {
                     value /= 1000;
@@ -113,6 +113,8 @@
             view.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
                 updateScaleWidget();
             });
+
+            window.addEventListener('resize', updateScaleWidget);
 
             debug.createTileDebugUI(menuGlobe.gui, view);
         </script>

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -1095,16 +1095,12 @@ GlobeControls.prototype.setZoom = function setZoom(zoom, isAnimated) {
  * This function compute the scale of a map
  * @param      {number}  pitch   Screen pitch, in millimeters ; 0.28 by default
  * @return     {number}  The zoom scale.
+ *
+ * @deprecated Use View#getScale instead.
  */
 GlobeControls.prototype.getScale = function getScale(pitch) {
-    // TODO: Why error div size height in Chrome?
-    // Screen pitch, in millimeters
-    pitch = (pitch || 0.28) / 1000;
-    const fov = THREE.Math.degToRad(this.camera.fov);
-    // projection one unit on screen
-    const gfx = this._view.mainLoop.gfxEngine;
-    const unitProjection = gfx.height / (2 * this.getRange() * Math.tan(fov * 0.5));
-    return pitch * unitProjection;
+    console.warn('Deprecated, use View#getScale instead.');
+    return this._view.getScale(pitch);
 };
 
 /**
@@ -1112,8 +1108,11 @@ GlobeControls.prototype.getScale = function getScale(pitch) {
  * @param      {number} pixels count pixels to project
  * @param      {number} pixelPitch Screen pixel pitch, in millimeters (default = 0.28 mm / standard pixel size of 0.28 millimeters as defined by the OGC)
  * @return     {number} projection in meters on globe
+ *
+ * @deprecated Use `View#getPixelsToMeters` instead.
  */
 GlobeControls.prototype.pixelsToMeters = function pixelsToMeters(pixels, pixelPitch = 0.28) {
+    console.warn('Deprecated use View#getPixelsToMeters instead.');
     const scaled = this.getScale(pixelPitch);
     const size = pixels * pixelPitch;
     return size / scaled / 1000;
@@ -1124,9 +1123,13 @@ GlobeControls.prototype.pixelsToMeters = function pixelsToMeters(pixels, pixelPi
  * @param      {number} pixels count pixels to project
  * @param      {number} pixelPitch Screen pixel pitch, in millimeters (default = 0.28 mm / standard pixel size of 0.28 millimeters as defined by the OGC)
  * @return     {number} projection in degree on globe
+ *
+ * @deprecated Use `View#getPixelsToMeters` and `GlobeControls#metersToDegrees`
+ * instead.
  */
 
 GlobeControls.prototype.pixelsToDegrees = function pixelsToDegrees(pixels, pixelPitch = 0.28) {
+    console.warn('Deprecated, use View#getPixelsToMeters and GlobeControls#getMetersToDegrees instead.');
     const chord = this.pixelsToMeters(pixels, pixelPitch);
     return THREE.Math.radToDeg(2 * Math.asin(chord / (2 * ellipsoidSizes.x)));
 };
@@ -1136,8 +1139,11 @@ GlobeControls.prototype.pixelsToDegrees = function pixelsToDegrees(pixels, pixel
  * @param      {number}  value Length in meter on globe
  * @param      {number}  pixelPitch Screen pixel pitch, in millimeters (default = 0.28 mm / standard pixel size of 0.28 millimeters as defined by the OGC)
  * @return     {number}  projection in pixels on screen
+ *
+ * @deprecated Use `View#getMetersToPixels` instead.
  */
 GlobeControls.prototype.metersToPixels = function metersToPixels(value, pixelPitch = 0.28) {
+    console.warn('Deprecated, use View#getMetersToPixels instead.');
     const scaled = this.getScale(pixelPitch);
     pixelPitch /= 1000;
     return value * scaled / pixelPitch;

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -184,9 +184,6 @@ class Feature {
             throw new Error(`Unsupported Feature type: ${type}`);
         }
         this.geometry = [];
-        /**
-         * @property {number[]} vertices the vertices
-         */
         this.vertices = [];
         this.normals = options.withNormal ? [] : undefined;
         this.crs = crs;

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -114,9 +114,9 @@ const raycaster = new THREE.Raycaster();
  *   - layer: the geometry layer used for picking
  */
 export default {
-    pickTilesAt: (_view, viewCoords, radius, layer) => {
+    pickTilesAt(view, viewCoords, radius, layer) {
         const results = [];
-        const _ids = screenCoordsToNodeId(_view, layer, viewCoords, radius);
+        const _ids = screenCoordsToNodeId(view, layer, viewCoords, radius);
 
         const extractResult = (node) => {
             if (_ids.includes(node.id) && node.isTileMesh) {
@@ -132,7 +132,7 @@ export default {
         return results;
     },
 
-    pickPointsAt: (view, viewCoords, radius, layer) => {
+    pickPointsAt(view, viewCoords, radius, layer) {
         if (!layer.root) {
             return;
         }

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -90,6 +90,7 @@ class GlobeView extends View {
         THREE.Object3D.DefaultUp.set(0, 0, 1);
         // Setup View
         super('EPSG:4978', viewerDiv, options);
+        this.isGlobeView = true;
 
         // Configure camera
         let positionCamera;

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -152,6 +152,18 @@ class GlobeView extends View {
 
         return super.addLayer(layer, this.tileLayer);
     }
+
+    getPixelsToDegrees(pixels = 1, screenCoord) {
+        return this.getMetersToDegrees(this.getPixelsToMeters(pixels, screenCoord));
+    }
+
+    getPixelsToDegreesFromDistance(pixels = 1, distance = 1) {
+        return this.getMetersToDegrees(this.getPixelsToMetersFromDistance(pixels, distance));
+    }
+
+    getMetersToDegrees(meters = 1) {
+        return THREE.Math.radToDeg(2 * Math.asin(meters / (2 * ellipsoidSizes.x)));
+    }
 }
 
 export default GlobeView;

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -11,6 +11,7 @@ class PlanarView extends View {
 
         // Setup View
         super(extent.crs, viewerDiv, options);
+        this.isPlanarView = true;
 
         // Configure camera
         const dim = extent.dimensions();

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -241,6 +241,10 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         return this.layers.find(l => l.id === id);
     }
 
+    getLayers(ids) {
+        return this.layers.filter(l => ids.includes(l.id));
+    }
+
     getElevationLayer() {
         return this.layers.find(l => l.id === this.elevationLayerIds[0]);
     }

--- a/src/Utils/FeaturesUtils.js
+++ b/src/Utils/FeaturesUtils.js
@@ -1,4 +1,5 @@
 import { FEATURE_TYPES } from 'Core/Feature';
+import Extent from 'Core/Geographic/Extent';
 
 function pointIsOverLine(point, linePoints, epsilon, offset, count, size) {
     const x0 = point.x;
@@ -69,7 +70,7 @@ function getClosestPoint(point, points, epsilon, offset, count, size) {
 
 function pointIsInsidePolygon(point, polygonPoints, offset, count, size) {
     // ray-casting algorithm based on
-    // http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
+    // http://wrf.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
 
     const x = point.x;
     const y = point.y;
@@ -126,6 +127,7 @@ function isFeatureUnderCoordinate(coordinate, feature, epsilon, result) {
     }
 }
 
+const ex = new Extent('EPSG:4326', 0, 0, 0, 0);
 export default {
     /**
      * Filter from a list of features, features that are under a coordinate.
@@ -144,8 +146,25 @@ export default {
 
         // We can take this shortcut because either Feature and
         // FeatureCollection have an extent property
-        if (features.extent && !features.extent.isPointInside(coordinate, epsilon)) {
-            return result;
+        if (features.extent) {
+            // Special case, because of the way tiles in VectorTileParser are
+            // handled (see Feature2Texture for a similar solution)
+            if ((features.scale.x != 1 && features.scale.y != 1)
+                || (features.translation.x != 0 && features.translation.y != 0)) {
+                ex.crs = coordinate.crs;
+                features.extent.as(coordinate.crs, ex);
+                if (!ex.isPointInside(coordinate, epsilon)) {
+                    return result;
+                }
+
+                coordinate.x = (coordinate.x + features.translation.x) * features.scale.x;
+                coordinate.y = (coordinate.y + features.translation.y) * features.scale.y;
+                if (features.scale.x != 1 && features.scale.y != 1) {
+                    epsilon *= Math.sqrt(features.scale.x ** 2 + features.scale.y ** 2);
+                }
+            } else if (!features.extent.isPointInside(coordinate, epsilon)) {
+                return result;
+            }
         }
         if (Array.isArray(features.features)) {
             for (const feature of features.features) {

--- a/test/functional/source_file_geojson_raster.js
+++ b/test/functional/source_file_geojson_raster.js
@@ -12,7 +12,7 @@ describe('source_file_geojson_raster', function _() {
 
     it('should pick feature from Layer with SourceFile', async () => {
         const pickFeatureCount = await page.evaluate(() => {
-            const precision = view.controls.pixelsToDegrees(5);
+            const precision = view.getPixelsToDegrees(5);
             const layers = view.getLayers(l => l.source && l.source.isFileSource);
             const geoCoord = new itowns.Coordinates('EPSG:4326', 1.41955, 42.88613, 0);
             for (let i = 0; i < layers.length; i++) {

--- a/test/unit/globeview.js
+++ b/test/unit/globeview.js
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import assert from 'assert';
 import GlobeView from 'Core/Prefab/GlobeView';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
@@ -6,8 +7,21 @@ import Renderer from './mock';
 
 const renderer = new Renderer();
 
-const positionOnGlobe = { longitude: 4.631512, latitude: 43.675626, altitude: 250000 };
+// 3919 is the approximate altitude giving a 1/25000 scale, on a screen with a
+// pitch of 0.28. The approximation is corrected below with an epsilon.
+const positionOnGlobe = { longitude: 4.631512, latitude: 43.675626, altitude: 3919 };
 const viewer = new GlobeView(renderer.domElement, positionOnGlobe, { renderer });
+const pickedPosition = new THREE.Vector3();
+pickedPosition.copy(viewer.camera.position());
+
+const cameraDirection = new THREE.Vector3();
+viewer.camera.camera3D.getWorldDirection(cameraDirection);
+cameraDirection.multiplyScalar(positionOnGlobe.altitude);
+pickedPosition.add(cameraDirection);
+
+viewer.getPickingPositionFromDepth = function getPickingPositionFromDepth(screenCoord, targetPoint = new THREE.Vector3()) {
+    return targetPoint.copy(pickedPosition);
+};
 
 const context = {
     camera: viewer.camera,
@@ -23,17 +37,50 @@ describe('GlobeView', function () {
     it('instance', function () {
         assert.ok(viewer);
     });
+
     it('update', function () {
         viewer.tileLayer.whenReady.then(() => {
             const node = viewer.tileLayer.level0Nodes[0];
             viewer.tileLayer.update(context, viewer.tileLayer, node);
         });
     });
+
     it('ObjectRemovalHelper', function () {
         viewer.tileLayer.whenReady.then(() => {
             const node = viewer.tileLayer.level0Nodes[0];
             ObjectRemovalHelper.removeChildrenAndCleanup(viewer.tileLayer, node);
             ObjectRemovalHelper.removeChildren(viewer.tileLayer, node);
+        });
+    });
+
+    describe('Measuring', function () {
+        it('should get the zoom scale', () => {
+            const computed = viewer.getScale();
+            const scale = 1 / 25000;
+            assert.ok(computed < scale + 10e-7);
+            assert.ok(computed > scale - 10e-7);
+        });
+
+        it('should get the distance from the camera', () => {
+            const realDistance = viewer.getDistanceFromCamera();
+            assert.ok(realDistance < positionOnGlobe.altitude + 10);
+            assert.ok(realDistance > positionOnGlobe.altitude - 10);
+        });
+
+        it('should convert a pixel distance to meters', () => {
+            // (1 / 0.28) pixel is equal to 1 cm on screen, so 25m on ground
+            const computed = viewer.getPixelsToMeters(1 / 0.28);
+            const meters = 25;
+            assert.ok(computed < meters + 10e-3);
+            assert.ok(computed > meters - 10e-3);
+        });
+
+        it('should convert a meter distance to pixels', () => {
+            // 25m on ground should give 1 cm on screen, so (1 / 0.28) pixels
+            const computed = 1 / viewer.getMetersToPixels(25);
+            const pixels = 0.28;
+            assert.ok(computed < pixels + 10e-4);
+            assert.ok(computed > pixels - 10e-4);
         });
     });
 });

--- a/test/unit/mock.js
+++ b/test/unit/mock.js
@@ -9,8 +9,8 @@ class Renderer {
         this.domElement = {
             addEventListener,
             getBoundingClientRect: () => ({
-                x: 10,
-                y: 10,
+                x: 400,
+                y: 300,
             }),
             removeEventListener: () => {},
             emitEvent: (event, params) => {
@@ -20,6 +20,8 @@ class Renderer {
                 }
             },
             focus: () => {},
+            clientWidth: 400,
+            clientHeight: 300,
         };
         this.context = {
             getParameter: () => 16,
@@ -55,8 +57,8 @@ class Renderer {
                     arc: () => { },
                     setTransform: () => { },
                     canvas: {
-                        width: 256,
-                        height: 256,
+                        width: 400,
+                        height: 300,
                     },
                 }),
             }),

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -16,49 +16,38 @@ const source = new FileSource({
 
 const colorLayer = new ColorLayer('l0', { source });
 
-describe('Viewer', function () {
-    it('Should instance viewer', () => {
-        const viewer = new View('EPSG:4326', renderer.domElement, {
-            renderer,
-        });
+let viewer;
 
+beforeEach('reset viewer', function () {
+    viewer = new View('EPSG:4326', renderer.domElement, {
+        renderer,
+    });
+});
+
+describe('Viewer', function () {
+    it('should instance viewer', () => {
         assert.ok(viewer);
     });
-    it('Should add globe layer', () => {
-        const viewer = new View('EPSG:4326', renderer.domElement, {
-            renderer,
-        });
-
+    it('should add globe layer', () => {
         viewer.addLayer(globelayer);
         const layers = viewer.getLayers();
         assert.equal(layers.length, 1);
     });
-    it('Should remove globe layer', () => {
-        const viewer = new View('EPSG:4326', renderer.domElement, {
-            renderer,
-        });
-
+    it('should remove globe layer', () => {
         viewer.addLayer(globelayer);
         assert.ok(viewer.getLayerById(globelayer.id));
         viewer.removeLayer(globelayer.id);
         const layers = viewer.getLayers();
         assert.equal(layers.length, 0);
     });
-    it('Should add color layer', () => {
-        const viewer = new View('EPSG:4326', renderer.domElement, {
-            renderer,
-        });
+    it('should add color layer', () => {
         viewer.addLayer(globelayer);
         viewer.addLayer(colorLayer, globelayer);
         const layer = viewer.getParentLayer(colorLayer);
         assert.equal(globelayer.id, layer.id);
         assert.equal(globelayer.attachedLayers.length, 1);
     });
-    it('Should call pick Object function', () => {
-        const viewer = new View('EPSG:4326', renderer.domElement, {
-            renderer,
-        });
-
+    it('should call pick Object function', () => {
         viewer.addLayer(globelayer);
         viewer.tileLayer = globelayer;
         const picked = viewer.pickObjectsAt({ x: 10, y: 10 }, 4);
@@ -66,10 +55,7 @@ describe('Viewer', function () {
         const pickedFrom = viewer.getPickingPositionFromDepth({ x: 10, y: 10 });
         assert.ok(pickedFrom.isVector3);
     });
-    it('Should update sources viewer and notify change', () => {
-        const viewer = new View('EPSG:4326', renderer.domElement, {
-            renderer,
-        });
+    it('should update sources viewer and notify change', () => {
         viewer.addLayer(globelayer);
         viewer.notifyChange(globelayer, true);
         assert.equal(viewer.mainLoop.needsRedraw, 1);


### PR DESCRIPTION
This new method comes in addition to `pickObjectsAt`: it looks for all
features under the given screen coordinate, and return it sorted by
layer.

In the same time, `FeatureToolTip` has been greatly improved.