### PR TITLE
fix/feat(view): use correct DOM element and resize the viewer

### DIFF
--- a/examples/effects_split.html
+++ b/examples/effects_split.html
@@ -90,14 +90,14 @@
             splitPosition = 0.5 * window.innerWidth;
             xD = 0;
             function splitSliderMove(evt) {
-                var s = (evt.clientX - xD) / splitSlider.parentElement.offsetWidth;
+                var s = (evt.offsetX - xD) / splitSlider.parentElement.offsetWidth;
                 splitSlider.style.left = (100.0 * s) + '%';
                 splitPosition = s * window.innerWidth;
                 view.notifyChange();
             }
 
             function mouseDown(evt) {
-                xD = evt.clientX - splitSlider.offsetLeft;
+                xD = evt.offsetX - splitSlider.offsetLeft;
                 window.addEventListener('mousemove', splitSliderMove, true);
             }
 

--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -4,7 +4,7 @@
  * Description: Classe pour créer un menu.
  */
 
-/* global dat,viewerDiv, itowns */
+/* global dat, itowns */
 
 dat.GUI.prototype.removeFolder = function removeFolder(name) {
     var folder = this.__folders[name];
@@ -38,7 +38,7 @@ function GuiTools(domId, view, w) {
     var width = w || 245;
     this.gui = new dat.GUI({ autoPlace: false, width: width });
     this.gui.domElement.id = domId;
-    viewerDiv.parentElement.appendChild(this.gui.domElement);
+    view.domElement.appendChild(this.gui.domElement);
     this.colorGui = this.gui.addFolder('Color Layers');
     this.elevationGui = this.gui.addFolder('Elevation Layers');
     this.elevationGui.hide();

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -76,7 +76,7 @@
                          ') in Points ' + p.object.layer.id);
                     }
                 }
