### PR TITLE
feat(controls): use a more global div for event listening

### DIFF
--- a/src/Controls/FirstPersonControls.js
+++ b/src/Controls/FirstPersonControls.js
@@ -91,7 +91,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
         };
         this.reset();
 
-        const domElement = view.mainLoop.gfxEngine.renderer.domElement;
+        const domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
         if (!options.disableEventListeners) {
             domElement.addEventListener('mousedown', this.onMouseDown.bind(this), false);
             domElement.addEventListener('touchstart', this.onMouseDown.bind(this), false);

--- a/src/Controls/FlyControls.js
+++ b/src/Controls/FlyControls.js
@@ -103,7 +103,7 @@ class FlyControls extends THREE.EventDispatcher {
      */
     constructor(view, options = {}) {
         super();
-        const domElement = view.mainLoop.gfxEngine.renderer.domElement;
+        const domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
         this.view = view;
         this.options = options;
         this._camera3D = view.camera.camera3D;

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -170,7 +170,7 @@ class GlobeControls extends THREE.EventDispatcher {
         this.player = new AnimationPlayer();
         this.view = view;
         this.camera = view.camera.camera3D;
-        this.domElement = view.mainLoop.gfxEngine.renderer.domElement;
+        this.domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
 
         // State control
         this.states = new StateControl();

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -105,7 +105,7 @@ const vectorZero = new THREE.Vector3();
 function PlanarControls(view, options = {}) {
     this.view = view;
     this.camera = view.camera.camera3D;
-    this.domElement = view.mainLoop.gfxEngine.renderer.domElement;
+    this.domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
 
     this.enableRotation = typeof (options.enableRotation) !== 'undefined' ? options.enableRotation : true;
     this.rotateSpeed = options.rotateSpeed || 2.0;

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -123,7 +123,7 @@ class StreetControls extends FirstPersonControls {
 
         this.isStreetControls = true;
 
-        const domElement = view.mainLoop.gfxEngine.renderer.domElement;
+        const domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
         domElement.addEventListener('mouseout', super.onMouseUp.bind(this));
 
         // two positions used by this control : current and next

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -523,7 +523,7 @@ class View extends THREE.EventDispatcher {
      */
     eventToViewCoords(event, target = _eventCoords, touchIdx = 0) {
         if (event.touches === undefined || !event.touches.length) {
-            return target.set(event.offsetX, event.offsetY);
+            return target.set(event.clientX, event.clientY);
         } else {
             const br = this.mainLoop.gfxEngine.renderer.domElement.getBoundingClientRect();
             return target.set(

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -181,7 +181,7 @@ describe('GlobeControls with globe example', function _() {
             const wheelEvent = new WheelEvent('mousewheel', {
                 deltaY: -50000,
             });
-            view.mainLoop.gfxEngine.renderer.domElement
+            view.mainLoop.gfxEngine.renderer.domElement.parentElement
                 .dispatchEvent(wheelEvent, document);
             window.dispatchEvent(wheelEvent, document);
         }));

--- a/test/unit/mock.js
+++ b/test/unit/mock.js
@@ -23,6 +23,7 @@ class Renderer {
             clientWidth: 400,
             clientHeight: 300,
         };
+        this.domElement.parentElement = Object.create(this.domElement);
         this.context = {
             getParameter: () => 16,
             createProgram: () => { },


### PR DESCRIPTION
In every `Controls`, the `div` that was listened was the `canvas`. Now
it it the parent of this canvas, usually named `viewerDiv`.

In the same time, the usage of `offsetX/Y` has been changer to
`clientX/Y`.