### PR TITLE
refactor(Vector Tiles): set style in vector tiles parser.

### DIFF
--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -26,6 +26,7 @@ export function parseSourceData(data, extDest, layer) {
         withNormal: layer.isGeometryLayer !== undefined,
         withAltitude: layer.isGeometryLayer !== undefined,
         layers: source.layers,
+        styles: source.styles,
         style: layer.style,
     };
 

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -142,17 +142,6 @@ class VectorTilesSource extends TMSSource {
             }
         });
     }
-
-    onParsedFile(collection) {
-        collection.features.forEach((feature) => {
-            feature.style = this.getStyleFromIdZoom(feature.id, collection.extent.zoom);
-        });
-        return collection;
-    }
-
-    getStyleFromIdZoom(id, zoom) {
-        return this.styles[id].find(s => s.zoom.min <= zoom && s.zoom.max > zoom);
-    }
 }
 
 export default VectorTilesSource;

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import assert from 'assert';
 import HttpsProxyAgent from 'https-proxy-agent';
-import VectorTileParser from 'Parser/VectorTileParser';
+import VectorTileParser, { getStyle } from 'Parser/VectorTileParser';
 import VectorTilesSource from 'Source/VectorTilesSource';
 import Extent from 'Core/Geographic/Extent';
 
@@ -13,9 +13,8 @@ describe('Vector tiles', function () {
 
     function parse(pbf, layers) {
         return VectorTileParser.parse(pbf, {
-            crsIn: 'EPSG:4326',
-            crsOut: 'EPSG:3857',
             layers,
+            styles: [[]],
         });
     }
 
@@ -136,9 +135,9 @@ describe('Vector tiles', function () {
             });
             source.whenReady.then(() => {
                 assert.equal(source.styles.land.length, 2);
-                assert.deepEqual(source.getStyleFromIdZoom('land', 3), source.styles.land[0]);
-                assert.deepEqual(source.getStyleFromIdZoom('land', 5), source.styles.land[1]);
-                assert.deepEqual(source.getStyleFromIdZoom('land', 8), source.styles.land[1]);
+                assert.deepEqual(getStyle(source.styles, 'land', 3), source.styles.land[0]);
+                assert.deepEqual(getStyle(source.styles, 'land', 5), source.styles.land[1]);
+                assert.deepEqual(getStyle(source.styles, 'land', 8), source.styles.land[1]);
                 done();
             });
         });


### PR DESCRIPTION
## Description

Move vector style parsing in `VectorTileParser`.

## Motivation
* Remove `onParsedFile` in Itowns.
* do all the geometry and style job in  `VectorStyleParse` and avoid a next step to add style.
* Remove Loop on all features to add Style.