### PR TITLE
WIP fix(controls): jittering move globe with chrome devtools is open.

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -559,6 +559,7 @@ class GlobeControls extends THREE.EventDispatcher {
                 break;
             case this.states.MOVE_GLOBE: {
                 const normalized = this.view.viewToNormalizedCoords(coords);
+                this.camera.updateMatrixWorld();
                 raycaster.setFromCamera(normalized, this.camera);
                 // If there's intersection then move globe else we stop the move
                 if (raycaster.ray.intersectSphere(pickSphere, intersection)) {


### PR DESCRIPTION
## Description
Try to fix.
When devtools is opened there are 2 raycasting (2 successive mouse move events) before the update camera, so the camera matrix world needs to be update before to cast a new ray.
When devtools is closed there are 1 raycasting before the update camera, so the camera matrix world is update by `mainloop.step`.

This fix isn't the best solution. May be a best synchronizing with the frame requester is a good way.

fix #1277 



