### PR TITLE
Point Cloud refactoring

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -52,6 +52,7 @@
                 "TMSSource",
                 "FileSource",
                 "OrientedImageSource",
+                "PointCloudSource",
                 "VectorTilesSource"
             ],
 

--- a/examples/pointcloud_25d_map.html
+++ b/examples/pointcloud_25d_map.html
@@ -173,8 +173,10 @@
 
                     // Configure Point Cloud layer
                     pointcloud = new itowns.PointCloudLayer('eglise_saint_blaise_arles', {
-                        file: fileName || 'infos/sources',
-                        url: serverUrl,
+                        source: new itowns.PointCloudSource({
+                            file: fileName || 'infos/sources',
+                            url: serverUrl,
+                        }),
                         table: lopocsTable,
                         material: searchParams.get('material') === 'three' ? new itowns.THREE.PointsMaterial({
                             color: 0xff8888,

--- a/examples/pointcloud_3d_map.html
+++ b/examples/pointcloud_3d_map.html
@@ -64,8 +64,10 @@
 
             // Configure Point Cloud layer
             pointcloud = new itowns.PointCloudLayer('eglise_saint_blaise_arles', {
-                file: 'eglise_saint_blaise_arles.js',
-                url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+                source: new itowns.PointCloudSource({
+                    file: 'eglise_saint_blaise_arles.js',
+                    url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+                }),
             },view);
 
             // add pointcloud to scene

--- a/src/Core/PointCloudNode.js
+++ b/src/Core/PointCloudNode.js
@@ -1,0 +1,132 @@
+import * as THREE from 'three';
+
+// Create an A(xis)A(ligned)B(ounding)B(ox) for the child `childIndex` of one aabb.
+// (PotreeConverter protocol builds implicit octree hierarchy by applying the same
+// subdivision algo recursively)
+const dHalfLength = new THREE.Vector3();
+
+class PointCloudNode {
+    constructor(numPoints = 0, childrenBitField = 0, layer) {
+        this.numPoints = numPoints;
+        this.childrenBitField = childrenBitField;
+        this.children = [];
+        this.layer = layer;
+        this.name = '';
+        this.bbox = new THREE.Box3();
+        this.sse = -1;
+        this.baseurl = layer.source.baseurl;
+    }
+
+    add(node, indexChild, root) {
+        this.children.push(node);
+        node.parent = this;
+        node.name = this.name + indexChild;
+        this.createChildAABB(indexChild, node.bbox);
+        if ((node.name.length % this.layer.hierarchyStepSize) == 0) {
+            node.baseurl = `${root.baseurl}/${node.name.substr(root.name.length)}`;
+        } else {
+            node.baseurl = root.baseurl;
+        }
+    }
+
+    createChildAABB(childIndex, box) {
+        // Code inspired from potree
+        box.copy(this.bbox);
+        this.bbox.getCenter(box.max);
+        dHalfLength.copy(box.max).sub(this.bbox.min);
+
+        if (childIndex === 1) {
+            box.min.z += dHalfLength.z;
+            box.max.z += dHalfLength.z;
+        } else if (childIndex === 3) {
+            box.min.z += dHalfLength.z;
+            box.max.z += dHalfLength.z;
+            box.min.y += dHalfLength.y;
+            box.max.y += dHalfLength.y;
+        } else if (childIndex === 0) {
+            //
+        } else if (childIndex === 2) {
+            box.min.y += dHalfLength.y;
+            box.max.y += dHalfLength.y;
+        } else if (childIndex === 5) {
+            box.min.z += dHalfLength.z;
+            box.max.z += dHalfLength.z;
+            box.min.x += dHalfLength.x;
+            box.max.x += dHalfLength.x;
+        } else if (childIndex === 7) {
+            box.min.add(dHalfLength);
+            box.max.add(dHalfLength);
+        } else if (childIndex === 4) {
+            box.min.x += dHalfLength.x;
+            box.max.x += dHalfLength.x;
+        } else if (childIndex === 6) {
+            box.min.y += dHalfLength.y;
+            box.max.y += dHalfLength.y;
+            box.min.x += dHalfLength.x;
+            box.max.x += dHalfLength.x;
+        }
+    }
+
+    getChildByName(name) {
+        if (this.name === name) {
+            return this;
+        }
+        const charIndex = this.name.length;
+        for (const child of this.children) {
+            if (child.name[charIndex] == name[charIndex]) {
+                return child.getChildByName(name);
+            }
+        }
+        throw new Error(`Cannot find node with name '${name}'`);
+    }
+
+    octreeUrl() {
+        return `${this.baseurl}/r${this.name}.${this.layer.source.extensionOctree}`;
+    }
+
+    nodeUrl() {
+        return `${this.baseurl}/r${this.name}.${this.layer.source.extension}?isleaf=${this.isLeaf ? 1 : 0}`;
+    }
+
+    get octreeIsLoaded() {
+        return !(this.childrenBitField && this.children.length === 0);
+    }
+
+    get isLeaf() {
+        return this.childrenBitField == 0;
+    }
+
+    loadNode() {
+        return this.layer.source.fetcher(this.nodeUrl(), this.layer.source.networkOptions).then(this.layer.source.parse);
+    }
+
+    loadOctree() {
+        return this.layer.source.fetcher(this.octreeUrl(), this.layer.source.networkOptions).then((blob) => {
+            const view = new DataView(blob);
+            const stack = [];
+            let offset = 0;
+
+            this.childrenBitField = view.getUint8(0); offset += 1;
+            this.numPoints = view.getUint32(1, true); offset += 4;
+
+            stack.push(this);
+
+            while (stack.length && offset < blob.byteLength) {
+                const snode = stack.shift();
+                // look up 8 children
+                for (let indexChild = 0; indexChild < 8; indexChild++) {
+                    // does snode have a #indexChild child ?
+                    if (snode.childrenBitField & (1 << indexChild) && (offset + 5) <= blob.byteLength) {
+                        const childrenBitField = view.getUint8(offset); offset += 1;
+                        const numPoints = view.getUint32(offset, true) || this.numPoints; offset += 4;
+                        const item = new PointCloudNode(numPoints, childrenBitField, this.layer);
+                        snode.add(item, indexChild, this);
+                        stack.push(item);
+                    }
+                }
+            }
+        });
+    }
+}
+
+export default PointCloudNode;

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -1,10 +1,8 @@
 import * as THREE from 'three';
 import GeometryLayer from 'Layer/GeometryLayer';
-import Fetcher from 'Provider/Fetcher';
-import PotreeBinParser from 'Parser/PotreeBinParser';
-import PotreeCinParser from 'Parser/PotreeCinParser';
 import PointsMaterial, { MODE } from 'Renderer/PointsMaterial';
 import Picking from 'Core/Picking';
+import PointCloudNode from 'Core/PointCloudNode';
 import Extent from 'Core/Geographic/Extent';
 import CancelledCommandException from 'Core/Scheduler/CancelledCommandException';
 
@@ -32,18 +30,18 @@ function initBoundingBox(elt, layer) {
     elt.obj.boxHelper.updateMatrixWorld();
 }
 
-function computeScreenSpaceError(context, layer, elt, distance) {
+function computeScreenSpaceError(context, pointSize, spacing, elt, distance) {
     if (distance <= 0) {
         return Infinity;
     }
-    const pointSpacing = layer.metadata.spacing / 2 ** elt.name.length;
+    const pointSpacing = spacing / 2 ** elt.name.length;
     // Estimate the onscreen distance between 2 points
     const onScreenSpacing = context.camera.preSSE * pointSpacing / distance;
     // [  P1  ]--------------[   P2   ]
     //     <--------------------->      = pointsSpacing (in world coordinates)
     //                                  ~ onScreenSpacing (in pixels)
-    // <------>                         = layer.pointSize (in pixels)
-    return Math.max(0.0, onScreenSpacing - layer.pointSize);
+    // <------>                         = pointSize (in pixels)
+    return Math.max(0.0, onScreenSpacing - pointSize);
 }
 
 function markForDeletion(elt) {
@@ -66,171 +64,6 @@ function markForDeletion(elt) {
     }
 }
 
-// Create an A(xis)A(ligned)B(ounding)B(ox) for the child `childIndex` of one aabb.
-// (PotreeConverter protocol builds implicit octree hierarchy by applying the same
-// subdivision algo recursively)
-const dHalfLength = new THREE.Vector3();
-function createChildAABB(aabb, childIndex) {
-    // Code inspired from potree
-    const box = aabb.clone();
-    aabb.getCenter(box.max);
-    dHalfLength.copy(box.max).sub(aabb.min);
-
-    if (childIndex === 1) {
-        box.min.z += dHalfLength.z;
-        box.max.z += dHalfLength.z;
-    } else if (childIndex === 3) {
-        box.min.z += dHalfLength.z;
-        box.max.z += dHalfLength.z;
-        box.min.y += dHalfLength.y;
-        box.max.y += dHalfLength.y;
-    } else if (childIndex === 0) {
-        //
-    } else if (childIndex === 2) {
-        box.min.y += dHalfLength.y;
-        box.max.y += dHalfLength.y;
-    } else if (childIndex === 5) {
-        box.min.z += dHalfLength.z;
-        box.max.z += dHalfLength.z;
-        box.min.x += dHalfLength.x;
-        box.max.x += dHalfLength.x;
-    } else if (childIndex === 7) {
-        box.min.add(dHalfLength);
-        box.max.add(dHalfLength);
-    } else if (childIndex === 4) {
-        box.min.x += dHalfLength.x;
-        box.max.x += dHalfLength.x;
-    } else if (childIndex === 6) {
-        box.min.y += dHalfLength.y;
-        box.max.y += dHalfLength.y;
-        box.min.x += dHalfLength.x;
-        box.max.x += dHalfLength.x;
-    }
-
-    return box;
-}
-
-
-export function parseOctree(layer, hierarchyStepSize, root) {
-    return Fetcher.arrayBuffer(`${root.baseurl}/r${root.name}.hrc`, layer.fetchOptions).then((blob) => {
-        const view = new DataView(blob);
-
-        const stack = [];
-
-        let offset = 0;
-
-        root.childrenBitField = view.getUint8(0); offset += 1;
-        root.numPoints = view.getUint32(1, true); offset += 4;
-        root.children = [];
-
-        stack.push(root);
-
-        while (stack.length && offset < blob.byteLength) {
-            const snode = stack.shift();
-            // look up 8 children
-            for (let i = 0; i < 8; i++) {
-                // does snode have a #i child ?
-                if (snode.childrenBitField & (1 << i) && (offset + 5) <= blob.byteLength) {
-                    const c = view.getUint8(offset); offset += 1;
-                    let n = view.getUint32(offset, true); offset += 4;
-                    if (n == 0) {
-                        n = root.numPoints;
-                    }
-                    const childname = snode.name + i;
-                    const bounds = createChildAABB(snode.bbox, i);
-
-                    let url = root.baseurl;
-                    if ((childname.length % hierarchyStepSize) == 0) {
-                        const myname = childname.substr(root.name.length);
-                        url = `${root.baseurl}/${myname}`;
-                    }
-                    const item = {
-                        numPoints: n,
-                        childrenBitField: c,
-                        children: [],
-                        name: childname,
-                        baseurl: url,
-                        bbox: bounds,
-                        layer,
-                        parent: snode,
-                    };
-                    snode.children.push(item);
-                    stack.push(item);
-                }
-            }
-        }
-
-        return root;
-    });
-}
-
-function findChildrenByName(node, name) {
-    if (node.name === name) {
-        return node;
-    }
-    const charIndex = node.name.length;
-    for (let i = 0; i < node.children.length; i++) {
-        if (node.children[i].name[charIndex] == name[charIndex]) {
-            return findChildrenByName(node.children[i], name);
-        }
-    }
-    throw new Error(`Cannot find node with name '${name}'`);
-}
-
-function computeBbox(layer) {
-    let bbox;
-    if (layer.isFromPotreeConverter) {
-        bbox = new THREE.Box3(
-            new THREE.Vector3(layer.metadata.boundingBox.lx, layer.metadata.boundingBox.ly, layer.metadata.boundingBox.lz),
-            new THREE.Vector3(layer.metadata.boundingBox.ux, layer.metadata.boundingBox.uy, layer.metadata.boundingBox.uz));
-    } else {
-        // lopocs
-        let idx = 0;
-        for (const entry of layer.metadata) {
-            if (entry.table == layer.table) {
-                break;
-            }
-            idx++;
-        }
-        bbox = new THREE.Box3(
-            new THREE.Vector3(layer.metadata[idx].bbox.xmin, layer.metadata[idx].bbox.ymin, layer.metadata[idx].bbox.zmin),
-            new THREE.Vector3(layer.metadata[idx].bbox.xmax, layer.metadata[idx].bbox.ymax, layer.metadata[idx].bbox.zmax));
-    }
-    return bbox;
-}
-
-export function parseMetadata(metadata, layer) {
-    layer.metadata = metadata;
-
-    var customBinFormat = true;
-
-    // Lopocs pointcloud server can expose the same file structure as PotreeConverter output.
-    // The only difference is the metadata root file (cloud.js vs infos/sources), and we can
-    // check for the existence of a `scale` field.
-    // (if `scale` is defined => we're fetching files from PotreeConverter)
-    if (layer.metadata.scale != undefined) {
-        layer.isFromPotreeConverter = true;
-        // PotreeConverter format
-        customBinFormat = layer.metadata.pointAttributes === 'CIN';
-        // do we have normal information
-        const normal = Array.isArray(layer.metadata.pointAttributes) &&
-            layer.metadata.pointAttributes.find(elem => elem.startsWith('NORMAL'));
-        if (normal) {
-            layer.material.defines[normal] = 1;
-        }
-    } else {
-        // Lopocs
-        layer.metadata.scale = 1;
-        layer.metadata.octreeDir = `itowns/${layer.table}.points`;
-        layer.metadata.hierarchyStepSize = 1000000; // ignore this with lopocs
-        customBinFormat = true;
-    }
-
-    layer.parse = customBinFormat ? PotreeCinParser.parse : PotreeBinParser.parse;
-    layer.extension = customBinFormat ? 'cin' : 'bin';
-    layer.supportsProgressiveDisplay = customBinFormat;
-}
-
 class PointCloudLayer extends GeometryLayer {
     /**
      * Constructs a new instance of point cloud layer.
@@ -241,8 +74,10 @@ class PointCloudLayer extends GeometryLayer {
      * // Create a new point cloud layer
      * const points = new PointCloudLayer('points',
      *  {
-     *      url: 'https://pointsClouds/',
-     *      file: 'points.js',
+     *      source: new PointCloudLayer({
+     *          url: 'https://pointsClouds/',
+     *          file: 'points.js',
+     *      }
      *  }, view);
      *
      * View.prototype.addLayer.call(view, points);
@@ -252,11 +87,9 @@ class PointCloudLayer extends GeometryLayer {
      * {@link View} that already has a layer going by that id.
      * @param      {object}  config   configuration, all elements in it
      * will be merged as is in the layer.
-     * @param {string} config.url The base url.
-     * @param {string} config.file file name.
      * @param {number} [config.pointBudget=2000000] max displayed points count.
+     * @param {PointCloudSource} config.source - Description and options of the source.
      * @param {number} [config.sseThreshold=2] screen space error Threshold.
-     * @param {Object} [config.fetchOptions={}] fetch config.
      * @param {number} [config.pointSize=4] point size.
      * @param {THREE.Material} [config.material] override material.
      * @param {number} [config.mode=MODE.COLOR] displaying mode.
@@ -264,29 +97,18 @@ class PointCloudLayer extends GeometryLayer {
      * @param  {View}  view  The view
      */
     constructor(id, config, view) {
-        if (!config.url) {
-            throw new Error('New PointCloudLayer: url is required');
-        }
-        if (!config.file) {
-            throw new Error('New PointCloudLayer: file is required');
-        }
-        super(id, new THREE.Group());
+        super(id, new THREE.Group(), config);
         this.isPointCloudLayer = true;
         this.protocol = 'potreeconverter';
-
-        this.file = config.file;
-        this.url = config.url;
 
         this.group = config.group || new THREE.Group();
         this.object3d.add(this.group);
         this.bboxes = config.bboxes || new THREE.Group();
         this.bboxes.visible = false;
-
         this.object3d.add(this.bboxes);
         this.group.updateMatrixWorld();
 
         // default config
-        this.fetchOptions = config.fetchOptions || {};
         this.octreeDepthLimit = config.octreeDepthLimit || -1;
         this.pointBudget = config.pointBudget || 2000000;
         this.pointSize = config.pointSize === 0 || !isNaN(config.pointSize) ? config.pointSize : 4;
@@ -296,27 +118,44 @@ class PointCloudLayer extends GeometryLayer {
         this.material.defines = this.material.defines || {};
         this.mode = MODE.COLOR || config.mode;
 
-        this.whenReady = Fetcher.json(`${this.url}/${this.file}`, this.fetchOptions)
-            .then((metadata) => {
-                parseMetadata(metadata, this);
-                const bbox = computeBbox(this);
-                return parseOctree(this, this.metadata.hierarchyStepSize, { baseurl: `${this.url}/${this.metadata.octreeDir}/r`, name: '', bbox });
-            })
-            .then((root) => {
-                this.root = root;
-                root.findChildrenByName = findChildrenByName.bind(root, root);
-                this.extent = Extent.fromBox3(view.referenceCrs, root.bbox);
+        this.whenReady = this.source.whenReady.then((cloud) => {
+            this.scale = new THREE.Vector3().addScalar(cloud.scale);
+            this.spacing = cloud.spacing;
+            this.hierarchyStepSize = cloud.hierarchyStepSize;
 
-                return this;
-            });
+            if (this.source.isFromPotreeConverter === true) {
+                const normal = Array.isArray(cloud.pointAttributes) &&
+                            cloud.pointAttributes.find(elem => elem.startsWith('NORMAL'));
+                if (normal) {
+                    this.material.defines[normal] = 1;
+                }
+            }
+            this.supportsProgressiveDisplay = this.source.customBinFormat;
+            this.root = new PointCloudNode(0, 0, this);
+
+            if (this.source.isFromPotreeConverter) {
+                this.root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
+                this.root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
+            } else {
+                // lopocs
+                let idx = 0;
+                for (const entry of cloud) {
+                    if (entry.table == this.table) {
+                        break;
+                    }
+                    idx++;
+                }
+                this.root.bbox.min.set(cloud[idx].bbox.xmin, cloud[idx].bbox.ymin, cloud[idx].bbox.zmin);
+                this.root.bbox.max.set(cloud[idx].bbox.xmax, cloud[idx].bbox.ymax, cloud[idx].bbox.zmax);
+            }
+
+            this.extent = Extent.fromBox3(view.referenceCrs, this.root.bbox);
+
+            return this.root.loadOctree().then(() => this);
+        });
     }
 
     preUpdate(context, changeSources) {
-        // Bail-out if not ready
-        if (!this.root) {
-            return [];
-        }
-
         // See https://cesiumjs.org/hosted-apps/massiveworlds/downloads/Ring/WorldScaleTerrainRendering.pptx
         // slide 17
         context.camera.preSSE =
@@ -360,8 +199,9 @@ class PointCloudLayer extends GeometryLayer {
                 }
             }
         }
+
         if (commonAncestorName) {
-            return [this.root.findChildrenByName(commonAncestorName)];
+            return [this.root.getChildByName(commonAncestorName)];
         }
 
         // Start updating from hierarchy root
@@ -408,14 +248,13 @@ class PointCloudLayer extends GeometryLayer {
             } else if (!elt.promise) {
                 const distance = Math.max(0.001, bbox.distanceToPoint(point));
                 // Increase priority of nearest node
-                const priority = computeScreenSpaceError(context, layer, elt, distance) / distance;
+                const priority = computeScreenSpaceError(context, layer.pointSize, layer.spacing, elt, distance) / distance;
                 elt.promise = context.scheduler.execute({
                     layer,
                     requester: elt,
                     view: context.view,
                     priority,
                     redraw: true,
-                    isLeaf: elt.childrenBitField == 0,
                     earlyDropFunction: cmd => !cmd.requester.visible || !this.visible,
                 }).then((pts) => {
                     if (this.onPointsCreated) {
@@ -442,7 +281,7 @@ class PointCloudLayer extends GeometryLayer {
 
         if (elt.children && elt.children.length) {
             const distance = bbox.distanceToPoint(point);
-            elt.sse = computeScreenSpaceError(context, layer, elt, distance) / this.sseThreshold;
+            elt.sse = computeScreenSpaceError(context, layer.pointSize, layer.spacing, elt, distance) / this.sseThreshold;
             if (elt.sse >= 1) {
                 return elt.children;
             } else {
@@ -454,10 +293,6 @@ class PointCloudLayer extends GeometryLayer {
     }
 
     postUpdate() {
-        if (!this.group) {
-            return;
-        }
-
         this.displayedCount = 0;
         for (const pts of this.group.children) {
             if (pts.material.visible) {
@@ -489,7 +324,7 @@ class PointCloudLayer extends GeometryLayer {
                 // This format doesn't require points to be evenly distributed, so
                 // we're going to sort the nodes by "importance" (= on screen size)
                 // and display only the first N nodes
-                this.group.children.sort((p1, p2) => p2.userData.metadata.sse - p1.userData.metadata.sse);
+                this.group.children.sort((p1, p2) => p2.userData.pointCloudNode.sse - p1.userData.pointCloudNode.sse);
 
                 let limitHit = false;
                 this.displayedCount = 0;
@@ -508,7 +343,7 @@ class PointCloudLayer extends GeometryLayer {
         const now = Date.now();
         for (let i = this.group.children.length - 1; i >= 0; i--) {
             const obj = this.group.children[i];
-            if (!obj.material.visible && (now - obj.userData.metadata.notVisibleSince) > 10000) {
+            if (!obj.material.visible && (now - obj.userData.pointCloudNode.notVisibleSince) > 10000) {
                 // remove from group
                 this.group.children.splice(i, 1);
 
@@ -522,7 +357,7 @@ class PointCloudLayer extends GeometryLayer {
                 obj.geometry.dispose();
                 obj.material = null;
                 obj.geometry = null;
-                obj.userData.metadata.obj = null;
+                obj.userData.pointCloudNode.obj = null;
 
                 if (__DEBUG__) {
                     if (obj.boxHelper) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -57,6 +57,7 @@ export { default as WMSSource } from 'Source/WMSSource';
 export { default as WMTSSource } from 'Source/WMTSSource';
 export { default as VectorTilesSource } from 'Source/VectorTilesSource';
 export { default as OrientedImageSource } from 'Source/OrientedImageSource';
+export { default as PointCloudSource } from 'Source/PointCloudSource';
 
 // Parsers provided by default in iTowns
 // Custom parser can be implemented as wanted, as long as the main function

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -66,7 +66,7 @@ export default {
     /** Parse .bin PotreeConverter format and convert to a THREE.BufferGeometry
      * @function parse
      * @param {ArrayBuffer} buffer - the bin buffer.
-     * @param {Object} pointAttributes - the point attributes information contained in layer.metadata coming from cloud.js
+     * @param {Object} pointAttributes - the point attributes information contained in cloud.js
      * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      *
      */

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -1,7 +1,5 @@
 import * as THREE from 'three';
-import Fetcher from 'Provider/Fetcher';
 import Extent from 'Core/Geographic/Extent';
-import { parseOctree } from 'Layer/PointCloudLayer';
 
 let nextuuid = 1;
 function addPickingAttribute(points) {
@@ -31,32 +29,30 @@ function addPickingAttribute(points) {
 export default {
     executeCommand(command) {
         const layer = command.layer;
-        const metadata = command.requester;
+        const pointCloudNode = command.requester;
 
-        // Query HRC if we don't have children metadata yet.
-        if (metadata.childrenBitField && metadata.children.length === 0) {
-            parseOctree(layer, layer.metadata.hierarchyStepSize, metadata).then(() => command.view.notifyChange(layer, false));
+        // Query HRC if we don't have children pointCloudNode yet.
+        if (!pointCloudNode.octreeIsLoaded) {
+            pointCloudNode.loadOctree().then(() => command.view.notifyChange(layer, false));
         }
 
         // `isLeaf` is for lopocs and allows the pointcloud server to consider that the current
         // node is the last one, even if we could subdivide even further.
         // It's necessary because lopocs doens't know about the hierarchy (it generates it on the fly
         // when we request .hrc files)
-        const url = `${metadata.baseurl}/r${metadata.name}.${layer.extension}?isleaf=${command.isLeaf ? 1 : 0}`;
-
-        return Fetcher.arrayBuffer(url, layer.fetchOptions).then(buffer => layer.parse(buffer, layer.metadata.pointAttributes)).then((geometry) => {
+        return pointCloudNode.loadNode().then((geometry) => {
             const points = new THREE.Points(geometry, layer.material.clone());
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            points.position.copy(metadata.bbox.min);
-            points.scale.set(layer.metadata.scale, layer.metadata.scale, layer.metadata.scale);
+            points.position.copy(pointCloudNode.bbox.min);
+            points.scale.copy(layer.scale);
             points.updateMatrix();
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
             points.layers.set(layer.threejsLayer);
             points.layer = layer;
-            points.extent = Extent.fromBox3(command.view.referenceCrs, metadata.bbox);
-            points.userData.metadata = metadata;
+            points.extent = Extent.fromBox3(command.view.referenceCrs, pointCloudNode.bbox);
+            points.userData.pointCloudNode = pointCloudNode;
             return points;
         });
     },

--- a/src/Source/PointCloudSource.js
+++ b/src/Source/PointCloudSource.js
@@ -1,0 +1,112 @@
+import Source from 'Source/Source';
+import Fetcher from 'Provider/Fetcher';
+import PotreeBinParser from 'Parser/PotreeBinParser';
+import PotreeCinParser from 'Parser/PotreeCinParser';
+
+/**
+ * @classdesc
+ * PointCloudSource are object containing informations on how to fetch points cloud resources.
+ *
+ *
+ */
+
+class PointCloudSource extends Source {
+    /**
+     * @param {Object} source - An object that can contain all properties of a
+     * PointCloudSource
+     * @param {string} source.url - folder url.
+     * @param {string} source.file - cloud file name.
+     *
+     * This `cloud` file stores information about the pointcloud in JSON format. the structure is :
+     *
+     * * __`version`__ - The cloud.js format may change over time. The version number is
+     * necessary so that parsers know how to interpret the data.
+     * * __`octreeDir`__ - Directory or URL where node data is stored. Usually points to
+     * "data".
+     * * __`boundingBox`__ - Contains the minimum and maximum of the axis aligned bounding box. This bounding box is cubic and aligned to fit to the octree root.
+     * * __`tightBoundingBox`__ - This bounding box thightly fits the point data.
+     * * __`pointAttributes`__ - Declares the point data format. May be 'LAS', 'LAZ' or in case if the BINARY format an array of attributes like
+     * `['POSITION_CARTESIAN', 'COLOR_PACKED', 'INTENSITY']`
+     * * __`POSITION_CARTESIAN`__ - 3 x 32bit signed integers for x/y/z coordinates
+     * * __`COLOR_PACKED`__ - 4 x unsigned byte for r,g,b,a colors.
+     * * __`spacing`__ - The minimum distance between points at root level.
+     * ```
+     * {
+     *     version: '1.6',
+     *     octreeDir: 'data',
+     *     boundingBox: {
+     *         lx: -4.9854,
+     *         ly: 1.0366,
+     *         lz: -3.4494,
+     *         ux: 0.702300000000001,
+     *         uy: 6.7243,
+     *         uz: 2.2383
+     *     },
+     *     tightBoundingBox: {
+     *         lx: -4.9854,
+     *         ly: 1.0375,
+     *         lz: -3.4494,
+     *         ux: -0.7889,
+     *         uy: 6.7243,
+     *         uz: 1.1245
+     *     },
+     *     pointAttributes: [
+     *         'POSITION_CARTESIAN',
+     *         'COLOR_PACKED'
+     *     ],
+     *     spacing: 0.03,
+     *     scale: 0.001,
+     *     hierarchyStepSize: 5
+     * }
+     * ```
+     *
+     * @extends Source
+     *
+     * @constructor
+     */
+    constructor(source) {
+        if (!source.url) {
+            throw new Error('New PointCloudSource: url is required');
+        }
+        if (!source.file) {
+            throw new Error('New PointCloudSource: file is required');
+        }
+
+        super(source);
+        this.file = source.file;
+        this.url = source.url;
+        this.fetcher = Fetcher.arrayBuffer;
+        this.extensionOctree = 'hrc';
+
+        // For cloud specification visit:
+        // https://github.com/PropellerAero/potree-propeller-private/blob/master/docs/file_format.md#cloudjs
+        this.whenReady = (source.cloud ? Promise.resolve(source.cloud) : Fetcher.json(`${this.url}/${this.file}`, this.networkOptions))
+            .then((cloud) => {
+                // Lopocs pointcloud server can expose the same file structure as PotreeConverter output.
+                // The only difference is the cloud root file (cloud.js vs infos/sources), and we can
+                // check for the existence of a `scale` field.
+                // (if `scale` is defined => we're fetching files from PotreeConverter)
+                if (cloud.scale != undefined) {
+                    this.isFromPotreeConverter = true;
+                    // PotreeConverter format
+                    this.customBinFormat = cloud.pointAttributes === 'CIN';
+                } else {
+                    // Lopocs
+                    cloud.scale = 1;
+                    cloud.cloudDir = `itowns/${this.table}.points`;
+                    cloud.hierarchyStepSize = 1000000; // ignore this with lopocs
+                    this.customBinFormat = true;
+                }
+
+                this.baseurl = `${this.url}/${cloud.octreeDir}/r`;
+                this.extension = this.customBinFormat ? 'cin' : 'bin';
+                this.parse = this.customBinFormat ?
+                    buffer => PotreeCinParser.parse(buffer, cloud.pointAttributes) :
+                    buffer => PotreeBinParser.parse(buffer, cloud.pointAttributes);
+
+                return cloud;
+            });
+    }
+}
+
+export default PointCloudSource;

--- a/test/unit/pointcloud.js
+++ b/test/unit/pointcloud.js
@@ -1,9 +1,11 @@
 import assert from 'assert';
 import PointCloudLayer from 'Layer/PointCloudLayer';
+import PointCloudSource from 'Source/PointCloudSource';
 import View from 'Core/View';
 import GlobeView from 'Core/Prefab/GlobeView';
 import HttpsProxyAgent from 'https-proxy-agent';
 import Coordinates from 'Core/Geographic/Coordinates';
+import PointCloudNode from 'Core/PointCloudNode';
 import Renderer from './mock';
 
 const renderer = new Renderer();
@@ -13,10 +15,12 @@ const viewer = new GlobeView(renderer.domElement, placement, { renderer });
 
 // Configure Point Cloud layer
 const pointcloud = new PointCloudLayer('eglise_saint_blaise_arles', {
-    file: 'eglise_saint_blaise_arles.js',
-    url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+    source: new PointCloudSource({
+        file: 'eglise_saint_blaise_arles.js',
+        url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+        networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+    }),
     onPointsCreated: () => {},
-    fetchOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
 }, viewer);
 
 const context = {
@@ -54,6 +58,36 @@ describe('point cloud', function () {
 
     it('postUpdate point cloud layer', function () {
         pointcloud.postUpdate(context, pointcloud);
+    });
+});
+
+const numPoints = 1000;
+const childrenBitField = 5;
+
+describe('point cloud node', function () {
+    it('instance', function (done) {
+        const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
+        assert.equal(root.numPoints, numPoints);
+        assert.equal(root.childrenBitField, childrenBitField);
+        done();
+    });
+
+    it('load octree', function (done) {
+        const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
+        root.loadOctree().then(() => {
+            assert.equal(7, root.children.length);
+            done();
+        });
+    });
+
+    it('load child node', function (done) {
+        const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
+        root.loadOctree().then(() => {
+            root.children[0].loadNode().then(() => {
+                assert.equal(2, root.children[0].children.length);
+                done();
+            });
+        });
     });
 });
 

--- a/test/unit/pointcloudlayerparsing.js
+++ b/test/unit/pointcloudlayerparsing.js
@@ -1,51 +1,92 @@
 import assert from 'assert';
-import PointCloudLayer, { parseMetadata } from 'Layer/PointCloudLayer';
+import PointCloudLayer from 'Layer/PointCloudLayer';
+import PointCloudSource from 'Source/PointCloudSource';
+import Coordinates from 'Core/Geographic/Coordinates';
+import GlobeView from 'Core/Prefab/GlobeView';
+import HttpsProxyAgent from 'https-proxy-agent';
+import Renderer from './mock';
 
 describe('PointCloudProvider', function () {
-    it('should correctly parse normal information in metadata', function () {
-        const layer = {
-            material: { defines: {} },
-        };
+    const renderer = new Renderer();
+    const placement = { coord: new Coordinates('EPSG:4326', 1.5, 43), range: 300000 };
+    const view = new GlobeView(renderer.domElement, placement, { renderer });
 
-        // no normals
-        const metadata = {
-            boundingBox: {
-                lx: 0,
-                ly: 1,
-                ux: 2,
-                uy: 3,
-            },
+    it('should correctly parse normal information in cloud', function (done) {
+        // No normals
+        const cloud = {
+            boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
             scale: 1.0,
             pointAttributes: ['POSITION', 'RGB'],
+            octreeDir: 'eglise_saint_blaise_arles',
         };
 
-        parseMetadata(metadata, layer);
-        const normalDefined = layer.material.defines.NORMAL || layer.material.defines.NORMAL_SPHEREMAPPED || layer.material.defines.NORMAL_OCT16;
-        assert.ok(!normalDefined);
+        const ps = [];
+        let source = new PointCloudSource({
+            file: 'eglise_saint_blaise_arles.js',
+            url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+            networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            cloud,
+        });
+        ps.push(new PointCloudLayer('pointsCloud', { source }, view).whenReady.then((l) => {
+            const normalDefined = l.material.defines.NORMAL || l.material.defines.NORMAL_SPHEREMAPPED || l.material.defines.NORMAL_OCT16;
+            assert.ok(!normalDefined);
+        }));
 
-        // normals as vector
-        layer.material = { defines: {} };
-        metadata.pointAttributes = ['POSITION', 'NORMAL', 'CLASSIFICATION'];
-        parseMetadata(metadata, layer);
-        assert.ok(layer.material.defines.NORMAL);
-        assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
-        assert.ok(!layer.material.defines.NORMAL_OCT16);
+        // // // normals as vector
+        source = new PointCloudSource({
+            file: 'eglise_saint_blaise_arles.js',
+            url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+            networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            cloud: {
+                boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                scale: 1.0,
+                pointAttributes: ['POSITION', 'NORMAL', 'CLASSIFICATION'],
+                octreeDir: 'eglise_saint_blaise_arles',
+            },
+        });
+        ps.push(new PointCloudLayer('pointsCloud', { source }, view).whenReady.then((l) => {
+            assert.ok(l.material.defines.NORMAL);
+            assert.ok(!l.material.defines.NORMAL_SPHEREMAPPED);
+            assert.ok(!l.material.defines.NORMAL_OCT16);
+        }));
 
-        // spheremapped normals
-        layer.material = { defines: {} };
-        metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'];
-        parseMetadata(metadata, layer);
-        assert.ok(!layer.material.defines.NORMAL);
-        assert.ok(layer.material.defines.NORMAL_SPHEREMAPPED);
-        assert.ok(!layer.material.defines.NORMAL_OCT16);
+        // // spheremapped normals
+        source = new PointCloudSource({
+            file: 'eglise_saint_blaise_arles.js',
+            url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+            networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            cloud: {
+                boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                scale: 1.0,
+                pointAttributes: ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'],
+                octreeDir: 'eglise_saint_blaise_arles',
+            },
+        });
+        ps.push(new PointCloudLayer('pointsCloud', { source }, view).whenReady.then((l) => {
+            assert.ok(!l.material.defines.NORMAL);
+            assert.ok(l.material.defines.NORMAL_SPHEREMAPPED);
+            assert.ok(!l.material.defines.NORMAL_OCT16);
+        }));
 
-        // oct16 normals
-        layer.material = { defines: {} };
-        metadata.pointAttributes = ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'];
-        parseMetadata(metadata, layer);
-        assert.ok(!layer.material.defines.NORMAL);
-        assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
-        assert.ok(layer.material.defines.NORMAL_OCT16);
+        // // oct16 normals
+        source = new PointCloudSource({
+            file: 'eglise_saint_blaise_arles.js',
+            url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+            networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            cloud: {
+                boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                scale: 1.0,
+                pointAttributes: ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'],
+                octreeDir: 'eglise_saint_blaise_arles',
+            },
+        });
+        ps.push(new PointCloudLayer('pointsCloud', { source }, view).whenReady.then((l) => {
+            assert.ok(!l.material.defines.NORMAL);
+            assert.ok(!l.material.defines.NORMAL_SPHEREMAPPED);
+            assert.ok(l.material.defines.NORMAL_OCT16);
+        }));
+
+        Promise.all(ps).then(() => done());
     });
 });
 

--- a/test/unit/pointcloudlayerprocessing.js
+++ b/test/unit/pointcloudlayerprocessing.js
@@ -1,5 +1,4 @@
 import assert from 'assert';
-// import PointCloudProcessing from 'Process/PointCloudProcessing';
 import PointCloudLayer from 'Layer/PointCloudLayer';
 
 const context = { camera: { height: 1, camera3D: { fov: 1 } } };
@@ -34,10 +33,10 @@ describe('preUpdate', function () {
         sources.add(elt1);
         sources.add(elt2);
         sources.add(elt3);
-        layer.root.findChildrenByName = (name) => {
+        layer.root.getChildByName = (name) => {
             assert.equal('12', name);
         };
-        PointCloudLayer.prototype.preUpdate(context, layer, sources);
+        PointCloudLayer.prototype.preUpdate.call(layer, context, sources);
     });
 
     it('should not search ancestors if layer are different root if no common ancestors', () => {
@@ -47,9 +46,9 @@ describe('preUpdate', function () {
         const sources = new Set();
         sources.add(elt1);
         sources.add(elt2);
-        layer.root.findChildrenByName = (name) => {
+        layer.root.getChildByName = (name) => {
             assert.equal('12', name);
         };
-        PointCloudLayer.prototype.preUpdate(context, layer, sources);
+        PointCloudLayer.prototype.preUpdate.call(layer, context, sources);
     });
 });

--- a/utils/debug/PointCloudDebug.js
+++ b/utils/debug/PointCloudDebug.js
@@ -59,11 +59,11 @@ export default {
                 for (const pts of layer.group.children) {
                     pts.material.visible = false;
                     for (const name of stickies) {
-                        if (pts.userData.metadata.name == name) {
+                        if (pts.userData.octree.name == name) {
                             pts.material.visible = true;
-                        } else if (!isInHierarchy(pts.userData.metadata, name)) {
+                        } else if (!isInHierarchy(pts.userData.octree, name)) {
                             continue;
-                        } else if (pts.userData.metadata.name.length < name.length) {
+                        } else if (pts.userData.octree.name.length < name.length) {
                             pts.material.visible = layer.dbgDisplayParents;
                             break;
                         } else {


### PR DESCRIPTION
## Description
 * introduce `PointCloudSource`, this class have the specific parser and fetcher.
 * introduce `PointCloudNode`, this class structures, the data, by nodes that make up the `octree`. `PointCloudNode` is to have its own loading methods. 


## Motivation and Context
* It's the continuation of the refactoring starting with #1288 

## The next steps
* it's clean the process methods in `PointCloudLayer` and move `BoxHelper` in tools.
* remove `lopocs` support.

## BREAKING CHANGES
To add points cloud, you need to instance:
* `PointCloudSource` to specify parameters to fetch data.
* `PointCloudLayer` to add this points cloud in viewer.