### PR TITLE
fix(core): remove objects of a GeometryLayer from the Scene

### DIFF
--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -193,12 +193,12 @@ class GeometryLayer extends Layer {
                     disposeMesh(obj);
                 }
             });
-        } else {
-            if (this.object3d.parent) {
-                this.object3d.parent.remove(this.object3d);
-            }
-            this.object3d.traverse(disposeMesh);
         }
+
+        if (this.object3d.parent) {
+            this.object3d.parent.remove(this.object3d);
+        }
+        this.object3d.traverse(disposeMesh);
     }
 
     /**


### PR DESCRIPTION
The property object3d (an instance of THREE.Object3D, most of the time
THREE.Group) was not correctly removed for a GeometryLayer, when calling
View#removeLayer.

Now, if the layer is a geometry one, the GeometryLayer#delete method is
called once more, and should remove the object3d property from its
parent (usually a THREE.Scene).

It should fix #1283 