### PR TITLE
3D Tiles on 2.5D map

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -1,0 +1,124 @@
+<html>
+    <head>
+        <title>Itowns - 3D Tiles on 2.5D map example</title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv" class="viewer"></div>
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="js/3dTilesHelper.js"></script>
+        <script type="text/javascript">
+            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
+            // Define geographic extent: CRS, min/max X, min/max Y
+            var extent = new itowns.Extent( 'EPSG:3946',
+                1837816.94334, 1847692.32501,
+                5170036.4587, 5178412.82698);
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            var viewerDiv = document.getElementById('viewerDiv');
+
+            // Instanciate PlanarView*
+            var cameraCoord = new itowns.Coordinates('EPSG:3946', 1841980,
+                5175682, 3000)
+            var view = new itowns.PlanarView(viewerDiv, extent, { placement: {
+                coord: cameraCoord, heading: -30, range: 4000, tilt: 30 } });
+
+            setupLoadingScreen(viewerDiv, view);
+
+            // Add a WMS imagery source
+            var wmsImagerySource = new itowns.WMSSource({
+                extent: extent,
+                name: 'Ortho2009_vue_ensemble_16cm_CC46',
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                version: '1.3.0',
+                projection: 'EPSG:3946',
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS imagery layer
+            var wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+                updateStrategy: {
+                    type: itowns.STRATEGY_DICHOTOMY,
+                    options: {},
+                },
+                source: wmsImagerySource,
+            });
+
+            view.addLayer(wmsImageryLayer);
+
+            // Add a WMS elevation source
+            var wmsElevationSource = new itowns.WMSSource({
+                extent: extent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                projection: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
+
+            // instanciate controls
+            // eslint-disable-next-line no-new
+            new itowns.PlanarControls(view, {});
+
+            // Add 3D Tiles layer
+            // This 3D Tiles tileset uses the draco compression that is an
+            // extension of gltf. We need to enable it.
+            itowns.enableDracoLoader('./libs/draco/');
+
+            var $3dTilesLayer = new itowns.C3DTilesLayer(
+                '3d-tiles-layer-building', {
+                    name: 'Lyon-2015-building',
+                    source: new itowns.C3DTilesSource({
+                        url:
+                            'http://rict.liris.cnrs.fr/DataStore/Lyon1er-2015/tileset.json',
+                    }),
+                }, view);
+
+            // Lights
+            var dirLight = new itowns.THREE.DirectionalLight(0xffffff, 1);
+            dirLight.position.set(-0.9, 0.3, 1);
+            dirLight.updateMatrixWorld();
+            view.scene.add( dirLight );
+
+            var ambLight = new itowns.THREE.AmbientLight(0xffffff, 0.2);
+            view.scene.add( ambLight );
+
+            // Pick 3D Tiles features when hovering them with the mouse and
+            // display their semantic information in an html div
+            var pickingArgs = {};
+            pickingArgs.htmlDiv = document.getElementById('featureInfo');
+            pickingArgs.view = view;
+            pickingArgs.layer = $3dTilesLayer;
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayer);
+
+            // Request redraw
+            view.notifyChange();
+
+            // Add a debug UI
+            var menu = new GuiTools('menuDiv', view);
+            var d = new debug.Debug(view, menu.gui);
+            debug.createTileDebugUI(menu.gui, view, view.tileLayer, d);
+            debug.create3dTilesDebugUI(menu.gui, view, $3dTilesLayer, d);
+        </script>
+    </body>
+</html>

--- a/examples/3dtiles_basic.html
+++ b/examples/3dtiles_basic.html
@@ -75,7 +75,7 @@
             itowns.View.prototype.addLayer.call(view,
                 $3dTilesLayerRequestVolume).then(function _() {
                     window.addEventListener('mousemove',
-                        (event) => fillHTMLWithPickingInfo(event, view, pickingArgs),false);
+                        (event) => fillHTMLWithPickingInfo(event, pickingArgs),false);
                 });
 
             // Add the UI Debug

