### PR TITLE
refacto(core): remove BuilderEllipsoidTile#OBB

### DIFF
--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -1,6 +1,5 @@
 import * as THREE from 'three';
 import Coordinates from 'Core/Geographic/Coordinates';
-import OBB from 'Renderer/OBB';
 import Extent from 'Core/Geographic/Extent';
 
 const PI_OV_FOUR = Math.PI / 4;
@@ -121,11 +120,6 @@ class BuilderEllipsoidTile {
             quaternion: quatToAlignLongitude.clone(),
             position: this.center(extent),
         };
-    }
-
-    // use for region for adaptation boundingVolume
-    OBB(boundingBox) {
-        return new OBB(boundingBox.min, boundingBox.max);
     }
 }
 

--- a/src/Core/Prefab/Planar/PlanarTileBuilder.js
+++ b/src/Core/Prefab/Planar/PlanarTileBuilder.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import OBB from 'Renderer/OBB';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 
@@ -53,11 +52,6 @@ class PlanarTileBuilder {
     // coord v tile to projected
     vProjecte(v, params) {
         params.projected.y = params.extent.south + v * (params.extent.north - params.extent.south);
-    }
-
-    // get oriented bounding box of tile
-    OBB(boundingBox) {
-        return new OBB(boundingBox.min, boundingBox.max);
     }
 
     computeSharableExtent(extent) {

--- a/src/Core/Prefab/TileBuilder.js
+++ b/src/Core/Prefab/TileBuilder.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import TileGeometry from 'Core/TileGeometry';
 import Cache from 'Core/Scheduler/Cache';
 import computeBuffers from 'Core/Prefab/computeBufferTileGeometry';
+import OBB from 'Renderer/OBB';
 
 const cacheBuffer = new Map();
 export default function newTileGeometry(builder, params) {
@@ -41,7 +42,7 @@ export default function newTileGeometry(builder, params) {
             }
 
             const geometry = new TileGeometry(params, buffers);
-            geometry.OBB = builder.OBB(geometry.boundingBox);
+            geometry.OBB = new OBB(geometry.boundingBox.min, geometry.boundingBox.max);
 
             geometry._count = 0;
             geometry.dispose = () => {

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -10,6 +10,7 @@ const size = new THREE.Vector3();
 const dimension = new THREE.Vector2();
 const center = new THREE.Vector3();
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
+let obb;
 
 class OBB extends THREE.Object3D {
     /**
@@ -80,26 +81,6 @@ class OBB extends THREE.Object3D {
     }
 
     /**
-     * Set bouding box value to points
-     *
-     * @param      {Array<THREE.Vector3>}  points  The points to set
-     * @return     {Array<THREE.Vector3>}  The points seted
-     */
-    toPoints(points) {
-        // top points of bounding box
-        points[0].set(this.box3D.max.x, this.box3D.max.y, this.box3D.max.z);
-        points[1].set(this.box3D.min.x, this.box3D.max.y, this.box3D.max.z);
-        points[2].set(this.box3D.min.x, this.box3D.min.y, this.box3D.max.z);
-        points[3].set(this.box3D.max.x, this.box3D.min.y, this.box3D.max.z);
-        points[4].set(this.box3D.max.x, this.box3D.max.y, this.box3D.min.z);
-        points[5].set(this.box3D.min.x, this.box3D.max.y, this.box3D.min.z);
-        points[6].set(this.box3D.min.x, this.box3D.min.y, this.box3D.min.z);
-        points[7].set(this.box3D.max.x, this.box3D.min.y, this.box3D.min.z);
-
-        return points;
-    }
-
-    /**
      * Determines if the sphere is above the XY space of the box
      *
      * @param      {Sphere}   sphere  The sphere
@@ -141,7 +122,9 @@ class OBB extends THREE.Object3D {
             };
 
             const geometry = new TileGeometry(paramsGeometry);
-            this.copy(builder.OBB(geometry.boundingBox));
+            obb.box3D.copy(geometry.boundingBox);
+            obb.natBox.copy(geometry.boundingBox);
+            this.copy(obb);
 
             this.updateZ(minHeight, maxHeight);
             this.position.copy(position);
@@ -159,5 +142,7 @@ class OBB extends THREE.Object3D {
         return this;
     }
 }
+
+obb = new OBB();
 
 export default OBB;

--- a/test/unit/obb.js
+++ b/test/unit/obb.js
@@ -23,9 +23,23 @@ describe('OBB', function () {
         assert.equal(obb.natBox.min.x, min.x);
         assert.equal(obb.natBox.max.x, max.x);
     });
+
     it('isSphereAboveXYBox should work properly', () => {
         const sphere = new THREE.Sphere(new THREE.Vector3(23, 0, 0), 5);
         assert.equal(obb.isSphereAboveXYBox(sphere), true);
+    });
+
+    it('updates the scale', () => {
+        const o1 = new OBB(min, max);
+        o1.z.min = -3;
+        o1.z.max = 5;
+        o1.updateScaleZ(2);
+        assert.equal(o1.z.min, -3);
+        assert.equal(o1.z.max, 5);
+        assert.equal(o1.z.scale, 2);
+        assert.equal(o1.z.delta, 16);
+        assert.equal(o1.box3D.min.z, -16);
+        assert.equal(o1.box3D.max.z, 20);
     });
 });
 


### PR DESCRIPTION
This method serves no real purpose, and having it here creates a
circular dependency, which is not good.

Solves #1381