### PR TITLE
fix(layer): hide labels when hiding LabelLayers

### DIFF
--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -67,6 +67,7 @@ class Label extends THREE.Object3D {
         });
 
         this.isLabel = true;
+        this.forceHidden = false;
         this.coordinates = coordinates;
 
         this.projectedPosition = { x: 0, y: 0 };

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -67,7 +67,6 @@ class Label extends THREE.Object3D {
         });
 
         this.isLabel = true;
-        this.forceHidden = false;
         this.coordinates = coordinates;
 
         this.projectedPosition = { x: 0, y: 0 };

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -101,6 +101,12 @@ class TileMesh extends THREE.Mesh {
             this.material.updateLayersUniforms();
         }
     }
+
+    findClosestDomElement() {
+        if (this.parent.isTileMesh) {
+            return this.parent.domElement || this.parent.findClosestDomElement();
+        }
+    }
 }
 
 export default TileMesh;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -74,6 +74,10 @@ function _preprocessLayer(view, layer, parentLayer) {
         labelLayer.source = source;
         labelLayer.style = layer.style;
 
+        layer.addEventListener('visible-property-changed', () => {
+            labelLayer.visible = layer.visible;
+        });
+
         layer.whenReady = layer.whenReady.then(() => {
             view.addLayer(labelLayer);
             return layer;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -80,6 +80,7 @@ function _preprocessLayer(view, layer, parentLayer) {
 
         layer.whenReady = layer.whenReady.then(() => {
             view.addLayer(labelLayer);
+            view.mainLoop.gfxEngine.label2dRenderer.registerLayer(labelLayer);
             return layer;
         });
     }

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -27,6 +27,7 @@ class LabelLayer extends Layer {
 
         this.isLabelLayer = true;
         this.crs = crs;
+        this.defineLayerProperty('visible', true);
     }
 
     /**
@@ -117,7 +118,7 @@ class LabelLayer extends Layer {
             return;
         }
 
-        if (this.frozen || !node.visible) {
+        if (this.frozen || !node.visible || !this.visible) {
             return;
         }
 
@@ -210,6 +211,10 @@ class LabelLayer extends Layer {
                     renderer.hideNodeDOM(node);
                     result.forEach(labels => labels.forEach(label => node.remove(label)));
                     node.domElement.parentElement.removeChild(node.domElement);
+                });
+
+                this.addEventListener('visible-property-changed', (event) => {
+                    result.forEach(labels => labels.forEach((label) => { label.forceHidden = !event.target.visible; }));
                 });
             }
 

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -27,7 +27,10 @@ class LabelLayer extends Layer {
 
         this.isLabelLayer = true;
         this.crs = crs;
-        this.defineLayerProperty('visible', true);
+        this.domElement = document.createElement('div');
+        this.defineLayerProperty('visible', true, () => {
+            this.domElement.style.display = this.visible ? 'block' : 'none';
+        });
     }
 
     /**
@@ -191,7 +194,7 @@ class LabelLayer extends Layer {
                 // Add all labels for this tile at once to batch it
                 node.domElement = document.createElement('div');
                 node.domElement.append(...labelsDiv);
-                renderer.domElement.appendChild(node.domElement);
+                (node.findClosestDomElement() || this.domElement).appendChild(node.domElement);
                 node.domElementVisible = true;
 
                 // Batch update the dimensions of labels all at once to avoid
@@ -211,10 +214,6 @@ class LabelLayer extends Layer {
                     renderer.hideNodeDOM(node);
                     result.forEach(labels => labels.forEach(label => node.remove(label)));
                     node.domElement.parentElement.removeChild(node.domElement);
-                });
-
-                this.addEventListener('visible-property-changed', (event) => {
-                    result.forEach(labels => labels.forEach((label) => { label.forceHidden = !event.target.visible; }));
                 });
             }
 

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -148,7 +148,7 @@ class Label2DRenderer {
             object.children.forEach(c => this.culling(c, currentMaxZoom, extent));
         // By verifying the maxzoom and the presence of the label inside the
         // visible extent, we can filter more labels.
-        } else if (object.zoom.max <= currentMaxZoom || !extent.isPointInside(object.coordinates)) {
+        } else if (object.forceHidden || object.zoom.max <= currentMaxZoom || !extent.isPointInside(object.coordinates)) {
             this.grid.hidden.push(object);
         } else {
             vector.setFromMatrixPosition(object.matrixWorld);

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -111,6 +111,10 @@ class Label2DRenderer {
         this.grid.resize();
     }
 
+    registerLayer(layer) {
+        this.domElement.appendChild(layer.domElement);
+    }
+
     render(scene, camera) {
         if (!this.infoTileLayer) { return; }
         this.grid.reset();
@@ -148,7 +152,7 @@ class Label2DRenderer {
             object.children.forEach(c => this.culling(c, currentMaxZoom, extent));
         // By verifying the maxzoom and the presence of the label inside the
         // visible extent, we can filter more labels.
-        } else if (object.forceHidden || object.zoom.max <= currentMaxZoom || !extent.isPointInside(object.coordinates)) {
+        } else if (object.zoom.max <= currentMaxZoom || !extent.isPointInside(object.coordinates)) {
             this.grid.hidden.push(object);
         } else {
             vector.setFromMatrixPosition(object.matrixWorld);


### PR DESCRIPTION
When hiding a `LabelLayer`, hide its associated `Label`s using
`forceHidden`. A check is then added in `Label2DRenderer` to hide all
`Label`s is needed.

Also, when hiding the layer that `LabelLayer` is associated with (if
any), it hides the `LabelLayer` as well.