### PR TITLE
perf: remove some instanceof that can be avoided

### DIFF
--- a/src/Layer/PotreeLayer.js
+++ b/src/Layer/PotreeLayer.js
@@ -4,7 +4,6 @@ import PointsMaterial, { MODE } from 'Renderer/PointsMaterial';
 import Picking from 'Core/Picking';
 import PotreeNode from 'Core/PotreeNode';
 import Extent from 'Core/Geographic/Extent';
-import CancelledCommandException from 'Core/Scheduler/CancelledCommandException';
 
 const point = new THREE.Vector3();
 const bboxMesh = new THREE.Mesh();
@@ -259,7 +258,7 @@ class PotreeLayer extends GeometryLayer {
 
                     elt.promise = null;
                 }, (err) => {
-                    if (err instanceof CancelledCommandException) {
+                    if (err.isCancelledCommandException) {
                         elt.promise = null;
                     }
                 });

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -3,7 +3,6 @@ import GeometryLayer from 'Layer/GeometryLayer';
 import { InfoTiledGeometryLayer } from 'Layer/InfoLayer';
 import Picking from 'Core/Picking';
 import convertToTile from 'Converter/convertToTile';
-import CancelledCommandException from 'Core/Scheduler/CancelledCommandException';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import { SIZE_DIAGONAL_TEXTURE } from 'Process/LayeredMaterialNodeProcessing';
 import { ImageryLayers } from 'Layer/Layer';
@@ -343,7 +342,7 @@ class TiledGeometryLayer extends GeometryLayer {
                 context.view.notifyChange(node, false);
             }, (err) => {
                 node.pendingSubdivision = false;
-                if (!(err instanceof CancelledCommandException)) {
+                if (!err.isCancelledCommandException) {
                     throw new Error(err);
                 }
             });

--- a/src/Process/handlerNodeError.js
+++ b/src/Process/handlerNodeError.js
@@ -1,9 +1,8 @@
-import CancelledCommandException from 'Core/Scheduler/CancelledCommandException';
 // max retry loading before changing the status to definitiveError
 const MAX_RETRY = 4;
 
 export default function handlingError(err, node, layer, targetLevel, view) {
-    if (err instanceof CancelledCommandException) {
+    if (err.isCancelledCommandException) {
         node.layerUpdateState[layer.id].success();
     } else if (err instanceof SyntaxError) {
         node.layerUpdateState[layer.id].failure(0, true);

--- a/test/hooks_functional.js
+++ b/test/hooks_functional.js
@@ -216,9 +216,9 @@ exports.mochaHooks = {
     },
     beforeEach: async () => {
         global.initialPosition = await page.evaluate(() => {
-            if (view instanceof itowns.GlobeView && view.controls) {
+            if (view.isGlobeView && view.controls) {
                 return Promise.resolve(itowns.CameraUtils.getTransformCameraLookingAtTarget(view, view.controls.camera));
-            } else if (view instanceof itowns.PlanarView) {
+            } else if (view.isPlanarView) {
                 // TODO: make the controls accessible from PlanarView before doing
                 // anything more here
                 return Promise.resolve();
@@ -228,7 +228,7 @@ exports.mochaHooks = {
     // reset browser state instead of closing it
     afterEach: async () => {
         await page.evaluate((init) => {
-            if (view instanceof itowns.GlobeView && view.controls) {
+            if (view.isGlobeView && view.controls) {
                 // eslint-disable-next-line no-param-reassign
                 init.coord = new itowns.Coordinates(
                     init.coord.crs,
@@ -238,7 +238,7 @@ exports.mochaHooks = {
                 );
                 view.controls.lookAtCoordinate(init, false);
                 view.notifyChange();
-            } else if (view instanceof itowns.PlanarView) {
+            } else if (view.isPlanarView) {
                 // TODO: make the controls accessible from PlanarView before doing
                 // anything more here
             }


### PR DESCRIPTION
They have been replaced by `is...` properties.
