### PR TITLE
refactor(Raster): use extent to handle texture instead of index integer.

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -771,7 +771,7 @@ class View extends THREE.EventDispatcher {
             }
 
             for (const materialLayer of tile.object.material.getLayers(layers)) {
-                for (const texture of materialLayer.textures) {
+                for (const texture of materialLayer.textures.values()) {
                     if (!texture.parsedData) {
                         continue;
                     }

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -10,6 +10,7 @@ import { ImageryLayers } from 'Layer/Layer';
 
 const subdivisionVector = new THREE.Vector3();
 const boundingSphereCenter = new THREE.Vector3();
+const offsetScale = new THREE.Vector4();
 
 /**
  * @property {InfoTiledGeometryLayer} info - Status information of layer
@@ -371,14 +372,16 @@ class TiledGeometryLayer extends GeometryLayer {
         // The induced geometric error is much too large and distorts the SSE
         const nodeLayer = node.material.getElevationLayer();
         if (nodeLayer) {
-            const currentTexture = nodeLayer.firstTexture();
-            if (currentTexture && currentTexture.extent) {
-                const offsetScale = nodeLayer.firstOffsetScale();
-                const ratio = offsetScale.z;
-                // ratio is node size / texture size
-                if (ratio < 1 / Math.pow(2, this.maxDeltaElevationLevel)) {
-                    return false;
+            for (const [extent, texture] of nodeLayer.textures.entries()) {
+                if (texture) {
+                    extent.offsetToParent(texture.coords, offsetScale);
+                    const ratio = offsetScale.z;
+                    // ratio is node size / texture size
+                    if (ratio < 1 / Math.pow(2, this.maxDeltaElevationLevel)) {
+                        return false;
+                    }
                 }
+                break;
             }
         }
 

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -371,9 +371,9 @@ class TiledGeometryLayer extends GeometryLayer {
         // The induced geometric error is much too large and distorts the SSE
         const nodeLayer = node.material.getElevationLayer();
         if (nodeLayer) {
-            const currentTexture = nodeLayer.textures[0];
+            const currentTexture = nodeLayer.firstTexture();
             if (currentTexture && currentTexture.extent) {
-                const offsetScale = nodeLayer.offsetScales[0];
+                const offsetScale = nodeLayer.firstOffsetScale();
                 const ratio = offsetScale.z;
                 // ratio is node size / texture size
                 if (ratio < 1 / Math.pow(2, this.maxDeltaElevationLevel)) {

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -1,3 +1,4 @@
+import { Vector4 } from 'three';
 import { chooseNextLevelToFetch } from 'Layer/LayerUpdateStrategy';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import { computeMinMaxElevation } from 'Parser/XbilParser';
@@ -5,6 +6,7 @@ import handlingError from 'Process/handlerNodeError';
 
 export const SIZE_TEXTURE_TILE = 256;
 export const SIZE_DIAGONAL_TEXTURE = Math.pow(2 * (SIZE_TEXTURE_TILE * SIZE_TEXTURE_TILE), 0.5);
+const offsetScale = new Vector4();
 
 function materialCommandQueuePriorityFunction(material) {
     // We know that 'node' is visible because commands can only be
@@ -188,10 +190,11 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
         const texture = nodeLayer.firstTexture();
         if (texture) {
             if (!useMinMaxFromParent) {
+                extentsDestination[0].offsetToParent(texture.coords, offsetScale);
                 const { min, max } = computeMinMaxElevation(
                     texture.image.data,
                     SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE,
-                    nodeLayer.firstOffsetScale());
+                    offsetScale);
                 node.setBBoxZ(min, max, layer.scale);
             } else {
                 // TODO: to verify we don't pass here,

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -40,12 +40,15 @@ function updateLayersUniforms(uniforms, olayers, max) {
     // flatten the 2d array [i,j] -> layers[_layerIds[i]].textures[j]
     let count = 0;
     for (const layer of olayers) {
-        layer.textureOffset = count;
-        for (let i = 0, il = layer.textures.length; i < il; ++i, ++count) {
-            if (count < max) {
-                offsetScales[count] = layer.offsetScales[i];
-                textures[count] = layer.textures[i];
-                layers[count] = layer;
+        if (layer.level > -1) {
+            layer.textureOffset = count;
+            for (const [extent, texture] of layer.textures.entries()) {
+                if (count < max) {
+                    offsetScales[count] = layer.offsetScales.get(extent);
+                    textures[count] = texture;
+                    layers[count] = layer;
+                }
+                ++count;
             }
         }
     }
@@ -222,11 +225,11 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         }
     }
 
-    addLayer(layer) {
+    addLayer(layer, extents) {
         if (layer.id in this.layers) {
             console.warn('The "{layer.id}" layer was already present in the material, overwritting.');
         }
-        const lml = new MaterialLayer(this, layer);
+        const lml = new MaterialLayer(this, layer, extents);
         this.layers.push(lml);
         if (layer.isColorLayer) {
             this.setSequence(layer.parent.colorLayersOrder);

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -44,7 +44,8 @@ function updateLayersUniforms(uniforms, olayers, max) {
             layer.textureOffset = count;
             for (const [extent, texture] of layer.textures.entries()) {
                 if (count < max) {
-                    offsetScales[count] = layer.offsetScales.get(extent);
+                    // Fix me: it's not possible to pass target offsetScales in offsetToParent
+                    offsetScales[count] = extent.offsetToParent(texture.coords);
                     textures[count] = texture;
                     layers[count] = layer;
                 }

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -84,7 +84,6 @@ class MaterialLayer {
 
         this.textures = new Map();
         extents.forEach(ex => this.textures.set(ex, null));
-        this.offsetScales = new Map();
         this.level = EMPTY_TEXTURE_ZOOM;
         this.material = material;
     }
@@ -131,23 +130,17 @@ class MaterialLayer {
         }
         this.level = EMPTY_TEXTURE_ZOOM;
         this.textures.forEach((v, k) => this.textures.set(k, null));
-        this.offsetScales.forEach((v, k) => this.offsetScales.set(k, null));
         this.material.layersNeedUpdate = true;
     }
 
     setTexture(texture, extent) {
         this.level = texture ? texture.coords.zoom : this.level;
         this.textures.set(extent, texture || null);
-        this.offsetScales.set(extent, extent.offsetToParent(texture.coords));
         this.material.layersNeedUpdate = true;
     }
 
     firstTexture() {
         return this.textures.values().next().value;
-    }
-
-    firstOffsetScale() {
-        return this.offsetScales.values().next().value;
     }
 
     setTextures(textures, extents) {

--- a/src/Utils/DEMUtils.js
+++ b/src/Utils/DEMUtils.js
@@ -390,7 +390,7 @@ function _readZ(layer, method, coord, nodes, cache) {
 
     const tile = tileWithValidElevationTexture;
     const tileLayer = tile.material.getElevationLayer();
-    const src = tileLayer.textures[0];
+    const src = tileLayer.firstTexture();
 
     // check cache value if existing
     if (cache) {
@@ -401,7 +401,7 @@ function _readZ(layer, method, coord, nodes, cache) {
 
     // Assuming that tiles are split in 4 children, we lookup the parent that
     // really owns this texture
-    const stepsUpInHierarchy = Math.round(Math.log2(1.0 / tileLayer.offsetScales[0].z));
+    const stepsUpInHierarchy = Math.round(Math.log2(1.0 / tileLayer.firstOffsetScale().z));
     for (let i = 0; i < stepsUpInHierarchy; i++) {
         tileWithValidElevationTexture = tileWithValidElevationTexture.parent;
     }

--- a/src/Utils/DEMUtils.js
+++ b/src/Utils/DEMUtils.js
@@ -399,9 +399,10 @@ function _readZ(layer, method, coord, nodes, cache) {
         }
     }
 
+    const offsetScale = tile.material.uniforms.elevationOffsetScales.value[0];
     // Assuming that tiles are split in 4 children, we lookup the parent that
     // really owns this texture
-    const stepsUpInHierarchy = Math.round(Math.log2(1.0 / tileLayer.firstOffsetScale().z));
+    const stepsUpInHierarchy = Math.round(Math.log2(1.0 / offsetScale.z));
     for (let i = 0; i < stepsUpInHierarchy; i++) {
         tileWithValidElevationTexture = tileWithValidElevationTexture.parent;
     }

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -70,12 +70,13 @@ describe('Provide in Sources', function () {
     const planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
     const colorlayer = new ColorLayer('color', { projection: 'WMTS:PM' });
     const elevationlayer = new ElevationLayer('elevation', { projection: 'WMTS:PM' });
+    const tile = new TileMesh(geom, material, planarlayer, extent);
 
     planarlayer.attach(colorlayer);
     planarlayer.attach(elevationlayer);
 
-    material.addLayer(colorlayer);
-    material.addLayer(elevationlayer);
+    material.addLayer(colorlayer, tile.getExtentsByProjection(colorlayer.projection));
+    material.addLayer(elevationlayer, tile.getExtentsByProjection(elevationlayer.projection));
 
     const nodeLayer = material.getLayer(colorlayer.id);
     const nodeLayerElevation = material.getLayer(elevationlayer.id);
@@ -126,7 +127,6 @@ describe('Provide in Sources', function () {
             },
         });
 
-        const tile = new TileMesh(geom, material, planarlayer, extent);
         material.visible = true;
         nodeLayer.level = 0;
         tile.parent = { };

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -51,7 +51,7 @@ describe('updateLayeredMaterialNodeImagery', function () {
         },
     });
 
-    const nodeLayer = new MaterialLayer(material, layer);
+    const nodeLayer = new MaterialLayer(material, layer, [extent]);
     material.getLayer = () => nodeLayer;
 
     beforeEach('reset state', function () {
@@ -111,6 +111,9 @@ describe('updateLayeredMaterialNodeImagery', function () {
         const tile = new TileMesh(geom, material, layer, newExtent, 15);
         // Emulate a situation where tile inherited a level 1 texture
         material.visible = true;
+        const nodeLayer = new MaterialLayer(material, layer, tile.getExtentsByProjection(layer.projection));
+        material.getLayer = () => nodeLayer;
+
         nodeLayer.level = 1;
         tile.parent = { };
         source.isWMTSSource = true;


### PR DESCRIPTION
## Description
Use extent to handle texture instead of index integer.

## Motivation and Context
it's more appropriate and intuitive to apply a texture on extent.
In addition, one texture could be applied individually.
