### PR TITLE
feat(style): add partial support for stops in vector tiles

### DIFF
--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -167,6 +167,9 @@ class Style {
     constructor(params = {}) {
         this.isStyle = true;
 
+        this.minzoom = 0;
+        this.maxzoom = 24;
+
         params.fill = params.fill || {};
         params.stroke = params.stroke || {};
         params.point = params.point || {};
@@ -271,14 +274,15 @@ class Style {
     /**
      * set Style from vector tile layer properties.
      * @param {object} layer vector tile layer.
-     * @param {Number} zoom vector tile layer.
      * @param {Object} sprites vector tile layer.
      * @param {boolean} [symbolToCircle=false]
      * @returns {Style}
      */
-    setFromVectorTileLayer(layer, zoom, sprites, symbolToCircle = false) {
+    setFromVectorTileLayer(layer, sprites, symbolToCircle = false) {
         layer.layout = layer.layout || {};
         layer.paint = layer.paint || {};
+
+        const zoom = this.minzoom;
 
         if (layer.type === 'fill' && !this.fill.color) {
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['fill-color'] || layer.paint['fill-pattern']));

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -18,7 +18,6 @@ export function parseSourceData(data, extDest, layer) {
         buildExtent: source.isFileSource || !layer.isGeometryLayer,
         crsIn: source.projection,
         crsOut: layer.projection,
-        sprites: layer.sprites || source.sprites,
         // TODO FIXME: error in filtering vector tile
         // filteringExtent: extentDestination.as(layer.projection),
         filteringExtent: !source.isFileSource && layer.isGeometryLayer ? extDest.as(source.projection) : undefined,
@@ -28,7 +27,7 @@ export function parseSourceData(data, extDest, layer) {
         mergeFeatures: layer.mergeFeatures === undefined ? true : layer.mergeFeatures,
         withNormal: layer.isGeometryLayer !== undefined,
         withAltitude: layer.isGeometryLayer !== undefined,
-        symbolToCircle: layer.symbolToCircle || false,
+        layers: source.layers,
     };
 
     return source.parser(data, options).then(parsedFile => source.onParsedFile(parsedFile));

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -1,3 +1,5 @@
+import { featureFilter } from '@mapbox/mapbox-gl-style-spec';
+import Style from 'Core/Style';
 import TMSSource from 'Source/TMSSource';
 import Fetcher from 'Provider/Fetcher';
 
@@ -5,19 +7,37 @@ function toTMSUrl(url) {
     return url.replace(/\{/g, '${');
 }
 
+function checkStopsValues(obj, target) {
+    for (const p in obj) {
+        if (obj[p].stops) {
+            obj[p].stops.forEach(s => target.push(s[0]));
+        }
+    }
+}
+
 /**
  * @classdesc
- * VectorTilesSource are object containing informations on how to fetch vector tiles resources.
+ * VectorTilesSource are object containing informations on how to fetch vector
+ * tiles resources.
  *
- * @property {string} style - the url to json style.
- * @property {string} sprite - the base url to sprites folder.
- * @property {function} filter - function to filter vector tiles layers, the parameter function is a layer.
- *
+ * @property {function} filter - function to filter vector tiles layers, the
+ * parameter function is a layer.
+ * @property {boolean} [symbolToCircle=false] - If true, all symbols from a tile
+ * will be considered as circle, and render as circles.
  */
 class VectorTilesSource extends TMSSource {
     /**
      * @param {Object} source - An object that can contain all properties of a
      * VectorTilesSource and {@link Source}.
+     * @param {string|Object} source.style - The URL of the JSON style, of the
+     * JSON style directly.
+     * @param {string} [source.sprite] - The base URL to load informations about
+     * the sprite of the style. If this is set, it overrides the `sprite` value
+     * of the `source.style`.
+     * @param {string} [source.url] - The base URL to load the tiles. If no url
+     * is specified, it reads it from the loaded style. Read [the Mapbox Style
+     * Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)
+     * for more informations.
      *
      * @constructor
      */
@@ -28,47 +48,97 @@ class VectorTilesSource extends TMSSource {
         source.url = source.url || '.';
         super(source);
         const ffilter = source.filter || (() => true);
-        this.filter = [];
-        const promises = [];
+        this.layers = {};
+        this.styles = {};
+        let promise;
 
         if (source.style) {
-            promises.push(Fetcher.json(source.style).then((style) => {
-                const s = Object.keys(style.sources)[0];
-                const os = style.sources[s];
-
-                style.layers.forEach((layer) => {
-                    layer.sourceUid = this.uid;
-                    if (layer.type === 'background') {
-                        this.backgroundLayer = layer;
-                    } else if (ffilter(layer)) {
-                        this.filter.push(layer);
-                    }
-                });
-                if (this.url == '.') {
-                    if (os.url) {
-                        return Fetcher.json(os.url).then((tileJSON) => {
-                            if (tileJSON.tiles[0]) {
-                                this.url = toTMSUrl(tileJSON.tiles[0]);
-                            }
-                        });
-                    } else if (os.tiles[0]) {
-                        this.url = toTMSUrl(os.tiles[0]);
-                    }
-                }
-            }));
+            if (typeof source.style == 'string') {
+                promise = Fetcher.json(source.style);
+            } else {
+                promise = Promise.resolve(source.style);
+            }
         } else {
             throw new Error('New VectorTilesSource: style is required');
         }
-        if (source.sprite) {
-            promises.push(Fetcher.json(`${source.sprite}.json`).then((sprites) => {
-                this.sprites = sprites;
-                return Fetcher.texture(`${source.sprite}.png`, { crossOrigin: 'anonymous' }).then((texture) => {
-                    this.sprites.img = texture.image;
-                });
-            }));
-        }
 
-        this.whenReady = Promise.all(promises);
+        this.whenReady = promise.then((style) => {
+            const baseurl = source.sprite || style.sprite;
+            if (baseurl) {
+                return Fetcher.json(`${baseurl}.json`).then((sprites) => {
+                    this.sprites = sprites;
+                    return Fetcher.texture(`${baseurl}.png`, this.networkOptions).then((texture) => {
+                        this.sprites.img = texture.image;
+                        return style;
+                    });
+                });
+            }
+
+            return style;
+        }).then((style) => {
+            const s = Object.keys(style.sources)[0];
+            const os = style.sources[s];
+
+            style.layers.forEach((layer) => {
+                layer.sourceUid = this.uid;
+                if (layer.type === 'background') {
+                    this.backgroundLayer = layer;
+                } else if (ffilter(layer)) {
+                    // TODO: add support for expressions
+                    // https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions
+                    const stops = [];
+                    stops.push(layer.minzoom == undefined ? 2 : layer.minzoom);
+                    checkStopsValues(layer.layout, stops);
+                    checkStopsValues(layer.paint, stops);
+                    stops.push(layer.maxzoom == undefined ? 24 : layer.maxzoom);
+                    stops.sort((a, b) => (a - b));
+
+                    this.styles[layer.id] = [];
+                    for (let i = 0; i < stops.length - 1; i++) {
+                        if (stops[i] == stops[i + 1]) { continue; }
+                        const style = new Style();
+                        style.minzoom = stops[i];
+                        style.maxzoom = stops[i + 1];
+                        style.setFromVectorTileLayer(layer, this.sprites, this.symbolToCircle);
+                        this.styles[layer.id].push(style);
+                    }
+
+                    if (!this.layers[layer['source-layer']]) {
+                        this.layers[layer['source-layer']] = [];
+                    }
+
+                    this.layers[layer['source-layer']].push({
+                        id: layer.id,
+                        filterExpression: featureFilter(layer.filter),
+                        minzoom: stops[0],
+                        maxzoom: stops[stops.length - 1],
+                    });
+                }
+            });
+
+            if (this.url == '.') {
+                if (os.url) {
+                    return Fetcher.json(os.url).then((tileJSON) => {
+                        if (tileJSON.tiles[0]) {
+                            this.url = toTMSUrl(tileJSON.tiles[0]);
+                        }
+                    });
+                } else if (os.tiles[0]) {
+                    this.url = toTMSUrl(os.tiles[0]);
+                }
+            }
+        });
+    }
+
+    onParsedFile(collection) {
+        collection.features.forEach((feature) => {
+            feature.style = this.getStyleFromIdZoom(feature.id, collection.extent.zoom);
+        });
+        return collection;
+    }
+
+    getStyleFromIdZoom(id, zoom) {
+        return this.styles[id].find(s => s.minzoom <= zoom && s.maxzoom > zoom);
     }
 }
 

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -22,18 +22,26 @@ class DOMElement {
         this.clientHeight = 300;
         this.width = 400;
         this.height = 300;
+        this.events = new Map();
         this.style = {
             display: 'block',
         };
         document.documentElement = this;
     }
 
-    removeEventListener() {}
     focus() {}
     appendChild(c) { this.children.push(c); }
     cloneNode() { return Object.create(this); }
     getBoundingClientRect() { return { x: 0, y: 0, width: this.width, height: this.height }; }
-    addEventListener() {}
+    addEventListener(event, cb) { this.events.set(event, cb); }
+    removeEventListener() {}
+    emitEvent(event, params) {
+        const callback = this.events.get(event);
+        if (callback) {
+            return callback(params);
+        }
+    }
+    createSVGMatrix() {}
 }
 
 // Mock document object for Mocha.
@@ -71,15 +79,15 @@ global.document = {
             const img = new DOMElement();
             img.width = 10;
             img.height = 10;
+            Object.defineProperty(img, 'src', {
+                set: () => img.emitEvent('load'),
+            });
             return img;
         }
 
         return new DOMElement();
     },
-    createElementNS: () => ({
-        createSVGMatrix: () => { },
-    }),
-    // documentElement: this.domElement,
+    createElementNS: (_, type) => (global.document.createElement(type)),
 };
 
 class Renderer {


### PR DESCRIPTION
If there are `stops` in any property of the Style, they will be taken
into account to override `minzoom` and `maxzoom` to reflect those
`stops`.

Note that this is a partial support, as the Mapbox Style specs have evolved:
https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions