### PR TITLE
refactor: rename .coords as .extent when it was an Extent

### DIFF
--- a/examples/js/plugins/TIFFParser.js
+++ b/examples/js/plugins/TIFFParser.js
@@ -73,8 +73,8 @@ var TIFFParser = (function _() {
             texture.flipY = true;
             texture.needsUpdate = true;
 
-            if (data.coords) {
-                texture.coords = data.coords;
+            if (data.extent) {
+                texture.extent = data.extent;
             }
 
             return Promise.resolve(texture);

--- a/src/Converter/textureConverter.js
+++ b/src/Converter/textureConverter.js
@@ -29,7 +29,7 @@ export default {
             extentDestination.as(CRS.formatToEPSG(layer.projection), extentTexture);
             texture = Feature2Texture.createTextureFromFeature(data, extentTexture, 256, layer.style, backgroundColor);
             texture.parsedData = data;
-            texture.coords = extentDestination;
+            texture.extent = extentDestination;
         } else if (data.isTexture) {
             texture = data;
         } else {

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -97,7 +97,7 @@ function vtFeatureToFeatureGeometry(vtFeature, feature, classify = false) {
 const defaultFilter = () => true;
 function readPBF(file, options) {
     const vectorTile = new VectorTile(new Protobuf(file));
-    const extentSource = options.extentSource || file.coords;
+    const extentSource = options.extentSource || file.extent;
     const sourceLayers = Object.keys(vectorTile.layers);
 
     if (sourceLayers.length < 1) {
@@ -190,7 +190,6 @@ export default {
      * @param {ArrayBuffer} file - The vector tile file to parse.
      * @param {Object} options - Options controlling the parsing.
      * @param {Extent} options.extent - The Extent to convert the input coordinates to.
-     * @param {Extent} options.coords - Coordinates of the layer.
      * @param {Extent=} options.filteringExtent - Optional filter to reject features
      * outside of this extent.
      * @param {boolean} [options.mergeFeatures=true] - If true all geometries are merged by type and multi-type

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -148,7 +148,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     return context.scheduler.execute(command).then(
         (result) => {
             // TODO: Handle error : result is undefined in provider. throw error
-            const pitchs = extentsDestination.map((ext, i) => ext.offsetToParent(result[i].coords, nodeLayer.offsetScales[i]));
+            const pitchs = extentsDestination.map((ext, i) => ext.offsetToParent(result[i].extent, nodeLayer.offsetScales[i]));
             nodeLayer.setTextures(result, pitchs);
             node.layerUpdateState[layer.id].success();
         },
@@ -242,7 +242,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
             }
             const elevation = {
                 texture: textures[0],
-                pitch: extentsDestination[0].offsetToParent(textures[0].coords, nodeLayer.offsetScales[0]),
+                pitch: extentsDestination[0].offsetToParent(textures[0].extent, nodeLayer.offsetScales[0]),
             };
 
             node.layerUpdateState[layer.id].success();

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -41,7 +41,7 @@ function fetchSourceData(extSrc, layer) {
 
     // Fetch data
     return source.fetcher(url, source.networkOptions).then((f) => {
-        f.coords = extSrc;
+        f.extent = extSrc;
         return f;
     });
 }

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -93,8 +93,8 @@ class MaterialLayer {
             let index = 0;
             for (const c of extents) {
                 for (const texture of parent.textures) {
-                    if (c.isInside(texture.coords)) {
-                        this.setTexture(index++, texture, c.offsetToParent(texture.coords));
+                    if (c.isInside(texture.extent)) {
+                        this.setTexture(index++, texture, c.offsetToParent(texture.extent));
                         break;
                     }
                 }
@@ -112,8 +112,8 @@ class MaterialLayer {
         const dataElevation = this.textures[0].image.data;
         const parentTexture = parent && parent.textures[0];
         if (dataElevation && parentTexture && !checkNodeElevationTextureValidity(dataElevation, nodatavalue)) {
-            const coords = this.textures[0].coords;
-            coords.offsetToParent(parentTexture.coords, pitch);
+            const extent = this.textures[0].extent;
+            extent.offsetToParent(parentTexture.extent, pitch);
             insertSignificantValuesFromParent(dataElevation, parentTexture.image.data, nodatavalue, pitch);
         }
     }
@@ -132,7 +132,7 @@ class MaterialLayer {
     }
 
     setTexture(index, texture, offsetScale) {
-        this.level = (texture && (index == 0)) ? texture.coords.zoom : this.level;
+        this.level = (texture && (index == 0)) ? texture.extent.zoom : this.level;
         this.textures[index] = texture || null;
         this.offsetScales[index] = offsetScale;
         this.material.layersNeedUpdate = true;

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -120,9 +120,9 @@ describe('Provide in Sources', function () {
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((textures) => {
-            assert.equal(textures[0].coords.zoom, zoom);
-            assert.equal(textures[0].coords.row, 511);
-            assert.equal(textures[0].coords.col, 512);
+            assert.equal(textures[0].extent.zoom, zoom);
+            assert.equal(textures[0].extent.row, 511);
+            assert.equal(textures[0].extent.col, 512);
         });
     });
 
@@ -147,9 +147,9 @@ describe('Provide in Sources', function () {
         updateLayeredMaterialNodeElevation(context, elevationlayer, tile, tile.parent);
         updateLayeredMaterialNodeElevation(context, elevationlayer, tile, tile.parent);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((textures) => {
-            assert.equal(textures[0].coords.zoom, zoom);
-            assert.equal(textures[0].coords.row, 511);
-            assert.equal(textures[0].coords.col, 512);
+            assert.equal(textures[0].extent.zoom, zoom);
+            assert.equal(textures[0].extent.row, 511);
+            assert.equal(textures[0].extent.col, 512);
             done();
         });
     });
@@ -173,7 +173,7 @@ describe('Provide in Sources', function () {
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
         updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((textures) => {
-            const e = textures[0].coords.as(tile.extent.crs);
+            const e = textures[0].extent.as(tile.extent.crs);
             assert.equal(e.zoom, zoom);
             assert.equal(e.west, tile.extent.west);
             assert.equal(e.east, tile.extent.east);

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -22,7 +22,7 @@ const paints = [{
 const multipolygon = fs.readFileSync('test/data/pbf/multipolygon.pbf');
 let id = 0;
 function parse(pbf, paint, type) {
-    pbf.coords = new Extent('TMS', 1, 1, 1);
+    pbf.extent = new Extent('TMS', 1, 1, 1);
     return VectorTileParser.parse(pbf, {
         crsIn: 'EPSG:4326',
         crsOut: 'EPSG:3857',


### PR DESCRIPTION
There was a lot of occurence where `.coords` was being used to store an
Extent, and not Coordinates as it may be implied. This commit fix this,
to avoid confusion and to simplify the process in later commits.