-                view.mainLoop.gfxEngine.renderer.domElement.addEventListener('dblclick', dblClickHandler);
+                view.domElement.addEventListener('dblclick', dblClickHandler);
 
                 function placeCamera(position, lookAt) {
                     view.camera.camera3D.position.copy(position);

--- a/src/Controls/FirstPersonControls.js
+++ b/src/Controls/FirstPersonControls.js
@@ -91,28 +91,27 @@ class FirstPersonControls extends THREE.EventDispatcher {
         };
         this.reset();
 
-        const domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
         if (!options.disableEventListeners) {
-            domElement.addEventListener('mousedown', this.onMouseDown.bind(this), false);
-            domElement.addEventListener('touchstart', this.onMouseDown.bind(this), false);
-            domElement.addEventListener('mousemove', this.onMouseMove.bind(this), false);
-            domElement.addEventListener('touchmove', this.onMouseMove.bind(this), false);
-            domElement.addEventListener('mouseup', this.onMouseUp.bind(this), false);
-            domElement.addEventListener('touchend', this.onMouseUp.bind(this), false);
-            domElement.addEventListener('keyup', this.onKeyUp.bind(this), true);
-            domElement.addEventListener('keydown', this.onKeyDown.bind(this), true);
-            domElement.addEventListener('mousewheel', this.onMouseWheel.bind(this), false);
-            domElement.addEventListener('DOMMouseScroll', this.onMouseWheel.bind(this), false); // firefox
+            view.domElement.addEventListener('mousedown', this.onMouseDown.bind(this), false);
+            view.domElement.addEventListener('touchstart', this.onMouseDown.bind(this), false);
+            view.domElement.addEventListener('mousemove', this.onMouseMove.bind(this), false);
+            view.domElement.addEventListener('touchmove', this.onMouseMove.bind(this), false);
+            view.domElement.addEventListener('mouseup', this.onMouseUp.bind(this), false);
+            view.domElement.addEventListener('touchend', this.onMouseUp.bind(this), false);
+            view.domElement.addEventListener('keyup', this.onKeyUp.bind(this), true);
+            view.domElement.addEventListener('keydown', this.onKeyDown.bind(this), true);
+            view.domElement.addEventListener('mousewheel', this.onMouseWheel.bind(this), false);
+            view.domElement.addEventListener('DOMMouseScroll', this.onMouseWheel.bind(this), false); // firefox
         }
 
         this.view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.update.bind(this));
 
         // focus policy
         if (options.focusOnMouseOver) {
-            domElement.addEventListener('mouseover', () => domElement.focus());
+            view.domElement.addEventListener('mouseover', () => view.domElement.focus());
         }
         if (options.focusOnClick) {
-            domElement.addEventListener('click', () => domElement.focus());
+            view.domElement.addEventListener('click', () => view.domElement.focus());
         }
 
         if (view.referenceCrs == 'EPSG:4978') {

--- a/src/Controls/FlyControls.js
+++ b/src/Controls/FlyControls.js
@@ -103,7 +103,6 @@ class FlyControls extends THREE.EventDispatcher {
      */
     constructor(view, options = {}) {
         super();
-        const domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
         this.view = view;
         this.options = options;
         this._camera3D = view.camera.camera3D;
@@ -115,26 +114,26 @@ class FlyControls extends THREE.EventDispatcher {
 
         this._isMouseDown = false;
 
-        domElement.addEventListener('mousedown', onDocumentMouseDown.bind(this), false);
-        domElement.addEventListener('touchstart', onTouchStart.bind(this), false);
+        view.domElement.addEventListener('mousedown', onDocumentMouseDown.bind(this), false);
+        view.domElement.addEventListener('touchstart', onTouchStart.bind(this), false);
         const bindedPM = onPointerMove.bind(this);
-        domElement.addEventListener('mousemove', bindedPM, false);
-        domElement.addEventListener('touchmove', bindedPM, false);
-        domElement.addEventListener('mouseup', onDocumentMouseUp.bind(this), false);
-        domElement.addEventListener('touchend', onDocumentMouseUp.bind(this), false);
-        domElement.addEventListener('mousewheel', onDocumentMouseWheel.bind(this), false);
-        domElement.addEventListener('DOMMouseScroll', onDocumentMouseWheel.bind(this), false); // firefox
-        domElement.addEventListener('keyup', onKeyUp.bind(this), true);
-        domElement.addEventListener('keydown', onKeyDown.bind(this), true);
+        view.domElement.addEventListener('mousemove', bindedPM, false);
+        view.domElement.addEventListener('touchmove', bindedPM, false);
+        view.domElement.addEventListener('mouseup', onDocumentMouseUp.bind(this), false);
+        view.domElement.addEventListener('touchend', onDocumentMouseUp.bind(this), false);
+        view.domElement.addEventListener('mousewheel', onDocumentMouseWheel.bind(this), false);
+        view.domElement.addEventListener('DOMMouseScroll', onDocumentMouseWheel.bind(this), false); // firefox
+        view.domElement.addEventListener('keyup', onKeyUp.bind(this), true);
+        view.domElement.addEventListener('keydown', onKeyDown.bind(this), true);
 
         this.view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_CAMERA_UPDATE, this.update.bind(this));
 
         // focus policy
         if (options.focusOnMouseOver) {
-            domElement.addEventListener('mouseover', () => domElement.focus());
+            view.domElement.addEventListener('mouseover', () => view.domElement.focus());
         }
         if (options.focusOnClick) {
-            domElement.addEventListener('click', () => domElement.focus());
+            view.domElement.addEventListener('click', () => view.domElement.focus());
         }
     }
 

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -170,7 +170,6 @@ class GlobeControls extends THREE.EventDispatcher {
         this.player = new AnimationPlayer();
         this.view = view;
         this.camera = view.camera.camera3D;
-        this.domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
 
         // State control
         this.states = new StateControl();
@@ -243,14 +242,14 @@ class GlobeControls extends THREE.EventDispatcher {
         this._onKeyUp = this.onKeyUp.bind(this);
         this._onBlurListener = this.onBlurListener.bind(this);
 
-        this.domElement.addEventListener('contextmenu', this._onContextMenuListener, false);
-        this.domElement.addEventListener('mousedown', this._onMouseDown, false);
-        this.domElement.addEventListener('mousewheel', this._onMouseWheel, false);
-        this.domElement.addEventListener('dblclick', this._ondblclick, false);
-        this.domElement.addEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
-        this.domElement.addEventListener('touchstart', this._onTouchStart, false);
-        this.domElement.addEventListener('touchend', this._onMouseUp, false);
-        this.domElement.addEventListener('touchmove', this._onTouchMove, false);
+        this.view.domElement.addEventListener('contextmenu', this._onContextMenuListener, false);
+        this.view.domElement.addEventListener('mousedown', this._onMouseDown, false);
+        this.view.domElement.addEventListener('mousewheel', this._onMouseWheel, false);
+        this.view.domElement.addEventListener('dblclick', this._ondblclick, false);
+        this.view.domElement.addEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
+        this.view.domElement.addEventListener('touchstart', this._onTouchStart, false);
+        this.view.domElement.addEventListener('touchend', this._onMouseUp, false);
+        this.view.domElement.addEventListener('touchmove', this._onTouchMove, false);
 
         // refresh control for each animation's frame
         this.player.addEventListener('animation-frame', this._update);
@@ -671,9 +670,9 @@ class GlobeControls extends THREE.EventDispatcher {
             default:
         }
         if (this.state != this.states.NONE) {
-            this.domElement.addEventListener('mousemove', this._onMouseMove, false);
-            this.domElement.addEventListener('mouseup', this._onMouseUp, false);
-            this.domElement.addEventListener('mouseleave', this._onMouseUp, false);
+            this.view.domElement.addEventListener('mousemove', this._onMouseMove, false);
+            this.view.domElement.addEventListener('mouseup', this._onMouseUp, false);
+            this.view.domElement.addEventListener('mouseleave', this._onMouseUp, false);
             this.dispatchEvent(this.startEvent);
         }
     }
@@ -695,9 +694,9 @@ class GlobeControls extends THREE.EventDispatcher {
     onMouseUp() {
         if (this.enabled === false) { return; }
 
-        this.domElement.removeEventListener('mousemove', this._onMouseMove, false);
-        this.domElement.removeEventListener('mouseup', this._onMouseUp, false);
-        this.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
+        this.view.domElement.removeEventListener('mousemove', this._onMouseMove, false);
+        this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
+        this.view.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
         this.dispatchEvent(this.endEvent);
 
         this.player.stop();
@@ -914,19 +913,19 @@ class GlobeControls extends THREE.EventDispatcher {
     }
 
     dispose() {
-        this.domElement.removeEventListener('contextmenu', this._onContextMenuListener, false);
+        this.view.domElement.removeEventListener('contextmenu', this._onContextMenuListener, false);
 
-        this.domElement.removeEventListener('mousedown', this._onMouseDown, false);
-        this.domElement.removeEventListener('mousemove', this._onMouseMove, false);
-        this.domElement.removeEventListener('mousewheel', this._onMouseWheel, false);
-        this.domElement.removeEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
-        this.domElement.removeEventListener('mouseup', this._onMouseUp, false);
-        this.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
-        this.domElement.removeEventListener('dblclick', this._ondblclick, false);
+        this.view.domElement.removeEventListener('mousedown', this._onMouseDown, false);
+        this.view.domElement.removeEventListener('mousemove', this._onMouseMove, false);
+        this.view.domElement.removeEventListener('mousewheel', this._onMouseWheel, false);
+        this.view.domElement.removeEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
+        this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
+        this.view.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
+        this.view.domElement.removeEventListener('dblclick', this._ondblclick, false);
 
-        this.domElement.removeEventListener('touchstart', this._onTouchStart, false);
-        this.domElement.removeEventListener('touchend', this._onMouseUp, false);
-        this.domElement.removeEventListener('touchmove', this._onTouchMove, false);
+        this.view.domElement.removeEventListener('touchstart', this._onTouchStart, false);
+        this.view.domElement.removeEventListener('touchend', this._onMouseUp, false);
+        this.view.domElement.removeEventListener('touchmove', this._onTouchMove, false);
 
         this.player.removeEventListener('animation-frame', this._onKeyUp);
 

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -685,7 +685,7 @@ function PlanarControls(view, options = {}) {
     };
 
     this.updateMousePositionAndDelta = function updateMousePositionAndDelta(event) {
-        mousePosition.set(event.clientX, event.clientY);
+        mousePosition.set(event.offsetX, event.offsetY);
 
         deltaMousePosition.copy(mousePosition).sub(lastMousePosition);
 

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -105,7 +105,6 @@ const vectorZero = new THREE.Vector3();
 function PlanarControls(view, options = {}) {
     this.view = view;
     this.camera = view.camera.camera3D;
-    this.domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
 
     this.enableRotation = typeof (options.enableRotation) !== 'undefined' ? options.enableRotation : true;
     this.rotateSpeed = options.rotateSpeed || 2.0;
@@ -198,15 +197,15 @@ function PlanarControls(view, options = {}) {
 
     // focus policy
     if (this.focusOnMouseOver) {
-        this.domElement.addEventListener('mouseover', () => this.domElement.focus());
+        this.view.domElement.addEventListener('mouseover', () => this.view.domElement.focus());
     }
     if (this.focusOnMouseClick) {
-        this.domElement.addEventListener('click', () => this.domElement.focus());
+        this.view.domElement.addEventListener('click', () => this.view.domElement.focus());
     }
 
     // prevent the default contextmenu from appearing when right-clicking
     // this allows to use right-click for input without the menu appearing
-    this.domElement.addEventListener('contextmenu', onContextMenu.bind(this), false);
+    this.view.domElement.addEventListener('contextmenu', onContextMenu.bind(this), false);
 
     // Updates the view and camera if needed, and handles the animated travel
     this.update = function update(dt, updateLoopRestarted) {
@@ -698,13 +697,13 @@ function PlanarControls(view, options = {}) {
      * @ignore
      */
     this.addInputListeners = function addInputListeners() {
-        this.domElement.addEventListener('keydown', _handlerOnKeyDown, true);
-        this.domElement.addEventListener('mousedown', _handlerOnMouseDown, false);
-        this.domElement.addEventListener('mouseup', _handlerOnMouseUp, false);
-        this.domElement.addEventListener('mousemove', _handlerOnMouseMove, false);
-        this.domElement.addEventListener('mousewheel', _handlerOnMouseWheel, false);
+        this.view.domElement.addEventListener('keydown', _handlerOnKeyDown, true);
+        this.view.domElement.addEventListener('mousedown', _handlerOnMouseDown, false);
+        this.view.domElement.addEventListener('mouseup', _handlerOnMouseUp, false);
+        this.view.domElement.addEventListener('mousemove', _handlerOnMouseMove, false);
+        this.view.domElement.addEventListener('mousewheel', _handlerOnMouseWheel, false);
         // For firefox
-        this.domElement.addEventListener('MozMousePixelScroll', _handlerOnMouseWheel, false);
+        this.view.domElement.addEventListener('MozMousePixelScroll', _handlerOnMouseWheel, false);
     };
 
     /**
@@ -713,13 +712,13 @@ function PlanarControls(view, options = {}) {
      * @ignore
      */
     this.removeInputListeners = function removeInputListeners() {
-        this.domElement.removeEventListener('keydown', _handlerOnKeyDown, true);
-        this.domElement.removeEventListener('mousedown', _handlerOnMouseDown, false);
-        this.domElement.removeEventListener('mouseup', _handlerOnMouseUp, false);
-        this.domElement.removeEventListener('mousemove', _handlerOnMouseMove, false);
-        this.domElement.removeEventListener('mousewheel', _handlerOnMouseWheel, false);
+        this.view.domElement.removeEventListener('keydown', _handlerOnKeyDown, true);
+        this.view.domElement.removeEventListener('mousedown', _handlerOnMouseDown, false);
+        this.view.domElement.removeEventListener('mouseup', _handlerOnMouseUp, false);
+        this.view.domElement.removeEventListener('mousemove', _handlerOnMouseMove, false);
+        this.view.domElement.removeEventListener('mousewheel', _handlerOnMouseWheel, false);
         // For firefox
-        this.domElement.removeEventListener('MozMousePixelScroll', _handlerOnMouseWheel, false);
+        this.view.domElement.removeEventListener('MozMousePixelScroll', _handlerOnMouseWheel, false);
     };
 
     /**
@@ -730,19 +729,19 @@ function PlanarControls(view, options = {}) {
     this.updateMouseCursorType = function updateMouseCursorType() {
         switch (this.state) {
             case STATE.NONE:
-                this.domElement.style.cursor = 'auto';
+                this.view.domElement.style.cursor = 'auto';
                 break;
             case STATE.DRAG:
-                this.domElement.style.cursor = 'move';
+                this.view.domElement.style.cursor = 'move';
                 break;
             case STATE.PAN:
-                this.domElement.style.cursor = 'cell';
+                this.view.domElement.style.cursor = 'cell';
                 break;
             case STATE.TRAVEL:
-                this.domElement.style.cursor = 'wait';
+                this.view.domElement.style.cursor = 'wait';
                 break;
             case STATE.ROTATE:
-                this.domElement.style.cursor = 'move';
+                this.view.domElement.style.cursor = 'move';
                 break;
             default:
                 break;

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -123,8 +123,7 @@ class StreetControls extends FirstPersonControls {
 
         this.isStreetControls = true;
 
-        const domElement = view.mainLoop.gfxEngine.renderer.domElement.parentElement;
-        domElement.addEventListener('mouseout', super.onMouseUp.bind(this));
+        view.domElement.addEventListener('mouseout', super.onMouseUp.bind(this));
 
         // two positions used by this control : current and next
         this.previousPosition = undefined;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -507,12 +507,12 @@ class View extends THREE.EventDispatcher {
      */
     eventToViewCoords(event, target = _eventCoords, touchIdx = 0) {
         if (event.touches === undefined || !event.touches.length) {
-            return target.set(event.clientX, event.clientY);
+            return target.set(event.offsetX, event.offsetY);
         } else {
-            const br = this.mainLoop.gfxEngine.renderer.domElement.getBoundingClientRect();
+            const br = this.mainLoop.gfxEngine.renderer.domElement.parentElement.getBoundingClientRect();
             return target.set(
-                event.touches[touchIdx].clientX - br.x,
-                event.touches[touchIdx].clientY - br.y);
+                event.touches[touchIdx].offsetX - br.x,
+                event.touches[touchIdx].offsetY - br.y);
         }
     }
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -107,6 +107,8 @@ class View extends THREE.EventDispatcher {
 
         super();
 
+        this.domElement = viewerDiv;
+
         this.referenceCrs = crs;
         coordinates.crs = crs;
 
@@ -157,7 +159,7 @@ class View extends THREE.EventDispatcher {
             }
         };
 
-        this.camera.resize(viewerDiv.clientWidth, viewerDiv.clientHeight);
+        this.camera.resize(this.domElement.clientWidth, this.domElement.clientHeight);
 
         const fn = () => {
             this.removeEventListener(VIEW_EVENTS.LAYERS_INITIALIZED, fn);
@@ -176,7 +178,7 @@ class View extends THREE.EventDispatcher {
         });
 
         // Focus needed to capture some key events.
-        viewerDiv.focus();
+        this.domElement.focus();
     }
 
 
@@ -503,7 +505,7 @@ class View extends THREE.EventDispatcher {
         if (event.touches === undefined || !event.touches.length) {
             return target.set(event.offsetX, event.offsetY);
         } else {
-            const br = this.mainLoop.gfxEngine.renderer.domElement.parentElement.getBoundingClientRect();
+            const br = this.domElement.getBoundingClientRect();
             return target.set(
                 event.touches[touchIdx].offsetX - br.x,
                 event.touches[touchIdx].offsetY - br.y);
@@ -874,11 +876,11 @@ class View extends THREE.EventDispatcher {
      */
     resize(width, height) {
         if (width == undefined) {
-            width = this.mainLoop.gfxEngine.renderer.domElement.parentElement.clientWidth;
+            width = this.domElement.clientWidth;
         }
 
         if (height == undefined) {
-            height = this.mainLoop.gfxEngine.renderer.domElement.parentElement.clientHeight;
+            height = this.domElement.clientHeight;
         }
 
         this.mainLoop.gfxEngine.onWindowResize(width, height);

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -136,13 +136,7 @@ class View extends THREE.EventDispatcher {
         this._frameRequesters = { };
         this._layers = [];
 
-        window.addEventListener('resize', () => {
-            // If the user gave us a container (<div>) then itowns' size is
-            // the container's size. Otherwise we use window' size.
-            this.mainLoop.gfxEngine.onWindowResize(viewerDiv.clientWidth, viewerDiv.clientHeight);
-            this.camera.resize(viewerDiv.clientWidth, viewerDiv.clientHeight);
-            this.notifyChange(this.camera.camera3D);
-        }, false);
+        window.addEventListener('resize', () => this.resize(), false);
 
         this._changeSources = new Set();
 
@@ -868,6 +862,28 @@ class View extends THREE.EventDispatcher {
         if (target.length() > 10000000) { return undefined; }
 
         return target;
+    }
+
+    /**
+     * Resize the viewer.
+     *
+     * @param {number} [width=viewerDiv.clientWidth] - The width to resize the
+     * viewer with. By default it is the `clientWidth` of the `viewerDiv`.
+     * @param {number} [height=viewerDiv.clientHeight] - The height to resize
+     * the viewer with. By default it is the `clientHeight` of the `viewerDiv`.
+     */
+    resize(width, height) {
+        if (width == undefined) {
+            width = this.mainLoop.gfxEngine.renderer.domElement.parentElement.clientWidth;
+        }
+
+        if (height == undefined) {
+            height = this.mainLoop.gfxEngine.renderer.domElement.parentElement.clientHeight;
+        }
+
+        this.mainLoop.gfxEngine.onWindowResize(width, height);
+        this.camera.resize(width, height);
+        this.notifyChange(this.camera.camera3D);
     }
 }
 

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -181,8 +181,7 @@ describe('GlobeControls with globe example', function _() {
             const wheelEvent = new WheelEvent('mousewheel', {
                 deltaY: -50000,
             });
-            view.mainLoop.gfxEngine.renderer.domElement.parentElement
-                .dispatchEvent(wheelEvent, document);
+            view.domElement.dispatchEvent(wheelEvent, document);
             window.dispatchEvent(wheelEvent, document);
         }));
         // On the travis server, the range is negative.

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -39,7 +39,7 @@ describe('GlobeControls', function () {
     });
 
     it('mouse down', function () {
-        renderer.domElement.parentElement.emitEvent('mousedown', event);
+        viewer.domElement.emitEvent('mousedown', event);
 
         event.touches = [{
             offsetX: 50,
@@ -47,8 +47,8 @@ describe('GlobeControls', function () {
             pageX: 100,
             pageY: 100,
         }];
-        renderer.domElement.parentElement.emitEvent('mousemove', event);
-        renderer.domElement.parentElement.emitEvent('mouseup', event);
+        viewer.domElement.emitEvent('mousemove', event);
+        viewer.domElement.emitEvent('mouseup', event);
     });
 
     it('dolly', function () {
@@ -58,30 +58,30 @@ describe('GlobeControls', function () {
 
     it('mouse down + crtl', function () {
         event.keyCode = 17;
-        renderer.domElement.parentElement.emitEvent('keydown', event);
-        renderer.domElement.parentElement.emitEvent('mousedown', event);
-        renderer.domElement.parentElement.emitEvent('mousemove', event);
-        renderer.domElement.parentElement.emitEvent('mouseup', event);
-        renderer.domElement.parentElement.emitEvent('keyup', event);
+        viewer.domElement.emitEvent('keydown', event);
+        viewer.domElement.emitEvent('mousedown', event);
+        viewer.domElement.emitEvent('mousemove', event);
+        viewer.domElement.emitEvent('mouseup', event);
+        viewer.domElement.emitEvent('keyup', event);
     });
 
     it('mouse wheel', function () {
-        renderer.domElement.parentElement.emitEvent('mousewheel', event);
+        viewer.domElement.emitEvent('mousewheel', event);
     });
 
     it('mouse dblclick', function () {
-        renderer.domElement.parentElement.emitEvent('dblclick', event);
+        viewer.domElement.emitEvent('dblclick', event);
     });
 
     it('touch start', function () {
-        renderer.domElement.parentElement.emitEvent('touchstart', event);
+        viewer.domElement.emitEvent('touchstart', event);
     });
 
     it('touch move', function () {
-        renderer.domElement.parentElement.emitEvent('touchmove', event);
+        viewer.domElement.emitEvent('touchmove', event);
     });
 
     it('touch end', function () {
-        renderer.domElement.parentElement.emitEvent('touchend', event);
+        viewer.domElement.emitEvent('touchend', event);
     });
 });

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -15,8 +15,8 @@ describe('GlobeControls', function () {
         preventDefault: () => {},
         button: THREE.MOUSE.LEFT,
         touches: [{
-            clientX: 150,
-            clientY: 200,
+            offsetX: 100,
+            offsetY: 200,
             pageX: 150,
             pageY: 200,
         }],
@@ -25,25 +25,37 @@ describe('GlobeControls', function () {
     it('instance GlobeControls', function () {
         assert.ok(viewer.controls);
     });
+
     it('Set Tilt', function (done) {
         viewer.controls.setTilt(10, false).then((e) => {
             assert.equal(e.tilt, 10);
             done();
         });
     });
+
     it('update', function () {
         viewer.controls.mouseToPan(10, 10);
         viewer.controls.update();
     });
+
     it('mouse down', function () {
         renderer.domElement.parentElement.emitEvent('mousedown', event);
+
+        event.touches = [{
+            offsetX: 50,
+            offsetY: 100,
+            pageX: 100,
+            pageY: 100,
+        }];
         renderer.domElement.parentElement.emitEvent('mousemove', event);
         renderer.domElement.parentElement.emitEvent('mouseup', event);
     });
+
     it('dolly', function () {
         viewer.controls.dollyIn();
         viewer.controls.dollyOut();
     });
+
     it('mouse down + crtl', function () {
         event.keyCode = 17;
         renderer.domElement.parentElement.emitEvent('keydown', event);
@@ -52,9 +64,11 @@ describe('GlobeControls', function () {
         renderer.domElement.parentElement.emitEvent('mouseup', event);
         renderer.domElement.parentElement.emitEvent('keyup', event);
     });
+
     it('mouse wheel', function () {
         renderer.domElement.parentElement.emitEvent('mousewheel', event);
     });
+
     it('mouse dblclick', function () {
         renderer.domElement.parentElement.emitEvent('dblclick', event);
     });


### PR DESCRIPTION
- __fix(view): use correct DOM element and offset__
Before that, when the viewer div was not in fullscreen, or covering the
whole page (a case we do not test a lot), there was a bad conversion
between a screen coordinates and the viewer div coordinates. This was
due to a change in e3ff159 and the use of `clientXY` instead of
`offsetXY`.
This change comes with a tiny test unit change when moving the mouse in
`globecontrols`, but we may need more deep testing here. I won't do it
now to have this fix in the 2.19.0 release.
Fixes #1333

- __feat(view): add a `resize` method for the viewer__
A `resize` method is now available in View, easing the process to resize
the viewer in case of itowns being an embedded component like in Lumino
(see #1333).

- __feat(view): add a `domElement` property__
There was a lot of occurrence where we would call the `viewerDiv` of the
constructor of a `View`, using a long call sequence through the
renderer. It is now over, as the property `domElement` can be used
directly on a `View`.

