### PR TITLE
Style inheritance

### DIFF
--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -75,7 +75,7 @@ var FeatureToolTip = (function _() {
             feature = features[p];
 
             geometry = feature.geometry;
-            style = (layer.style && layer.style.isStyle) ? layer.style : (feature.style || feature.geometry.properties.style);
+            style = (geometry.properties && geometry.properties.style) || feature.style || layer.style;
             fill = style.fill.color;
             stroke = '1.25px ' + style.stroke.color;
 

--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -57,12 +57,12 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
             var optionsGeoJsonParser = {
-                        buildExtent: true,
-                        crsIn: 'EPSG:4326',
-                        crsOut: view.tileLayer.extent.crs,
-                        mergeFeatures: true,
-                        withNormal: false,
-                        withAltitude: false,
+                buildExtent: true,
+                crsIn: 'EPSG:4326',
+                crsOut: view.tileLayer.extent.crs,
+                mergeFeatures: true,
+                withNormal: false,
+                withAltitude: false,
             };
 
             // Convert by iTowns
@@ -74,19 +74,21 @@
                         parsedData,
                     });
 
+                    var ariegeStyle = new itowns.Style({
+                        fill: {
+                            color: 'orange',
+                            opacity: 0.5,
+                        },
+                        stroke: {
+                            color:'white',
+                        },
+                    });
+
                     var ariegeLayer = new itowns.ColorLayer('ariege', {
                         name: 'ariege',
                         transparent: true,
-                        style: {
-                            fill: {
-                              color: 'orange',
-                              opacity: 0.5,
-                            },
-                            stroke: {
-                                color:'white',
-                            },
-                        },
                         source: ariegeSource,
+                        style: ariegeStyle,
                     });
 
                     return view.addLayer(ariegeLayer);
@@ -100,25 +102,25 @@
                         parsedData,
                     });
 
-                    return itowns.Fetcher.texture('images/cross.png').then(texture => {
-                        var pyoLayer = new itowns.ColorLayer('pyrenees-orientales', {
-                            name: 'pyrenees-orientales',
-                            transparent: true,
-                            style: {
-                                fill: {
-                                  pattern: texture.image,
-                                  opacity: 0.8,
-                                },
-                                stroke: {
-                                    color:'IndianRed',
-                                },
-                            },
-                            source: pyoSource,
-                        });
+                    var pyoStyle = new itowns.Style({
+                        fill: {
+                            pattern: 'images/cross.png',
+                            opacity: 0.8,
+                        },
+                        stroke: {
+                            color:'IndianRed',
+                        },
+                    });
 
-                        return view.addLayer(pyoLayer);
-                    }).then(FeatureToolTip.addLayer);
-                });
+                    var pyoLayer = new itowns.ColorLayer('pyrenees-orientales', {
+                        name: 'pyrenees-orientales',
+                        transparent: true,
+                        source: pyoSource,
+                        style: pyoStyle,
+                    });
+
+                    return view.addLayer(pyoLayer);
+                }).then(FeatureToolTip.addLayer);
 
             debug.createTileDebugUI(menuGlobe.gui, view);
         </script>

--- a/examples/source_file_gpx_raster.html
+++ b/examples/source_file_gpx_raster.html
@@ -75,10 +75,8 @@
                             field: '{name}',
                             transform: 'uppercase',
                             font: ['Arial', 'sans-serif'],
