### PR TITLE
fix(style): add onload handler for symbol icon

### DIFF
--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -374,12 +374,16 @@ class Style {
                 if (!this.icon) {
                     this.icon = {};
                     this.icon.dom = getImageFromSprite(sprites, iconSrc);
-                    this.icon.dom.width *= size;
-                    this.icon.dom.height *= size;
+
+                    this.icon.dom.onload = () => {
+                        this.icon.dom.width *= size;
+                        this.icon.dom.height *= size;
+
+                        this.icon.halfWidth = this.icon.dom.width / 2;
+                        this.icon.halfHeight = this.icon.dom.height / 2;
+                    };
 
                     this.icon.anchor = readVectorProperty(layer.layout['icon-anchor'], zoom) || 'center';
-                    this.icon.halfWidth = this.icon.dom.width / 2;
-                    this.icon.halfHeight = this.icon.dom.height / 2;
 
                     cacheStyle.set(this.icon, iconSrc, size, size);
                 }

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -27,6 +27,10 @@ class DOMElement {
             display: 'block',
         };
         document.documentElement = this;
+
+        Object.defineProperty(this, 'onload', {
+            set: f => f(),
+        });
     }
 
     focus() {}


### PR DESCRIPTION
When an icon was set for vector tiles' style, there could be an loading
time, even if we are using `toDataURL`. This results in width and height
being `0`.

This problem is fixed by using `onload` to scale the icon correctly.
