### PR TITLE
feat(renderer): adding a first implementation of Labels

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -12,7 +12,8 @@
                 "Feature",
                 "FeatureGeometry",
                 "FeatureCollection",
-                "Style"
+                "Style",
+                "Label"
             ],
 
             "View": [
@@ -40,6 +41,7 @@
                 "OrientedImageLayer",
                 "PointCloudLayer",
                 "C3DTilesLayer",
+                "LabelLayer",
 
                 "GlobeLayer",
                 "PlanarLayer"

--- a/examples/source_file_gpx_raster.html
+++ b/examples/source_file_gpx_raster.html
@@ -22,7 +22,9 @@
             // Define initial camera position
             var placement = {
                 coord: new itowns.Coordinates('EPSG:4326', 0.089, 42.8989),
-                range: 80000,
+                range: 30000,
+                tilt: 20,
+                heading: 70,
             }
 
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
@@ -33,7 +35,6 @@
             var menuGlobe = new GuiTools('menuDiv', view);
 
             setupLoadingScreen(viewerDiv, view);
-            FeatureToolTip.init(viewerDiv, view);
 
             // Add one imagery layer to the scene
             // This layer is defined in a json file but it could be defined as a plain js
@@ -59,6 +60,28 @@
             // Parse and Convert by iTowns
             itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
                 .then(function _(gpx) {
+                    var gpxStyle = new itowns.Style({
+                        zoom: {
+                            min: 9,
+                        },
+                        stroke: {
+                            color: 'red',
+                        },
+                        point: {
+                            color: 'white',
+                            line: 'red',
+                        },
+                        text: {
+                            field: '{name}',
+                            transform: 'uppercase',
+                            font: ['Arial', 'sans-serif'],
+                            halo: {
+                                color: 'white',
+                                width: 1,
+                            },
+                        },
+                    });
+
                     var gpxSource = new itowns.FileSource({
                         fetchedData: gpx,
                         projection: 'EPSG:4326',
@@ -69,19 +92,12 @@
                         name: 'Ultra 2009',
                         transparent: true,
                         source: gpxSource,
-                        style: {
-                            stroke: {
-                                color: 'red',
-                            },
-                            point: {
-                                color: 'white',
-                                line: 'red',
-                            }
-                        },
+                        style: gpxStyle,
+                        labelEnabled: true,
                     });
 
                     return view.addLayer(gpxLayer);
-                }).then(FeatureToolTip.addLayer);
+                });
 
             debug.createTileDebugUI(menuGlobe.gui, view);
         </script>

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -332,4 +332,19 @@ export class FeatureCollection {
         this.features.push(ref);
         return ref;
     }
