### PR TITLE
fix(source): set the Style.minzoom correctly in VectorTilesSource

### DIFF
--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -167,8 +167,10 @@ class Style {
     constructor(params = {}) {
         this.isStyle = true;
 
-        this.minzoom = 0;
-        this.maxzoom = 24;
+        this.zoom = {
+            min: 0,
+            max: 24,
+        };
 
         params.fill = params.fill || {};
         params.stroke = params.stroke || {};
@@ -282,7 +284,7 @@ class Style {
         layer.layout = layer.layout || {};
         layer.paint = layer.paint || {};
 
-        const zoom = this.minzoom;
+        const zoom = this.zoom.min;
 
         if (layer.type === 'fill' && !this.fill.color) {
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['fill-color'] || layer.paint['fill-pattern']));

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -127,7 +127,7 @@ function readPBF(file, options) {
 
         for (let i = sourceLayer.length - 1; i >= 0; i--) {
             const vtFeature = sourceLayer.feature(i);
-            const layers = options.layers[layer_id].filter(l => l.filterExpression.filter({ zoom: z }, vtFeature) && z >= l.minzoom && z < l.maxzoom);
+            const layers = options.layers[layer_id].filter(l => l.filterExpression.filter({ zoom: z }, vtFeature) && z >= l.zoom.min && z < l.zoom.max);
             let feature;
 
             for (const layer of layers) {
@@ -174,7 +174,7 @@ export default {
      * @param {function=} options.filter - Filter function to remove features.
      * @param {Object} options.layers - Object containing subobject with
      * informations on a specific layer. Informations available is `id`,
-     * `filterExpression`, `minzoom` and `maxzoom`. See {@link
+     * `filterExpression`, `zoom.min` and `zoom.max`. See {@link
      * VectorTilesSource} for more precision. The key of each information is the
      * `source-layer` property of the layer.
      * @param {string=} options.isInverted - This option is to be set to the

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -91,8 +91,8 @@ class VectorTilesSource extends TMSSource {
                     checkStopsValues(layer.paint, stops);
 
                     let minStop = Math.min(...stops);
-                    // if none is found, default to 2
-                    minStop = (minStop == Infinity) ? 2 : minStop;
+                    // if none is found, default to 0
+                    minStop = (minStop == Infinity) ? 0 : minStop;
                     // compare to layer.minzoom and take the highest
                     minStop = (layer.minzoom == undefined) ? minStop : Math.max(layer.minzoom, minStop);
 

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -86,12 +86,22 @@ class VectorTilesSource extends TMSSource {
                 } else if (ffilter(layer)) {
                     // TODO: add support for expressions
                     // https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions
-                    const stops = [];
-                    stops.push(layer.minzoom == undefined ? 2 : layer.minzoom);
+                    let stops = [];
                     checkStopsValues(layer.layout, stops);
                     checkStopsValues(layer.paint, stops);
+
+                    let minStop = Math.min(...stops);
+                    // if none is found, default to 2
+                    minStop = (minStop == undefined || minStop == Infinity) ? 2 : minStop;
+                    // compare to layer.minzoom and take the highest
+                    minStop = (layer.minzoom == undefined) ? minStop : Math.max(layer.minzoom, minStop);
+
+                    stops.push(minStop);
                     stops.push(layer.maxzoom == undefined ? 24 : layer.maxzoom);
                     stops.sort((a, b) => (a - b));
+
+                    // remove all value < minStop
+                    stops = stops.filter(s => s >= minStop);
 
                     this.styles[layer.id] = [];
                     for (let i = 0; i < stops.length - 1; i++) {

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -107,8 +107,8 @@ class VectorTilesSource extends TMSSource {
                     for (let i = 0; i < stops.length - 1; i++) {
                         if (stops[i] == stops[i + 1]) { continue; }
                         const style = new Style();
-                        style.minzoom = stops[i];
-                        style.maxzoom = stops[i + 1];
+                        style.zoom.min = stops[i];
+                        style.zoom.max = stops[i + 1];
                         style.setFromVectorTileLayer(layer, this.sprites, this.symbolToCircle);
                         this.styles[layer.id].push(style);
                     }
@@ -121,8 +121,10 @@ class VectorTilesSource extends TMSSource {
                         id: layer.id,
                         order,
                         filterExpression: featureFilter(layer.filter),
-                        minzoom: stops[0],
-                        maxzoom: stops[stops.length - 1],
+                        zoom: {
+                            min: stops[0],
+                            max: stops[stops.length - 1],
+                        },
                     });
                 }
             });
@@ -149,7 +151,7 @@ class VectorTilesSource extends TMSSource {
     }
 
     getStyleFromIdZoom(id, zoom) {
-        return this.styles[id].find(s => s.minzoom <= zoom && s.maxzoom > zoom);
+        return this.styles[id].find(s => s.zoom.min <= zoom && s.zoom.max > zoom);
     }
 }
 

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -92,7 +92,7 @@ class VectorTilesSource extends TMSSource {
 
                     let minStop = Math.min(...stops);
                     // if none is found, default to 2
-                    minStop = (minStop == undefined || minStop == Infinity) ? 2 : minStop;
+                    minStop = (minStop == Infinity) ? 2 : minStop;
                     // compare to layer.minzoom and take the highest
                     minStop = (layer.minzoom == undefined) ? minStop : Math.max(layer.minzoom, minStop);
 

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -19,13 +19,15 @@ describe('Vector tiles', function () {
         });
     }
 
-    it('returns two squares', () => {
+    it('returns two squares', (done) => {
         parse(multipolygon, {
             geojson: [{
                 id: 0,
                 filterExpression: { filter: () => true },
-                minzoom: 1,
-                maxzoom: 24,
+                zoom: {
+                    min: 1,
+                    max: 24,
+                },
             }],
         }).then((collection) => {
             const feature = collection.features[0];
@@ -41,18 +43,22 @@ describe('Vector tiles', function () {
             assert.equal(square1[1], square1[4 * size + 1]);
             assert.equal(square2[0], square2[4 * size]);
             assert.equal(square2[1], square2[4 * size + 1]);
+
+            done();
         });
     });
 
-    it('returns nothing', () => {
+    it('returns nothing', (done) => {
         parse(null).then((collection) => {
             assert.equal(collection, undefined);
+            done();
         });
     });
 
-    it('filters all features out', () => {
+    it('filters all features out', (done) => {
         parse(multipolygon, {}).then((collection) => {
             assert.equal(collection.features.length, 0);
+            done();
         });
     });
 
@@ -144,13 +150,13 @@ describe('Vector tiles', function () {
             });
             source.whenReady.then(() => {
                 assert.equal(source.styles.land.length, 1);
-                assert.equal(source.styles.land[0].minzoom, 5);
-                assert.equal(source.styles.land[0].maxzoom, 13);
+                assert.equal(source.styles.land[0].zoom.min, 5);
+                assert.equal(source.styles.land[0].zoom.max, 13);
                 done();
             });
         });
 
-        it('sets the correct Style#minzoom', (done) => {
+        it('sets the correct Style#zoom.min', (done) => {
             const source = new VectorTilesSource({
                 url: 'fakeurl',
                 style: {
@@ -200,11 +206,11 @@ describe('Vector tiles', function () {
             });
 
             source.whenReady.then(() => {
-                assert.equal(source.styles.first[0].minzoom, 0);
-                assert.equal(source.styles.second[0].minzoom, 5);
-                assert.equal(source.styles.third[0].minzoom, 4);
-                assert.equal(source.styles.fourth[0].minzoom, 1);
-                assert.equal(source.styles.fifth[0].minzoom, 4);
+                assert.equal(source.styles.first[0].zoom.min, 0);
+                assert.equal(source.styles.second[0].zoom.min, 5);
+                assert.equal(source.styles.third[0].zoom.min, 4);
+                assert.equal(source.styles.fourth[0].zoom.min, 1);
+                assert.equal(source.styles.fifth[0].zoom.min, 4);
                 done();
             });
         });

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -149,5 +149,74 @@ describe('Vector tiles', function () {
                 done();
             });
         });
+
+        it('sets the correct Style#minzoom', (done) => {
+            const source = new VectorTilesSource({
+                url: 'fakeurl',
+                style: {
+                    sources: { geojson: {} },
+                    layers: [{
+                        // minzoom is 2 (default value)
+                        id: 'first',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                        },
+                    }, {
+                        // minzoom is 5 (specified)
+                        id: 'second',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                        },
+                        minzoom: 5,
+                    }, {
+                        // minzoom is 4 (first stop)
+                        id: 'third',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                            'fill-opacity': { stops: [[4, 1], [7, 0.5]] },
+                        },
+                    }, {
+                        // minzoom is 3 (specified is higher than first stop)
+                        id: 'fourth',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                            'fill-opacity': { stops: [[1, 1], [7, 0.5]] },
+                        },
+                        minzoom: 3,
+                    }, {
+                        // minzoom is 1 (first stop and no specified minzoom)
+                        id: 'fifth',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                            'fill-opacity': { stops: [[1, 1], [7, 0.5]] },
+                        },
+                    }, {
+                        // minzoom is 4 (first stop is higher than specified)
+                        id: 'sixth',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                            'fill-opacity': { stops: [[4, 1], [7, 0.5]] },
+                        },
+                        minzoom: 3,
+                    }],
+                },
+            });
+
+            source.whenReady.then(() => {
+                assert.equal(source.styles.first[0].minzoom, 2);
+                assert.equal(source.styles.second[0].minzoom, 5);
+                assert.equal(source.styles.third[0].minzoom, 4);
+                assert.equal(source.styles.fourth[0].minzoom, 3);
+                assert.equal(source.styles.fifth[0].minzoom, 1);
+                assert.equal(source.styles.sixth[0].minzoom, 4);
+                done();
+            });
+        });
     });
 });

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -156,7 +156,7 @@ describe('Vector tiles', function () {
                 style: {
                     sources: { geojson: {} },
                     layers: [{
-                        // minzoom is 2 (default value)
+                        // minzoom is 0 (default value)
                         id: 'first',
                         type: 'fill',
                         paint: {
@@ -179,17 +179,8 @@ describe('Vector tiles', function () {
                             'fill-opacity': { stops: [[4, 1], [7, 0.5]] },
                         },
                     }, {
-                        // minzoom is 3 (specified is higher than first stop)
-                        id: 'fourth',
-                        type: 'fill',
-                        paint: {
-                            'fill-color': 'rgb(255, 0, 0)',
-                            'fill-opacity': { stops: [[1, 1], [7, 0.5]] },
-                        },
-                        minzoom: 3,
-                    }, {
                         // minzoom is 1 (first stop and no specified minzoom)
-                        id: 'fifth',
+                        id: 'fourth',
                         type: 'fill',
                         paint: {
                             'fill-color': 'rgb(255, 0, 0)',
@@ -197,7 +188,7 @@ describe('Vector tiles', function () {
                         },
                     }, {
                         // minzoom is 4 (first stop is higher than specified)
-                        id: 'sixth',
+                        id: 'fifth',
                         type: 'fill',
                         paint: {
                             'fill-color': 'rgb(255, 0, 0)',
@@ -209,12 +200,11 @@ describe('Vector tiles', function () {
             });
 
             source.whenReady.then(() => {
-                assert.equal(source.styles.first[0].minzoom, 2);
+                assert.equal(source.styles.first[0].minzoom, 0);
                 assert.equal(source.styles.second[0].minzoom, 5);
                 assert.equal(source.styles.third[0].minzoom, 4);
-                assert.equal(source.styles.fourth[0].minzoom, 3);
-                assert.equal(source.styles.fifth[0].minzoom, 1);
-                assert.equal(source.styles.sixth[0].minzoom, 4);
+                assert.equal(source.styles.fourth[0].minzoom, 1);
+                assert.equal(source.styles.fifth[0].minzoom, 4);
                 done();
             });
         });


### PR DESCRIPTION
The previous behavior was as follow:
- check the presence of `minzoom` for a specific layer
- if it is not present, use `2` has a default value
- insert this value to the `stops` array
The resulting problem is that if `minzoom` is not defined and the first
`stop` value was greater than 2, it was still adding a `2 to first stop`
step.

A solution has been added here, to consider that the `minzoom` is either
the specified minzoom, or whichever is the highest between 2 and the
littlest `stop`.
