### PR TITLE
fix(feature): return style when filtering features

### DIFF
--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -75,7 +75,7 @@ var FeatureToolTip = (function _() {
             feature = features[p];
 
             geometry = feature.geometry;
-            style = (layer.style && layer.style.isStyle) ? layer.style : (geometry._feature.style || geometry.properties.style);
+            style = (layer.style && layer.style.isStyle) ? layer.style : feature.style;
             fill = style.fill.color;
             stroke = '1.25px ' + style.stroke.color;
 

--- a/src/Utils/FeaturesUtils.js
+++ b/src/Utils/FeaturesUtils.js
@@ -123,6 +123,7 @@ function isFeatureUnderCoordinate(coordinate, feature, epsilon, result) {
                     type: feature.type,
                     geometry,
                     coordinates: under.coordinates /* || coordinates */,
+                    style: feature.style,
                 });
             }
         }


### PR DESCRIPTION
In FeatureUtils, when filtering features under a coordinate, the style
of each feature is returned, in order to be used (in FeatureToolTip for
this case). It is a fix that corrects f703723.

This is not the best fix to do, but the quickest at the time. In the
future, I recommend getting rid of the FeatureUtils and do all the work
directly in Feature/FeatureCollection, and return a partial Feature or
FeatureCollection depending on the case.
