### PR TITLE
fix(example): add the GUITools to the parent of viewerDiv

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -144,6 +144,7 @@ canvas {
 /* PLUGINS/GUI */
 .dg.main {
     position: absolute;
+    top: 0;
 }
 
 @media (max-width: 600px) {

--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -38,7 +38,7 @@ function GuiTools(domId, view, w) {
     var width = w || 245;
     this.gui = new dat.GUI({ autoPlace: false, width: width });
     this.gui.domElement.id = domId;
-    viewerDiv.appendChild(this.gui.domElement);
+    viewerDiv.parentElement.appendChild(this.gui.domElement);
     this.colorGui = this.gui.addFolder('Color Layers');
     this.elevationGui = this.gui.addFolder('Elevation Layers');
     this.elevationGui.hide();


### PR DESCRIPTION
Before this fix, there was a call on mouse events when interacting with
the GUI, as the GUI was inside viewerDiv, and the events are listened
from the viewerDiv.
