### PR TITLE
refactor: remove the Feature reference from FeatureGeometry

### DIFF
--- a/examples/js/plugins/CSVnVRTParser.js
+++ b/examples/js/plugins/CSVnVRTParser.js
@@ -120,10 +120,10 @@ var CSVnVRTParser = (function _() {
                             }
                         }
 
-                        geometry.startSubGeometry(1);
+                        geometry.startSubGeometry(1, feature);
                         coord.crs = (layer.GeometryField.SRS && layer.GeometryField.SRS.value) || _crs;
                         coord.setFromValues(Number(line[x]), Number(line[y]), Number(line[z]) || 0);
-                        geometry.pushCoordinates(coord);
+                        geometry.pushCoordinates(coord, feature);
 
                         geometry.updateExtent();
                         feature.updateExtent(geometry);

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -30,15 +30,15 @@ const firstPtIsOut = (extent, aCoords, crs) => {
     return !extent.isPointInside(coord);
 };
 const toFeature = {
-    populateGeometry(crsIn, coordinates, geometry, setAltitude = true) {
-        geometry.startSubGeometry(coordinates.length);
+    populateGeometry(crsIn, coordinates, geometry, setAltitude = true, feature) {
+        geometry.startSubGeometry(coordinates.length, feature);
         const useAlti = setAltitude && typeof coordinates[0][2] == 'number';
 
         // coordinates is a list of pair [[x1, y1], [x2, y2], ..., [xn, yn]]
         for (const pair of coordinates) {
             coord.crs = crsIn;
             coord.setFromValues(pair[0], pair[1], useAlti ? pair[2] : 0);
-            geometry.pushCoordinates(coord);
+            geometry.pushCoordinates(coord, feature);
         }
         geometry.updateExtent();
     },
@@ -50,7 +50,7 @@ const toFeature = {
         const geometry = feature.bindNewGeometry();
         geometry.properties = properties;
         geometry.properties.style = new Style().setFromGeojsonProperties(properties, feature.type);
-        this.populateGeometry(crsIn, coordsIn, geometry, setAltitude);
+        this.populateGeometry(crsIn, coordsIn, geometry, setAltitude, feature);
         feature.updateExtent(geometry);
     },
     polygon(feature, crsIn, coordsIn, filteringExtent, setAltitude, properties) {
@@ -64,7 +64,7 @@ const toFeature = {
 
         // Then read contour and holes
         for (let i = 0; i < coordsIn.length; i++) {
-            this.populateGeometry(crsIn, coordsIn[i], geometry, setAltitude);
+            this.populateGeometry(crsIn, coordsIn[i], geometry, setAltitude, feature);
         }
         feature.updateExtent(geometry);
     },

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -54,14 +54,14 @@ function vtFeatureToFeatureGeometry(vtFeature, feature, classify = false) {
                         geometry = feature.bindNewGeometry();
                         geometry.properties = vtFeature.properties;
                     }
-                    geometry.closeSubGeometry(count);
+                    geometry.closeSubGeometry(count, feature);
                     geometry.getLastSubGeometry().ccw = sum < 0;
                 }
                 count = 0;
                 sum = 0;
             }
             count++;
-            geometry.pushCoordinatesValues(x, y);
+            geometry.pushCoordinatesValues(feature, x, y);
             if (count == 1) {
                 firstPoint.set(x, y);
                 lastPoint.set(x, y);
@@ -72,7 +72,7 @@ function vtFeatureToFeatureGeometry(vtFeature, feature, classify = false) {
         } else if (cmd === 7) {
             if (count) {
                 count++;
-                geometry.pushCoordinatesValues(firstPoint.x, firstPoint.y);
+                geometry.pushCoordinatesValues(feature, firstPoint.x, firstPoint.y);
                 if (classify) {
                     sum += (lastPoint.x - firstPoint.x) * (lastPoint.y + firstPoint.y);
                 }
@@ -88,7 +88,7 @@ function vtFeatureToFeatureGeometry(vtFeature, feature, classify = false) {
             geometry = feature.bindNewGeometry();
             geometry.properties = vtFeature.properties;
         }
-        geometry.closeSubGeometry(count);
+        geometry.closeSubGeometry(count, feature);
         geometry.getLastSubGeometry().ccw = sum < 0;
     }
     feature.updateExtent(geometry);

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -44,10 +44,10 @@ describe('Feature', function () {
         const geometry = featureLine.bindNewGeometry();
 
         coord.setFromValues(-10, -10, 0);
-        geometry.pushCoordinates(coord);
+        geometry.pushCoordinates(coord, featureLine);
         coord.setFromValues(10, 10, 0);
-        geometry.pushCoordinates(coord);
-        geometry.closeSubGeometry(2);
+        geometry.pushCoordinates(coord, featureLine);
+        geometry.closeSubGeometry(2, featureLine);
 
         featureLine.updateExtent(geometry);
 


### PR DESCRIPTION
Even if it was a simple pointer, scenes with a lot of FeatureGeometry
were having a lot of memory taken because of those pointers.