### PR TITLE
fix(examples): wrong min and max altitude in 2.5D examples.

### DIFF
--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -53,7 +53,7 @@
             viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate PlanarView*
-            view = new itowns.PlanarView(viewerDiv, extent, { disableSkirt: true,
+            view = new itowns.PlanarView(viewerDiv, extent, {
                 placement: {
                     coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0),
                     heading: -45,
@@ -80,6 +80,27 @@
             });
 
             view.addLayer(wmsImageryLayer);
+
+            // Add a WMS elevation source
+            var wmsElevationSource = new itowns.WMSSource({
+                extent: extent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                projection: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
+
             // eslint-disable-next-line no-new
             new itowns.PlanarControls(view, {});
 
@@ -97,6 +118,23 @@
                     return color.setRGB(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
                 }
                 return color.setRGB(1, 1, 1);
+            }
+
+            var tile;
+            function altitudeLine(properties, contour) {
+                var result;
+                var z = 0;
+                if (contour) {
+                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0, tile);
+                    if (!result) {
+                        result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0);
+                    }
+                    if (result) {
+                        tile = [result.tile];
+                        z = result.z;
+                    }
+                    return z + 5;
+                }
             }
 
             lyonTclBusSource = new itowns.WFSSource({
@@ -119,7 +157,8 @@
             var lyonTclBusLayer = new itowns.GeometryLayer('lyon_tcl_bus', new itowns.THREE.Group(), {
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
-                    color: colorLine }),
+                    color: colorLine,
+                    altitude: altitudeLine }),
                 onMeshCreated: setMaterialLineWidth,
                 source: lyonTclBusSource,
             });
@@ -138,6 +177,10 @@
 
             function extrudeBuildings(properties) {
                 return properties.hauteur;
+            }
+
+            function altitudeBuildings(properties) {
+                return properties.z_min - properties.hauteur;
             }
 
             meshes = [];
@@ -183,6 +226,7 @@
                 convert: itowns.Feature2Mesh.convert({
                     color: colorBuildings,
                     batchId: function (property, featureId) { return featureId; },
+                    altitude: altitudeBuildings,
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {
                     mesh.scale.z = 0.01;

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -50,10 +50,7 @@
             viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate PlanarView*
-            view = new itowns.PlanarView(viewerDiv, extent, {
-                disableSkirt: true,
-                placement: { heading: -49.6, range: 6200, tilt: 17 }
-            });
+            view = new itowns.PlanarView(viewerDiv, extent, { placement: { heading: -49.6, range: 6200, tilt: 17 } });
             setupLoadingScreen(viewerDiv, view);
 
             // Add a WMS imagery source
@@ -90,8 +87,8 @@
             // Add a WMS elevation layer
             var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
                 useColorTextureElevation: true,
-                colorTextureElevationMinZ: 37,
-                colorTextureElevationMaxZ: 240,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
                 source: wmsElevationSource,
             });
 

--- a/examples/view_multi_25d.html
+++ b/examples/view_multi_25d.html
@@ -137,8 +137,8 @@
                 var elevationLayer = new itowns.ElevationLayer('wms_elevation' + wms + index, {
                     source: elevationSource,
                     useColorTextureElevation: true,
-                    colorTextureElevationMinZ: 37,
-                    colorTextureElevationMaxZ: 240,
+                    colorTextureElevationMinZ: 144,
+                    colorTextureElevationMaxZ: 622,
                 });
                 view.addLayer(elevationLayer, tileLayer);
             }

--- a/test/functional/source_stream_wfs_25d.js
+++ b/test/functional/source_stream_wfs_25d.js
@@ -12,8 +12,8 @@ describe('source_stream_wfs_25d', function _() {
 
     it('should pick the correct building', async () => {
         // test picking
-        const buildingId = await page.evaluate(() => picking({ x: 342, y: 243 }));
-        assert.equal(buildingId.id, 'bati_indifferencie.5265944');
+        const buildingId = await page.evaluate(() => picking({ x: 97, y: 213 }));
+        assert.equal(buildingId.id, 'bati_indifferencie.5266051');
     });
     it('should remove GeometryLayer', async () => {
         const countGeometryLayerStart = await page.evaluate(() => view.getLayers(l => l.isGeometryLayer).length);


### PR DESCRIPTION
## Description
Change wrong min and max altitude in 2.5D examples. (see [comment](https://github.com/iTowns/itowns/issues/989#issuecomment-585831640))