### PR TITLE
Update proj4 geocent

### DIFF
--- a/test/unit/camera.js
+++ b/test/unit/camera.js
@@ -3,6 +3,10 @@ import Camera from 'Renderer/Camera';
 import Coordinates from 'Core/Geographic/Coordinates';
 
 
+function compareWithEpsilon(a, b, epsilon) {
+    return a - epsilon < b && a + epsilon > b;
+}
+
 describe('camera', function () {
     it('should set good aspect in camera3D', function () {
         const camera = new Camera('', 100, 50);
@@ -23,8 +27,8 @@ describe('camera', function () {
         const coordinates = new Coordinates('EPSG:4326', 40, 52, 2002);
         camera.setPosition(coordinates);
         const resultCoordinates = camera.position('EPSG:4326');
-        assert.ok(resultCoordinates.longitude == coordinates.longitude);
-        assert.ok(resultCoordinates.latitude.toFixed(8) == coordinates.latitude);
-        assert.ok(resultCoordinates.altitude.toFixed(8) == coordinates.altitude);
+        assert.ok(compareWithEpsilon(resultCoordinates.longitude, coordinates.longitude, 10e-8));
+        assert.ok(compareWithEpsilon(resultCoordinates.latitude, coordinates.latitude, 10e-8));
+        assert.ok(compareWithEpsilon(resultCoordinates.altitude, coordinates.altitude, 10e-8));
     });
 });

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -4,18 +4,24 @@ import GlobeView from 'Core/Prefab/GlobeView';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Renderer from './mock';
 
-const renderer = new Renderer();
-
-const placement = { coord: new Coordinates('EPSG:4326', 2.351323, 48.856712), range: 250000 };
-const viewer = new GlobeView(renderer.domElement, placement, { renderer });
-
-const event = {
-    stopPropagation: () => {},
-    preventDefault: () => {},
-    button: THREE.MOUSE.LEFT,
-};
-
 describe('GlobeControls', function () {
+    const renderer = new Renderer();
+
+    const placement = { coord: new Coordinates('EPSG:4326', 2.351323, 48.856712), range: 250000 };
+    const viewer = new GlobeView(renderer.domElement, placement, { renderer });
+
+    const event = {
+        stopPropagation: () => {},
+        preventDefault: () => {},
+        button: THREE.MOUSE.LEFT,
+        touches: [{
+            clientX: 150,
+            clientY: 200,
+            pageX: 150,
+            pageY: 200,
+        }],
+    };
+
     it('instance GlobeControls', function () {
         assert.ok(viewer.controls);
     });
@@ -53,7 +59,6 @@ describe('GlobeControls', function () {
         renderer.domElement.emitEvent('dblclick', event);
     });
 
-    event.touches = [1, 1];
     it('touch start', function () {
         renderer.domElement.emitEvent('touchstart', event);
     });


### PR DESCRIPTION
By updating the proj4 version to 2.6.0, we get the support for
geocentric projection, like EPSG:4978. Now the complicated behavior in
Coordinates#as can be ditched.