### PR TITLE
feat(layer): add `getCurrentMaxZoom` property to InfoLayer

### DIFF
--- a/src/Layer/InfoLayer.js
+++ b/src/Layer/InfoLayer.js
@@ -60,6 +60,16 @@ export class InfoTiledGeometryLayer extends InfoLayer {
             });
     }
 
+    get currentMaxTileZoom() {
+        let zoom = -1;
+        this.displayed.tiles.forEach((t) => {
+            if (t.extent.zoom > zoom) {
+                zoom = t.extent.zoom;
+            }
+        });
+        return zoom;
+    }
+
     clear() {
         this.displayed.tiles.clear();
     }


### PR DESCRIPTION
This new method returns the value of maximum zoom of all tiles presents
on the screen.