### PR TITLE
refacto(cache): ditch Map() in Cache for simple tree

### DIFF
--- a/src/Core/Prefab/TileBuilder.js
+++ b/src/Core/Prefab/TileBuilder.js
@@ -8,14 +8,13 @@ export default function newTileGeometry(builder, params) {
     const { sharableExtent, quaternion, position } = builder.computeSharableExtent(params.extent);
     const south = sharableExtent.south.toFixed(6);
     const bufferKey = `${builder.projection}_${params.disableSkirt ? 0 : 1}_${params.segment}`;
-    const geometryKey = `${bufferKey}_${params.level}_${south}`;
-    let promiseGeometry = Cache.get(geometryKey);
+    let promiseGeometry = Cache.get(bufferKey, params.level, south);
 
     // build geometry if doesn't exist
     if (!promiseGeometry) {
         let resolve;
         promiseGeometry = new Promise((r) => { resolve = r; });
-        Cache.set(geometryKey, promiseGeometry);
+        Cache.set(promiseGeometry, Cache.POLICIES.INFINITE, bufferKey, params.level, south);
 
         params.extent = sharableExtent;
         params.center = builder.center(params.extent).clone();
@@ -49,7 +48,7 @@ export default function newTileGeometry(builder, params) {
                 geometry._count--;
                 if (geometry._count == 0) {
                     THREE.BufferGeometry.prototype.dispose.call(geometry);
-                    Cache.delete(bufferKey);
+                    Cache.delete(bufferKey, params.level, south);
                 }
             };
             resolve(geometry);

--- a/src/Core/Scheduler/Cache.js
+++ b/src/Core/Scheduler/Cache.js
@@ -62,11 +62,16 @@ const Cache = {
             // eslint-disable-next-line
             return;
         } else if (data[key1][key2] == undefined) {
-            return data[key1].value;
+            entry = data[key1];
         } else if (data[key1][key2][key3] == undefined) {
-            return data[key1][key2].value;
+            entry = data[key1][key2];
         } else {
-            return data[key1][key2][key3].value;
+            entry = data[key1][key2][key3];
+        }
+
+        if (entry.value) {
+            entry.lastTimeUsed = Date.now();
+            return entry.value;
         }
     },
 
@@ -80,14 +85,14 @@ const Cache = {
      * @function
      *
      * @param {Object} value
-     * @param {number} [lifetime=Infinity]
+     * @param {number} lifetime
      * @param {string} key1
      * @param {string} [key2]
      * @param {string} [key3]
      *
      * @return {Object} the added value
      */
-    set: (value, lifetime = Infinity, key1, key2, key3) => {
+    set: (value, lifetime, key1, key2, key3) => {
         entry = {
             value,
             lastTimeUsed: Date.now(),

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -60,10 +60,9 @@ export default {
 
             // Tag to Cache data
             const exTag = source.isVectorSource ? extentsDestination[i] : extSource;
-            const tag = `${source.uid}-${exTag.toString('-')}`;
 
             // Get converted source data, in cache
-            let convertedSourceData = Cache.get(tag);
+            let convertedSourceData = Cache.get(source.uid, layer.id, exTag.toString('-'));
 
             // If data isn't in cache
             if (!convertedSourceData) {
@@ -85,7 +84,7 @@ export default {
                         .then(parsedData => layer.convert(parsedData, extDest, layer), err => error(err, source));
                 }
                 // Put converted data in cache
-                Cache.set(tag, convertedSourceData, Cache.POLICIES.TEXTURE);
+                Cache.set(convertedSourceData, Cache.POLICIES.TEXTURE, source.uid, layer.id, exTag.toString('-'));
             }
 
             // Verify some command is resolved


### PR DESCRIPTION
The previous Cache was working on a single Map, which can become really
slow and big after a few minutes of navigation in iTowns.

Now, the Cache is composed of a single tree, that can contain node up
to 3 levels. It simplifies things attached to a layer, a source or
others things like a zoom value. Instead of having a complex string
composed with all those information, it now uses several key accross all
the node of the Cache.

In term of performance, the proposed implementation is 20 times faster
than the previous one.