### PR TITLE
refactor(geographic): unify and encapsulate crs.

### DIFF
--- a/src/Core/Geographic/Crs.js
+++ b/src/Core/Geographic/Crs.js
@@ -2,40 +2,20 @@ import proj4 from 'proj4';
 
 proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
 
-const TMS = [
-    'WMTS:WGS84',
-    'WMTS:PM',
-];
+function isTms(crs) {
+    return crs.startsWith('TMS');
+}
 
-const EPSG = [
-    'EPSG:4326',
-    'EPSG:3857',
-];
+function isEpsg(crs) {
+    return crs.startsWith('EPSG');
+}
 
 function formatToTms(crs) {
-    if (crs) {
-        if (crs.includes('WMTS')) {
-            return crs;
-        }
-        const i = EPSG.indexOf(crs);
-        if (i > -1) {
-            return TMS[i];
-        } else if (crs.includes('EPSG')) {
-            return `WMTS:TMS:${crs.replace('EPSG:', '')}`;
-        }
-    }
+    return isTms(crs) ? crs : `TMS:${crs.match(/\d+/)[0]}`;
 }
 
 function formatToEPSG(crs) {
-    if (crs) {
-        if (crs.includes('EPSG')) {
-            return crs;
-        } else if (EPSG[TMS.indexOf(crs)]) {
-            return EPSG[TMS.indexOf(crs)];
-        } else {
-            return `EPSG:${crs.match(/\d+/)[0]}`;
-        }
-    }
+    return isEpsg(crs) ? crs : `EPSG:${crs.match(/\d+/)[0]}`;
 }
 
 const UNIT = {
@@ -44,7 +24,7 @@ const UNIT = {
 };
 
 function is4326(crs) {
-    return crs.indexOf('EPSG:4326') == 0;
+    return crs === 'EPSG:4326';
 }
 
 function _unitFromProj4Unit(projunit) {
@@ -162,10 +142,14 @@ export default {
      */
     formatToEPSG,
     /**
-     * format crs to tile matrix set notation : WMTS:XXXX.
+     * format crs to tile matrix set notation : TMS:XXXX.
      *
      * @param      {string}  crs     The crs to format
      * @return     {string}  formated crs
      */
     formatToTms,
+    isTms,
+    isEpsg,
+    tms_3857: 'TMS:3857',
+    tms_4326: 'TMS:4326',
 };

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -4,6 +4,7 @@ import { ellipsoidSizes } from 'Core/Math/Ellipsoid';
 import { globalExtentTMS, schemeTiles } from 'Core/Geographic/Extent';
 import BuilderEllipsoidTile from 'Core/Prefab/Globe/BuilderEllipsoidTile';
 import { SIZE_DIAGONAL_TEXTURE } from 'Process/LayeredMaterialNodeProcessing';
+import CRS from 'Core/Geographic/Crs';
 
 // matrix to convert sphere to ellipsoid
 const worldToScaledEllipsoid = new THREE.Matrix4();
@@ -51,13 +52,13 @@ class GlobeLayer extends TiledGeometryLayer {
      */
     constructor(id, object3d, config = {}) {
         // Configure tiles
-        const scheme = schemeTiles.get('WMTS:WGS84');
+        const scheme = schemeTiles.get(CRS.tms_4326);
         const schemeTile = globalExtentTMS.get('EPSG:4326').subdivisionByScheme(scheme);
 
         // Supported tile matrix set for color/elevation layer
         config.tileMatrixSets = [
-            'WMTS:WGS84',
-            'WMTS:PM',
+            CRS.tms_4326,
+            CRS.tms_3857,
         ];
         const uvCount = config.tileMatrixSets.length;
         const builder = new BuilderEllipsoidTile({ projection: 'EPSG:4978', uvCount });

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -72,7 +72,7 @@ class GlobeView extends View {
      *
      * @example
      * var viewerDiv = document.getElementById('viewerDiv');
-     * var position = new itowns.Coordinates('WGS84', 2.35, 48.8, 25e6);
+     * var position = new itowns.Coordinates('EPSG:4326', 2.35, 48.8, 25e6);
      * var view = new itowns.GlobeView(viewerDiv, position);
      *
      * @example

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -38,10 +38,9 @@ class PlanarLayer extends TiledGeometryLayer {
      * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
     constructor(id, extent, object3d, config = {}) {
-        const tileMatrixSets = [];
         const tms = CRS.formatToTms(extent.crs);
-        tileMatrixSets.push(tms);
-        if (tms.includes(':TMS')) {
+        const tileMatrixSets = [tms];
+        if (!globalExtentTMS.get(extent.crs)) {
             // Add new global extent for this new projection.
             globalExtentTMS.set(extent.crs, extent);
         }

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -40,7 +40,7 @@ export default {
      * </ul>
      *
      * @example
-     * coords = new Coordinates('WMTS:WGS84', 12, 1410, 2072);
+     * coords = new Extent(CRS.formatToTms('EPSG:4326'), 12, 1410, 2072);
      * source.url = 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=%TILEMATRIX&TILEROW=%ROW&TILECOL=%COL';
      * url = URLBuilder.xyz(coords, source);
      *

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -147,7 +147,7 @@ class OBB extends THREE.Object3D {
             this.position.copy(position);
             this.quaternion.copy(quaternion);
             this.updateMatrixWorld(true);
-        } else if (!extent.isTiledCrs() && CRS.isMetricUnit(extent.crs)) {
+        } else if (!CRS.isTms(extent.crs) && CRS.isMetricUnit(extent.crs)) {
             extent.center(coord).toVector3(this.position);
             extent.dimensions(dimension);
             size.set(dimension.x, dimension.y, Math.abs(maxHeight - minHeight));

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -55,8 +55,8 @@ describe('Provide in Sources', function () {
     };
 
     const planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
-    const colorlayer = new ColorLayer('color', { projection: 'WMTS:PM' });
-    const elevationlayer = new ElevationLayer('elevation', { projection: 'WMTS:PM' });
+    const colorlayer = new ColorLayer('color', { projection: 'EPSG:3857' });
+    const elevationlayer = new ElevationLayer('elevation', { projection: 'EPSG:3857' });
 
     planarlayer.attach(colorlayer);
     planarlayer.attach(elevationlayer);

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { Box3, Vector3 } from 'three';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
+import CRS from 'Core/Geographic/Crs';
 
 describe('Extent', function () {
     const minX = 0;
@@ -114,36 +115,36 @@ describe('Extent', function () {
     });
 
     it('should clone tiled extent like expected', function () {
-        const withValues = new Extent('WMTS:WGS84', zoom, row, col);
+        const withValues = new Extent('TMS:4326', zoom, row, col);
         const clonedExtent = withValues.clone();
         assert.equal(clonedExtent.zoom, withValues.zoom);
         assert.equal(clonedExtent.row, withValues.row);
         assert.equal(clonedExtent.col, withValues.col);
     });
 
-    it('should isTiledCrs return true if extent is tiled extent', function () {
-        const withValues = new Extent('WMTS:WGS84G', zoom, row, col);
-        assert.ok(withValues.isTiledCrs());
+    it('should isTms return true if extent is tiled extent', function () {
+        const withValues = new Extent('TMS:4326', zoom, row, col);
+        assert.ok(CRS.isTms(withValues.crs));
     });
 
-    it('should convert extent WMTS:WGS84G like expected', function () {
-        const withValues = new Extent('WMTS:WGS84', 0, 0, 0).as('EPSG:4326');
+    it('should convert extent TMS:4326 like expected', function () {
+        const withValues = new Extent('TMS:4326', 0, 0, 0).as('EPSG:4326');
         assert.equal(-180, withValues.west);
         assert.equal(0, withValues.east);
         assert.equal(-90, withValues.south);
         assert.equal(90, withValues.north);
     });
 
-    it('should convert extent WMTS:PM to EPSG:3857 like expected', function () {
-        const withValues = new Extent('WMTS:PM', 0, 0, 0).as('EPSG:3857');
+    it('should convert extent TMS:3857 to EPSG:3857 like expected', function () {
+        const withValues = new Extent('TMS:3857', 0, 0, 0).as('EPSG:3857');
         assert.equal(-20037508.342789244, withValues.west);
         assert.equal(20037508.342789244, withValues.east);
         assert.equal(-20037508.342789244, withValues.south);
         assert.equal(20037508.342789244, withValues.north);
     });
 
-    it('should convert extent WMTS:PM to EPSG:4326 like expected', function () {
-        const withValues = new Extent('WMTS:PM', 0, 0, 0);
+    it('should convert extent TMS:3857 to EPSG:4326 like expected', function () {
+        const withValues = new Extent('TMS:3857', 0, 0, 0);
         const result = withValues.as('EPSG:4326');
         assert.equal(-180.00000000000003, result.west);
         assert.equal(180.00000000000003, result.east);
@@ -195,8 +196,8 @@ describe('Extent', function () {
     });
 
     it('should return expected offset using tiled extent', function () {
-        const withValues = new Extent('WMTS:WGS84G', zoom, row, col);
-        const parent = new Extent('WMTS:WGS84G', zoom - 2, row, col);
+        const withValues = new Extent('TMS:4326', zoom, row, col);
+        const parent = new Extent('TMS:4326', zoom - 2, row, col);
         const offset = withValues.offsetToParent(parent);
         assert.equal(offset.x, 0.5);
         assert.equal(offset.y, 0.5);
@@ -205,7 +206,7 @@ describe('Extent', function () {
     });
 
     it('should return expected tiled extent parent', function () {
-        const withValues = new Extent('WMTS:WGS84G', zoom, row, col);
+        const withValues = new Extent('TMS:4326', zoom, row, col);
         const parent = withValues.tiledExtentParent(zoom - 2);
         assert.equal(parent.zoom, 3);
         assert.equal(parent.row, 5);

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -41,12 +41,12 @@ describe('updateLayeredMaterialNodeImagery', function () {
         projection: 'EPSG:4326',
         info: { update: () => {} },
         tileMatrixSets: [
-            'WMTS:WGS84',
-            'WMTS:PM',
+            'TMS:4326',
+            'TMS:3857',
         ],
         parent: { tileMatrixSets: [
-            'WMTS:WGS84',
-            'WMTS:PM',
+            'TMS:4326',
+            'TMS:3857',
         ],
         },
     });

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -7,14 +7,14 @@ describe('URL creations', function () {
     const layer = {};
 
     it('should correctly replace ${x}, ${y} and ${z} by 359, 512 and 10', function () {
-        var coords = new Extent('WMTS:TMS:4857', 10, 512, 359);
+        var coords = new Extent('TMS:4857', 10, 512, 359);
         layer.url = 'http://server.geo/tms/${z}/${y}/${x}.jpg';
         const result = URLBuilder.xyz(coords, layer);
         assert.equal(result, 'http://server.geo/tms/10/512/359.jpg');
     });
 
     it('should correctly replace %COL, %ROW, %TILEMATRIX by 2072, 1410 and 12', function () {
-        const coords = new Extent('WMTS:WGS84', 12, 1410, 2072);
+        const coords = new Extent('TMS:4326', 12, 1410, 2072);
         layer.url = 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=%TILEMATRIX&TILEROW=%ROW&TILECOL=%COL';
         const result = URLBuilder.xyz(coords, layer);
         assert.equal(result, 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=12&TILEROW=1410&TILECOL=2072');

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -103,7 +103,7 @@ describe('Sources', function () {
 
         it('should instance and use WMTSSource', function () {
             const source = new WMTSSource(paramsWMTS);
-            const extent = new Extent('WMTS:PM', 5, 0, 0);
+            const extent = new Extent('TMS:3857', 5, 0, 0);
             assert.ok(source.isWMTSSource);
             assert.ok(source.urlFromExtent(extent));
             assert.ok(source.extentInsideLimit(extent));
@@ -121,7 +121,7 @@ describe('Sources', function () {
                 5: { minTileRow: 0, maxTileRow: 32, minTileCol: 0, maxTileCol: 32 },
             };
             const source = new WMTSSource(paramsWMTS);
-            const extent = new Extent('WMTS:PM', 5, 0, 0);
+            const extent = new Extent('TMS:3857', 5, 0, 0);
             assert.ok(source.isWMTSSource);
             assert.ok(source.urlFromExtent(extent));
             assert.ok(source.extentInsideLimit(extent));
@@ -186,7 +186,7 @@ describe('Sources', function () {
 
         it('should instance and use TMSSource', function () {
             const source = new TMSSource(paramsTMS);
-            const extent = new Extent('WMTS:PM', 5, 0, 0);
+            const extent = new Extent('TMS:3857', 5, 0, 0);
             assert.ok(source.isTMSSource);
             assert.ok(source.urlFromExtent(extent));
             assert.ok(source.extentInsideLimit(extent));


### PR DESCRIPTION
## Description
* unify and encapsulate crs.
* crs string aren't hard coded.
* there are two types of crs : `EPSG:XXXX` and `TMS:XXXX`