-                            halo: {
-                                color: 'white',
-                                width: 1,
-                            },
+                            haloColor: 'white',
+                            haloWidth: 1,
                         },
                     });
 

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -109,7 +109,7 @@ function drawFeature(ctx, feature, extent, style, invCtxScale) {
 
     for (const geometry of feature.geometries) {
         if (geometry.extent.intersectsExtent(extent)) {
-            const geoStyle = style.isStyle ? style : geometry.properties.style;
+            const geoStyle = geometry.properties.style || style;
             if (feature.type === FEATURE_TYPES.POINT) {
                 // cross multiplication to know in the extent system the real size of
                 // the point

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import Extent from 'Core/Geographic/Extent';
 import Coordinates from 'Core/Geographic/Coordinates';
+import Style from 'Core/Style';
 
 function defaultExtent(crs) {
     return new Extent(crs, Infinity, -Infinity, Infinity, -Infinity);
@@ -167,6 +168,7 @@ export const FEATURE_TYPES = {
  * FeatureGeometry}.
  * @property {Extent?} extent - The extent containing all the geometries
  * composing the feature.
+ * @property {Style} style - The style of the Feature.
  */
 class Feature {
     /**
@@ -177,6 +179,8 @@ class Feature {
      * @param {boolean} [options.buildExtent] Build extent and update when adding new vertice.
      * @param {boolean} [options.withAltitude] Set vertice altitude when adding new vertice.
      * @param {boolean} [options.withNormal] Set vertice normal when adding new vertice.
+     * @param {Style} [options.style] The style to inherit when creating a new
+     * style for this feature.
      */
     constructor(type, crs, options = {}) {
         if (Object.keys(FEATURE_TYPES).find(t => FEATURE_TYPES[t] === type)) {
@@ -197,6 +201,7 @@ class Feature {
         }
         this._pos = 0;
         this._pushValues = (this.size === 3 ? push3DValues : push2DValues).bind(this);
+        this.style = new Style({}, options.style);
     }
     /**
      * Instance a new {@link FeatureGeometry}  and push in {@link Feature}.
@@ -347,5 +352,13 @@ export class FeatureCollection {
         coordinates.y = (coordinates.y / this.scale.y) - this.translation.y;
         coordinates.z = (coordinates.z / this.scale.z) - this.translation.z;
         return coordinates;
+    }
+
+    setParentStyle(style) {
+        if (style) {
+            this.features.forEach((f) => {
+                f.style.parent = style;
+            });
+        }
     }
 }

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -1,5 +1,6 @@
 import { FEATURE_TYPES } from 'Core/Feature';
 import Cache from 'Core/Scheduler/Cache';
+import Fetcher from 'Provider/Fetcher';
 
 const cacheStyle = new Cache();
 
@@ -100,8 +101,9 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * any [valid color
  * string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * Default is no value, indicating that no filling needs to be done.
- * @property {Image|Canvas} fill.pattern - Defines a pattern to fill the surface
- * with. See [this
+ * @property {Image|Canvas|string} fill.pattern - Defines a pattern to fill the
+ * surface with. It can be an `Image` to use directly, or an url to fetch the
+ * pattern from. See [this
  * example](http://www.itowns-project.org/itowns/examples/#source_file_geojson_raster)
  * for how to use.
  * @property {number} fill.opacity - The opacity of the color or the
@@ -230,6 +232,11 @@ class Style {
         defineStyleProperty(this, 'fill', 'color', params.fill.color);
         defineStyleProperty(this, 'fill', 'opacity', params.fill.opacity, 1.0);
         defineStyleProperty(this, 'fill', 'pattern', params.fill.pattern);
+        if (typeof this.fill.pattern == 'string') {
+            Fetcher.texture(this.fill.pattern).then((pattern) => {
+                this.fill.pattern = pattern.image;
+            });
+        }
 
         this.stroke = {};
         defineStyleProperty(this, 'stroke', 'color', params.stroke.color);

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -60,7 +60,7 @@ class ColorLayer extends Layer {
         config.cacheLifeTime = config.cacheLifeTime == undefined ? CACHE_POLICIES.TEXTURE : config.cacheLifeTime;
         super(id, config);
         this.isColorLayer = true;
-        this.style = config.style ? new Style(config.style) : {};
+        this.style = new Style(config.style);
         this.defineLayerProperty('visible', true);
         this.defineLayerProperty('opacity', 1.0);
         this.defineLayerProperty('sequence', 0);

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -95,7 +95,6 @@ class LabelLayer extends Layer {
                     content = this.style.getTextFromProperties(g.properties);
                 }
 
-                // FIXME: Style management needs improvement, see #1318.
                 const label = new Label(content,
                     coord.clone(),
                     g.properties.style || f.style || this.style);

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -102,6 +102,10 @@ class Layer extends THREE.EventDispatcher {
                 return parseSourceData(this.source.fetchedData, this.source.extent, this);
             }
         }).then(() => {
+            if (this.source.parsedData && this.source.parsedData.isFeatureCollection) {
+                this.source.parsedData.setParentStyle(this.style);
+            }
+
             this.ready = true;
             return this;
         });

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -49,7 +49,7 @@ const toFeature = {
 
         const geometry = feature.bindNewGeometry();
         geometry.properties = properties;
-        geometry.properties.style = new Style().setFromGeojsonProperties(properties, feature.type);
+        geometry.properties.style = new Style({}, feature.style).setFromGeojsonProperties(properties, feature.type);
         this.populateGeometry(crsIn, coordsIn, geometry, setAltitude, feature);
         feature.updateExtent(geometry);
     },
@@ -60,7 +60,7 @@ const toFeature = {
         }
         const geometry = feature.bindNewGeometry();
         geometry.properties = properties;
-        geometry.properties.style = new Style().setFromGeojsonProperties(properties, feature.type);
+        geometry.properties.style = new Style({}, feature.style).setFromGeojsonProperties(properties, feature.type);
 
         // Then read contour and holes
         for (let i = 0; i < coordsIn.length; i++) {

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -26,6 +26,7 @@ export function parseSourceData(data, extDest, layer) {
         withNormal: layer.isGeometryLayer !== undefined,
         withAltitude: layer.isGeometryLayer !== undefined,
         layers: source.layers,
+        style: layer.style,
     };
 
     return source.parser(data, options).then(parsedFile => source.onParsedFile(parsedFile));

--- a/test/unit/style.js
+++ b/test/unit/style.js
@@ -6,7 +6,7 @@ describe('Style', function () {
     style1.point.color = 'red';
     style1.fill.color = 'blue';
     style1.stroke.color = 'black';
-    style1.text.halo.width = 1;
+    style1.text.haloWidth = 1;
 
     it('Copy style', () => {
         const style2 = new Style().copy(style1);
@@ -14,12 +14,14 @@ describe('Style', function () {
         assert.equal(style1.fill.color, style2.fill.color);
         assert.equal(style1.stroke.color, style2.stroke.color);
     });
+
     it('Clone style', () => {
         const style2 = style1.clone(style1);
         assert.equal(style1.point.color, style2.point.color);
         assert.equal(style1.fill.color, style2.fill.color);
         assert.equal(style1.stroke.color, style2.stroke.color);
     });
+
     it('applyToHTML', () => {
         const dom = document.createElement('canvas');
         style1.applyToHTML(dom);


### PR DESCRIPTION
Two commits, that try to add `Style` inheritance. Still need to fill in some proper documentation, but we can discuss it in the meantime.

#### feat(style): add Style inheritance

It is now possible to specify a `Style` parent for another `Style`. That
way, it is possible to define a global `Style` for a `ColorLayer`, while
defining one with property specific to a `FeatureGeometry` for example.
The `Style` of the `FeatureGeometry` will then only have the minimum
requirement, and it will read missing properties from its parent. It is
a dynamic reading, so it the parent values are changing, it is changing
as well for the child style.

This is a proposition for improvement in #1318.

BREAKING CHANGE: `Style#text.halo` is not available anymore, and each
property of it as been place in the `text` object, with the `halo`
prefix: `haloWidth`, `haloColor` and `haloBlur`.

#### chore: update tests and examples to support the new Style inheritance

