### PR TITLE
chore(test): move variables declaration in describe()

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -25,9 +25,12 @@ See the [node website](https://nodejs.org) to install node and npm.
 * Test and lint changes: see test, lint and test-examples npm script
 
 ## Debugging
-* `babel-inline-import-loader` prevents the source map debug in browser.
-   if you want launch server and debug with the original source map, run : `npm run debug`.
-* To debug iTowns package on your side project. You can link iTowns package with `npm link ../path/iTowns/` in project folder and auto-transpile to `lib/` when iTowns sources are modified with command `npm run watch` in iTowns folder.
+* `babel-inline-import-loader` prevents the source map debug in browser. If you
+  want launch server and debug with the original source map, run : `npm run
+  debug`.
+* To debug iTowns package on your side project. You can link iTowns package with
+  `npm link ../path/iTowns/` in project folder and auto-transpile to `lib/` when
+  iTowns sources are modified with command `npm run watch` in iTowns folder.
 
 ## Testing
 For unit and functional test, defines `HTTPS_PROXY` if you launch test behind a proxy.
@@ -62,13 +65,22 @@ When running tests on examples, some environment variables can be set:
   downloaded during puppeteer install.
 * `DEBUG`: run Chrome in a window with the debug tools open.
 * `REMOTE_DEBUGGING`: run Chrome in headless mode and set up remote debugging.
-  Example: `REMOTE_DEBUGGING=9222` will setup remote debugging on port 9222. Then
-  start another Chrome instance, browse to `chrome://inspect/#devices` and add
-  `localhost:9222` in Discover network targets.
+  Example: `REMOTE_DEBUGGING=9222` will setup remote debugging on port 9222.
+  Then start another Chrome instance, browse to `chrome://inspect/#devices` and
+  add `localhost:9222` in Discover network targets.
 
 Note: Chrome in headless mode doesn't support the WebGL `EXT_frag_depth`
 extension. So rendering may differ and some bugs can only be present in headless
 mode.
+
+### Syntax in tests
+
+[mochajs](https://mochajs.org/) is used for both type of tests. To avoid
+problems with same name variables, keep them in the smallest scope. For example,
+a variable should almost always be in the `it()` section of a test. However, it
+can be useful to keep a single shared variable for a bunch of tests (in the same
+file). For this, declare it in the `describe()` section, and set it (if
+possible) in a `before()` section.
 
 ### Useful commands for continuous testing
 

--- a/test/unit/3dtiles.js
+++ b/test/unit/3dtiles.js
@@ -56,6 +56,10 @@ function tilesetWithSphere(transformMatrix) {
     return tileset;
 }
 
+function compareWithEpsilon(a, b, epsilon) {
+    return a - epsilon < b && a + epsilon > b;
+}
+
 describe('Distance computation using boundingVolume.region', function () {
     const camera = new Camera('EPSG:4978', 100, 100);
     camera.camera3D.position.copy(new Coordinates('EPSG:4326', 0, 0, 10000).as('EPSG:4978').toVector3());
@@ -69,7 +73,7 @@ describe('Distance computation using boundingVolume.region', function () {
 
         computeNodeSSE(camera, tile);
 
-        assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude);
+        assert.ok(compareWithEpsilon(tile.distance, camera.position().as('EPSG:4326').altitude, 10e-5));
     });
 
     it('should not be affected by transform', function () {
@@ -82,7 +86,7 @@ describe('Distance computation using boundingVolume.region', function () {
 
         computeNodeSSE(camera, tile);
 
-        assert.equal(tile.distance, camera.position().as('EPSG:4326').altitude);
+        assert.ok(compareWithEpsilon(tile.distance, camera.position().as('EPSG:4326').altitude, 10e-5));
     });
 });
 

--- a/test/unit/3dtileslayerprocess.js
+++ b/test/unit/3dtileslayerprocess.js
@@ -6,23 +6,26 @@ import HttpsProxyAgent from 'https-proxy-agent';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Renderer from './mock';
 
-const renderer = new Renderer();
-const p = { coord: new Coordinates('EPSG:4326', -75.6114, 40.03428, 0), heading: 180, range: 4000, tilt: 22 };
-const viewer = new GlobeView(renderer.domElement, p, { renderer, noControls: true });
-const threedTilesLayer = new C3DTilesLayer('3d-tiles-discrete-lod', {
-    url: 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithDiscreteLOD/tileset.json',
-    networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
-}, viewer);
-
-const context = {
-    camera: viewer.camera,
-    engine: viewer.mainLoop.gfxEngine,
-    scheduler: viewer.mainLoop.scheduler,
-    geometryLayer: threedTilesLayer,
-    view: viewer,
-};
-
 describe('3Dtiles layer', function () {
+    const renderer = new Renderer();
+
+    const p = { coord: new Coordinates('EPSG:4326', -75.6114, 40.03428, 0), heading: 180, range: 4000, tilt: 22 };
+
+    const viewer = new GlobeView(renderer.domElement, p, { renderer, noControls: true });
+
+    const threedTilesLayer = new C3DTilesLayer('3d-tiles-discrete-lod', {
+        url: 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/3d-tiles-samples/master/tilesets/TilesetWithDiscreteLOD/tileset.json',
+        networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+    }, viewer);
+
+    const context = {
+        camera: viewer.camera,
+        engine: viewer.mainLoop.gfxEngine,
+        scheduler: viewer.mainLoop.scheduler,
+        geometryLayer: threedTilesLayer,
+        view: viewer,
+    };
+
     it('Add 3dtiles layer', function (done) {
         View.prototype.addLayer.call(viewer, threedTilesLayer).then((layer) => {
             assert.equal(layer.root.children.length, 1);

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -5,43 +5,43 @@ import Ellipsoid from 'Core//Math/Ellipsoid';
 import CameraUtils from 'Utils/CameraUtils';
 import DEMUtils from 'Utils/DEMUtils';
 
-THREE.Object3D.DefaultUp = new THREE.Vector3(0, 0, 1);
-
-DEMUtils.getElevationValueAt = () => ({ z: 0 });
-
-const raycaster = new THREE.Raycaster();
-const center = new THREE.Vector2();
-const ellipsoid = new Ellipsoid();
-
-function pickEllipsoid(camera) {
-    raycaster.setFromCamera(center, camera);
-    return ellipsoid.intersection(raycaster.ray);
-}
-
-const view = {};
-const camera = new THREE.PerspectiveCamera();
-
-view.getPickingPositionFromDepth = function getPickingPositionFromDepth() {
-    return pickEllipsoid(camera);
-};
-view.referenceCrs = 'EPSG:4978';
-view.getLayers = () => [{
-    extent: {
-        crs: 'EPSG:4326',
-    },
-}];
-view.addFrameRequester = () => {};
-view.removeFrameRequester = () => {};
-view.notifyChange = () => { camera.updateMatrixWorld(true); };
-
-const range = 25000000;
-const coord = new Coordinates('EPSG:4326', 2.35, 48.85, 0);
-
 function equalToFixed(value1, value2, toFixed) {
     return value1.toFixed(toFixed) === value2.toFixed(toFixed);
 }
 
 describe('Camera utils unit test', function () {
+    THREE.Object3D.DefaultUp = new THREE.Vector3(0, 0, 1);
+
+    DEMUtils.getElevationValueAt = () => ({ z: 0 });
+
+    const raycaster = new THREE.Raycaster();
+    const center = new THREE.Vector2();
+    const ellipsoid = new Ellipsoid();
+
+    function pickEllipsoid(camera) {
+        raycaster.setFromCamera(center, camera);
+        return ellipsoid.intersection(raycaster.ray);
+    }
+
+    const view = {};
+    const camera = new THREE.PerspectiveCamera();
+
+    view.getPickingPositionFromDepth = function getPickingPositionFromDepth() {
+        return pickEllipsoid(camera);
+    };
+    view.referenceCrs = 'EPSG:4978';
+    view.getLayers = () => [{
+        extent: {
+            crs: 'EPSG:4326',
+        },
+    }];
+    view.addFrameRequester = () => {};
+    view.removeFrameRequester = () => {};
+    view.notifyChange = () => { camera.updateMatrixWorld(true); };
+
+    const range = 25000000;
+    const coord = new Coordinates('EPSG:4326', 2.35, 48.85, 0);
+
     it('init like expected', function () {
         const params = { range, coord };
         CameraUtils.transformCameraToLookAtTarget(view, camera, params).then((result) => {

--- a/test/unit/camera.js
+++ b/test/unit/camera.js
@@ -2,7 +2,6 @@ import assert from 'assert';
 import Camera from 'Renderer/Camera';
 import Coordinates from 'Core/Geographic/Coordinates';
 
-
 function compareWithEpsilon(a, b, epsilon) {
     return a - epsilon < b && a + epsilon > b;
 }

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -11,6 +11,7 @@ import TileProvider from 'Provider/TileProvider';
 import WMTSSource from 'Source/WMTSSource';
 import WMSSource from 'Source/WMSSource';
 import WFSSource from 'Source/WFSSource';
+import Fetcher from 'Provider/Fetcher';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import ColorLayer from 'Layer/ColorLayer';
 import ElevationLayer from 'Layer/ElevationLayer';
@@ -20,15 +21,15 @@ import Feature2Mesh from 'Converter/Feature2Mesh';
 import LayeredMaterial from 'Renderer/LayeredMaterial';
 import Renderer from './mock';
 
-const renderer = new Renderer();
-renderer.setClearColor();
-
 const holes = require('../data/geojson/holesPoints.geojson.json');
 
-supportedFetchers.set('image/png', () => Promise.resolve(new THREE.Texture()));
-supportedFetchers.set('application/json', () => Promise.resolve(holes));
-
 describe('Provide in Sources', function () {
+    const renderer = new Renderer();
+    renderer.setClearColor();
+
+    supportedFetchers.set('image/png', () => Promise.resolve(new THREE.Texture()));
+    supportedFetchers.set('application/json', () => Promise.resolve(holes));
+
     // Misc var to initialize a TileMesh instance
     const geom = new THREE.Geometry();
     geom.OBB = new OBB(new THREE.Vector3(), new THREE.Vector3(1, 1, 1));
@@ -92,6 +93,11 @@ describe('Provide in Sources', function () {
 
     context.elevationLayers = [elevationlayer];
     context.colorLayers = [colorlayer];
+
+    after(function () {
+        supportedFetchers.set('image/png', Fetcher.texture);
+        supportedFetchers.set('application/json', Fetcher.json);
+    });
 
     beforeEach('reset state', function () {
         // clear commands array

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -2,15 +2,15 @@ import assert from 'assert';
 import Feature, { FEATURE_TYPES } from 'Core/Feature';
 import Coordinates from 'Core/Geographic/Coordinates';
 
-const options_A = {
-    withNormal: true,
-    withAltitude: true,
-    buildExtent: true,
-};
-
-const coord = new Coordinates('EPSG:4326', 0, 0, 0);
-
 describe('Feature', function () {
+    const options_A = {
+        withNormal: true,
+        withAltitude: true,
+        buildExtent: true,
+    };
+
+    const coord = new Coordinates('EPSG:4326', 0, 0, 0);
+
     it('Should instance Features', function () {
         const featurePoint = new Feature(FEATURE_TYPES.POINT, 'EPSG:4326');
         const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');

--- a/test/unit/feature2mesh.js
+++ b/test/unit/feature2mesh.js
@@ -9,10 +9,6 @@ const geojson = require('../data/geojson/holes.geojson.json');
 proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
-function parse() {
-    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, mergeFeatures: false });
-}
-
 function computeAreaOfMesh(mesh) {
     // Sum each triangle area
     let area = 0;
@@ -30,6 +26,10 @@ function computeAreaOfMesh(mesh) {
 }
 
 describe('Feature2Mesh', function () {
+    function parse() {
+        return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, mergeFeatures: false });
+    }
+
     it('rect mesh area should match geometry extent', () =>
         parse().then((features) => {
             const mesh = Feature2Mesh.convert()(features);

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -6,9 +6,9 @@ import { FEATURE_TYPES } from 'Core/Feature';
 
 const geojson = require('../data/geojson/simple.geojson.json');
 
-const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true, mergeFeatures: false, withAltitude: false, withNormal: false });
-
 describe('FeaturesUtils', function () {
+    const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true, mergeFeatures: false, withAltitude: false, withNormal: false });
+
     it('should correctly parse geojson', () =>
         promise.then((collection) => {
             assert.equal(collection.features.length, 3);

--- a/test/unit/featureprocess.js
+++ b/test/unit/featureprocess.js
@@ -12,56 +12,56 @@ import OBB from 'Renderer/OBB';
 import TileMesh from 'Core/TileMesh';
 import Renderer from './mock';
 
-const renderer = new Renderer();
-
-const placement = { coord: new Coordinates('EPSG:4326', 1.5, 43), range: 300000 };
-const viewer = new GlobeView(renderer.domElement, placement, { renderer });
-
-function extrude() {
-    return 5000;
-}
-
-function color() {
-    return new THREE.Color(0xffcc00);
-}
-
-
-const ariege = new GeometryLayer('ariege', new THREE.Group());
-ariege.update = FeatureProcessing.update;
-ariege.convert = Feature2Mesh.convert({
-    color,
-    extrude,
-});
-
-ariege.source = new FileSource({
-    url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
-    projection: 'EPSG:4326',
-    format: 'application/json',
-    zoom: { min: 0, max: 0 },
-    // extent: new Extent('EPSG:4326', -90, -10, -900, 900),
-});
-
-ariege.source.zoom = 0;
-
-if (process.env.HTTPS_PROXY) {
-    ariege.source.networkOptions = { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) };
-}
-
-const context = {
-    camera: viewer.camera,
-    engine: viewer.mainLoop.gfxEngine,
-    scheduler: viewer.mainLoop.scheduler,
-    geometryLayer: ariege,
-    view: viewer,
-};
-
-const extent = new Extent('EPSG:4326', 1.40625, 2.8125, 42.1875, 42.1875);
-const geom = new THREE.Geometry();
-geom.OBB = new OBB(new THREE.Vector3(), new THREE.Vector3(1, 1, 1));
-const tile = new TileMesh(geom, new THREE.Material(), viewer.tileLayer, extent, 7);
-tile.parent = {};
-
 describe('Layer with Feature process', function () {
+    const renderer = new Renderer();
+
+    const placement = { coord: new Coordinates('EPSG:4326', 1.5, 43), range: 300000 };
+    const viewer = new GlobeView(renderer.domElement, placement, { renderer });
+
+    function extrude() {
+        return 5000;
+    }
+
+    function color() {
+        return new THREE.Color(0xffcc00);
+    }
+
+
+    const ariege = new GeometryLayer('ariege', new THREE.Group());
+    ariege.update = FeatureProcessing.update;
+    ariege.convert = Feature2Mesh.convert({
+        color,
+        extrude,
+    });
+
+    ariege.source = new FileSource({
+        url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
+        projection: 'EPSG:4326',
+        format: 'application/json',
+        zoom: { min: 0, max: 0 },
+        // extent: new Extent('EPSG:4326', -90, -10, -900, 900),
+    });
+
+    ariege.source.zoom = 0;
+
+    if (process.env.HTTPS_PROXY) {
+        ariege.source.networkOptions = { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) };
+    }
+
+    const context = {
+        camera: viewer.camera,
+        engine: viewer.mainLoop.gfxEngine,
+        scheduler: viewer.mainLoop.scheduler,
+        geometryLayer: ariege,
+        view: viewer,
+    };
+
+    const extent = new Extent('EPSG:4326', 1.40625, 2.8125, 42.1875, 42.1875);
+    const geom = new THREE.Geometry();
+    geom.OBB = new OBB(new THREE.Vector3(), new THREE.Vector3(1, 1, 1));
+    const tile = new TileMesh(geom, new THREE.Material(), viewer.tileLayer, extent, 7);
+    tile.parent = {};
+
     it('add layer', function (done) {
         viewer.addLayer(ariege).then((layer) => {
             assert.ok(layer);

--- a/test/unit/globeview.js
+++ b/test/unit/globeview.js
@@ -3,86 +3,89 @@ import assert from 'assert';
 import GlobeView from 'Core/Prefab/GlobeView';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import Coordinates from 'Core/Geographic/Coordinates';
-
 import Renderer from './mock';
 
-const renderer = new Renderer();
-
-// 3919 is the approximate altitude giving a 1/25000 scale, on a screen with a
-// pitch of 0.28. The approximation is corrected below with an epsilon.
-const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 3919 };
-const viewer = new GlobeView(renderer.domElement, placement, { renderer });
-const pickedPosition = new THREE.Vector3();
-pickedPosition.copy(viewer.camera.position());
-
-const cameraDirection = new THREE.Vector3();
-viewer.camera.camera3D.getWorldDirection(cameraDirection);
-cameraDirection.multiplyScalar(placement.range);
-pickedPosition.add(cameraDirection);
-
-viewer.getPickingPositionFromDepth = function getPickingPositionFromDepth(screenCoord, targetPoint = new THREE.Vector3()) {
-    return targetPoint.copy(pickedPosition);
-};
-
-const context = {
-    camera: viewer.camera,
-    engine: viewer.mainLoop.gfxEngine,
-    scheduler: viewer.mainLoop.scheduler,
-    geometryLayer: viewer.tileLayer,
-    elevationLayers: [],
-    colorLayers: [],
-    view: viewer,
-};
+function compareWithEpsilon(a, b, epsilon) {
+    return a - epsilon < b && a + epsilon > b;
+}
 
 describe('GlobeView', function () {
+    const renderer = new Renderer();
+
+    // 3919 is the approximate altitude giving a 1/25000 scale, on a screen with a
+    // pitch of 0.28. The approximation is corrected below with an epsilon.
+    const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 3919 };
+    const viewer = new GlobeView(renderer.domElement, placement, { renderer });
+    const pickedPosition = new THREE.Vector3();
+    pickedPosition.copy(viewer.camera.position());
+
+    const cameraDirection = new THREE.Vector3();
+    viewer.camera.camera3D.getWorldDirection(cameraDirection);
+    cameraDirection.multiplyScalar(placement.range);
+    pickedPosition.add(cameraDirection);
+
+    viewer.getPickingPositionFromDepth = function getPickingPositionFromDepth(screenCoord, targetPoint = new THREE.Vector3()) {
+        return targetPoint.copy(pickedPosition);
+    };
+
+    const context = {
+        camera: viewer.camera,
+        engine: viewer.mainLoop.gfxEngine,
+        scheduler: viewer.mainLoop.scheduler,
+        geometryLayer: viewer.tileLayer,
+        elevationLayers: [],
+        colorLayers: [],
+        view: viewer,
+    };
+
     it('instance', function () {
         assert.ok(viewer);
     });
 
-    it('update', function () {
+    it('update', function (done) {
         viewer.tileLayer.whenReady.then(() => {
             const node = viewer.tileLayer.level0Nodes[0];
             viewer.tileLayer.update(context, viewer.tileLayer, node);
+            done();
         });
     });
 
-    it('ObjectRemovalHelper', function () {
+    it('ObjectRemovalHelper', function (done) {
         viewer.tileLayer.whenReady.then(() => {
             const node = viewer.tileLayer.level0Nodes[0];
             ObjectRemovalHelper.removeChildrenAndCleanup(viewer.tileLayer, node);
             ObjectRemovalHelper.removeChildren(viewer.tileLayer, node);
+            done();
         });
     });
 
-    describe('Measuring', function () {
-        it('should get the zoom scale', () => {
-            const computed = viewer.getScale();
-            const scale = 1 / 25000;
-            assert.ok(computed < scale + 10e-7);
-            assert.ok(computed > scale - 10e-7);
-        });
+    it('should get the zoom scale', () => {
+        const computed = viewer.getScale();
+        const scale = 1 / 25000;
+        assert.ok(compareWithEpsilon(computed, scale, 10e-7));
+        assert.ok(compareWithEpsilon(computed, scale, 10e-7));
+    });
 
-        it('should get the distance from the camera', () => {
-            const realDistance = viewer.getDistanceFromCamera();
-            assert.ok(realDistance < placement.range + 10);
-            assert.ok(realDistance > placement.range - 10);
-        });
+    it('should get the distance from the camera', () => {
+        const realDistance = viewer.getDistanceFromCamera();
+        assert.ok(compareWithEpsilon(realDistance, placement.range, 10));
+        assert.ok(compareWithEpsilon(realDistance, placement.range, 10));
+    });
 
-        it('should convert a pixel distance to meters', () => {
-            // (1 / 0.28) pixel is equal to 1 cm on screen, so 25m on ground
-            const computed = viewer.getPixelsToMeters(1 / 0.28);
-            const meters = 25;
-            assert.ok(computed < meters + 10e-3);
-            assert.ok(computed > meters - 10e-3);
-        });
+    it('should convert a pixel distance to meters', () => {
+        // (1 / 0.28) pixel is equal to 1 cm on screen, so 25m on ground
+        const computed = viewer.getPixelsToMeters(1 / 0.28);
+        const meters = 25;
+        assert.ok(compareWithEpsilon(computed, meters, 10e-3));
+        assert.ok(compareWithEpsilon(computed, meters, 10e-3));
+    });
 
-        it('should convert a meter distance to pixels', () => {
-            // 25m on ground should give 1 cm on screen, so (1 / 0.28) pixels
-            const computed = 1 / viewer.getMetersToPixels(25);
-            const pixels = 0.28;
-            assert.ok(computed < pixels + 10e-4);
-            assert.ok(computed > pixels - 10e-4);
-        });
+    it('should convert a meter distance to pixels', () => {
+        // 25m on ground should give 1 cm on screen, so (1 / 0.28) pixels
+        const computed = 1 / viewer.getMetersToPixels(25);
+        const pixels = 0.28;
+        assert.ok(compareWithEpsilon(computed, pixels, 10e-4));
+        assert.ok(compareWithEpsilon(computed, pixels, 10e-4));
     });
 });
 

--- a/test/unit/obb.js
+++ b/test/unit/obb.js
@@ -7,18 +7,18 @@ import BuilderEllipsoidTile from 'Core/Prefab/Globe/BuilderEllipsoidTile';
 import newTileGeometry from 'Core/Prefab/TileBuilder';
 import OBB from 'Renderer/OBB';
 
-const max = new THREE.Vector3(10, 10, 10);
-const min = new THREE.Vector3(-10, -10, -10);
-const lookAt = new THREE.Vector3(1, 0, 0);
-const translate = new THREE.Vector3(0, 0, 20);
-const obb = new OBB(min, max);
-obb.lookAt(lookAt);
-obb.translateX(translate.x);
-obb.translateY(translate.y);
-obb.translateZ(translate.z);
-obb.update();
-
 describe('OBB', function () {
+    const max = new THREE.Vector3(10, 10, 10);
+    const min = new THREE.Vector3(-10, -10, -10);
+    const lookAt = new THREE.Vector3(1, 0, 0);
+    const translate = new THREE.Vector3(0, 0, 20);
+    const obb = new OBB(min, max);
+    obb.lookAt(lookAt);
+    obb.translateX(translate.x);
+    obb.translateY(translate.y);
+    obb.translateZ(translate.z);
+    obb.update();
+
     it('should correctly instance obb', () => {
         assert.equal(obb.natBox.min.x, min.x);
         assert.equal(obb.natBox.max.x, max.x);

--- a/test/unit/pointcloud.js
+++ b/test/unit/pointcloud.js
@@ -8,30 +8,37 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import PointCloudNode from 'Core/PointCloudNode';
 import Renderer from './mock';
 
-const renderer = new Renderer();
+describe('Point Cloud', function () {
+    const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 250 };
+    let renderer;
+    let viewer;
+    let pointcloud;
+    let context;
+    let elt;
 
-const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 250 };
-const viewer = new GlobeView(renderer.domElement, placement, { renderer });
+    before(function () {
+        renderer = new Renderer();
+        viewer = new GlobeView(renderer.domElement, placement, { renderer });
 
-// Configure Point Cloud layer
-const pointcloud = new PointCloudLayer('eglise_saint_blaise_arles', {
-    source: new PointCloudSource({
-        file: 'eglise_saint_blaise_arles.js',
-        url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
-        networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
-    }),
-    onPointsCreated: () => {},
-}, viewer);
+        // Configure Point Cloud layer
+        pointcloud = new PointCloudLayer('eglise_saint_blaise_arles', {
+            source: new PointCloudSource({
+                file: 'eglise_saint_blaise_arles.js',
+                url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+                networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            }),
+            onPointsCreated: () => {},
+        }, viewer);
 
-const context = {
-    camera: viewer.camera,
-    engine: viewer.mainLoop.gfxEngine,
-    scheduler: viewer.mainLoop.scheduler,
-    geometryLayer: pointcloud,
-    view: viewer,
-};
+        context = {
+            camera: viewer.camera,
+            engine: viewer.mainLoop.gfxEngine,
+            scheduler: viewer.mainLoop.scheduler,
+            geometryLayer: pointcloud,
+            view: viewer,
+        };
+    });
 
-describe('point cloud', function () {
     it('Add point cloud layer', function (done) {
         View.prototype.addLayer.call(viewer, pointcloud).then((layer) => {
             context.camera.camera3D.updateMatrixWorld();
@@ -41,7 +48,6 @@ describe('point cloud', function () {
         });
     });
 
-    let elt;
     it('preupdate point cloud layer', function () {
         elt = pointcloud.preUpdate(context, new Set([pointcloud]));
         assert.equal(elt.length, 1);
@@ -59,35 +65,34 @@ describe('point cloud', function () {
     it('postUpdate point cloud layer', function () {
         pointcloud.postUpdate(context, pointcloud);
     });
-});
 
-const numPoints = 1000;
-const childrenBitField = 5;
+    describe('Point Cloud Node', function () {
+        const numPoints = 1000;
+        const childrenBitField = 5;
 
-describe('point cloud node', function () {
-    it('instance', function (done) {
-        const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
-        assert.equal(root.numPoints, numPoints);
-        assert.equal(root.childrenBitField, childrenBitField);
-        done();
-    });
-
-    it('load octree', function (done) {
-        const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
-        root.loadOctree().then(() => {
-            assert.equal(7, root.children.length);
+        it('instance', function (done) {
+            const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
+            assert.equal(root.numPoints, numPoints);
+            assert.equal(root.childrenBitField, childrenBitField);
             done();
         });
-    });
 
-    it('load child node', function (done) {
-        const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
-        root.loadOctree().then(() => {
-            root.children[0].loadNode().then(() => {
-                assert.equal(2, root.children[0].children.length);
+        it('load octree', function (done) {
+            const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
+            root.loadOctree().then(() => {
+                assert.equal(7, root.children.length);
                 done();
+            });
+        });
+
+        it('load child node', function (done) {
+            const root = new PointCloudNode(numPoints, childrenBitField, pointcloud);
+            root.loadOctree().then(() => {
+                root.children[0].loadNode().then(() => {
+                    assert.equal(2, root.children[0].children.length);
+                    done();
+                });
             });
         });
     });
 });
-

--- a/test/unit/pointcloudlayerprocessing.js
+++ b/test/unit/pointcloudlayerprocessing.js
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import PointCloudLayer from 'Layer/PointCloudLayer';
 
-const context = { camera: { height: 1, camera3D: { fov: 1 } } };
-
 describe('preUpdate', function () {
+    const context = { camera: { height: 1, camera3D: { fov: 1 } } };
+
     it('should return root if no change source', () => {
         const layer = { root: {} };
         const sources = new Set();

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -3,9 +3,9 @@ import assert from 'assert';
 import URLBuilder from 'Provider/URLBuilder';
 import Extent from 'Core/Geographic/Extent';
 
-const layer = {};
-
 describe('URL creations', function () {
+    const layer = {};
+
     it('should correctly replace ${x}, ${y} and ${z} by 359, 512 and 10', function () {
         var coords = new Extent('WMTS:TMS:4857', 10, 512, 359);
         layer.url = 'http://server.geo/tms/${z}/${y}/${x}.jpg';

--- a/test/unit/scheduler.js
+++ b/test/unit/scheduler.js
@@ -1,42 +1,42 @@
 import assert from 'assert';
 import Scheduler from 'Core/Scheduler/Scheduler';
 
-const scheduler = new Scheduler();
-global.window = {
-    addEventListener() {},
-    setTimeout,
-};
-
-scheduler.addProtocolProvider('test', {
-    preprocessDataLayer: () => {
-    },
-    executeCommand: (cmd) => {
-        setTimeout(() => {
-            cmd.done = true;
-            cmd._r(cmd);
-        }, 0);
-        return new Promise((resolve) => {
-            cmd._r = resolve;
-        });
-    },
-});
-
-const view = {
-    notifyChange: () => {},
-};
-
-function cmd(layerId = 'foo', prio = 0) {
-    return {
-        layer: {
-            id: layerId,
-            protocol: 'test',
-            priority: prio,
-        },
-        view,
-    };
-}
-
 describe('Command execution', function () {
+    const scheduler = new Scheduler();
+    global.window = {
+        addEventListener() {},
+        setTimeout,
+    };
+
+    scheduler.addProtocolProvider('test', {
+        preprocessDataLayer: () => {
+        },
+        executeCommand: (cmd) => {
+            setTimeout(() => {
+                cmd.done = true;
+                cmd._r(cmd);
+            }, 0);
+            return new Promise((resolve) => {
+                cmd._r = resolve;
+            });
+        },
+    });
+
+    const view = {
+        notifyChange: () => {},
+    };
+
+    function cmd(layerId = 'foo', prio = 0) {
+        return {
+            layer: {
+                id: layerId,
+                protocol: 'test',
+                priority: prio,
+            },
+            view,
+        };
+    }
+
     it('should execute one command', function (done) {
         scheduler.execute(cmd()).then((c) => {
             assert.ok(c.done);

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -9,34 +9,34 @@ import TMSSource from 'Source/TMSSource';
 import FileSource from 'Source/FileSource';
 import Extent from 'Core/Geographic/Extent';
 
-function defer() {
-    var deferredPromise = {};
-    deferredPromise.promise = new Promise(function (resolve) {
-        deferredPromise.resolve = resolve;
-    });
-    return deferredPromise;
-}
-
-const geojson = defer();
-
-// To load geojson without parse the file content
-const urlGeojson = Path.resolve(__dirname, '../data/geojson/holes.geojson.json');
-fs.readFile(urlGeojson, 'utf8', function (err, content) {
-    geojson.resolve(content);
-});
-
-global.window = {};
-global.URL = function URL() {
-    this.ref = undefined;
-};
-
-const vendorSpecific = {
-    buffer: 4096,
-    format_options: 'dpi:300;quantizer:octree',
-    tiled: true,
-};
-
 describe('Sources', function () {
+    function defer() {
+        var deferredPromise = {};
+        deferredPromise.promise = new Promise(function (resolve) {
+            deferredPromise.resolve = resolve;
+        });
+        return deferredPromise;
+    }
+
+    const geojson = defer();
+
+    // To load geojson without parse the file content
+    const urlGeojson = Path.resolve(__dirname, '../data/geojson/holes.geojson.json');
+    fs.readFile(urlGeojson, 'utf8', function (err, content) {
+        geojson.resolve(content);
+    });
+
+    global.window = {};
+    global.URL = function URL() {
+        this.ref = undefined;
+    };
+
+    const vendorSpecific = {
+        buffer: 4096,
+        format_options: 'dpi:300;quantizer:octree',
+        tiled: true,
+    };
+
     describe('Source', function () {
         const paramsSource = {
             url: 'http://',

--- a/test/unit/tilemesh.js
+++ b/test/unit/tilemesh.js
@@ -17,40 +17,40 @@ FakeTileMesh.prototype = Object.create({});
 FakeTileMesh.prototype.constructor = FakeTileMesh;
 FakeTileMesh.prototype.findCommonAncestor = TileMesh.prototype.findCommonAncestor;
 
-const tree = [
-    [new FakeTileMesh(0)],
-];
-
-// root + three levels
-for (let i = 1; i < 4; i++) {
-    tree[i] = [];
-    // four child per parent
-    for (let j = 0; j < Math.pow(4, i); j++) {
-        const tile = new FakeTileMesh(i, tree[i - 1][~~(j / 4)]);
-        tree[i].push(tile);
-    }
-}
-
-const globalExtent = globalExtentTMS.get('EPSG:3857');
-// const view = new PlanarView(viewerDiv, globalExtent, { maxSubdivisionLevel: 20 });
-
-const planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
-
-// Mock scheduler
-const context = {
-    view: {
-        notifyChange: () => true,
-    },
-    scheduler: {
-        commands: [],
-        execute: (cmd) => {
-            context.scheduler.commands.push(cmd);
-            return new Promise(() => { /* no-op */ });
-        },
-    },
-};
-
 describe('TileMesh', function () {
+    const tree = [
+        [new FakeTileMesh(0)],
+    ];
+
+    // root + three levels
+    for (let i = 1; i < 4; i++) {
+        tree[i] = [];
+        // four child per parent
+        for (let j = 0; j < Math.pow(4, i); j++) {
+            const tile = new FakeTileMesh(i, tree[i - 1][~~(j / 4)]);
+            tree[i].push(tile);
+        }
+    }
+
+    const globalExtent = globalExtentTMS.get('EPSG:3857');
+    // const view = new PlanarView(viewerDiv, globalExtent, { maxSubdivisionLevel: 20 });
+
+    const planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
+
+    // Mock scheduler
+    const context = {
+        view: {
+            notifyChange: () => true,
+        },
+        scheduler: {
+            commands: [],
+            execute: (cmd) => {
+                context.scheduler.commands.push(cmd);
+                return new Promise(() => { /* no-op */ });
+            },
+        },
+    };
+
     it('should find the correct common ancestor between two tiles of same level', function () {
         const res = tree[2][0].findCommonAncestor(tree[2][1]);
         assert.equal(res, tree[1][0]);

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -3,41 +3,41 @@ import assert from 'assert';
 import VectorTileParser from 'Parser/VectorTileParser';
 import Extent from 'Core/Geographic/Extent';
 
-const paints = [{
-    'fill-color': 'rgb(50%, 0%, 0%)',
-    'fill-opacity': 0.5,
-}, {
-    'fill-color': 'rgba(0, 0, 0, 0.5)',
-}, {
-    'fill-color': 'hsla(0, 10%, 0%, 0.3)',
-}, {
-    'line-color': 'hsla(0, 0%, 50%, 0.3)',
-    'line-width': 3,
-    'line-opacity': 0.4,
-}, {
-    'icon-image': 'icon.png',
-},
-];
-
-// this PBF file comes from https://github.com/mapbox/vector-tile-js
-// it contains two square polygons
-const multipolygon = fs.readFileSync('test/data/pbf/multipolygon.pbf');
-let id = 0;
-function parse(pbf, paint, type) {
-    pbf.extent = new Extent('TMS', 1, 1, 1);
-    return VectorTileParser.parse(pbf, {
-        crsIn: 'EPSG:4326',
-        crsOut: 'EPSG:3857',
-        filter: [{
-            'source-layer': 'geojson',
-            paint,
-            id: id++,
-            type,
-        }],
-    });
-}
-
 describe('Vector tiles', function () {
+    const paints = [{
+        'fill-color': 'rgb(50%, 0%, 0%)',
+        'fill-opacity': 0.5,
+    }, {
+        'fill-color': 'rgba(0, 0, 0, 0.5)',
+    }, {
+        'fill-color': 'hsla(0, 10%, 0%, 0.3)',
+    }, {
+        'line-color': 'hsla(0, 0%, 50%, 0.3)',
+        'line-width': 3,
+        'line-opacity': 0.4,
+    }, {
+        'icon-image': 'icon.png',
+    },
+    ];
+
+    // this PBF file comes from https://github.com/mapbox/vector-tile-js
+    // it contains two square polygons
+    const multipolygon = fs.readFileSync('test/data/pbf/multipolygon.pbf');
+    let id = 0;
+    function parse(pbf, paint, type) {
+        pbf.extent = new Extent('TMS', 1, 1, 1);
+        return VectorTileParser.parse(pbf, {
+            crsIn: 'EPSG:4326',
+            crsOut: 'EPSG:3857',
+            filter: [{
+                'source-layer': 'geojson',
+                paint,
+                id: id++,
+                type,
+            }],
+        });
+    }
+
     it('should return two squares', () =>
         parse(multipolygon).then((collection) => {
             const feature = collection.features[0];

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -6,33 +6,41 @@ import GlobeLayer from 'Core/Prefab/Globe/GlobeLayer';
 import FileSource from 'Source/FileSource';
 import Renderer from './mock';
 
-const renderer = new Renderer();
-
-const globelayer = new GlobeLayer('globe', new THREE.Group());
-const source = new FileSource({
-    url: '..',
-    projection: 'EPSG:4326',
-});
-
-const colorLayer = new ColorLayer('l0', { source });
-
-let viewer;
-
-beforeEach('reset viewer', function () {
-    viewer = new View('EPSG:4326', renderer.domElement, {
-        renderer,
-    });
-});
-
 describe('Viewer', function () {
+    let renderer;
+    let viewer;
+    let globelayer;
+    let source;
+    let colorLayer;
+
+    before(function () {
+        renderer = new Renderer();
+
+        globelayer = new GlobeLayer('globe', new THREE.Group());
+        source = new FileSource({
+            url: '..',
+            projection: 'EPSG:4326',
+        });
+
+        colorLayer = new ColorLayer('l0', { source });
+    });
+
+    beforeEach('reset viewer', function () {
+        viewer = new View('EPSG:4326', renderer.domElement, {
+            renderer,
+        });
+    });
+
     it('should instance viewer', () => {
         assert.ok(viewer);
     });
+
     it('should add globe layer', () => {
         viewer.addLayer(globelayer);
         const layers = viewer.getLayers();
         assert.equal(layers.length, 1);
     });
+
     it('should remove globe layer', () => {
         viewer.addLayer(globelayer);
         assert.ok(viewer.getLayerById(globelayer.id));
@@ -40,6 +48,7 @@ describe('Viewer', function () {
         const layers = viewer.getLayers();
         assert.equal(layers.length, 0);
     });
+
     it('should add color layer', () => {
         viewer.addLayer(globelayer);
         viewer.addLayer(colorLayer, globelayer);
@@ -47,6 +56,7 @@ describe('Viewer', function () {
         assert.equal(globelayer.id, layer.id);
         assert.equal(globelayer.attachedLayers.length, 1);
     });
+
     it('should call pick Object function', () => {
         viewer.addLayer(globelayer);
         viewer.tileLayer = globelayer;
@@ -55,6 +65,7 @@ describe('Viewer', function () {
         const pickedFrom = viewer.getPickingPositionFromDepth({ x: 10, y: 10 });
         assert.ok(pickedFrom.isVector3);
     });
+
     it('should update sources viewer and notify change', () => {
         viewer.addLayer(globelayer);
         viewer.notifyChange(globelayer, true);


### PR DESCRIPTION
In some unit tests, variables were declared before the first
`describe()` section of the file. When calling `npm run test-unit`, all
files are loaded and executed at the same time, with all `describe`
content being moved to a queue. So this causes a problem with things
declared before `describe`: a lot of variables (noticeably `context`)
were being rewritten and shared between all tests. While all tests were
passing, some of them would be false positive.
Moving all those declarations in `describe` fixes this.