### PR TITLE
WebGL 2.0 Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11400,9 +11400,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.117.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.117.1.tgz",
-      "integrity": "sha512-t4zeJhlNzUIj9+ub0l6nICVimSuRTZJOqvk3Rmlu+YGdTOJ49Wna8p7aumpkXJakJfITiybfpYE1XN1o1Z34UQ==",
+      "version": "0.120.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.120.1.tgz",
+      "integrity": "sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "proj4": "^2.6.2",
-    "three": "^0.117.1"
+    "three": "0.120.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -91,7 +91,7 @@
     "proj4": "^2.6.2",
     "puppeteer": "^5.2.1",
     "replace-in-file": "^6.1.0",
-    "three": "^0.117.1",
+    "three": "0.120.1",
     "url-polyfill": "^1.1.10",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",

--- a/src/Core/Prefab/TileBuilder.js
+++ b/src/Core/Prefab/TileBuilder.js
@@ -25,38 +25,49 @@ export default function newTileGeometry(builder, params) {
         let cachedBuffers = cacheBuffer.get(bufferKey);
         params.buildIndexAndUv_0 = !cachedBuffers;
         params.builder = builder;
-        return Promise.resolve(computeBuffers(params)).then((buffers) => {
-            if (!cachedBuffers) {
-                cachedBuffers = {};
-                cachedBuffers.index = new THREE.BufferAttribute(buffers.index, 1);
-                cachedBuffers.uv = new THREE.BufferAttribute(buffers.uvs[0], 2);
+        let buffers;
+        try {
+            buffers = computeBuffers(params);
+        } catch (e) {
+            return Promise.reject(e);
+        }
 
-                // Update cacheBuffer
-                cacheBuffer.set(bufferKey, cachedBuffers);
+        if (!cachedBuffers) {
+            cachedBuffers = {};
+            cachedBuffers.index = new THREE.BufferAttribute(buffers.index, 1);
+            cachedBuffers.uv = new THREE.BufferAttribute(buffers.uvs[0], 2);
+
+            // Update cacheBuffer
+            cacheBuffer.set(bufferKey, cachedBuffers);
+        }
+
+        buffers.index = cachedBuffers.index;
+        buffers.uvs[0] = cachedBuffers.uv;
+        buffers.position = new THREE.BufferAttribute(buffers.position, 3);
+        buffers.normal = new THREE.BufferAttribute(buffers.normal, 3);
+        if (params.builder.uvCount > 1) {
+            buffers.uvs[1] = new THREE.BufferAttribute(buffers.uvs[1], 1);
+        }
+
+        const geometry = new TileGeometry(params, buffers);
+        geometry.OBB = new OBB(geometry.boundingBox.min, geometry.boundingBox.max);
+
+        geometry._count = 0;
+        geometry.dispose = () => {
+            geometry._count--;
+            if (geometry._count <= 0) {
+                // To avoid remove index buffer and attribute buffer uv_0
+                //  error un-bound buffer in webgl with VAO rendering.
+                // Could be removed if the attribute buffer deleting is
+                //  taken into account in the buffer binding state (in THREE.WebGLBindingStates code).
+                geometry.index = null;
+                delete geometry.attributes.uv_0;
+                THREE.BufferGeometry.prototype.dispose.call(geometry);
+                cacheTile.delete(south, params.level, bufferKey);
             }
-
-            buffers.index = cachedBuffers.index;
-            buffers.uvs[0] = cachedBuffers.uv;
-            buffers.position = new THREE.BufferAttribute(buffers.position, 3);
-            buffers.normal = new THREE.BufferAttribute(buffers.normal, 3);
-            if (params.builder.uvCount > 1) {
-                buffers.uvs[1] = new THREE.BufferAttribute(buffers.uvs[1], 1);
-            }
-
-            const geometry = new TileGeometry(params, buffers);
-            geometry.OBB = new OBB(geometry.boundingBox.min, geometry.boundingBox.max);
-
-            geometry._count = 0;
-            geometry.dispose = () => {
-                geometry._count--;
-                if (geometry._count == 0) {
-                    THREE.BufferGeometry.prototype.dispose.call(geometry);
-                    cacheTile.delete(south, params.level, bufferKey);
-                }
-            };
-            resolve(geometry);
-            return { geometry, quaternion, position };
-        });
+        };
+        resolve(geometry);
+        return Promise.resolve({ geometry, quaternion, position });
     }
 
     return promiseGeometry.then(geometry => ({ geometry, quaternion, position }));

--- a/src/Core/Prefab/computeBufferTileGeometry.js
+++ b/src/Core/Prefab/computeBufferTileGeometry.js
@@ -26,7 +26,7 @@ export default function computeBuffers(params) {
     const computeUvs = [];
 
     const builder = params.builder;
-    const nSeg = params.segment;
+    const nSeg = params.segment || 8;
     // segments count :
     // Tile : (nSeg + 1) * (nSeg + 1)
     // Skirt : 8 * (nSeg - 1)

--- a/src/Core/Prefab/computeBufferTileGeometry.js
+++ b/src/Core/Prefab/computeBufferTileGeometry.js
@@ -31,6 +31,10 @@ export default function computeBuffers(params) {
     // Tile : (nSeg + 1) * (nSeg + 1)
     // Skirt : 8 * (nSeg - 1)
     const nVertex = (nSeg + 1) * (nSeg + 1) + (params.disableSkirt ? 0 : 4 * nSeg);
+    if (nVertex > 2 ** 32) {
+        throw new Error('Tile segments count is too big');
+    }
+
     const triangles = (nSeg) * (nSeg) * 2 + (params.disableSkirt ? 0 : 4 * nSeg * 2);
 
     outBuffers.position = new Float32Array(nVertex * 3);
@@ -49,8 +53,6 @@ export default function computeBuffers(params) {
             outBuffers.index = new Uint16Array(triangles * 3);
         } else if (nVertex < 2 ** 32) {
             outBuffers.index = new Uint32Array(triangles * 3);
-        } else {
-            throw new Error('Tile segments count is too big');
         }
         outBuffers.uvs[0] = new Float32Array(nVertex * 2);
         computeUvs[0] = (id, u, v) => {

--- a/src/Core/Prefab/computeBufferTileGeometry.js
+++ b/src/Core/Prefab/computeBufferTileGeometry.js
@@ -43,7 +43,15 @@ export default function computeBuffers(params) {
 
     computeUvs[0] = () => {};
     if (params.buildIndexAndUv_0) {
-        outBuffers.index = new Uint32Array(triangles * 3);
+        if (nVertex < 2 ** 8) {
+            outBuffers.index = new Uint8Array(triangles * 3);
+        } else if (nVertex < 2 ** 16) {
+            outBuffers.index = new Uint16Array(triangles * 3);
+        } else if (nVertex < 2 ** 32) {
+            outBuffers.index = new Uint32Array(triangles * 3);
+        } else {
+            throw new Error('Tile segments count is too big');
+        }
         outBuffers.uvs[0] = new Float32Array(nVertex * 2);
         computeUvs[0] = (id, u, v) => {
             outBuffers.uvs[0][id * 2 + 0] = u;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -241,6 +241,9 @@ class View extends THREE.EventDispatcher {
                 } else {
                     return layer._reject(new Error(`Cant add color layer ${layer.id}: the maximum layer is reached`));
                 }
+            } else if (layer.isElevationLayer && layer.source.format == 'image/x-bil;bits=32') {
+                layer.source.networkOptions.isWebGL2 = this.mainLoop.gfxEngine.renderer.capabilities.isWebGL2;
+                parentLayer.attach(layer);
             } else {
                 parentLayer.attach(layer);
             }
@@ -334,7 +337,7 @@ class View extends THREE.EventDispatcher {
     notifyChange(changeSource = undefined, needsRedraw = true) {
         if (changeSource) {
             this._changeSources.add(changeSource);
-            if ((changeSource.isTileMesh || changeSource.isCamera) && this._fullSizeDepthBuffer) {
+            if ((changeSource.isTileMesh || changeSource.isCamera)) {
                 this._fullSizeDepthBuffer.needsUpdate = true;
             }
         }

--- a/src/Provider/Fetcher.js
+++ b/src/Provider/Fetcher.js
@@ -1,4 +1,4 @@
-import { TextureLoader, DataTexture, AlphaFormat, FloatType } from 'three';
+import { TextureLoader, DataTexture, RedFormat, FloatType, AlphaFormat } from 'three';
 
 const textureLoader = new TextureLoader();
 const SIZE_TEXTURE_TILE = 256;
@@ -15,9 +15,15 @@ const arrayBuffer = (url, options = {}) => fetch(url, options).then((response) =
     return response.arrayBuffer();
 });
 
-const getTextureFloat = function getTextureFloat(buffer) {
-    return new DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, AlphaFormat, FloatType);
-};
+function getTextureFloat(buffer, isWebGL2 = true) {
+    if (isWebGL2) {
+        const texture = new DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, RedFormat, FloatType);
+        texture.internalFormat = 'R32F';
+        return texture;
+    } else {
+        return new DataTexture(buffer, SIZE_TEXTURE_TILE, SIZE_TEXTURE_TILE, AlphaFormat, FloatType);
+    }
+}
 
 /**
  * Utilitary to fetch resources from a server using the [fetch API]{@link
@@ -130,7 +136,7 @@ export default {
     textureFloat(url, options = {}) {
         return arrayBuffer(url, options).then((buffer) => {
             const floatArray = new Float32Array(buffer);
-            const texture = getTextureFloat(floatArray);
+            const texture = getTextureFloat(floatArray, options.isWebGL2);
             return texture;
         });
     },

--- a/src/Renderer/OrientedImageMaterial.js
+++ b/src/Renderer/OrientedImageMaterial.js
@@ -126,6 +126,13 @@ class OrientedImageMaterial extends THREE.RawShaderMaterial {
         this.fragmentShader = ShaderUtils.unrollLoops(textureFS, this.defines);
     }
 
+    onBeforeCompile(shader, renderer) {
+        if (renderer.capabilities.isWebGL2) {
+            this.defines.WEBGL2 = true;
+            shader.glslVersion = '300 es';
+        }
+    }
+
     /**
      * Set new textures and new position/orientation of the camera set.
      * @param {THREE.Texture} textures - Array of [THREE.Texture]{@link https://threejs.org/docs/#api/en/textures/Texture}.

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -57,6 +57,13 @@ class PointsMaterial extends THREE.RawShaderMaterial {
         }
     }
 
+    onBeforeCompile(shader, renderer) {
+        if (renderer.capabilities.isWebGL2) {
+            this.defines.WEBGL2 = true;
+            shader.glslVersion = '300 es';
+        }
+    }
+
     copy(source) {
         super.copy(source);
         if (source.uniforms.projectiveTextureAlphaBorder) {

--- a/src/Renderer/Shader/Chunk/WebGL2_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/WebGL2_pars_fragment.glsl
@@ -1,0 +1,17 @@
+// Copy from GLSL 3.0 conversion for built-in materials and ShaderMaterial in THREE.WebGLProgram
+// https://github.com/mrdoob/three.js/blob/696d7836d1fc56c4702a475e6991c4adef7357f4/src/renderers/webgl/WebGLProgram.js#L682
+#if defined(WEBGL2)
+#define varying in
+out highp vec4 pc_fragColor;
+#define gl_FragColor pc_fragColor
+#define gl_FragDepthEXT gl_FragDepth
+#define texture2D texture
+#define textureCube texture
+#define texture2DProj textureProj
+#define texture2DLodEXT textureLod
+#define texture2DProjLodEXT textureProjLod
+#define textureCubeLodEXT textureLod
+#define texture2DGradEXT textureGrad
+#define texture2DProjGradEXT textureProjGrad
+#define textureCubeGradEXT textureGrad
+#endif

--- a/src/Renderer/Shader/Chunk/WebGL2_pars_vertex.glsl
+++ b/src/Renderer/Shader/Chunk/WebGL2_pars_vertex.glsl
@@ -1,0 +1,7 @@
+// Copy from GLSL 3.0 conversion for built-in materials and ShaderMaterial in THREE.WebGLProgram
+// https://github.com/mrdoob/three.js/blob/696d7836d1fc56c4702a475e6991c4adef7357f4/src/renderers/webgl/WebGLProgram.js#L682
+#if defined(WEBGL2)
+#define attribute in
+#define varying out
+#define texture2D texture
+#endif

--- a/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
@@ -42,7 +42,7 @@ vec4 getOutlineColor(vec3 outlineColor, vec2 uv) {
 #endif
 
 uniform float minBorderDistance;
-vec4 getLayerColor(int textureOffset, sampler2D texture, vec4 offsetScale, Layer layer) {
+vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer layer) {
     if ( textureOffset >= colorTextureCount ) return vec4(0);
 
     vec3 uv;
@@ -53,7 +53,7 @@ vec4 getLayerColor(int textureOffset, sampler2D texture, vec4 offsetScale, Layer
 
     float borderDistance = getBorderDistance(uv.xy);
     if (textureOffset != layer.textureOffset + int(uv.z) || borderDistance < minBorderDistance ) return vec4(0);
-    vec4 color = texture2D(texture, pitUV(uv.xy, offsetScale));
+    vec4 color = texture2D(tex, pitUV(uv.xy, offsetScale));
     if(color.a > 0.0) {
         if(layer.effect > 2.0) {
             color.rgb /= color.a;

--- a/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
+++ b/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
@@ -20,19 +20,21 @@
         return Result;
     }
 
-    float getElevationMode(vec2 uv, sampler2D texture, int mode) {
+    float getElevationMode(vec2 uv, sampler2D tex, int mode) {
         if (mode == ELEVATION_RGBA)
-            return decode32(texture2D( texture, uv ).abgr * 255.0);
-        if (mode == ELEVATION_DATA)
-            return texture2D( texture, uv ).w;
-        if (mode == ELEVATION_COLOR)
-            return texture2D( texture, uv ).r;
+            return decode32(texture2D( tex, uv ).abgr * 255.0);
+        if (mode == ELEVATION_DATA || mode == ELEVATION_COLOR)
+        #if defined(WEBGL2)
+            return texture2D( tex, uv ).r;
+        #else
+            return texture2D( tex, uv ).w;
+        #endif
         return 0.;
     }
 
-    float getElevation(vec2 uv, sampler2D texture, vec4 offsetScale, Layer layer) {
+    float getElevation(vec2 uv, sampler2D tex, vec4 offsetScale, Layer layer) {
         uv = uv * offsetScale.zw + offsetScale.xy;
-        float d = getElevationMode(uv, texture, layer.mode);
+        float d = getElevationMode(uv, tex, layer.mode);
         if (d < layer.zmin || d > layer.zmax) d = 0.;
         return d * layer.scale + layer.bias;
     }

--- a/src/Renderer/Shader/Chunk/projective_texturing_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/projective_texturing_pars_fragment.glsl
@@ -62,7 +62,7 @@ vec4 mixBaseColor(vec4 aColor, vec4 baseColor) {
     return baseColor;
 }
 
-vec4 projectiveTextureColor(vec4 coords, Distortion distortion, sampler2D texture, sampler2D mask, vec4 baseColor) {
+vec4 projectiveTextureColor(vec4 coords, Distortion distortion, sampler2D tex, sampler2D mask, vec4 baseColor) {
     vec3 p = coords.xyz / coords.w;
     if(p.z * p.z < 1.) {
 #if USE_DISTORTION
@@ -76,10 +76,10 @@ vec4 projectiveTextureColor(vec4 coords, Distortion distortion, sampler2D textur
         if(d > 0.) {
 
 #if DEBUG_ALPHA_BORDER
-        vec3 r = texture2D(texture, p.xy).rgb;
+        vec3 r = texture2D(tex, p.xy).rgb;
         return mixBaseColor(vec4( r.r * d, r.g, r.b, 1.0), baseColor);
 #else
-        vec4 color = texture2D(texture, p.xy);
+        vec4 color = texture2D(tex, p.xy);
         color.a *= d;
         if (boostLight) {
             return mixBaseColor(vec4(sqrt(color.rgb), color.a), baseColor);

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -1,3 +1,4 @@
+#include <itowns/WebGL2_pars_fragment>
 #include <itowns/precision_qualifier>
 #include <logdepthbuf_pars_fragment>
 #if defined(USE_TEXTURES_PROJECTIVE)

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -1,3 +1,4 @@
+#include <itowns/WebGL2_pars_vertex>
 #include <itowns/precision_qualifier>
 #include <itowns/project_pars_vertex>
 #if defined(USE_TEXTURES_PROJECTIVE)

--- a/src/Renderer/Shader/ProjectiveTextureFS.glsl
+++ b/src/Renderer/Shader/ProjectiveTextureFS.glsl
@@ -1,3 +1,4 @@
+#include <itowns/WebGL2_pars_fragment>
 #include <itowns/precision_qualifier>
 #include <logdepthbuf_pars_fragment>
 #include <itowns/projective_texturing_pars_fragment>

--- a/src/Renderer/Shader/ProjectiveTextureVS.glsl
+++ b/src/Renderer/Shader/ProjectiveTextureVS.glsl
@@ -1,3 +1,4 @@
+#include <itowns/WebGL2_pars_vertex>
 #include <itowns/precision_qualifier>
 #include <itowns/project_pars_vertex>
 #include <itowns/projective_texturing_pars_vertex>

--- a/src/Renderer/Shader/ShaderChunk.js
+++ b/src/Renderer/Shader/ShaderChunk.js
@@ -18,6 +18,8 @@ import project_pars_vertex from './Chunk/project_pars_vertex.glsl';
 import projective_texturing_vertex from './Chunk/projective_texturing_vertex.glsl';
 import projective_texturing_pars_vertex from './Chunk/projective_texturing_pars_vertex.glsl';
 import projective_texturing_pars_fragment from './Chunk/projective_texturing_pars_fragment.glsl';
+import WebGL2_pars_vertex from './Chunk/WebGL2_pars_vertex.glsl';
+import WebGL2_pars_fragment from './Chunk/WebGL2_pars_fragment.glsl';
 
 const ShaderChunk = {
     color_layers_pars_fragment,
@@ -38,6 +40,8 @@ const ShaderChunk = {
     projective_texturing_pars_vertex,
     projective_texturing_pars_fragment,
     project_pars_vertex,
+    WebGL2_pars_vertex,
+    WebGL2_pars_fragment,
 };
 
 /**

--- a/src/Renderer/Shader/TileFS.glsl
+++ b/src/Renderer/Shader/TileFS.glsl
@@ -1,3 +1,4 @@
+#include <itowns/WebGL2_pars_fragment>
 #include <itowns/precision_qualifier>
 #include <logdepthbuf_pars_fragment>
 #include <itowns/pitUV>

--- a/src/Renderer/Shader/TileVS.glsl
+++ b/src/Renderer/Shader/TileVS.glsl
@@ -1,3 +1,4 @@
+#include <itowns/WebGL2_pars_vertex>
 #include <itowns/precision_qualifier>
 #include <common>
 #include <itowns/project_pars_vertex>

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -25,6 +25,10 @@ class c3DEngine {
             options.logarithmicDepthBuffer = this.gLDebug || NOIE;
         }
 
+        if (options.isWebGL2 === undefined) {
+            options.isWebGL2 = true;
+        }
+
         const renderer = rendererOrDiv.domElement ? rendererOrDiv : undefined;
         const viewerDiv = renderer ? renderer.domElement : rendererOrDiv;
 
@@ -61,8 +65,7 @@ class c3DEngine {
             this.label2dRenderer.setSize(this.width, this.height);
             viewerDiv.appendChild(this.label2dRenderer.domElement);
 
-            // WIP: support WebGL 2.0 see https://github.com/iTowns/itowns/pull/1443
-            this.renderer = renderer || new THREE.WebGLRenderer({
+            this.renderer = renderer || new (options.isWebGL2 ? THREE.WebGLRenderer : THREE.WebGL1Renderer)({
                 canvas: document.createElement('canvas'),
                 antialias: options.antialias,
                 alpha: options.alpha,
@@ -72,7 +75,8 @@ class c3DEngine {
             this.renderer.domElement.style.zIndex = 0;
             this.renderer.domElement.style.top = 0;
         } catch (ex) {
-            console.error('Failed to create WebGLRenderer', ex);
+            const versionWebGL = options.isWebGL2 ? '2' : '1';
+            console.error(`Failed to create WebGLRenderer webGL ${versionWebGL}.`);
             this.renderer = null;
         }
 
@@ -89,9 +93,9 @@ class c3DEngine {
         if (!renderer && options.logarithmicDepthBuffer) {
             // We don't support logarithmicDepthBuffer when EXT_frag_depth is missing.
             // So recreated a renderer if needed.
-            if (!this.renderer.extensions.get('EXT_frag_depth')) {
+            if (!this.renderer.capabilities.isWebGL2 && !this.renderer.extensions.get('EXT_frag_depth')) {
                 this.renderer.dispose();
-                this.renderer = new THREE.WebGLRenderer({
+                this.renderer = new (options.isWebGL2 ? THREE.WebGLRenderer : THREE.WebGL1Renderer)({
                     canvas: document.createElement('canvas'),
                     antialias: options.antialias,
                     alpha: options.alpha,

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -161,14 +161,15 @@ class c3DEngine {
             };
         }
 
+        zone.buffer = zone.buffer || new Uint8Array(4 * zone.width * zone.height);
+
         this.renderViewToRenderTarget(view, this.fullSizeRenderTarget, zone);
 
-        const pixelBuffer = new Uint8Array(4 * zone.width * zone.height);
         this.renderer.readRenderTargetPixels(
             this.fullSizeRenderTarget,
-            zone.x, this.height - (zone.y + zone.height), zone.width, zone.height, pixelBuffer);
+            zone.x, this.height - (zone.y + zone.height), zone.width, zone.height, zone.buffer);
 
-        return pixelBuffer;
+        return zone.buffer;
     }
 
     /**

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -15,6 +15,9 @@ global.requestAnimationFrame = () => {};
 global.fetch = fetch;
 global.fetch.Promise = Promise;
 
+// this could be replaced by jsdom.Navigator in https://github.com/iTowns/itowns/pull/1412
+global.navigator = undefined;
+
 class DOMElement {
     constructor() {
         this.children = [];
@@ -124,6 +127,7 @@ class Renderer {
         };
         this.capabilities = {
             logarithmicDepthBuffer: true,
+            isWebGL2: true,
         };
         this.debug = {};
     }

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -299,4 +299,35 @@ describe('Provide in Sources', function () {
             done();
         });
     });
+
+    it('should get updated MaterialLayer', (done) => {
+        colorlayer.source = new WMTSSource({
+            url: 'http://',
+            name: 'name',
+            format: `${formatTag}image/png`,
+            tileMatrixSet: 'PM',
+            projection: 'EPSG:3857',
+            extent: globalExtent,
+            zoom: {
+                min: 0,
+                max: 12,
+            },
+        });
+
+        const tile = new TileMesh(geom, new LayeredMaterial(), planarlayer, extent);
+        tile.material.visible = true;
+        nodeLayer.level = EMPTY_TEXTURE_ZOOM;
+        tile.parent = { };
+
+        updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
+        updateLayeredMaterialNodeImagery(context, colorlayer, tile, tile.parent);
+        DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((result) => {
+            tile.material.setSequence([colorlayer.id]);
+            tile.material.getLayer(colorlayer.id).setTextures(result, [new THREE.Vector4()]);
+            assert.equal(tile.material.uniforms.colorTextures.value[0], undefined);
+            tile.material.updateLayersUniforms();
+            assert.equal(tile.material.uniforms.colorTextures.value[0].extent.zoom, 10);
+            done();
+        });
+    });
 });

--- a/test/unit/obb.js
+++ b/test/unit/obb.js
@@ -51,6 +51,7 @@ function assertVerticesAreInOBB(builder, extent) {
         extent,
         disableSkirt: true,
         level: 0,
+        segment: 1,
     };
 
     newTileGeometry(builder, params).then((result) => {

--- a/test/unit/potree.js
+++ b/test/unit/potree.js
@@ -6,6 +6,8 @@ import GlobeView from 'Core/Prefab/GlobeView';
 import HttpsProxyAgent from 'https-proxy-agent';
 import Coordinates from 'Core/Geographic/Coordinates';
 import PotreeNode from 'Core/PotreeNode';
+import PointsMaterial from 'Renderer/PointsMaterial';
+import OrientedImageMaterial from 'Renderer/OrientedImageMaterial';
 import Renderer from './bootstrap';
 
 describe('Potree', function () {
@@ -94,6 +96,29 @@ describe('Potree', function () {
                     done();
                 });
             });
+        });
+    });
+
+    describe('Point Material and oriented images', () => {
+        const orientedImageMaterial = new OrientedImageMaterial([]);
+        const pMaterial = new PointsMaterial({ orientedImageMaterial });
+        const pMaterial2 = new PointsMaterial();
+        it('instance', () => {
+            assert.ok(pMaterial);
+        });
+        it('Define isWebGL2 on before compile', () => {
+            const shader = {};
+            pMaterial.onBeforeCompile(shader, renderer);
+            assert.equal(shader.glslVersion, '300 es');
+        });
+        it('copy', () => {
+            pMaterial2.copy(pMaterial);
+            assert.equal(pMaterial2.uniforms.projectiveTextureAlphaBorder.value, 20);
+        });
+        it('update', () => {
+            pMaterial.visible = false;
+            pMaterial2.update(pMaterial);
+            assert.equal(pMaterial2.visible, false);
         });
     });
 });

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -107,6 +107,13 @@ describe('Viewer', function () {
         assert.equal(height, viewer.camera.height);
     });
 
+    it('read pixel with readDepthBuffer returns a pixel buffer', () => {
+        viewer.tileLayer = { level0Nodes: [] };
+        const bufferPixel = viewer.readDepthBuffer(0, 0, 1, 1);
+
+        assert.equal(bufferPixel.length, 4);
+    });
+
     it('Capabilities', () => {
         renderer.context.getProgramParameter = () => false;
         renderer.context.getParameter = () => 32;


### PR DESCRIPTION
## Description

- [x] **WebGl 2.0 support**
   - [x] `webGLRenderer#render` throws error:
      - [x] **_WebGL: INVALID_OPERATION: drawElements: no buffer is bound to enabled attribute_**
        Fixed with removing common attribute in before dispose geometry;
      - [x] With Chrome v85 **THREE.WebGLProgram: gl.getProgramInfoLog() return string with null char**
      - [x] Another undefined webGL error. This could be the same cause.          
              on Firefox/ubuntu : **WebGL warning: drawElementsInstanced: Index buffer not bound.** 
              on Safari/macOs : **INVALID_OPERATION: drawElements: no ELEMENT_ARRAY_BUFFER bound**
   - [x] `RawShaderMaterial` and _GLSL 3.0_ conversion;
     - problem with `RawShaderMaterial` to add version and special defines before auto defines mechanism;
   - [x] avoid undefined uniforms;
   - [x] fix unit tests fail;
   - [x] fix point cloud shader;
   - [x] fix `DataTexture` instance with float array: use `RedFormat` and `R32F` for internal format;
   - [x] avoid `#pragma unrool` with WebGL 2.0; => **it's same problem with WebGl 2.0**
   - [x]  fix `OrientedImageMaterial`;

fix #1444 
