### PR TITLE
Rename collection feature geometries

### DIFF
--- a/examples/source_file_gpx_3d.html
+++ b/examples/source_file_gpx_3d.html
@@ -72,9 +72,9 @@
                         crsOut: view.referenceCrs,
                         mergeFeatures: true,
                     }))
-                    .then(features => itowns.Feature2Mesh.convert({
+                    .then(collection => itowns.Feature2Mesh.convert({
                         color: new itowns.THREE.Color(0xff0000),
-                    })(features))
+                    })(collection))
                     .then(function (mesh) {
                         if (mesh) {
                             mesh.traverse((m) => {

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -260,7 +260,7 @@
 
                 if (intersects.length) {
                     batchId = intersects[0].object.geometry.attributes.batchId.array[intersects[0].face.a];
-                    properties = intersects[0].object.feature.geometry[batchId].properties;
+                    properties = intersects[0].object.feature.geometries[batchId].properties;
                     Object.keys(properties).map(function (objectKey) {
                         var value = properties[objectKey];
                         var key = objectKey.toString();

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -217,7 +217,7 @@
 
                     if (intersects.length) {
                         batchId = intersects[0].object.geometry.attributes.batchId.array[intersects[0].face.a];
-                        properties = intersects[0].object.feature.geometry[batchId].properties;
+                        properties = intersects[0].object.feature.geometries[batchId].properties;
 
                         Object.keys(properties).map(function (objectKey) {
                             var value = properties[objectKey];

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -54,7 +54,7 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
             function isValidData(data) {
-                return data.features[0].geometry.length < 1000;
+                return data.features[0].geometries.length < 1000;
             }
 
             var wfsBuildingSource = new itowns.WFSSource({

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -143,7 +143,7 @@ function featureToPoint(feature, options) {
         vertices = new Float32Array(ptsIn);
     }
 
-    for (const geometry of feature.geometry) {
+    for (const geometry of feature.geometries) {
         const color = getProperty('color', options, randomColor, geometry.properties);
         const start = geometry.indices[0].offset;
         const count = geometry.indices[0].count;
@@ -188,12 +188,12 @@ function featureToLine(feature, options) {
 
     let lines;
 
-    if (feature.geometry.length > 1) {
-        const countIndices = (count - feature.geometry.length) * 2;
+    if (feature.geometries.length > 1) {
+        const countIndices = (count - feature.geometries.length) * 2;
         const indices = new Uint16Array(countIndices);
         let i = 0;
         // Multi line case
-        for (const geometry of feature.geometry) {
+        for (const geometry of feature.geometries) {
             const color = getProperty('color', options, randomColor, geometry.properties);
             const start = geometry.indices[0].offset;
             // To avoid integer overflow with indice value (16 bits)
@@ -223,11 +223,11 @@ function featureToLine(feature, options) {
         geom.setIndex(new THREE.BufferAttribute(indices, 1));
         lines = new THREE.LineSegments(geom, lineMaterial);
     } else {
-        const color = getProperty('color', options, randomColor, feature.geometry[0].properties);
+        const color = getProperty('color', options, randomColor, feature.geometries[0].properties);
         fillColorArray(colors, count, color);
         geom.setAttribute('color', new THREE.BufferAttribute(colors, 3, true));
         if (batchIds) {
-            const id = options.batchId(feature.geometry.properties, featureId);
+            const id = options.batchId(feature.geometries[0].properties, featureId);
             fillBatchIdArray(id, batchIds, 0, count);
             geom.setAttribute('batchId', new THREE.BufferAttribute(batchIds, 1));
         }
@@ -250,7 +250,7 @@ function featureToPolygon(feature, options) {
     const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
     let featureId = 0;
 
-    for (const geometry of feature.geometry) {
+    for (const geometry of feature.geometries) {
         const start = geometry.indices[0].offset;
         // To avoid integer overflow with indice value (16 bits)
         if (start > 0xffff) {
@@ -311,8 +311,8 @@ function area(contour, offset, count) {
 
 function featureToExtrudedPolygon(feature, options) {
     const ptsIn = feature.vertices;
-    const offset = feature.geometry[0].indices[0].offset;
-    const count = feature.geometry[0].indices[0].count;
+    const offset = feature.geometries[0].indices[0].offset;
+    const count = feature.geometries[0].indices[0].count;
     const isClockWise = area(ptsIn, offset, count) < 0;
 
     const normals = feature.normals;
@@ -326,7 +326,7 @@ function featureToExtrudedPolygon(feature, options) {
     const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
     let featureId = 0;
 
-    for (const geometry of feature.geometry) {
+    for (const geometry of feature.geometries) {
         const altitude = getProperty('altitude', options, 0, geometry.properties);
         const extrude = getProperty('extrude', options, 0, geometry.properties);
 
@@ -388,9 +388,9 @@ function featureToExtrudedPolygon(feature, options) {
 }
 
 /**
- * Convert a [Feature]{@link Feature#geometry}'s geometry to a Mesh
+ * Convert a [Feature]{@link Feature} to a Mesh
  *
- * @param {Object} feature - a Feature's geometry
+ * @param {Feature} feature - the feature to convert
  * @param {Object} options - options controlling the conversion
  * @param {number|function} options.altitude - define the base altitude of the mesh
  * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -107,7 +107,7 @@ function drawFeature(ctx, feature, extent, style, invCtxScale) {
     const extentDim = extent.dimensions();
     const scaleRadius = extentDim.x / ctx.canvas.width;
 
-    for (const geometry of feature.geometry) {
+    for (const geometry of feature.geometries) {
         if (geometry.extent.intersectsExtent(extent)) {
             const geoStyle = style.isStyle ? style : geometry.properties.style;
             if (feature.type === FEATURE_TYPES.POINT) {

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -163,7 +163,8 @@ export const FEATURE_TYPES = {
  * @property {number} size - the number of values of the array that should be associated with a coordinates.
  * The size is 3 with altitude and 2 without altitude.
  * @property {string} crs - Geographic or Geocentric coordinates system.
- * @property {Array.<FeatureGeometry>} geometry - The feature's geometry.
+ * @property {FeatureGeometry[]} geometries - An array containing all {@link
+ * FeatureGeometry}.
  * @property {Extent?} extent - The extent containing all the geometries
  * composing the feature.
  */
@@ -183,7 +184,7 @@ class Feature {
         } else {
             throw new Error(`Unsupported Feature type: ${type}`);
         }
-        this.geometry = [];
+        this.geometries = [];
         this.vertices = [];
         this.normals = options.withNormal ? [] : undefined;
         this.crs = crs;
@@ -203,7 +204,7 @@ class Feature {
      */
     bindNewGeometry() {
         const geometry = new FeatureGeometry(this);
-        this.geometry.push(geometry);
+        this.geometries.push(geometry);
         return geometry;
     }
     /**
@@ -220,7 +221,7 @@ class Feature {
      * @returns {number} the count of geometry.
      */
     get geometryCount() {
-        return this.geometry.length;
+        return this.geometries.length;
     }
 }
 
@@ -269,7 +270,7 @@ export class FeatureCollection {
      * Remove features that don't have [FeatureGeometry]{@link FeatureGeometry}.
      */
     removeEmptyFeature() {
-        this.features = this.features.filter(feature => feature.geometry.length);
+        this.features = this.features.filter(feature => feature.geometries.length);
     }
 
     /**
@@ -324,7 +325,7 @@ export class FeatureCollection {
     newFeatureByReference(feature) {
         const ref = new Feature(feature.type, this.crs, this.optionsFeature);
         ref.extent = feature.extent;
-        ref.geometry = feature.geometry;
+        ref.geometries = feature.geometries;
         ref.normals = feature.normals;
         ref.size = feature.size;
         ref.vertices = feature.vertices;

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -63,7 +63,7 @@ class LabelLayer extends Layer {
 
             const featureField = f.style && f.style.text.field;
 
-            f.geometry.forEach((g) => {
+            f.geometries.forEach((g) => {
                 const minzoom = (g.properties.style && g.properties.style.zoom.min)
                     || (f.style && f.style.zoom.min)
                     || (this.style && this.style.zoom && this.style.zoom.min);

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -115,14 +115,14 @@ function toFeatureType(jsonType) {
 
 const keyProperties = ['type', 'geometry', 'properties'];
 
-function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, featureCollection) {
+function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, collection) {
     if (options.filter && !options.filter(json.properties, json.geometry)) {
         return;
     }
 
     const jsonType = json.geometry.type.toLowerCase();
     const featureType = toFeatureType(jsonType);
-    const feature = options.mergeFeatures ? featureCollection.requestFeatureByType(featureType) : new Feature(featureType, crsOut, options);
+    const feature = options.mergeFeatures ? collection.requestFeatureByType(featureType) : new Feature(featureType, crsOut, options);
     const geometryCount = feature.geometryCount;
     const coordinates = jsonType != 'point' ? json.geometry.coordinates : [json.geometry.coordinates];
     const setAltitude = !options.overrideAltitudeInToZero && options.withAltitude;
@@ -145,21 +145,21 @@ function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, fea
 }
 
 function jsonFeaturesToFeatures(crsIn, crsOut, jsonFeatures, filteringExtent, options) {
-    const features = new FeatureCollection(crsOut, options);
+    const collection = new FeatureCollection(crsOut, options);
 
     for (const jsonFeature of jsonFeatures) {
-        const feature = jsonFeatureToFeature(crsIn, crsOut, jsonFeature, filteringExtent, options, features);
+        const feature = jsonFeatureToFeature(crsIn, crsOut, jsonFeature, filteringExtent, options, collection);
         if (feature && !options.mergeFeatures) {
-            features.pushFeature(feature);
+            collection.pushFeature(feature);
         }
     }
 
     if (options.mergeFeatures) {
-        features.removeEmptyFeature();
-        features.updateExtent();
+        collection.removeEmptyFeature();
+        collection.updateExtent();
     }
 
-    return features;
+    return collection;
 }
 
 /**

--- a/src/Utils/FeaturesUtils.js
+++ b/src/Utils/FeaturesUtils.js
@@ -138,38 +138,38 @@ export default {
      *
      * @param {Coordinates} coordinate - The coordinate for the filter
      * condition.
-     * @param {Feature|FeatureCollection} features - A single feature or a
+     * @param {Feature|FeatureCollection} collection - A single feature or a
      * collection of them, to filter given the previous coordinate.
      * @param {number} [epsilon=0.1] Tolerance around the coordinate (in
      * coordinate's unit).
      *
      * @return {Feature[]} Array of filtered features.
      */
-    filterFeaturesUnderCoordinate(coordinate, features, epsilon = 0.1) {
+    filterFeaturesUnderCoordinate(coordinate, collection, epsilon = 0.1) {
         const result = [];
 
         coord.copy(coordinate);
 
         // We can take this shortcut because either Feature and
         // FeatureCollection have an extent property
-        if (features.extent) {
-            coord.as(Crs.formatToEPSG(features.extent.crs), coord);
-            features.extent.as(coord.crs, ex);
+        if (collection.extent) {
+            coord.as(Crs.formatToEPSG(collection.extent.crs), coord);
+            collection.extent.as(coord.crs, ex);
 
             if (!ex.isPointInside(coord, epsilon)) {
                 return result;
             // Special case, because of the way tiles in VectorTileParser are
             // handled (see Feature2Texture for a similar solution)
-            } else if ((features.scale.x != 1 && features.scale.y != 1) || (features.translation.x != 0 && features.translation.y != 0)) {
-                coord.x = (coord.x + features.translation.x) * features.scale.x;
-                coord.y = (coord.y + features.translation.y) * features.scale.y;
-                if (features.scale.x != 1 && features.scale.y != 1) {
-                    epsilon *= Math.sqrt(features.scale.x ** 2 + features.scale.y ** 2);
+            } else if (collection.isFeatureCollection && (collection.scale.x != 1 && collection.scale.y != 1) || (collection.translation.x != 0 && collection.translation.y != 0)) {
+                coord.x = (coord.x + collection.translation.x) * collection.scale.x;
+                coord.y = (coord.y + collection.translation.y) * collection.scale.y;
+                if (collection.scale.x != 1 && collection.scale.y != 1) {
+                    epsilon *= Math.sqrt(collection.scale.x ** 2 + collection.scale.y ** 2);
                 }
             }
         }
-        if (Array.isArray(features.features)) {
-            for (const feature of features.features) {
+        if (collection.isFeatureCollection) {
+            for (const feature of collection.features) {
                 if (feature.extent && !feature.extent.isPointInside(coord, epsilon)) {
                     continue;
                 }

--- a/src/Utils/FeaturesUtils.js
+++ b/src/Utils/FeaturesUtils.js
@@ -113,7 +113,7 @@ function isFeatureSingleGeometryUnderCoordinate(coordinate, type, coordinates, e
 
 function isFeatureUnderCoordinate(coordinate, feature, epsilon, result) {
     const featCoord = coordinate.as(feature.crs);
-    for (const geometry of feature.geometry) {
+    for (const geometry of feature.geometries) {
         if (geometry.extent == undefined || geometry.extent.isPointInside(featCoord, epsilon)) {
             const offset = geometry.indices[0].offset * feature.size;
             const count = geometry.indices[0].count * feature.size;
@@ -176,8 +176,8 @@ export default {
 
                 isFeatureUnderCoordinate(coord, feature, epsilon, result);
             }
-        } else if (features.geometry) {
-            isFeatureUnderCoordinate(coord, features, epsilon, result);
+        } else if (collection.geometries) {
+            isFeatureUnderCoordinate(coord, collection, epsilon, result);
         }
 
         return result;

--- a/test/unit/feature2mesh.js
+++ b/test/unit/feature2mesh.js
@@ -31,9 +31,9 @@ describe('Feature2Mesh', function () {
     const parsed2 = GeoJsonParser.parse(geojson2, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, mergeFeatures: false });
 
     it('rect mesh area should match geometry extent', () =>
-        parsed.then((features) => {
-            const mesh = Feature2Mesh.convert()(features);
-            const extentSize = features.extent.dimensions();
+        parsed.then((collection) => {
+            const mesh = Feature2Mesh.convert()(collection);
+            const extentSize = collection.extent.dimensions();
 
             assert.equal(
                 extentSize.x * extentSize.y,
@@ -41,8 +41,8 @@ describe('Feature2Mesh', function () {
         }));
 
     it('square mesh area should match geometry extent minus holes', () =>
-        parsed.then((feature) => {
-            const mesh = Feature2Mesh.convert()(feature);
+        parsed.then((collection) => {
+            const mesh = Feature2Mesh.convert()(collection);
 
             const noHoleArea = computeAreaOfMesh(mesh.children[0]);
             const holeArea = computeAreaOfMesh(mesh.children[1]);
@@ -54,8 +54,8 @@ describe('Feature2Mesh', function () {
         }));
 
     it('convert points, lines and mesh', () =>
-        parsed2.then((features) => {
-            const mesh = Feature2Mesh.convert()(features);
+        parsed2.then((collection) => {
+            const mesh = Feature2Mesh.convert()(collection);
             assert.equal(mesh.children[0].type, 'Points');
             assert.equal(mesh.children[1].type, 'Line');
             assert.equal(mesh.children[2].type, 'Mesh');

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -42,7 +42,7 @@ describe('FeaturesUtils', function () {
             assert.equal(filter[0].type == FEATURE_TYPES.LINE, 1.0);
         }));
     it('should remember individual feature properties', () =>
-        promise.then((feature) => {
-            assert.equal(feature.features[2].geometry[0].properties.my_prop, 14);
+        promise.then((collection) => {
+            assert.equal(collection.features[2].geometry[0].properties.my_prop, 14);
         }));
 });

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -43,6 +43,6 @@ describe('FeaturesUtils', function () {
         }));
     it('should remember individual feature properties', () =>
         promise.then((collection) => {
-            assert.equal(collection.features[2].geometry[0].properties.my_prop, 14);
+            assert.equal(collection.features[2].geometries[0].properties.my_prop, 14);
         }));
 });


### PR DESCRIPTION
Two quick commits, to harmonized two things.

- chore: rename some features variables to collection to avoid confusion
- refacto(core): rename `Feature#geometry` to `Feature#geometries`
**BREAKING CHANGES**: `Feature#geometry` is no longer available, use
`Feature#geometries` instead.

