### PR TITLE
fix(example): picking in kml raster example.

### DIFF
--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -75,7 +75,7 @@ var FeatureToolTip = (function _() {
             feature = features[p];
 
             geometry = feature.geometry;
-            style = (layer.style && layer.style.isStyle) ? layer.style : feature.style;
+            style = (layer.style && layer.style.isStyle) ? layer.style : (feature.style || feature.geometry.properties.style);
             fill = style.fill.color;
             stroke = '1.25px ' + style.stroke.color;
 


### PR DESCRIPTION
## Description
fix picking in kml raster example.
