### PR TITLE
fix(renderer): set the correct size for labels dom element

### DIFF
--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -80,7 +80,6 @@ class Label2DRenderer {
         this.domElement = document.createElement('div');
         this.domElement.style.overflow = 'hidden';
         this.domElement.style.position = 'absolute';
-        this.domElement.style.top = 0;
         this.domElement.style.zIndex = 1;
 
         // Used to destroy labels that are not added to the DOM

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -58,7 +58,7 @@ class c3DEngine {
         // Create renderer
         try {
             this.label2dRenderer = new Label2DRenderer();
-            this.label2dRenderer.setSize(window.innerWidth, window.innerHeight);
+            this.label2dRenderer.setSize(this.width, this.height);
             viewerDiv.appendChild(this.label2dRenderer.domElement);
 
             this.renderer = renderer || new THREE.WebGLRenderer({
@@ -67,7 +67,7 @@ class c3DEngine {
                 alpha: options.alpha,
                 logarithmicDepthBuffer: options.logarithmicDepthBuffer,
             });
-            this.renderer.domElement.style.position = 'absolute';
+            this.renderer.domElement.style.position = 'relative';
             this.renderer.domElement.style.zIndex = 0;
             this.renderer.domElement.style.top = 0;
         } catch (ex) {


### PR DESCRIPTION
The initial position of the `Label2DRenderer#domElement` was not
correct, as it was looking for the whole windows size. Now it follows
the same size than the `domElement` of the view.

Additionally, some style have been changed to support offsets.
