### PR TITLE
refactor(GeoJsonParser): change filteringExtent parsing option 

### DIFF
--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -99,7 +99,7 @@ class Layer extends THREE.EventDispatcher {
             this._reject = rj;
         }).then(() => {
             if (this.source.fetchedData && !this.source.parsedData) {
-                return parseSourceData(this.source.fetchedData, this.source.extent, this);
+                return parseSourceData(this.source.fetchedData, this);
             }
         }).then(() => {
             if (this.source.parsedData && this.source.parsedData.isFeatureCollection) {

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -179,8 +179,8 @@ export default {
      * @property {string} crsOut - The CRS to convert the input coordinates
      * to.
      * @property {string} crsIn - Override the data CRS.
-     * @property {Extent} [filteringExtent] - Optional filter to reject
-     * features outside of this extent.
+     * @property {Extent|boolean} [filteringExtent=undefined] - Optional filter to reject
+     * features outside of extent. Extent filetring is file extent if filteringExtent is true.
      * @property {boolean} [buildExtent=false] - If true the geometry will
      * have an extent property containing the area covered by the geom
      * @property {function} [filter] - Filter function to remove features
@@ -202,7 +202,6 @@ export default {
      */
     parse(json, options = {}) {
         const crsOut = options.crsOut;
-        const filteringExtent = options.filteringExtent;
         if (typeof (json) === 'string') {
             json = JSON.parse(json);
         }
@@ -211,6 +210,15 @@ export default {
         options.mergeFeatures = options.mergeFeatures == undefined ? true : options.mergeFeatures;
         options.withNormal = options.withNormal == undefined ? true : options.withNormal;
         options.withAltitude = options.withAltitude == undefined ? true : options.withAltitude;
+
+        let filteringExtent;
+        if (options.filteringExtent) {
+            if (typeof options.filteringExtent == 'boolean') {
+                filteringExtent = json.extent.as(options.crsIn);
+            } else if (options.filteringExtent.isExtent) {
+                filteringExtent = options.filteringExtent;
+            }
+        }
 
         switch (json.type.toLowerCase()) {
             case 'featurecollection':

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -9,16 +9,14 @@ const error = (err, source) => {
     throw err;
 };
 
-export function parseSourceData(data, extDest, layer) {
+export function parseSourceData(data, layer) {
     const source = layer.source;
 
     const options = {
         buildExtent: source.isFileSource || !layer.isGeometryLayer,
         crsIn: source.projection,
         crsOut: layer.projection,
-        // TODO FIXME: error in filtering vector tile
-        // filteringExtent: extentDestination.as(layer.projection),
-        filteringExtent: !source.isFileSource && layer.isGeometryLayer ? extDest.as(source.projection) : undefined,
+        filteringExtent: !source.isFileSource && layer.isGeometryLayer,
         overrideAltitudeInToZero: layer.overrideAltitudeInToZero,
         filter: layer.filter || source.filter,
         isInverted: source.isInverted,
@@ -75,7 +73,7 @@ export default {
                 } else {
                     // Fetch, parse and convert
                     convertedSourceData = fetchSourceData(extSource, layer)
-                        .then(fetchedData => parseSourceData(fetchedData, extDest, layer), err => error(err, source))
+                        .then(fetchedData => parseSourceData(fetchedData, layer), err => error(err, source))
                         .then(parsedData => layer.convert(parsedData, extDest, layer), err => error(err, source));
                 }
                 // Put converted data in cache

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -73,9 +73,8 @@ let uid = 0;
  *  GeometryLayer}.</li>
  *  <li>`crsIn : string` - The projection of the source.</li>
  *  <li>`crsOut : string` - The projection of the layer.</li>
- *  <li>`filteringExtent : Extent` - If the layer inherits from {@link
- *  GeometryLayer}, it is set to the extent of destination, otherwise it is
- *  undefined.</li>
+ *  <li>`filteringExtent : Extent|boolean` - If the layer inherits from {@link
+ *  GeometryLayer}, it is set filtering with the extent, or extent file if it is true.</li>
  *  <li>`filter : function` - Property of the layer.</li>
  *  <li>`mergeFeatures : boolean (default true)` - Property of the layer,
  *  default to true.</li>


### PR DESCRIPTION
## Description

Change `filteringExtent` parsing option  to `boolean` or `Extent`, instead of only `Extent`.

## Motivation and Context
This simplifies the functions in the providers.


