### PR TITLE
fix(view): check every offset for eventToViewCoords

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -502,13 +502,15 @@ class View extends THREE.EventDispatcher {
      * @return {THREE.Vector2} - view coordinates (in pixels, 0-0 = top-left of the View)
      */
     eventToViewCoords(event, target = _eventCoords, touchIdx = 0) {
+        const br = this.domElement.getBoundingClientRect();
+
         if (event.touches === undefined || !event.touches.length) {
-            return target.set(event.offsetX, event.offsetY);
+            const targetBoundingRect = event.target.getBoundingClientRect();
+            return target.set(targetBoundingRect.x + event.offsetX - br.x,
+                targetBoundingRect.y + event.offsetY - br.y);
         } else {
-            const br = this.domElement.getBoundingClientRect();
-            return target.set(
-                event.touches[touchIdx].offsetX - br.x,
-                event.touches[touchIdx].offsetY - br.y);
+            return target.set(event.touches[touchIdx].clientX - br.x,
+                event.touches[touchIdx].clientY - br.y);
         }
     }
 

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -15,8 +15,8 @@ describe('GlobeControls', function () {
         preventDefault: () => {},
         button: THREE.MOUSE.LEFT,
         touches: [{
-            offsetX: 100,
-            offsetY: 200,
+            clientX: 100,
+            clientY: 200,
             pageX: 150,
             pageY: 200,
         }],
@@ -42,8 +42,8 @@ describe('GlobeControls', function () {
         viewer.domElement.emitEvent('mousedown', event);
 
         event.touches = [{
-            offsetX: 50,
-            offsetY: 100,
+            clientX: 50,
+            clientY: 100,
             pageX: 100,
             pageY: 100,
         }];


### PR DESCRIPTION
If the event is triggered on a child a `this.domElement`, an offset is
computed, given the bounding rectangle of both `this.domElement` and
`event.target`.