--- a/examples/3dtiles_batch_table.html
+++ b/examples/3dtiles_batch_table.html
@@ -74,7 +74,7 @@
             pickingArgs.layer = $3dTilesLayerBTHierarchy;
             itowns.View.prototype.addLayer.call(view, $3dTilesLayerBTHierarchy).then(function _() {
                 window.addEventListener('mousemove',
-                    (event) => fillHTMLWithPickingInfo(event, view, pickingArgs),false);
+                    (event) => fillHTMLWithPickingInfo(event, pickingArgs),false);
             });
 
             // Add a debug UI

--- a/examples/config.json
+++ b/examples/config.json
@@ -10,7 +10,8 @@
 
     "3d Tiles": {
         "3dtiles_basic": "Basic",
-        "3dtiles_batch_table": "Batch table"
+        "3dtiles_batch_table": "Batch table",
+        "3dtiles_25d": "On 2.5D map"
     },
 
     "Potree": {

--- a/examples/js/3dTilesHelper.js
+++ b/examples/js/3dTilesHelper.js
@@ -1,14 +1,11 @@
 // Function allowing picking on a given 3D tiles layer and filling an html div
 // with information on the picked feature
-// This function expects arguments passed through the binding of this (see
-// 3dtiles.html and 3dtiles_hierarchy.html for more information on how to
-// bind this).
 // Expected arguments:
-// this.htmlDiv (div element which contains the picked information)
-// this.view : iTowns view where the picking must be done
-// this.layer : the layer on which the picking must be done
+// pickingArg.htmlDiv (div element which contains the picked information)
+// pickingArg.view : iTowns view where the picking must be done
+// pickingArg.layer : the layer on which the picking must be done
 // eslint-disable-next-line
-function fillHTMLWithPickingInfo(event, view, pickingArg) {
+function fillHTMLWithPickingInfo(event, pickingArg) {
     if (!pickingArg.layer.isC3DTilesLayer) {
         console.warn('Function fillHTMLWithPickingInfo only works' +
             ' for C3DTilesLayer layers.');
@@ -21,7 +18,7 @@ function fillHTMLWithPickingInfo(event, view, pickingArg) {
     }
 
     // Get intersected objects
-    var intersects = view.pickObjectsAt(event, 5, pickingArg.layer);
+    var intersects = pickingArg.view.pickObjectsAt(event, 5, pickingArg.layer);
     if (intersects.length === 0) { return; }
 
     // Get information from intersected objects (from the batch table and

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -61,13 +61,12 @@ export function enableDracoLoader(path, config) {
     if (!path) {
         throw new Error('Path to draco folder is mandatory');
     }
-    DRACOLoader.setDecoderPath(path);
-    if (config) {
-        DRACOLoader.setDecoderConfig(config);
-    }
     const dracoLoader = new DRACOLoader();
+    dracoLoader.setDecoderPath(path);
+    if (config) {
+        dracoLoader.setDecoderConfig(config);
+    }
     glTFLoader.setDRACOLoader(dracoLoader);
-    DRACOLoader.getDecoderModule();
 }
 
 export default {

--- a/test/functional/3dtiles_25d.js
+++ b/test/functional/3dtiles_25d.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+
+describe('3dtiles_25d', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(
+            'examples/3dtiles_25d.html',
+            this.fullTitle(),
+        );
+    });
+
+    it('should run', async () => {
+        assert.ok(result);
+    });
+
+    it('should pick the planar layer', async () => {
+        const layers = await page.evaluate(
+            () => view.pickObjectsAt({
+                x: 194,
+                y: 100,
+            })
+                .map(p => p.layer.id),
+        );
+
+        assert.ok(layers.indexOf('planar') >= 0);
+    });
+});


### PR DESCRIPTION
## Description
This is a followup of PR #1034. 
Since I won't have time to apply the process you suggested to reduce the size of the tiles, I use a smaller dataset in this PR (only the 1st borough of Lyon). 

## Motivation and Context
I think it would be useful to have an example of 3D Tiles on plane in the codebase of iTowns. It demonstrates this capability and it is useful for us (and other people working with 3D Tiles on a planar view of itowns in their projects) for debugging purposes.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/16967916/85863978-33473880-b7c4-11ea-8afe-c32ce89380b4.png)

