### PR TITLE
feat(tile): add a refreshMaterial method

### DIFF
--- a/src/Layer/LayerUpdateState.js
+++ b/src/Layer/LayerUpdateState.js
@@ -4,6 +4,7 @@ const UPDATE_STATE = {
     ERROR: 2,
     DEFINITIVE_ERROR: 3,
     FINISHED: 4,
+    FORCE: 5,
 };
 const PAUSE_BETWEEN_ERRORS = [1.0, 3.0, 7.0, 60.0];
 
@@ -21,7 +22,8 @@ function LayerUpdateState() {
 
 LayerUpdateState.prototype.canTryUpdate = function canTryUpdate(timestamp = Date.now()) {
     switch (this.state) {
-        case UPDATE_STATE.IDLE: {
+        case UPDATE_STATE.IDLE:
+        case UPDATE_STATE.FORCE: {
             return true;
         }
         case UPDATE_STATE.DEFINITIVE_ERROR:
@@ -71,6 +73,14 @@ LayerUpdateState.prototype.failure = function failure(timestamp, definitive, fai
 
 LayerUpdateState.prototype.inError = function inError() {
     return this.state == UPDATE_STATE.DEFINITIVE_ERROR || this.state == UPDATE_STATE.ERROR;
+};
+
+LayerUpdateState.prototype.forceUpdate = function forceUpdate() {
+    this.state = UPDATE_STATE.FORCE;
+};
+
+LayerUpdateState.prototype.isForcingUpdate = function isForcingUpdate() {
+    return this.state === UPDATE_STATE.FORCE;
 };
 
 export default LayerUpdateState;

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -154,7 +154,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     }
 
     node.layerUpdateState[layer.id].newTry();
-    const parsedData = nodeLayer.textures.map(t => t.parsedData);
+    const parsedData = node.layerUpdateState[layer.id].isForcingUpdate() ? nodeLayer.textures.map(t => t.parsedData) : [];
     const command = buildCommand(context.view, layer, extentsSource, extentsDestination, node, forceUpdate, parsedData);
 
     return context.scheduler.execute(command).then(

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -76,7 +76,7 @@ export default {
                 const extDest = extentsDestination[i];
 
                 // Already fetched and parsed data that can be used
-                const validedParsedData = !command.forceUpdate && (isValidData(parsedData[i], extDest, layer.isValidData) || source.parsedData);
+                const validedParsedData = isValidData(parsedData[i], extDest, layer.isValidData) || source.parsedData;
                 if (validedParsedData) {
                     // Convert
                     convertedSourceData = layer.convert(validedParsedData, extDest, layer);

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -198,8 +198,8 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
     }
 
     // TODO: rename to setColorLayerIds and add setElevationLayerIds ?
-    setSequence(sequenceLayer) {
-        this.colorLayerIds = sequenceLayer;
+    setSequence(sequenceLayer = []) {
+        this.colorLayerIds = sequenceLayer.slice(0);
         this.layersNeedUpdate = true;
     }
 

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -139,7 +139,7 @@ class MaterialLayer {
     }
 
     setTextures(textures, pitchs) {
-        this.dispose(false);
+        this.dispose();
         for (let i = 0, il = textures.length; i < il; ++i) {
             this.setTexture(i, textures[i], pitchs[i]);
         }


### PR DESCRIPTION
In a case where you have a server, with the data updated from what is
displayed, you want to update it without destroying the whole layer and
recreating it. If you know the tile you want to update, you can use the
new `TileMesh#refreshMaterial` method.

In the same time, a new `FORCE` state has been added to
`LayerUpdateState`, that is used when doing this refresh.

I also wanted to refactor a little bit `LayerUpdateState`, but I'm leaving this
for a later time.