### PR TITLE
feat(renderer): emit a (in)visible event for LayeredMaterial

### DIFF
--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -166,6 +166,18 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         this.uniforms.colorTextures = new THREE.Uniform(new Array(nbSamplers[1]).fill(null));
         this.uniforms.colorOffsetScales = new THREE.Uniform(new Array(nbSamplers[1]).fill(identityOffsetScale));
         this.uniforms.colorTextureCount = new THREE.Uniform(0);
+
+        let _visible = this.visible;
+        // can't do an ES6 setter/getter here
+        Object.defineProperty(this, 'visible', {
+            get() { return _visible; },
+            set(v) {
+                if (_visible != v) {
+                    _visible = v;
+                    this.dispatchEvent({ type: v ? 'shown' : 'hidden' });
+                }
+            },
+        });
     }
 
     getUniformByType(type) {

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -153,33 +153,24 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
                 // if we don't do that, our OBBHelper will never get removed,
                 // because once a node is invisible, children are not removed
                 // any more
-                // FIXME a proper way of notifying tile deletion to children layers should be implemented
-                const descriptor = Object.getOwnPropertyDescriptor(node.material, 'visible');
-                const getVisible = descriptor.get || (() => descriptor.value);
-                const setVisible = descriptor.set || ((value) => { descriptor.value = value; });
-                Object.defineProperty(node.material, 'visible', {
-                    get: getVisible,
-                    set: (value) => {
-                        setVisible(value);
-                        if (!value) {
-                            let i = node.children.length;
-                            while (i--) {
-                                const c = node.children[i];
-                                if (c.layer === sb_layer_id) {
-                                    if (c.dispose) {
-                                        c.dispose();
-                                    } else if (Array.isArray(c.material)) {
-                                        for (const material of c.material) {
-                                            material.dispose();
-                                        }
-                                    } else {
-                                        c.material.dispose();
-                                    }
-                                    node.children.splice(i, 1);
+                const hiddenHandler = node.material.addEventListener('hidden', () => {
+                    node.material.removeEventListener(hiddenHandler);
+                    let i = node.children.length;
+                    while (i--) {
+                        const c = node.children[i];
+                        if (c.layer === sb_layer_id) {
+                            if (c.dispose) {
+                                c.dispose();
+                            } else if (Array.isArray(c.material)) {
+                                for (const material of c.material) {
+                                    material.dispose();
                                 }
+                            } else {
+                                c.material.dispose();
                             }
+                            node.children.splice(i, 1);
                         }
-                    },
+                    }
                 });
             }
 


### PR DESCRIPTION
Knowing the visibility of a `LayeredMaterial` is useful. For example in a
`GlobeView`, if you zoom in, "parent" tiles seems hidden; in fact, there
are not, it is only their material (so `LayeredMaterial`) that is set to
not visible.

Adding an event when changing this property can be useful to hide others
things, like in `TileDebug`, or in later PR to come (#1303 for example).