### PR TITLE
fix(layer): get correct extent destination for a LabelLayer

### DIFF
--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -142,7 +142,7 @@ class LabelLayer extends Layer {
             return;
         }
 
-        const extentsDestination = node.getExtentsByProjection(this.source.projection);
+        const extentsDestination = node.getExtentsByProjection(this.source.projection) || [node.extent];
 
         const extentsSource = [];
         for (const extentDest of extentsDestination) {


### PR DESCRIPTION
Before that, no default extent destination was set for the LabelLayer.
It was fine when using this layer with another one (using the
`labelEnabled` flag), but not when using is alone.

Now it works, defaulting to `[node.extent]`.