### PR TITLE
refacto(DEMUtils): change the getElevationValueAt method

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -25,7 +25,8 @@
                 "CRS",
                 "Extent",
                 "OrientationUtils",
-                "OBB"
+                "OBB",
+                "DEMUtils"
             ],
 
             "Layer": [

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -123,9 +123,9 @@
                 var result;
                 var z = 0;
                 if (contour) {
-                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0, tile);
+                    result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0, tile);
                     if (!result) {
-                        result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0);
+                        result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0);
                     }
                     if (result) {
                         tile = [result.tile];

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -68,9 +68,9 @@
                 var result;
                 var z = 0;
                 if (contour) {
-                    result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0, tile);
+                    result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0, tile);
                     if (!result) {
-                        result = itowns.DEMUtils.getElevationValueAt(view.tileLayer, contour, 0);
+                        result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0);
                     }
                     tile = [result.tile];
                     if (result) {

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -224,10 +224,10 @@ Camera.prototype.adjustAltitudeToAvoidCollisionWithLayer = function adjustAltitu
     if (elevationLayer !== undefined) {
         const elevationUnderCamera = DEMUtils.getElevationValueAt(elevationLayer, camLocation);
         if (elevationUnderCamera != undefined) {
-            const difElevation = camLocation.altitude - (elevationUnderCamera.z + minDistanceCollision);
+            const difElevation = camLocation.altitude - (elevationUnderCamera + minDistanceCollision);
             // We move the camera to avoid collisions if too close to terrain
             if (difElevation < 0) {
-                camLocation.altitude = elevationUnderCamera.z + minDistanceCollision;
+                camLocation.altitude = elevationUnderCamera + minDistanceCollision;
                 view.camera.camera3D.position.copy(camLocation.as(view.referenceCrs));
                 view.notifyChange(this.camera3D);
             }

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -292,8 +292,7 @@ class CameraRig extends THREE.Object3D {
         if (view && camera) {
             const startAltitude = this.target.position.z;
             this.placeTargetOnGround = () => {
-                const result = DEMUtils.getElevationValueAt(tileLayer(view), coord || this.coord, DEMUtils.PRECISE_READ_Z);
-                const altitude = Math.max(0, result ? result.z : 0);
+                const altitude = Math.max(0, DEMUtils.getElevationValueAt(tileLayer(view), coord || this.coord, DEMUtils.PRECISE_READ_Z) || 0);
                 this.target.position.z = startAltitude * (1.0 - options.t) + altitude * options.t;
                 this.target.updateMatrixWorld(true);
                 this.applyTransformToCamera(view, camera);

--- a/test/functional/view_25d_map.js
+++ b/test/functional/view_25d_map.js
@@ -43,7 +43,7 @@ describe('view_25d_map', function _() {
                 .getPickingPositionFromDepth().distanceTo(view.camera.camera3D.position);
 
             const altitude = itowns.DEMUtils
-                .getElevationValueAt(view.tileLayer, extent.center().clone()).z;
+                .getElevationValueAt(view.tileLayer, extent.center().clone());
 
             return { depthMethod, altitude };
         });

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -12,7 +12,7 @@ function equalToFixed(value1, value2, toFixed) {
 describe('Camera utils unit test', function () {
     THREE.Object3D.DefaultUp = new THREE.Vector3(0, 0, 1);
 
-    DEMUtils.getElevationValueAt = () => ({ z: 0 });
+    DEMUtils.getElevationValueAt = () => 0;
 
     const raycaster = new THREE.Raycaster();
     const center = new THREE.Vector2();


### PR DESCRIPTION
It now only returns a single elevation value, while the newly
`getTerrainObjectAt` returns the previous object.

Also added some documentation for this module as well.

BREAKING CHANGES: the method `DEMUtils.getElevationValueAt` only returns
a value now, if you want the previous object, use
`DEMUtils.getTerrainObjectAt` instead.
