### PR TITLE
refactor(FileSource): pre-Parse file in constructor Layer.

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -91,7 +91,8 @@ test-unit -- --watch`.
 If you want to work on a single test and debug it, without having all the extra
 output, you can use this command `npm run base-test-unit test/unit/3dtiles.js`
 and of course replace 3dtiles.js with the correct filename. You can also append
-the `-- --watch` flag as well.
+the `-- --watch` flag as well. If you want disable reporting and keep error message
+in console add `--reporter min`.
 
 ## Contribute back
 

--- a/examples/source_file_geojson_3d.html
+++ b/examples/source_file_geojson_3d.html
@@ -47,7 +47,15 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
             // Add a geometry layer, which will contain the multipolygon to display
-            var marne = new itowns.GeometryLayer('Marne', new itowns.THREE.Group());
+            var marne = new itowns.GeometryLayer('Marne', new itowns.THREE.Group(), {
+                // Use a FileSource to load a single file once
+                source: new itowns.FileSource({
+                    url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/multipolygon.geojson',
+                    projection: 'EPSG:4326',
+                    format: 'application/json',
+                    zoom: { min: 10, max: 10 },
+                })
+            });
             marne.update = itowns.FeatureProcessing.update;
             marne.convert = itowns.Feature2Mesh.convert({
                 color: new itowns.THREE.Color(0xbbffbb),
@@ -55,13 +63,6 @@
             marne.transparent = true;
             marne.opacity = 0.7;
 
-            // Use a FileSource to load a single file once
-            marne.source = new itowns.FileSource({
-                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/multipolygon.geojson',
-                projection: 'EPSG:4326',
-                format: 'application/json',
-                zoom: { min: 10, max: 10 },
-            });
 
             view.addLayer(marne).then(function menu(layer) {
                 var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { STRATEGY_MIN_NETWORK_TRAFFIC } from 'Layer/LayerUpdateStrategy';
 import InfoLayer from 'Layer/InfoLayer';
 import Source from 'Source/Source';
+import { parseSourceData } from 'Provider/DataSourceProvider';
 
 /**
  * @property {boolean} isLayer - Used to checkout whether this layer is a Layer.
@@ -90,6 +91,10 @@ class Layer extends THREE.EventDispatcher {
         this.whenReady = new Promise((re, rj) => {
             this._resolve = re;
             this._reject = rj;
+        }).then(() => {
+            if (this.source.fetchedData && !this.source.parsedData) {
+                return parseSourceData(this.source.fetchedData, this.source.extent, this);
+            }
         }).then(() => {
             this.ready = true;
             return this;

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -11,7 +11,7 @@ const error = (err, source) => {
     throw err;
 };
 
-function parseSourceData(data, extDest, layer) {
+export function parseSourceData(data, extDest, layer) {
     const source = layer.source;
 
     const options = {

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -129,6 +129,15 @@ class FileSource extends Source {
 
         this.fetchedData = source.fetchedData;
         this.parsedData = source.parsedData;
+
+        if (!this.fetchedData && !this.parsedData) {
+            this.whenReady = this.fetcher(this.urlFromExtent(), this.networkOptions).then((f) => {
+                this.fetchedData = f;
+            });
+        }
+
+        this.whenReady.then(() => this.fetchedData);
+
         this.zoom = source.zoom || { min: 5, max: 21 };
     }
 

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -14,7 +14,7 @@ export const supportedFetchers = new Map([
     ['application/x-protobuf;type=mapbox-vector', Fetcher.arrayBuffer],
 ]);
 
-const supportedParsers = new Map([
+export const supportedParsers = new Map([
     ['geojson', GeoJsonParser.parse],
     ['application/json', GeoJsonParser.parse],
     ['application/kml', KMLParser.parse],

--- a/test/unit/1__start.js
+++ b/test/unit/1__start.js
@@ -3,3 +3,8 @@ import Renderer from './mock';
 // to add global.document
 const renderer = new Renderer();
 renderer.render();
+
+global.window = {};
+global.URL = function URL() {
+    this.ref = undefined;
+};

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -6,12 +6,11 @@ import TileMesh from 'Core/TileMesh';
 import Extent, { globalExtentTMS } from 'Core/Geographic/Extent';
 import OBB from 'Renderer/OBB';
 import DataSourceProvider from 'Provider/DataSourceProvider';
-import { supportedFetchers } from 'Source/Source';
+import { supportedFetchers, supportedParsers } from 'Source/Source';
 import TileProvider from 'Provider/TileProvider';
 import WMTSSource from 'Source/WMTSSource';
 import WMSSource from 'Source/WMSSource';
 import WFSSource from 'Source/WFSSource';
-import Fetcher from 'Provider/Fetcher';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import ColorLayer from 'Layer/ColorLayer';
 import ElevationLayer from 'Layer/ElevationLayer';
@@ -26,9 +25,13 @@ const holes = require('../data/geojson/holesPoints.geojson.json');
 describe('Provide in Sources', function () {
     const renderer = new Renderer();
     renderer.setClearColor();
-
-    supportedFetchers.set('image/png', () => Promise.resolve(new THREE.Texture()));
-    supportedFetchers.set('application/json', () => Promise.resolve(holes));
+    // /!\ Avoid to overload fetcher because could troubleshoot the other unit tests?
+    // formatTag to avoid it
+    const formatTag = 'dspUnitTest';
+    supportedFetchers.set(`${formatTag}image/png`, () => Promise.resolve(new THREE.Texture()));
+    supportedFetchers.set(`${formatTag}application/json`, () => Promise.resolve(holes));
+    supportedParsers.set(`${formatTag}image/png`, supportedParsers.get('image/png'));
+    supportedParsers.set(`${formatTag}application/json`, supportedParsers.get('application/json'));
 
     // Misc var to initialize a TileMesh instance
     const geom = new THREE.Geometry();
@@ -82,7 +85,7 @@ describe('Provide in Sources', function () {
     featureLayer.source = new WFSSource({
         url: 'http://',
         typeName: 'name',
-        format: 'application/json',
+        format: `${formatTag}application/json`,
         extent: globalExtent,
         projection: 'EPSG:3857',
         zoom: { min: zoom, max: zoom },
@@ -94,11 +97,6 @@ describe('Provide in Sources', function () {
     context.elevationLayers = [elevationlayer];
     context.colorLayers = [colorlayer];
 
-    after(function () {
-        supportedFetchers.set('image/png', Fetcher.texture);
-        supportedFetchers.set('application/json', Fetcher.json);
-    });
-
     beforeEach('reset state', function () {
         // clear commands array
         context.scheduler.commands = [];
@@ -108,7 +106,7 @@ describe('Provide in Sources', function () {
         colorlayer.source = new WMTSSource({
             url: 'http://',
             name: 'name',
-            format: 'image/png',
+            format: `${formatTag}image/png`,
             tileMatrixSet: 'PM',
             projection: 'EPSG:3857',
             extent: globalExtent,
@@ -136,7 +134,7 @@ describe('Provide in Sources', function () {
         elevationlayer.source = new WMTSSource({
             url: 'http://',
             name: 'name',
-            format: 'image/png',
+            format: `${formatTag}image/png`,
             tileMatrixSet: 'PM',
             projection: 'EPSG:3857',
             zoom: {
@@ -163,7 +161,7 @@ describe('Provide in Sources', function () {
         colorlayer.source = new WMSSource({
             url: 'http://',
             name: 'name',
-            format: 'image/png',
+            format: `${formatTag}image/png`,
             extent: globalExtent,
             projection: 'EPSG:3857',
             zoom: {

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -18,7 +18,7 @@ describe('Viewer', function () {
 
         globelayer = new GlobeLayer('globe', new THREE.Group());
         source = new FileSource({
-            url: '..',
+            parsedData: {},
             projection: 'EPSG:4326',
         });
 


### PR DESCRIPTION
## Description
* Fetch/Parse `FileSource` data when is added.
  * Fetch in `FileSource`
  * Parse fetched data in `Layer`: inline or by callBack? 
       ➡️ **I choose inline parsing.**

## Motivation and Context
* Build `FileSource#extent` on Layer adding.
* Remove specific test for `FileSource` in ProcessingFeature.
* Avoid multi fetch/parse/convert in ProcessingFeature for `FileSource`.


