### PR TITLE
fix(VectorTile): Differentiated style caches with the VectorTileSources.

### DIFF
--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -144,7 +144,7 @@ function readPBF(file, options) {
             const layers = layersSource.filter(l => l.filterExpression({ zoom: z }, vtFeature) && (!l.minzoom || l.minzoom <= z) && (!l.maxzoom || l.maxzoom >= z));
             let feature;
             for (const layer of layers) {
-                const tag = `${layer.id}_zoom_${z}`;
+                const tag = `${layer.sourceUid}_${layer.id}_zoom_${z}`;
                 // Fix doens't pass instance of properties
                 let style = styleCache.get(tag);
                 if (!style) {

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -37,6 +37,7 @@ class VectorTilesSource extends TMSSource {
                 const os = style.sources[s];
 
                 style.layers.forEach((layer) => {
+                    layer.sourceUid = this.uid;
                     if (layer.type === 'background') {
                         this.backgroundLayer = layer;
                     } else if (ffilter(layer)) {


### PR DESCRIPTION
## Description
New `VectorTileSource` aren't correctly loaded after change vector tile style file.  Differentiated style caches with the `VectorTileSources`.

Fix #1334 