### PR TITLE
fix(process): error checking level elevation.

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -181,24 +181,12 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
         const parentLayer = parent.material && parent.material.getLayer(layer.id);
         nodeLayer.initFromParent(parentLayer, extentsDestination);
 
-        // If the texture resolution has a poor precision for this node, we don't
-        // extract min-max from the texture (too few information), we instead chose
-        // to use parent's min-max.
-        const useMinMaxFromParent = extentsDestination[0].zoom - nodeLayer.zoom > 6;
-        if (nodeLayer.textures[0]) {
-            if (!useMinMaxFromParent) {
-                const { min, max } = computeMinMaxElevation(
-                    nodeLayer.textures[0].image.data,
-                    SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-                    nodeLayer.offsetScales[0]);
-                node.setBBoxZ(min, max, layer.scale);
-            } else {
-                // TODO: to verify we don't pass here,
-                // To follow issue, see #1011 https://github.com/iTowns/itowns/issues/1011
-            }
-        }
-
         if (nodeLayer.level >= layer.source.zoom.min) {
+            const { min, max } = computeMinMaxElevation(
+                nodeLayer.textures[0].image.data,
+                SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
+                nodeLayer.offsetScales[0]);
+            node.setBBoxZ(min, max, layer.scale);
             context.view.notifyChange(node, false);
             return;
         }

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -18,6 +18,7 @@ import GeometryLayer from 'Layer/GeometryLayer';
 import PlanarLayer from 'Core/Prefab/Planar/PlanarLayer';
 import Feature2Mesh from 'Converter/Feature2Mesh';
 import LayeredMaterial from 'Renderer/LayeredMaterial';
+import { EMPTY_TEXTURE_ZOOM } from 'Renderer/MaterialLayer';
 
 const holes = require('../data/geojson/holesPoints.geojson.json');
 
@@ -115,7 +116,7 @@ describe('Provide in Sources', function () {
 
         const tile = new TileMesh(geom, material, planarlayer, extent);
         material.visible = true;
-        nodeLayer.level = 0;
+        nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.parent = { };
 
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
@@ -142,7 +143,7 @@ describe('Provide in Sources', function () {
 
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
-        nodeLayerElevation.level = 0;
+        nodeLayerElevation.level = EMPTY_TEXTURE_ZOOM;
         tile.parent = {};
 
         updateLayeredMaterialNodeElevation(context, elevationlayer, tile, tile.parent);
@@ -168,7 +169,7 @@ describe('Provide in Sources', function () {
         });
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
-        nodeLayer.level = 0;
+        nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.parent = { };
 
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
@@ -186,7 +187,7 @@ describe('Provide in Sources', function () {
     it('should get 4 TileMesh from TileProvider', (done) => {
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
-        nodeLayer.level = 0;
+        nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.parent = { };
 
         planarlayer.subdivideNode(context, tile);
@@ -202,7 +203,7 @@ describe('Provide in Sources', function () {
     it('should get 3 meshs with WFS source and DataSourceProvider', (done) => {
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
-        nodeLayer.level = 0;
+        nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.parent = { pendingSubdivision: false };
         featureLayer.mergeFeatures = false;
         tile.layerUpdateState = { test: new LayerUpdateState() };
@@ -243,7 +244,7 @@ describe('Provide in Sources', function () {
             zoom);
         material.visible = true;
         tile.parent = { pendingSubdivision: false };
-        nodeLayer.level = 0;
+        nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.material.visible = true;
         featureLayer.source.uid = 22;
         const colorlayerWfs = new ColorLayer('color', { projection: 'EPSG:3857',


### PR DESCRIPTION
## Description
Remove checking the level elevation in raster process.
it's better to (always) compute min max in cropped elevation texture .
If not the `bbox` is too big and there's **too much tile subdivision**.

fix #1011 
