### PR TITLE
chore: build/transpile itowns to specific targets.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
-    "presets": ["@babel/preset-env"],
+    "presets": [["@babel/preset-env",
+        {
+            "targets": "> 5%"
+        }
+    ]],
     "plugins": [
         ["module-resolver",  { "root": ["./src"] } ],
         ["babel-plugin-inline-import", {

--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
     "presets": [["@babel/preset-env",
         {
-            "targets": "> 5%"
+            "targets": "> 0.5%, last 2 versions, Firefox ESR, not dead"
         }
     ]],
     "plugins": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,16 +16,17 @@ const debugBuild = process.env.NODE_ENV === 'development';
 // Note that we don't support .babelrc in parent folders
 var babelrc = fs.readFileSync(path.resolve(__dirname, '.babelrc'));
 var babelConf = JSON.parse(babelrc);
-var newPresets = [];
-for (var preset of babelConf.presets) {
-    if (!Array.isArray(preset)) {
-        preset = [preset];
-    }
-    preset.push({ modules: false });
-    newPresets.push(preset);
-}
+// TODO verify utility
+// var newPresets = [];
+// for (var preset of babelConf.presets) {
+//     if (!Array.isArray(preset)) {
+//         preset = [preset];
+//     }
+//     preset.push({ modules: false });
+//     newPresets.push(preset);
+// }
 
-babelConf.presets = newPresets;
+// babelConf.presets = newPresets;
 babelConf.babelrc = false; // disabel babelrc reading, as we've just done it
 const replacementPluginConf = babelConf.plugins.find(plugin => Array.isArray(plugin) && plugin[0] === 'minify-replace');
 replacementPluginConf[1].replacements.find(decl => decl.identifierName === '__DEBUG__').replacement.value = debugBuild;


### PR DESCRIPTION
## Description
With babel it's possible to transpile itowns to specific targets. ([visiting](https://babeljs.io/docs/en/babel-preset-env)).
I would like target to specific browser using [browserslist](https://github.com/browserslist/browserslist).

## Questions
* For example, the possible targets could be browsers supporting ES6.
* In `webpack.config.js` there is this comment (see bellow), I think it's obsolete,  then we could remove target option  `{ modules: false }`, WDYT?
```
/*
   configuring babel:
   - when babel runs alone (for `test-unit` for instance), we let him deal with
   ES6 modules, because node doesn't support them yet (planned for v10 lts).
   - however, webpack also has ES6 module support and these 2 don't play well
   together. When running webpack (either `build` or `start` script), we prefer
   to rely on webpack loaders (much more powerful and gives more possibilities),
   so let's disable modules for babel here.
*/
```
