### PR TITLE
fix: sort features by order in VectorTileParser

### DIFF
--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -146,6 +146,7 @@ function readPBF(file, options) {
     });
 
     collection.removeEmptyFeature();
+    collection.features.sort((a, b) => a.order - b.order);
     // TODO verify if is needed to updateExtent for previous features.
     collection.updateExtent();
     collection.extent = file.extent;

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -79,7 +79,7 @@ class VectorTilesSource extends TMSSource {
             const s = Object.keys(style.sources)[0];
             const os = style.sources[s];
 
-            style.layers.forEach((layer) => {
+            style.layers.forEach((layer, order) => {
                 layer.sourceUid = this.uid;
                 if (layer.type === 'background') {
                     this.backgroundLayer = layer;
@@ -109,6 +109,7 @@ class VectorTilesSource extends TMSSource {
 
                     this.layers[layer['source-layer']].push({
                         id: layer.id,
+                        order,
                         filterExpression: featureFilter(layer.filter),
                         minzoom: stops[0],
                         maxzoom: stops[stops.length - 1],


### PR DESCRIPTION
This was removed in 0bca7c4, but it is necessary because features in a
mvt/pbf isn't always in the right order when reading it.

#### What we currently have (no fix)

<img width="328" alt="Capture d’écran 2020-05-13 à 09 09 28" src="https://user-images.githubusercontent.com/741255/81782064-88bbd480-94f9-11ea-818b-7db54743ba2d.png">

#### What we should have (fix)

<img width="396" alt="Capture d’écran 2020-05-13 à 09 09 06" src="https://user-images.githubusercontent.com/741255/81782067-8b1e2e80-94f9-11ea-8b21-6456e2dad28a.png">

