### PR TITLE
fix(3dtile): avoid to clone overrideMaterials to each each assignment.

### DIFF
--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -191,7 +191,7 @@ export default {
                                 }
                                 if (typeof (options.overrideMaterials) === 'object' &&
                                     options.overrideMaterials.isMaterial) {
-                                    mesh.material = options.overrideMaterials.clone();
+                                    mesh.material = options.overrideMaterials;
                                 } else {
                                     mesh.material = new THREE.MeshLambertMaterial({ color: 0xffffff });
                                 }


### PR DESCRIPTION
## Description
Avoid to clone overrideMaterials to each each assignment.