+
+    /**
+     * Transforms a given {@link Coordinates}, using the translation and the
+     * scale of this collection.
+     *
+     * @param {Coordinates} coordinates - The coordinates to transform
+     *
+     * @return {Coordinates} The same coordinates, with transformation applied.
+     */
+    transformCoordinates(coordinates) {
+        coordinates.x = (coordinates.x / this.scale.x) - this.translation.x;
+        coordinates.y = (coordinates.y / this.scale.y) - this.translation.y;
+        coordinates.z = (coordinates.z / this.scale.z) - this.translation.z;
+        return coordinates;
+    }
 }

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -1,0 +1,154 @@
+import * as THREE from 'three';
+import DEMUtils from 'Utils/DEMUtils';
+import Coordinates from 'Core/Geographic/Coordinates';
+
+const coord = new Coordinates('EPSG:4326');
+let rect;
+
+// set it once
+let STYLE_TRANSFORM = '';
+if (document.documentElement.style.transform !== undefined) {
+    STYLE_TRANSFORM = 'transform';
+} else if (document.documentElement.style.webkitTransform !== undefined) {
+    STYLE_TRANSFORM = 'webkitTransform';
+} else if (document.documentElement.style.mozTransform !== undefined) {
+    STYLE_TRANSFORM = 'mozTransform';
+} else if (document.documentElement.style.oTransform !== undefined) {
+    STYLE_TRANSFORM = 'oTransform';
+} else {
+    STYLE_TRANSFORM = 'transform';
+}
+
+/**
+ * An object that handles the display of a text and/or an icon, linked to a 3D
+ * position. The content of the `Label` is managed through a DOM object, in a
+ * `<div>` handled by the `Label2DRenderer`.
+ *
+ * @property {boolean} isLabel - Used to checkout whether this object is a
+ * Label. Default is true. You should not change this, as it is used internally
+ * for optimisation.
+ * @property {Element} content - The DOM object that contains the content of the
+ * label. The style and the position are applied on this object.
+ * @property {THREE.Vector3} position - The position in the 3D world of the
+ * label.
+ * @property {Coordinates} coordinates - The coordinates of the label.
+ */
+class Label extends THREE.Object3D {
+    /**
+     * @param {Element|string} content - The content; can be a
+     * string, with or without HTML tags in it, or it can be an Element.
+     * @param {Coordinates} coordinates - The world coordinates, where to place
+     * the Label.
+     * @param {Style} style - The style to apply to the content. Once the style
+     * is applied, it cannot be changed directly. However, if it really needed,
+     * it can be accessed through `label.content.style`, but it is highly
+     * discouraged to do so.
+     */
+    constructor(content, coordinates, style = {}) {
+        if (content == undefined || coordinates == undefined) {
+            throw new Error('content and coordinates are mandatory to add a Label');
+        }
+
+        super();
+
+        let _visible = this.visible;
+        // can't do an ES6 setter/getter here
+        Object.defineProperty(this, 'visible', {
+            set(v) {
+                if (v != _visible) { // avoid changing the style
+                    _visible = v;
+                    this.content.style.display = v ? 'block' : 'none';
+                    // TODO: add smooth transition for fade in/out
+                }
+            },
+            get() {
+                return _visible;
+            },
+        });
+
+        this.isLabel = true;
+        this.coordinates = coordinates;
+
+        this.projectedPosition = { x: 0, y: 0 };
+        this.boundaries = { left: 0, right: 0, top: 0, bottom: 0 };
+
+        this.content = document.createElement('div');
+        this.content.style.userSelect = 'none';
+        this.content.style.position = 'absolute';
+        if (typeof content == 'string') {
+            this.content.textContent = content || '';
+        } else {
+            this.content.appendChild(content);
+        }
+        this.baseContent = content;
+
+        if (style.isStyle) {
+            this.anchor = style.getTextAnchorPosition();
+            style.applyToHTML(this.content);
+        }
+
+        this.zoom = {
+            min: style.zoom && style.zoom.min != undefined ? style.zoom.min : 2,
+            max: style.zoom && style.zoom.max != undefined ? style.zoom.max : 24,
+        };
+    }
+
+    /**
+     * Moves a label on the screen, using screen coordinates. It updates the
+     * boundaries as it moves it.
+     *
+     * @param {number} x - X coordinates in pixels, from left.
+     * @param {number} y - Y coordinates in pixels, from top.
+     */
+    updateProjectedPosition(x, y) {
+        if (x != this.projectedPosition.x || y != this.projectedPosition.y) {
+            this.projectedPosition.x = x;
+            this.projectedPosition.y = y;
+
+            this.boundaries.left = x + this.offset.left;
+            this.boundaries.right = x + this.offset.right;
+            this.boundaries.top = y + this.offset.top;
+            this.boundaries.bottom = y + this.offset.bottom;
+        }
+    }
+
+    updateCSSPosition() {
+        this.content.style[STYLE_TRANSFORM] = `translate(${this.boundaries.left}px, ${this.boundaries.top}px)`;
+    }
+
+    /**
+     * Updates the screen dimensions of the label, using
+     * `getBoundingClientRect`.  It updates `width` and `height` property of the
+     * label, and the boundaries.
+     */
+    initDimensions() {
+        if (!this.offset) {
+            rect = this.content.getBoundingClientRect();
+            const width = Math.round(rect.width);
+            const height = Math.round(rect.height);
+            this.offset = {
+                left: width * this.anchor[0],
+                top: height * this.anchor[1],
+            };
+            this.offset.right = this.offset.left + width;
+            this.offset.bottom = this.offset.top + height;
+        }
+    }
+
+    update3dPosition(crs) {
+        this.coordinates.as(crs, coord);
+        coord.toVector3(this.position);
+        this.parent.worldToLocal(this.position);
+        this.updateMatrixWorld();
+    }
+
+    updateElevationFromLayer(layer) {
+        const elevation = DEMUtils.getElevationValueAt(layer, this.coordinates, DEMUtils.FAST_READ_Z);
+        if (elevation && elevation != this.coordinates.z) {
+            this.coordinates.z = elevation;
+            return true;
+        }
+    }
+}
+
+export default Label;

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -95,6 +95,7 @@ class GlobeView extends View {
         this.camera.camera3D.far = ellipsoidSizes.x * 10;
 
         const tileLayer = new GlobeLayer('globe', options.object3d, options);
+        this.mainLoop.gfxEngine.label2dRenderer.infoTileLayer = tileLayer.info;
 
         const sun = new THREE.DirectionalLight();
         sun.position.set(-0.5, 0, 1);

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -22,6 +22,7 @@ class PlanarView extends View {
         this.camera.camera3D.updateProjectionMatrix();
 
         const tileLayer = new PlanarLayer('planar', extent, options.object3d, options);
+        this.mainLoop.gfxEngine.label2dRenderer.infoTileLayer = tileLayer.info;
 
         this.addLayer(tileLayer);
 

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -182,8 +182,8 @@ class Style {
         this.isStyle = true;
 
         this.zoom = {
-            min: 0,
-            max: 24,
+            min: params.zoom && params.zoom.min != undefined ? params.zoom.min : undefined,
+            max: params.zoom && params.zoom.max != undefined ? params.zoom.max : undefined,
         };
 
         params.fill = params.fill || {};
@@ -298,7 +298,7 @@ class Style {
         layer.layout = layer.layout || {};
         layer.paint = layer.paint || {};
 
-        const zoom = this.zoom.min;
+        const zoom = this.zoom.min || 0;
 
         if (layer.type === 'fill' && !this.fill.color) {
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['fill-color'] || layer.paint['fill-pattern']));
@@ -369,7 +369,7 @@ class Style {
                 let size = readVectorProperty(layer.layout['icon-size'], zoom);
                 if (size == undefined) { size = 1; }
 
-                this.icon = cacheStyle.get(iconSrc, size);
+                this.icon = cacheStyle.get(iconSrc, size, size);
 
                 if (!this.icon) {
                     this.icon = {};
@@ -381,7 +381,7 @@ class Style {
                     this.icon.halfWidth = this.icon.dom.width / 2;
                     this.icon.halfHeight = this.icon.dom.height / 2;
 
-                    cacheStyle.set(this.icon, iconSrc, size);
+                    cacheStyle.set(this.icon, iconSrc, size, size);
                 }
             }
         }
@@ -406,6 +406,7 @@ class Style {
         domElement.style.textTransform = this.text.transform;
         domElement.style.letterSpacing = `${this.text.spacing}em`;
         domElement.style.textAlign = this.text.justify;
+        domElement.style['white-space'] = 'pre-line';
 
         // NOTE: find a better way to support text halo
         if (this.text.halo.width > 0) {

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -1,0 +1,221 @@
+import LayerUpdateState from 'Layer/LayerUpdateState';
+import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
+import Layer from 'Layer/Layer';
+import Coordinates from 'Core/Geographic/Coordinates';
+import Extent from 'Core/Geographic/Extent';
+import Label from 'Core/Label';
+import { FEATURE_TYPES } from 'Core/Feature';
+
+const coord = new Coordinates('EPSG:4326', 0, 0, 0);
+
+let content;
+const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
+
+/**
+ * A layer to handle a bunch of `Label`. This layer can be created on its own,
+ * but it is better to use the option `labelEnabled` on another `Layer` to let
+ * it work with it (see the `vector_tile_raster_2d` example).
+ *
+ * @property {boolean} isLabelLayer - Used to checkout whether this layer is a
+ * LabelLayer.  Default is true. You should not change this, as it is used
+ * internally for optimisation.
+ * @property {string} crs - The crs of this layer.
+ */
+class LabelLayer extends Layer {
+    constructor(id, crs) {
+        super(id);
+
+        this.isLabelLayer = true;
+        this.crs = crs;
+    }
+
+    /**
+     * Reads each {@link FeatureGeometry} that contains label configuration, and
+     * creates the corresponding {@link Label}. To create a `Label`, a geometry
+     * needs to have a `label` object with at least a few properties:
+     * - `content`, which refers to `Label#content`
+     * - `position`, which refers to `Label#position`
+     * - (optional) `config`, containing miscellaneous configuration for the
+     *   label
+     *
+     * The geometry (or its parent Feature) needs to have a Style set.
+     *
+     * @param {FeatureCollection} data - The FeatureCollection to read the
+     * labels from.
+     * @param {Extent} extent
+     *
+     * @return {Label[]} An array containing all the created labels.
+     */
+    convert(data, extent) {
+        const labels = [];
+
+        const layerField = this.style && this.style.text && this.style.text.field;
+
+        // Converting the extent now is faster for further operation
+        extent.as(data.crs, _extent);
+        coord.crs = data.crs;
+
+        data.features.forEach((f) => {
+            // TODO: add support for LINE and POLYGON
+            if (f.type !== FEATURE_TYPES.POINT) {
+                return;
+            }
+
+            const featureField = f.style && f.style.text.field;
+
+            f.geometry.forEach((g) => {
+                const minzoom = (g.properties.style && g.properties.style.zoom.min)
+                    || (f.style && f.style.zoom.min)
+                    || (this.style && this.style.zoom && this.style.zoom.min);
+
+                // Don't create a label if it is in-between two steps of zoom
+                if (!this.source.isFileSource) {
+                    if (data.extent.zoom != minzoom) { return; }
+                } else if (extent.zoom != minzoom) { return; }
+
+                // NOTE: this only works because only POINT is supported, it
+                // needs more work for LINE and POLYGON
+                coord.setFromArray(f.vertices, g.size * g.indices[0].offset);
+                data.transformCoordinates(coord);
+                if (f.size == 2) { coord.z = 0; }
+                if (!_extent.isPointInside(coord)) { return; }
+
+                const geometryField = g.properties.style && g.properties.style.text.field;
+                if (!geometryField && !featureField && !layerField) {
+                    return;
+                } else if (geometryField) {
+                    content = g.properties.style.getTextFromProperties(g.properties);
+                } else if (featureField) {
+                    content = f.style.getTextFromProperties(g.properties);
+                } else if (layerField) {
+                    content = this.style.getTextFromProperties(g.properties);
+                }
+
+                // FIXME: Style management needs improvement, see #1318.
+                const label = new Label(content,
+                    coord.clone(),
+                    g.properties.style || f.style || this.style);
+
+                if (f.size == 2) {
+                    label.needsAltitude = true;
+                }
+
+                labels.push(label);
+            });
+        });
+
+        return labels;
+    }
+
+    // placeholder
+    preUpdate() {}
+
+    update(context, layer, node, parent) {
+        if (!parent && node.children.length) {
+            // if node has been removed dispose three.js resource
+            ObjectRemovalHelper.removeChildrenAndCleanupRecursively(this, node);
+            return;
+        }
+
+        if (this.frozen || !node.visible) {
+            return;
+        }
+
+        if (node.layerUpdateState[this.id] === undefined) {
+            node.layerUpdateState[this.id] = new LayerUpdateState();
+        }
+
+        const elevationLayer = node.material.getElevationLayer();
+        if (elevationLayer && node.layerUpdateState[elevationLayer.id].canTryUpdate()) {
+            node.children.forEach((c) => {
+                if (c.isLabel && c.needsAltitude && c.updateElevationFromLayer(this.parent)) {
+                    c.update3dPosition(this.crs);
+                }
+            });
+        }
+
+        if (!node.layerUpdateState[this.id].canTryUpdate()) {
+            return;
+        }
+
+        const extentsDestination = node.getExtentsByProjection(this.source.projection);
+
+        const extentsSource = [];
+        for (const extentDest of extentsDestination) {
+            const ext = this.source.projection == extentDest.crs ? extentDest : extentDest.as(this.source.projection);
+            if (!this.source.extentInsideLimit(ext)) {
+                node.layerUpdateState[this.id].noMoreUpdatePossible();
+                return;
+            }
+            extentsSource.push(extentDest);
+        }
+        node.layerUpdateState[this.id].newTry();
+
+        const command = {
+            layer: this,
+            extentsSource,
+            view: context.view,
+            threejsLayer: this.threejsLayer,
+            requester: node,
+        };
+
+        return context.scheduler.execute(command).then((result) => {
+            if (!result) { return; }
+
+            const renderer = context.view.mainLoop.gfxEngine.label2dRenderer;
+            const labelsDiv = [];
+
+            result.forEach((labels) => {
+                if (!node.parent) {
+                    labels.forEach((l) => {
+                        ObjectRemovalHelper.removeChildrenAndCleanupRecursively(this, l);
+                        renderer.removeLabelDOM(l);
+                    });
+                    return;
+                }
+
+                labels.forEach((label) => {
+                    if (label.needsAltitude) {
+                        label.updateElevationFromLayer(this.parent);
+                    }
+
+                    node.add(label);
+                    label.update3dPosition(this.crs);
+
+                    labelsDiv.push(label.content);
+                });
+            });
+
+            if (labelsDiv.length > 0) {
+                // Add all labels for this tile at once to batch it
+                node.domElement = document.createElement('div');
+                node.domElement.append(...labelsDiv);
+                renderer.domElement.appendChild(node.domElement);
+                node.domElementVisible = true;
+
+                // Batch update the dimensions of labels all at once to avoid
+                // redraw for at least this tile.
+                result.forEach(labels => labels.forEach(label => label.initDimensions()));
+                result.forEach(labels => labels.forEach((label) => { label.visible = false; }));
+
+                // Sort labels so they can be the first in the renderer. That
+                // way, we cull labels on parent tile first, and then on
+                // children tile. This allows a z-order priority, and reduce
+                // flickering.
+                node.children.sort(c => (c.isLabel ? -1 : 1));
+
+                // Necessary event listener, to remove any Label attached to
+                // this tile
+                node.addEventListener('removed', () => {
+                    renderer.hideNodeDOM(node);
+                    result.forEach(labels => labels.forEach(label => node.remove(label)));
+                    node.domElement.parentElement.removeChild(node.domElement);
+                });
+            }
+
+            node.layerUpdateState[this.id].noMoreUpdatePossible();
+        });
+    }
+}
+
+export default LabelLayer;

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -19,6 +19,9 @@ import Cache from 'Core/Scheduler/Cache';
  * @property {Promise} whenReady - this promise is resolved when the layer is added and all initializations are done.
  * This promise is resolved with this layer.
  * This promise is returned by [View#addLayer]{@link View}.
+ * @property {boolean} [labelEnabled=false] - Used to tell if this layer has
+ * labels to display from its data. For example, it needs to be set to `true`
+ * for a layer with vector tiles.
  */
 class Layer extends THREE.EventDispatcher {
     /**

--- a/src/Main.js
+++ b/src/Main.js
@@ -33,6 +33,7 @@ export { default as Capabilities } from 'Core/System/Capabilities';
 // Internal itowns format
 export { default as Feature, FeatureCollection, FeatureGeometry, FEATURE_TYPES } from 'Core/Feature';
 export { default as Style } from 'Core/Style';
+export { default as Label } from 'Core/Label';
 
 // Layers provided by default in iTowns
 // A custom layer should at least implements Layer
@@ -49,6 +50,7 @@ export { STRATEGY_MIN_NETWORK_TRAFFIC, STRATEGY_GROUP, STRATEGY_PROGRESSIVE, STR
 export { default as ColorLayersOrdering } from 'Renderer/ColorLayersOrdering';
 export { default as GlobeLayer } from 'Core/Prefab/Globe/GlobeLayer';
 export { default as PlanarLayer } from 'Core/Prefab/Planar/PlanarLayer';
+export { default as LabelLayer } from 'Layer/LabelLayer';
 
 // Sources provided by default in iTowns
 // A custom source should at least implements Source

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -83,6 +83,11 @@ class Label2DRenderer {
         this.domElement.style.top = 0;
         this.domElement.style.zIndex = 1;
 
+        // Used to destroy labels that are not added to the DOM
+        this.garbage = document.createElement('div');
+        this.garbage.style.display = 'none';
+        this.domElement.appendChild(this.garbage);
+
         this.halfWidth = 0;
         this.halfHeight = 0;
 
@@ -117,7 +122,7 @@ class Label2DRenderer {
         this.grid.visible.forEach((l, i) => {
             if (this.grid.insert(l, i)) {
                 l.visible = true;
-                l.move();
+                l.updateCSSPosition();
             }
         });
 
@@ -149,7 +154,7 @@ class Label2DRenderer {
             vector.setFromMatrixPosition(object.matrixWorld);
             vector.applyMatrix4(viewProjectionMatrix);
 
-            object.preMove(Math.round(vector.x * this.halfWidth + this.halfWidth), Math.round(-vector.y * this.halfHeight + this.halfHeight));
+            object.updateProjectedPosition(Math.round(vector.x * this.halfWidth + this.halfWidth), Math.round(-vector.y * this.halfHeight + this.halfHeight));
 
             // Are considered duplicates, labels that have the same screen
             // coordinates and the same base content.

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -1,0 +1,190 @@
+import * as THREE from 'three';
+
+// A grid to manage labels on the screen.
+class ScreenGrid {
+    constructor(x = 12, y = 10, width, height) {
+        this.x = x;
+        this.y = y;
+
+        this.grid = [];
+        this.hidden = [];
+        this.visible = [];
+
+        this.resize();
+        this.reset();
+
+        this.width = width;
+        this.height = height;
+    }
+
+    // Reset each cell and hidden and visible.
+    reset() {
+        for (let i = 0; i < this.x; i++) {
+            for (let j = 0; j < this.y; j++) {
+                this.grid[i][j] = false;
+            }
+        }
+
+        this.hidden = [];
+        this.visible = [];
+    }
+
+    // Add rows if needed — but don't delete anything else. Columns are taken
+    // care in reset().
+    resize() {
+        for (let i = 0; i < this.x; i++) {
+            if (!this.grid[i]) {
+                this.grid[i] = [];
+            }
+        }
+    }
+
+    // Insert a label using its boundaries. It is either added to hidden or
+    // visible, given the result. The grid is populated with true for every
+    // filled cell.
+    insert(obj) {
+        const minx = Math.max(0, Math.floor(obj.boundaries.left / this.width * this.x));
+        const maxx = Math.min(this.x - 1, Math.floor(obj.boundaries.right / this.width * this.x));
+        const miny = Math.max(0, Math.floor(obj.boundaries.top / this.height * this.y));
+        const maxy = Math.min(this.y - 1, Math.floor(obj.boundaries.bottom / this.height * this.y));
+
+        for (let i = minx; i <= maxx; i++) {
+            for (let j = miny; j <= maxy; j++) {
+                if (this.grid[i][j]) {
+                    this.hidden.push(obj);
+                    return false;
+                }
+            }
+        }
+
+        for (let i = minx; i <= maxx; i++) {
+            for (let j = miny; j <= maxy; j++) {
+                this.grid[i][j] = true;
+            }
+        }
+
+        return true;
+    }
+}
+
+const viewProjectionMatrix = new THREE.Matrix4();
+const vector = new THREE.Vector3();
+
+/**
+ * This renderer is inspired by the
+ * [`THREE.CSS2DRenderer`](https://threejs.org/docs/#examples/en/renderers/CSS2DRenderer).
+ * It is instanciated in `c3DEngine`, as another renderer to handles Labels.
+ */
+class Label2DRenderer {
+    constructor() {
+        this.domElement = document.createElement('div');
+        this.domElement.style.overflow = 'hidden';
+        this.domElement.style.position = 'absolute';
+        this.domElement.style.top = 0;
+        this.domElement.style.zIndex = 1;
+
+        this.halfWidth = 0;
+        this.halfHeight = 0;
+
+        this.grid = new ScreenGrid();
+
+        this.infoTileLayer = undefined;
+    }
+
+    setSize(width, height) {
+        this.domElement.style.width = `${width}`;
+        this.domElement.style.height = `${height}`;
+
+        this.halfWidth = width / 2;
+        this.halfHeight = height / 2;
+
+        this.grid.width = width;
+        this.grid.height = height;
+        this.grid.x = Math.ceil(width / 30);
+        this.grid.y = Math.ceil(height / 30);
+
+        this.grid.resize();
+    }
+
+    render(scene, camera) {
+        if (!this.infoTileLayer) { return; }
+        this.grid.reset();
+
+        viewProjectionMatrix.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+
+        this.culling(scene, this.infoTileLayer.currentMaxTileZoom, this.infoTileLayer.displayed.extent);
+
+        this.grid.visible.forEach((l, i) => {
+            if (this.grid.insert(l, i)) {
+                l.visible = true;
+                l.move();
+            }
+        });
+
+        this.grid.hidden.forEach((label) => { label.visible = false; });
+    }
+
+    culling(object, currentMaxZoom, extent) {
+        if (!object.isLabel) {
+            if (!object.visible) {
+                this.hideNodeDOM(object);
+                return;
+            }
+
+            // Don't go further if the node can't be in the screen space (it
+            // does not need to be rendered to continue the culling)
+            if (object.extent && !object.extent.intersectsExtent(extent)) {
+                this.hideNodeDOM(object);
+                return;
+            }
+
+            this.showNodeDOM(object);
+
+            object.children.forEach(c => this.culling(c, currentMaxZoom, extent));
+        // By verifying the maxzoom and the presence of the label inside the
+        // visible extent, we can filter more labels.
+        } else if (object.zoom.max <= currentMaxZoom || !extent.isPointInside(object.coordinates)) {
+            this.grid.hidden.push(object);
+        } else {
+            vector.setFromMatrixPosition(object.matrixWorld);
+            vector.applyMatrix4(viewProjectionMatrix);
+
+            object.preMove(Math.round(vector.x * this.halfWidth + this.halfWidth), Math.round(-vector.y * this.halfHeight + this.halfHeight));
+
+            // Are considered duplicates, labels that have the same screen
+            // coordinates and the same base content.
+            if (this.grid.visible.some(l => l.projectedPosition.x == object.projectedPosition.x
+                && l.projectedPosition.y == object.projectedPosition.y
+                && l.baseContent == object.baseContent)) {
+                object.parent.remove(object);
+                this.grid.hidden.push(object);
+            } else if (object.visible) {
+                // Give priority to already visible label, to reduce jittering
+                this.grid.visible.unshift(object);
+            } else {
+                this.grid.visible.push(object);
+            }
+        }
+    }
+
+    removeLabelDOM(label) {
+        this.garbage.appendChild(label.content);
+        this.garbage.innerHTML = '';
+    }
+
+    hideNodeDOM(node) {
+        if (node.domElementVisible == true) {
+            node.domElement.style.display = 'none';
+            node.domElementVisible = false;
+        }
+    }
+
+    showNodeDOM(node) {
+        if (node.domElementVisible == false) {
+            node.domElement.style.display = 'block';
+            node.domElementVisible = true;
+        }
+    }
+}
+
+export default Label2DRenderer;

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -61,10 +61,10 @@ global.document = {
                 setTransform: () => { },
                 setLineDash: () => { },
                 drawImage: (img, sx, sy, sw, sh, dx, dy, dw, dh) => {
-                    this.width = dw;
-                    this.height = dh;
+                    canvas.width = dw;
+                    canvas.height = dh;
 
-                    const image = new DOMElement();
+                    const image = global.document.createElement('img');
                     image.width = dw;
                     image.height = dh;
                     return image;
@@ -72,7 +72,7 @@ global.document = {
                 canvas,
             });
 
-            canvas.toDataURL = () => ({ width: this.width, height: this.height });
+            canvas.toDataURL = () => ({ width: canvas.width, height: canvas.height });
 
             return canvas;
         } else if (type == 'img') {

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -1,0 +1,116 @@
+import assert from 'assert';
+import Label from 'Core/Label';
+import Style from 'Core/Style';
+import { FeatureCollection, FEATURE_TYPES } from 'Core/Feature';
+import Coordinates from 'Core/Geographic/Coordinates';
+import Extent from 'Core/Geographic/Extent';
+import LabelLayer from 'Layer/LabelLayer';
+
+describe('LabelLayer', function () {
+    let layer;
+    let collection;
+    let extent;
+
+    before('init LabelLayer and a FeatureCollection like', function () {
+        layer = new LabelLayer('layer', 'EPSG:4978');
+        layer.source = {};
+        layer.style = new Style();
+        layer.style.zoom = {
+            min: 0,
+            max: 10,
+        };
+        layer.style.text.field = 'content';
+
+        collection = new FeatureCollection('EPSG:4326', { buildExtent: true });
+        const feature = collection.requestFeatureByType(FEATURE_TYPES.POINT);
+        const geometry = feature.bindNewGeometry();
+        geometry.startSubGeometry(0, feature);
+        geometry.pushCoordinatesValues(feature, 0, 0);
+        geometry.closeSubGeometry(3, feature);
+        geometry.properties = { content: 'foo' };
+
+        extent = new Extent('EPSG:4978', -10, 10, -10, 10);
+    });
+
+    it('should create Labels from a FeatureCollection like object', function () {
+        const labels = layer.convert(collection, extent);
+        assert.ok(labels[0].isLabel);
+    });
+});
+
+describe('Label', function () {
+    let label;
+    let style;
+    const c = new Coordinates('EPSG:4978');
+
+    before('init style', function () {
+        style = new Style();
+        style.setFromVectorTileLayer({
+            type: 'symbol',
+            paint: {},
+            layout: {
+                'icon-image': 'icon',
+            },
+        }, {
+            img: '',
+            icon: { x: 0, y: 0, width: 10, height: 10 },
+        });
+    });
+
+    it('should throw errors for bad Label construction', function () {
+        assert.throws(() => { label = new Label(); });
+        assert.throws(() => { label = new Label('content'); });
+    });
+
+    it('should correctly create Labels', function () {
+        assert.doesNotThrow(() => { label = new Label('', c); });
+        assert.doesNotThrow(() => { label = new Label(document.createElement('div'), c); });
+    });
+
+    it('should set the correct icon anchor position', function () {
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.right, 'calc(50% - 5px)');
+        assert.equal(label.content.children[0].style.top, 'calc(50% - 5px)');
+
+        style.text.anchor = 'left';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.right, 'calc(100% - 5px)');
+        assert.equal(label.content.children[0].style.top, 'calc(50% - 5px)');
+
+        style.text.anchor = 'right';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.top, 'calc(50% - 5px)');
+
+        style.text.anchor = 'top';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.right, 'calc(50% - 5px)');
+
+        style.text.anchor = 'bottom';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.top, 'calc(100% - 5px)');
+        assert.equal(label.content.children[0].style.right, 'calc(50% - 5px)');
+
+        style.text.anchor = 'bottom-left';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.right, 'calc(100% - 5px)');
+        assert.equal(label.content.children[0].style.top, 'calc(100% - 5px)');
+
+        style.text.anchor = 'bottom-right';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.top, 'calc(100% - 5px)');
+
+        style.text.anchor = 'top-left';
+        label = new Label('', c, style);
+        assert.equal(label.content.children[0].style.right, 'calc(100% - 5px)');
+    });
+
+    it('should hide the DOM', function () {
+        label = new Label('', c, style);
+
+        assert.equal(label.content.style.display, 'block');
+        label.visible = false;
+        assert.equal(label.content.style.display, 'none');
+        label.visible = true;
+        assert.equal(label.content.style.display, 'block');
+    });
+});

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -25,7 +25,7 @@ describe('Viewer', function () {
             projection: 'EPSG:4326',
         });
 
-        colorLayer = new ColorLayer('l0', { source });
+        colorLayer = new ColorLayer('l0', { source, labelEnabled: true });
         colorLayer2 = new ColorLayer('l1', { source });
     });
 
