### PR TITLE
refacto(controls): reuse picked position

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -639,7 +639,7 @@ class GlobeControls extends THREE.EventDispatcher {
         event.preventDefault();
 
         this.updateTarget();
-        previous = CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera);
+        previous = CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera, pickedPosition);
         this.state = this.states.inputToState(event.button, currentKey);
 
         const coords = this.view.eventToViewCoords(event);
@@ -680,7 +680,7 @@ class GlobeControls extends THREE.EventDispatcher {
         if (this.enabled === false || currentKey) { return; }
         this.player.stop();
         const point = this.view.getPickingPositionFromDepth(this.view.eventToViewCoords(event));
-        const range = this.getRange();
+        const range = this.getRange(point);
         if (point && range > this.minDistance) {
             return this.lookAtCoordinate({
                 coord: new Coordinates('EPSG:4978', point),
@@ -744,9 +744,9 @@ class GlobeControls extends THREE.EventDispatcher {
             this.dollyIn();
         }
 
-        const previousRange = this.getRange();
+        const previousRange = this.getRange(pickedPosition);
         this.update();
-        const newRange = this.getRange();
+        const newRange = this.getRange(pickedPosition);
         if (Math.abs(newRange - previousRange) / previousRange > 0.001) {
             this.dispatchEvent({
                 type: CONTROL_EVENTS.RANGE_CHANGED,
@@ -974,26 +974,32 @@ class GlobeControls extends THREE.EventDispatcher {
 
     /**
      * Returns the "range": the distance in meters between the camera and the current central point on the screen.
+     * @param {THREE.Vector3} [position] - The position to consider as picked on
+     * the ground.
      * @return {number} number
      */
-    getRange() {
-        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera).range;
+    getRange(position) {
+        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera, position).range;
     }
 
     /**
      * Returns the tilt of the current camera in degrees.
-     * @return {Angle} number - The angle of the rotation in degrees.
+     * @param {THREE.Vector3} [position] - The position to consider as picked on
+     * the ground.
+     * @return {number} The angle of the rotation in degrees.
      */
-    getTilt() {
-        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera).tilt;
+    getTilt(position) {
+        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera, position).tilt;
     }
 
     /**
      * Returns the heading of the current camera in degrees.
-     * @return {Angle} number - The angle of the rotation in degrees.
+     * @param {THREE.Vector3} [position] - The position to consider as picked on
+     * the ground.
+     * @return {number} The angle of the rotation in degrees.
      */
-    getHeading() {
-        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera).heading;
+    getHeading(position) {
+        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera, position).heading;
     }
 
     /**
@@ -1013,7 +1019,8 @@ class GlobeControls extends THREE.EventDispatcher {
      * @return {Array<number>}
      */
     getCameraOrientation() {
-        return [this.getTilt(), this.getHeading()];
+        this.view.getPickingPositionFromDepth(null, pickedPosition);
+        return [this.getTilt(pickedPosition), this.getHeading(pickedPosition)];
     }
 
     /**


### PR DESCRIPTION
The picked position on the ground was computed 3 times for a mouse wheel
handling, while it was the same everytime. This has been fixed by adding
a parameter to `CameraUtils#getTransformCameraLookingAtTarget`.

This impacts only `GlobeControls` as far as I know. One thing I'm not sure on is the impact on the `getLookAtFromMath` part. I don't see when this is used, beside for functional testing ?

### Before
<img width="379" alt="Capture d’écran 2020-05-12 à 13 15 42" src="https://user-images.githubusercontent.com/741255/81680145-142e5a80-9453-11ea-9ec1-e5830e31d3c7.png">

### After
<img width="343" alt="Capture d’écran 2020-05-12 à 13 17 25" src="https://user-images.githubusercontent.com/741255/81680158-1690b480-9453-11ea-9880-9cbf7d4c5dc7.png">