@@ -81,17 +81,18 @@ describe('Viewer', function () {
     });
 
     it('ColorLayersOrdering', (done) => {
-        viewer.addLayer(globelayer);
-        viewer.tileLayer = globelayer;
-        viewer.addLayer(colorLayer, globelayer).then(() => {
-            viewer.addLayer(colorLayer2, globelayer).then(() => {
-                ColorLayersOrdering.moveLayerUp(viewer, colorLayer.id);
-                assert.equal(colorLayer.sequence, 1);
-                ColorLayersOrdering.moveLayerDown(viewer, colorLayer.id);
-                assert.equal(colorLayer.sequence, 0);
-                ColorLayersOrdering.moveLayerToIndex(viewer, colorLayer.id, 1);
-                assert.equal(colorLayer.sequence, 1);
-                done();
+        viewer.addLayer(globelayer).then(() => {
+            viewer.tileLayer = globelayer;
+            viewer.addLayer(colorLayer, globelayer).then(() => {
+                viewer.addLayer(colorLayer2, globelayer).then(() => {
+                    ColorLayersOrdering.moveLayerUp(viewer, colorLayer.id);
+                    assert.equal(colorLayer.sequence, 1);
+                    ColorLayersOrdering.moveLayerDown(viewer, colorLayer.id);
+                    assert.equal(colorLayer.sequence, 0);
+                    ColorLayersOrdering.moveLayerToIndex(viewer, colorLayer.id, 1);
+                    assert.equal(colorLayer.sequence, 1);
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
This is a first PR in managing labels (either text, icon or both) in iTowns. There is still a lot of room for improvement, but I would like to see this first bit going into the codebase before it is too big to review. Below is the result for the published `vector_tile_raster_2d` example.

![image](https://user-images.githubusercontent.com/741255/72812206-5c85fa80-3c61-11ea-9ba7-f935ee0deafb.png)

Here is the result for another unpublished example using vector tile as well:

![image](https://user-images.githubusercontent.com/741255/72813094-1336aa80-3c63-11ea-929c-68b8e0a4f84c.png)

#### feat(renderer): add a renderer for Labels

This new renderer (Label2DRenderer) is launched in c3DEngine, alongside
WebGLRenderer. It manages Labels present on the scene.

#### feat(label): add a first implementation of Labels

This commit has two main aspects:
- `Label` object, which represents a text and/or an icon. It has a 3D
position, and it is displayed through DOM.
- `LabelLayer`, which is managing the present labels on a scene. It can
be created on its own, or it can get data from another layer.

There has also been some update in the `vector_tile_raster_2d` example,
as well as in the parsing of vector tiles and style.

