### PR TITLE
refacto: add an abstract PointCloud system

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -40,6 +40,7 @@
                 "ColorLayersOrdering",
                 "OrientedImageLayer",
                 "PointCloudLayer",
+                "PotreeLayer",
                 "C3DTilesLayer",
                 "LabelLayer",
 
@@ -55,7 +56,7 @@
                 "TMSSource",
                 "FileSource",
                 "OrientedImageSource",
-                "PointCloudSource",
+                "PotreeSource",
                 "VectorTilesSource"
             ],
 

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -61,8 +61,9 @@
                     source: new itowns.PotreeSource({
                         file: 'eglise_saint_blaise_arles.js',
                         url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/eglise_saint_blaise_arles',
-                    })
-                }, view);
+                    }),
+                    crs: view.referenceCrs,
+                });
 
                 // point selection on double-click
                 function dblClickHandler(event) {

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -61,8 +61,8 @@
                     source: new itowns.PotreeSource({
                         file: 'eglise_saint_blaise_arles.js',
                         url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/eglise_saint_blaise_arles',
+                        projection: view.referenceCrs,
                     }),
-                    crs: view.referenceCrs,
                 });
 
                 // point selection on double-click

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -65,8 +65,8 @@
                 source: new itowns.PotreeSource({
                     file: 'eglise_saint_blaise_arles.js',
                     url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+                    projection: view.referenceCrs,
                 }),
-                crs: view.referenceCrs,
             });
 
             // add potreeLayer to scene

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -66,7 +66,8 @@
                     file: 'eglise_saint_blaise_arles.js',
                     url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
                 }),
-            },view);
+                crs: view.referenceCrs,
+            });
 
             // add potreeLayer to scene
             function onLayerReady() {

--- a/src/Core/PointCloudNode.js
+++ b/src/Core/PointCloudNode.js
@@ -1,0 +1,45 @@
+import * as THREE from 'three';
+
+class PointCloudNode extends THREE.EventDispatcher {
+    constructor(numPoints = 0, layer) {
+        super();
+
+        this.numPoints = numPoints;
+        this.layer = layer;
+
+        this.children = [];
+        this.bbox = new THREE.Box3();
+        this.sse = -1;
+    }
+
+    add(node, indexChild) {
+        this.children.push(node);
+        node.parent = this;
+        this.createChildAABB(node, indexChild);
+    }
+
+    load() {
+        // Query octree/HRC if we don't have children potreeNode yet.
+        if (!this.octreeIsLoaded) {
+            this.loadOctree();
+        }
+
+        return this.layer.source.fetcher(this.url, this.layer.source.networkOptions).then(this.layer.source.parse);
+    }
+
+    findCommonAncestor(node) {
+        if (node.depth == this.depth) {
+            if (node.id == this.id) {
+                return node;
+            } else if (node.depth != 0) {
+                return this.parent.findCommonAncestor(node.parent);
+            }
+        } else if (node.depth < this.depth) {
+            return this.parent.findCommonAncestor(node);
+        } else {
+            return this.findCommonAncestor(node.parent);
+        }
+    }
+}
+
+export default PointCloudNode;

--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -8,7 +8,7 @@ import PriorityQueue from 'js-priority-queue';
 import DataSourceProvider from 'Provider/DataSourceProvider';
 import TileProvider from 'Provider/TileProvider';
 import $3dTilesProvider from 'Provider/3dTilesProvider';
-import PotreeProvider from 'Provider/PotreeProvider';
+import PointCloudProvider from 'Provider/PointCloudProvider';
 import CancelledCommandException from './CancelledCommandException';
 
 function queueOrdering(a, b) {
@@ -123,7 +123,7 @@ Scheduler.prototype.initDefaultProviders = function initDefaultProviders() {
     // Register all providers
     this.addProtocolProvider('tile', TileProvider);
     this.addProtocolProvider('3d-tiles', $3dTilesProvider);
-    this.addProtocolProvider('potreeconverter', PotreeProvider);
+    this.addProtocolProvider('pointcloud', PointCloudProvider);
 };
 
 Scheduler.prototype.runCommand = function runCommand(command, queue, executingCounterUpToDate) {

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -1,0 +1,372 @@
+import * as THREE from 'three';
+import GeometryLayer from 'Layer/GeometryLayer';
+import PointsMaterial, { MODE } from 'Renderer/PointsMaterial';
+import Picking from 'Core/Picking';
+
+const point = new THREE.Vector3();
+const bboxMesh = new THREE.Mesh();
+const box3 = new THREE.Box3();
+bboxMesh.geometry.boundingBox = box3;
+
+function initBoundingBox(elt, layer) {
+    elt.tightbbox.getSize(box3.max);
+    box3.max.multiplyScalar(0.5);
+    box3.min.copy(box3.max).negate();
+    elt.obj.boxHelper = new THREE.BoxHelper(bboxMesh);
+    elt.obj.boxHelper.geometry = new THREE.Geometry().fromBufferGeometry(elt.obj.boxHelper.geometry.toNonIndexed());
+    elt.obj.boxHelper.computeLineDistances();
+    elt.obj.boxHelper.material = elt.childrenBitField ? new THREE.LineDashedMaterial({ dashSize: 0.25, gapSize: 0.25 }) : new THREE.LineBasicMaterial();
+    elt.obj.boxHelper.material.color.setHex(0);
+    elt.obj.boxHelper.material.linewidth = 2;
+    elt.obj.boxHelper.frustumCulled = false;
+    elt.obj.boxHelper.position.copy(elt.tightbbox.min).add(box3.max);
+    elt.obj.boxHelper.autoUpdateMatrix = false;
+    elt.obj.boxHelper.layers.mask = layer.bboxes.layers.mask;
+    layer.bboxes.add(elt.obj.boxHelper);
+    elt.obj.boxHelper.updateMatrix();
+    elt.obj.boxHelper.updateMatrixWorld();
+}
+
+function computeScreenSpaceError(context, pointSize, spacing, elt, distance) {
+    if (distance <= 0) {
+        return Infinity;
+    }
+    const pointSpacing = spacing / 2 ** elt.depth;
+    // Estimate the onscreen distance between 2 points
+    const onScreenSpacing = context.camera.preSSE * pointSpacing / distance;
+    // [  P1  ]--------------[   P2   ]
+    //     <--------------------->      = pointsSpacing (in world coordinates)
+    //                                  ~ onScreenSpacing (in pixels)
+    // <------>                         = pointSize (in pixels)
+    return Math.max(0.0, onScreenSpacing - pointSize);
+}
+
+function markForDeletion(elt) {
+    if (elt.obj) {
+        elt.obj.material.visible = false;
+        if (__DEBUG__) {
+            if (elt.obj.boxHelper) {
+                elt.obj.boxHelper.material.visible = false;
+            }
+        }
+    }
+
+    if (!elt.notVisibleSince) {
+        elt.notVisibleSince = Date.now();
+        // Set .sse to an invalid value
+        elt.sse = -1;
+    }
+    for (const child of elt.children) {
+        markForDeletion(child);
+    }
+}
+
+/**
+ * The basis for all point clouds related layers.
+ *
+ * @property {boolean} isPointCloudLayer - Used to checkout whether this layer
+ * is a PointCloudLayer. Default is `true`. You should not change this, as it is
+ * used internally for optimisation.
+ * @property {THREE.Group|THREE.Object3D} group - Contains the created
+ * `THREE.Points` meshes, usually with an instance of a `THREE.Points` per node.
+ * @property {THREE.Group|THREE.Object3D} bboxes - Contains the bounding boxes
+ * (`THREE.Box3`) of the tree, usually one per node.
+ * @property {number} octreeDepthLimit - The depth limit at which to stop
+ * browsing the octree. Can be used to limit the browsing, without having to
+ * edit manually the source of the point cloud. No limit by default (`-1`).
+ * @property {number} [pointBudget=2000000] - Maximum number of points to
+ * display at the same time. This influences the performance of rendering.
+ * Default to two millions points.
+ * @property {number} [sseThreshold=2] - Threshold of the **S**creen **S**pace
+ * **E**rror. Default to `2`.
+ * @property {number} [pointSize=4] - The size (in pixels) of the points.
+ * Default to `4`.
+ * @property {THREE.Material|PointsMaterial} [material=new PointsMaterial] - The
+ * material to use to display the points of the cloud. Be default it is a new
+ * `PointsMaterial`.
+ * @property {number} [mode=MODE.COLOR] - The displaying mode of the points.
+ * Values are specified in `PointsMaterial`.
+ */
+class PointCloudLayer extends GeometryLayer {
+    /**
+     * Constructs a new instance of point cloud layer.
+     * Constructs a new instance of a Point Cloud Layer. This should not be used
+     * directly, but rather implemented using `extends`.
+     *
+     * @constructor
+     * @extends GeometryLayer
+     *
+     * @param {string} id - The id of the layer, that should be unique. It is
+     * not mandatory, but an error will be emitted if this layer is added a
+     * {@link View} that already has a layer going by that id.
+     * @param {Object} [config] - Optional configuration, all elements in it
+     * will be merged as is in the layer. For example, if the configuration
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name. See the list of properties to know which one can be specified.
+     */
+    constructor(id, config = {}) {
+        super(id, new THREE.Group(), config);
+        this.isPointCloudLayer = true;
+        this.protocol = 'pointcloud';
+
+        this.group = config.group || new THREE.Group();
+        this.object3d.add(this.group);
+        this.bboxes = config.bboxes || new THREE.Group();
+        this.bboxes.visible = false;
+        this.object3d.add(this.bboxes);
+        this.group.updateMatrixWorld();
+
+        // default config
+        this.octreeDepthLimit = config.octreeDepthLimit || -1;
+        this.pointBudget = config.pointBudget || 2000000;
+        this.pointSize = config.pointSize === 0 || !isNaN(config.pointSize) ? config.pointSize : 4;
+        this.sseThreshold = config.sseThreshold || 2;
+        this.material = config.material || {};
+        this.material = this.material.isMaterial ? config.material : new PointsMaterial(config.material);
+        this.material.defines = this.material.defines || {};
+        this.mode = config.mode || MODE.COLOR;
+    }
+
+    preUpdate(context, changeSources) {
+        // See https://cesiumjs.org/hosted-apps/massiveworlds/downloads/Ring/WorldScaleTerrainRendering.pptx
+        // slide 17
+        context.camera.preSSE =
+            context.camera.height /
+                (2 * Math.tan(THREE.MathUtils.degToRad(context.camera.camera3D.fov) * 0.5));
+
+        if (this.material) {
+            this.material.visible = this.visible;
+            this.material.opacity = this.opacity;
+            this.material.transparent = this.opacity < 1;
+            this.material.size = this.pointSize;
+        }
+
+        // lookup lowest common ancestor of changeSources
+        let commonAncestor;
+        for (const source of changeSources.values()) {
+            if (source.isCamera || source == this) {
+                // if the change is caused by a camera move, no need to bother
+                // to find common ancestor: we need to update the whole tree:
+                // some invisible tiles may now be visible
+                return [this.root];
+            }
+            if (source.obj === undefined) {
+                continue;
+            }
+            // filter sources that belong to our layer
+            if (source.obj.isPoints && source.obj.layer == this) {
+                if (!commonAncestor) {
+                    commonAncestor = source;
+                } else {
+                    commonAncestor = source.findCommonAncestor(commonAncestor);
+
+                    if (!commonAncestor) {
+                        return [this.root];
+                    }
+                }
+            }
+        }
+
+        if (commonAncestor) {
+            return [commonAncestor];
+        }
+
+        // Start updating from hierarchy root
+        return [this.root];
+    }
+
+    update(context, layer, elt) {
+        elt.visible = false;
+
+        if (this.octreeDepthLimit >= 0 && this.octreeDepthLimit < elt.depth) {
+            markForDeletion(elt);
+            return;
+        }
+
+        // pick the best bounding box
+        const bbox = (elt.tightbbox ? elt.tightbbox : elt.bbox);
+        elt.visible = context.camera.isBox3Visible(bbox, this.object3d.matrixWorld);
+        if (!elt.visible) {
+            markForDeletion(elt);
+            return;
+        }
+
+        elt.notVisibleSince = undefined;
+        point.copy(context.camera.camera3D.position).sub(this.object3d.position);
+
+        // only load geometry if this elements has points
+        if (elt.numPoints > 0) {
+            if (elt.obj) {
+                if (elt.obj.material.update) {
+                    elt.obj.material.update(this.material);
+                } else {
+                    elt.obj.material.copy(this.material);
+                }
+                if (__DEBUG__) {
+                    if (this.bboxes.visible) {
+                        if (!elt.obj.boxHelper) {
+                            initBoundingBox(elt, layer);
+                        }
+                        elt.obj.boxHelper.visible = true;
+                        elt.obj.boxHelper.material.color.r = 1 - elt.sse;
+                        elt.obj.boxHelper.material.color.g = elt.sse;
+                    }
+                }
+            } else if (!elt.promise) {
+                const distance = Math.max(0.001, bbox.distanceToPoint(point));
+                // Increase priority of nearest node
+                const priority = computeScreenSpaceError(context, layer.pointSize, layer.spacing, elt, distance) / distance;
+                elt.promise = context.scheduler.execute({
+                    layer,
+                    requester: elt,
+                    view: context.view,
+                    priority,
+                    redraw: true,
+                    earlyDropFunction: cmd => !cmd.requester.visible || !this.visible,
+                }).then((pts) => {
+                    if (this.onPointsCreated) {
+                        this.onPointsCreated(layer, pts);
+                    }
+
+                    elt.obj = pts;
+                    // store tightbbox to avoid ping-pong (bbox = larger => visible, tight => invisible)
+                    elt.tightbbox = pts.tightbbox;
+
+                    // make sure to add it here, otherwise it might never
+                    // be added nor cleaned
+                    this.group.add(elt.obj);
+                    elt.obj.updateMatrixWorld(true);
+
+                    elt.promise = null;
+                }, (err) => {
+                    if (err.isCancelledCommandException) {
+                        elt.promise = null;
+                    }
+                });
+            }
+        }
+
+        if (elt.children && elt.children.length) {
+            const distance = bbox.distanceToPoint(point);
+            elt.sse = computeScreenSpaceError(context, layer.pointSize, layer.spacing, elt, distance) / this.sseThreshold;
+            if (elt.sse >= 1) {
+                return elt.children;
+            } else {
+                for (const child of elt.children) {
+                    markForDeletion(child);
+                }
+            }
+        }
+    }
+
+    postUpdate() {
+        this.displayedCount = 0;
+        for (const pts of this.group.children) {
+            if (pts.material.visible) {
+                const count = pts.geometry.attributes.position.count;
+                pts.geometry.setDrawRange(0, count);
+                this.displayedCount += count;
+            }
+        }
+
+        if (this.displayedCount > this.pointBudget) {
+            // 2 different point count limit implementation, depending on the potree source
+            if (this.supportsProgressiveDisplay) {
+                // In this format, points are evenly distributed within a node,
+                // so we can draw a percentage of each node and still get a correct
+                // representation
+                const reduction = this.pointBudget / this.displayedCount;
+                for (const pts of this.group.children) {
+                    if (pts.material.visible) {
+                        const count = Math.floor(pts.geometry.drawRange.count * reduction);
+                        if (count > 0) {
+                            pts.geometry.setDrawRange(0, count);
+                        } else {
+                            pts.material.visible = false;
+                        }
+                    }
+                }
+                this.displayedCount *= reduction;
+            } else {
+                // This format doesn't require points to be evenly distributed, so
+                // we're going to sort the nodes by "importance" (= on screen size)
+                // and display only the first N nodes
+                this.group.children.sort((p1, p2) => p2.userData.node.sse - p1.userData.node.sse);
+
+                let limitHit = false;
+                this.displayedCount = 0;
+                for (const pts of this.group.children) {
+                    const count = pts.geometry.attributes.position.count;
+                    if (limitHit || (this.displayedCount + count) > this.pointBudget) {
+                        pts.material.visible = false;
+                        limitHit = true;
+                    } else {
+                        this.displayedCount += count;
+                    }
+                }
+            }
+        }
+
+        const now = Date.now();
+        for (let i = this.group.children.length - 1; i >= 0; i--) {
+            const obj = this.group.children[i];
+            if (!obj.material.visible && (now - obj.userData.node.notVisibleSince) > 10000) {
+                // remove from group
+                this.group.children.splice(i, 1);
+
+                if (Array.isArray(obj.material)) {
+                    for (const material of obj.material) {
+                        material.dispose();
+                    }
+                } else {
+                    obj.material.dispose();
+                }
+                obj.geometry.dispose();
+                obj.material = null;
+                obj.geometry = null;
+                obj.userData.node.obj = null;
+
+                if (__DEBUG__) {
+                    if (obj.boxHelper) {
+                        obj.boxHelper.removeMe = true;
+                        if (Array.isArray(obj.boxHelper.material)) {
+                            for (const material of obj.boxHelper.material) {
+                                material.dispose();
+                            }
+                        } else {
+                            obj.boxHelper.material.dispose();
+                        }
+                        obj.boxHelper.geometry.dispose();
+                    }
+                }
+            }
+        }
+
+        if (__DEBUG__) {
+            this.bboxes.children = this.bboxes.children.filter(b => !b.removeMe);
+        }
+    }
+
+    pickObjectsAt(view, mouse, radius, target = []) {
+        return Picking.pickPointsAt(view, mouse, radius, this, target);
+    }
+
+    getObjectToUpdateForAttachedLayers(meta) {
+        if (meta.obj) {
+            const p = meta.parent;
+            if (p && p.obj) {
+                return {
+                    element: meta.obj,
+                    parent: p.obj,
+                };
+            } else {
+                return {
+                    element: meta.obj,
+                };
+            }
+        }
+    }
+}
+
+export default PointCloudLayer;

--- a/src/Layer/PotreeLayer.js
+++ b/src/Layer/PotreeLayer.js
@@ -1,73 +1,23 @@
 import * as THREE from 'three';
-import GeometryLayer from 'Layer/GeometryLayer';
-import PointsMaterial, { MODE } from 'Renderer/PointsMaterial';
-import Picking from 'Core/Picking';
+import PointCloudLayer from 'Layer/PointCloudLayer';
 import PotreeNode from 'Core/PotreeNode';
 import Extent from 'Core/Geographic/Extent';
 
-const point = new THREE.Vector3();
 const bboxMesh = new THREE.Mesh();
 const box3 = new THREE.Box3();
 bboxMesh.geometry.boundingBox = box3;
 
-function initBoundingBox(elt, layer) {
-    elt.tightbbox.getSize(box3.max);
-    box3.max.multiplyScalar(0.5);
-    box3.min.copy(box3.max).negate();
-    elt.obj.boxHelper = new THREE.BoxHelper(bboxMesh);
-    elt.obj.boxHelper.geometry = new THREE.Geometry().fromBufferGeometry(elt.obj.boxHelper.geometry.toNonIndexed());
-    elt.obj.boxHelper.computeLineDistances();
-    elt.obj.boxHelper.material = elt.childrenBitField ? new THREE.LineDashedMaterial({ dashSize: 0.25, gapSize: 0.25 }) : new THREE.LineBasicMaterial();
-    elt.obj.boxHelper.material.color.setHex(0);
-    elt.obj.boxHelper.material.linewidth = 2;
-    elt.obj.boxHelper.frustumCulled = false;
-    elt.obj.boxHelper.position.copy(elt.tightbbox.min).add(box3.max);
-    elt.obj.boxHelper.autoUpdateMatrix = false;
-    elt.obj.boxHelper.layers.mask = layer.bboxes.layers.mask;
-    layer.bboxes.add(elt.obj.boxHelper);
-    elt.obj.boxHelper.updateMatrix();
-    elt.obj.boxHelper.updateMatrixWorld();
-}
-
-function computeScreenSpaceError(context, pointSize, spacing, elt, distance) {
-    if (distance <= 0) {
-        return Infinity;
-    }
-    const pointSpacing = spacing / 2 ** elt.name.length;
-    // Estimate the onscreen distance between 2 points
-    const onScreenSpacing = context.camera.preSSE * pointSpacing / distance;
-    // [  P1  ]--------------[   P2   ]
-    //     <--------------------->      = pointsSpacing (in world coordinates)
-    //                                  ~ onScreenSpacing (in pixels)
-    // <------>                         = pointSize (in pixels)
-    return Math.max(0.0, onScreenSpacing - pointSize);
-}
-
-function markForDeletion(elt) {
-    if (elt.obj) {
-        elt.obj.material.visible = false;
-        if (__DEBUG__) {
-            if (elt.obj.boxHelper) {
-                elt.obj.boxHelper.material.visible = false;
-            }
-        }
-    }
-
-    if (!elt.notVisibleSince) {
-        elt.notVisibleSince = Date.now();
-        // Set .sse to an invalid value
-        elt.sse = -1;
-    }
-    for (const child of elt.children) {
-        markForDeletion(child);
-    }
-}
-
-class PotreeLayer extends GeometryLayer {
+/**
+ * @property {boolean} isPotreeLayer - Used to checkout whether this layer
+ * is a PotreeLayer. Default is `true`. You should not change this, as it is
+ * used internally for optimisation.
+ */
+class PotreeLayer extends PointCloudLayer {
     /**
-     * Constructs a new instance of point cloud layer.
+     * Constructs a new instance of Potree layer.
+     *
      * @constructor
-     * @extends GeometryLayer
+     * @extends PointCloudLayer
      *
      * @example
      * // Create a new point cloud layer
@@ -77,45 +27,25 @@ class PotreeLayer extends GeometryLayer {
      *          url: 'https://pointsClouds/',
      *          file: 'points.js',
      *      }
-     *  }, view);
+     *  });
      *
      * View.prototype.addLayer.call(view, points);
      *
-     * @param      {string}  id - The id of the layer, that should be unique. It is
+     * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
      * {@link View} that already has a layer going by that id.
-     * @param      {object}  config   configuration, all elements in it
-     * will be merged as is in the layer.
-     * @param {number} [config.pointBudget=2000000] max displayed points count.
-     * @param {PotreeSource} config.source - Description and options of the source.
-     * @param {number} [config.sseThreshold=2] screen space error Threshold.
-     * @param {number} [config.pointSize=4] point size.
-     * @param {THREE.Material} [config.material] override material.
-     * @param {number} [config.mode=MODE.COLOR] displaying mode.
-     *
-     * @param  {View}  view  The view
+     * @param {Object} config - Configuration, all elements in it
+     * will be merged as is in the layer. For example, if the configuration
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name. See the list of properties to know which one can be specified.
+     * @param {string} [config.crs=ESPG:4326] - The CRS of the {@link View} this
+     * layer will be attached to. This is used to determine the extent of this
+     * layer.  Default to `EPSG:4326`.
      */
-    constructor(id, config, view) {
-        super(id, new THREE.Group(), config);
+    constructor(id, config) {
+        super(id, config);
         this.isPotreeLayer = true;
-        this.protocol = 'potreeconverter';
-
-        this.group = config.group || new THREE.Group();
-        this.object3d.add(this.group);
-        this.bboxes = config.bboxes || new THREE.Group();
-        this.bboxes.visible = false;
-        this.object3d.add(this.bboxes);
-        this.group.updateMatrixWorld();
-
-        // default config
-        this.octreeDepthLimit = config.octreeDepthLimit || -1;
-        this.pointBudget = config.pointBudget || 2000000;
-        this.pointSize = config.pointSize === 0 || !isNaN(config.pointSize) ? config.pointSize : 4;
-        this.sseThreshold = config.sseThreshold || 2;
-        this.material = config.material || {};
-        this.material = this.material.isMaterial ? config.material : new PointsMaterial(config.material);
-        this.material.defines = this.material.defines || {};
-        this.mode = MODE.COLOR || config.mode;
 
         const resolve = this.addInitializationStep();
 
@@ -125,7 +55,7 @@ class PotreeLayer extends GeometryLayer {
             this.hierarchyStepSize = cloud.hierarchyStepSize;
 
             const normal = Array.isArray(cloud.pointAttributes) &&
-                        cloud.pointAttributes.find(elem => elem.startsWith('NORMAL'));
+                cloud.pointAttributes.find(elem => elem.startsWith('NORMAL'));
             if (normal) {
                 this.material.defines[normal] = 1;
             }
@@ -136,254 +66,9 @@ class PotreeLayer extends GeometryLayer {
             this.root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
             this.root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
 
-            this.extent = Extent.fromBox3(view.referenceCrs, this.root.bbox);
+            this.extent = Extent.fromBox3(config.crs || 'EPSG:4326', this.root.bbox);
             return this.root.loadOctree().then(resolve);
         });
-    }
-
-    preUpdate(context, changeSources) {
-        // See https://cesiumjs.org/hosted-apps/massiveworlds/downloads/Ring/WorldScaleTerrainRendering.pptx
-        // slide 17
-        context.camera.preSSE =
-            context.camera.height /
-                (2 * Math.tan(THREE.MathUtils.degToRad(context.camera.camera3D.fov) * 0.5));
-
-        if (this.material) {
-            this.material.visible = this.visible;
-            this.material.opacity = this.opacity;
-            this.material.transparent = this.opacity < 1;
-            this.material.size = this.pointSize;
-        }
-
-        // lookup lowest common ancestor of changeSources
-        let commonAncestorName;
-        for (const source of changeSources.values()) {
-            if (source.isCamera || source == this) {
-                // if the change is caused by a camera move, no need to bother
-                // to find common ancestor: we need to update the whole tree:
-                // some invisible tiles may now be visible
-                return [this.root];
-            }
-            if (source.obj === undefined) {
-                continue;
-            }
-            // filter sources that belong to our layer
-            if (source.obj.isPoints && source.obj.layer == this) {
-                if (!commonAncestorName) {
-                    commonAncestorName = source.name;
-                } else {
-                    let i;
-                    for (i = 0; i < Math.min(source.name.length, commonAncestorName.length); i++) {
-                        if (source.name[i] != commonAncestorName[i]) {
-                            break;
-                        }
-                    }
-                    commonAncestorName = commonAncestorName.substr(0, i);
-                    if (commonAncestorName.length == 0) {
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (commonAncestorName) {
-            return [this.root.getChildByName(commonAncestorName)];
-        }
-
-        // Start updating from hierarchy root
-        return [this.root];
-    }
-
-    update(context, layer, elt) {
-        elt.visible = false;
-
-        if (this.octreeDepthLimit >= 0 && this.octreeDepthLimit < elt.name.length) {
-            markForDeletion(elt);
-            return;
-        }
-
-        // pick the best bounding box
-        const bbox = (elt.tightbbox ? elt.tightbbox : elt.bbox);
-        elt.visible = context.camera.isBox3Visible(bbox, this.object3d.matrixWorld);
-        if (!elt.visible) {
-            markForDeletion(elt);
-            return;
-        }
-
-        elt.notVisibleSince = undefined;
-        point.copy(context.camera.camera3D.position).sub(this.object3d.position);
-
-        // only load geometry if this elements has points
-        if (elt.numPoints > 0) {
-            if (elt.obj) {
-                if (elt.obj.material.update) {
-                    elt.obj.material.update(this.material);
-                } else {
-                    elt.obj.material.copy(this.material);
-                }
-                if (__DEBUG__) {
-                    if (this.bboxes.visible) {
-                        if (!elt.obj.boxHelper) {
-                            initBoundingBox(elt, layer);
-                        }
-                        elt.obj.boxHelper.visible = true;
-                        elt.obj.boxHelper.material.color.r = 1 - elt.sse;
-                        elt.obj.boxHelper.material.color.g = elt.sse;
-                    }
-                }
-            } else if (!elt.promise) {
-                const distance = Math.max(0.001, bbox.distanceToPoint(point));
-                // Increase priority of nearest node
-                const priority = computeScreenSpaceError(context, layer.pointSize, layer.spacing, elt, distance) / distance;
-                elt.promise = context.scheduler.execute({
-                    layer,
-                    requester: elt,
-                    view: context.view,
-                    priority,
-                    redraw: true,
-                    earlyDropFunction: cmd => !cmd.requester.visible || !this.visible,
-                }).then((pts) => {
-                    if (this.onPointsCreated) {
-                        this.onPointsCreated(layer, pts);
-                    }
-
-                    elt.obj = pts;
-                    // store tightbbox to avoid ping-pong (bbox = larger => visible, tight => invisible)
-                    elt.tightbbox = pts.tightbbox;
-
-                    // make sure to add it here, otherwise it might never
-                    // be added nor cleaned
-                    this.group.add(elt.obj);
-                    elt.obj.updateMatrixWorld(true);
-
-                    elt.promise = null;
-                }, (err) => {
-                    if (err.isCancelledCommandException) {
-                        elt.promise = null;
-                    }
-                });
-            }
-        }
-
-        if (elt.children && elt.children.length) {
-            const distance = bbox.distanceToPoint(point);
-            elt.sse = computeScreenSpaceError(context, layer.pointSize, layer.spacing, elt, distance) / this.sseThreshold;
-            if (elt.sse >= 1) {
-                return elt.children;
-            } else {
-                for (const child of elt.children) {
-                    markForDeletion(child);
-                }
-            }
-        }
-    }
-
-    postUpdate() {
-        this.displayedCount = 0;
-        for (const pts of this.group.children) {
-            if (pts.material.visible) {
-                const count = pts.geometry.attributes.position.count;
-                pts.geometry.setDrawRange(0, count);
-                this.displayedCount += count;
-            }
-        }
-
-        if (this.displayedCount > this.pointBudget) {
-            // 2 different point count limit implementation, depending on the potree source
-            if (this.supportsProgressiveDisplay) {
-                // In this format, points are evenly distributed within a node,
-                // so we can draw a percentage of each node and still get a correct
-                // representation
-                const reduction = this.pointBudget / this.displayedCount;
-                for (const pts of this.group.children) {
-                    if (pts.material.visible) {
-                        const count = Math.floor(pts.geometry.drawRange.count * reduction);
-                        if (count > 0) {
-                            pts.geometry.setDrawRange(0, count);
-                        } else {
-                            pts.material.visible = false;
-                        }
-                    }
-                }
-                this.displayedCount *= reduction;
-            } else {
-                // This format doesn't require points to be evenly distributed, so
-                // we're going to sort the nodes by "importance" (= on screen size)
-                // and display only the first N nodes
-                this.group.children.sort((p1, p2) => p2.userData.potreeNode.sse - p1.userData.potreeNode.sse);
-
-                let limitHit = false;
-                this.displayedCount = 0;
-                for (const pts of this.group.children) {
-                    const count = pts.geometry.attributes.position.count;
-                    if (limitHit || (this.displayedCount + count) > this.pointBudget) {
-                        pts.material.visible = false;
-                        limitHit = true;
-                    } else {
-                        this.displayedCount += count;
-                    }
-                }
-            }
-        }
-
-        const now = Date.now();
-        for (let i = this.group.children.length - 1; i >= 0; i--) {
-            const obj = this.group.children[i];
-            if (!obj.material.visible && (now - obj.userData.potreeNode.notVisibleSince) > 10000) {
-                // remove from group
-                this.group.children.splice(i, 1);
-
-                if (Array.isArray(obj.material)) {
-                    for (const material of obj.material) {
-                        material.dispose();
-                    }
-                } else {
-                    obj.material.dispose();
-                }
-                obj.geometry.dispose();
-                obj.material = null;
-                obj.geometry = null;
-                obj.userData.potreeNode.obj = null;
-
-                if (__DEBUG__) {
-                    if (obj.boxHelper) {
-                        obj.boxHelper.removeMe = true;
-                        if (Array.isArray(obj.boxHelper.material)) {
-                            for (const material of obj.boxHelper.material) {
-                                material.dispose();
-                            }
-                        } else {
-                            obj.boxHelper.material.dispose();
-                        }
-                        obj.boxHelper.geometry.dispose();
-                    }
-                }
-            }
-        }
-
-        if (__DEBUG__) {
-            this.bboxes.children = this.bboxes.children.filter(b => !b.removeMe);
-        }
-    }
-
-    pickObjectsAt(view, mouse, radius, target = []) {
-        return Picking.pickPointsAt(view, mouse, radius, this, target);
-    }
-
-    getObjectToUpdateForAttachedLayers(meta) {
-        if (meta.obj) {
-            const p = meta.parent;
-            if (p && p.obj) {
-                return {
-                    element: meta.obj,
-                    parent: p.obj,
-                };
-            } else {
-                return {
-                    element: meta.obj,
-                };
-            }
-        }
     }
 }
 

--- a/src/Layer/PotreeLayer.js
+++ b/src/Layer/PotreeLayer.js
@@ -66,7 +66,7 @@ class PotreeLayer extends PointCloudLayer {
             this.root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
             this.root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
 
-            this.extent = Extent.fromBox3(config.crs || 'EPSG:4326', this.root.bbox);
+            this.extent = Extent.fromBox3(this.source.projection || 'EPSG:4326', this.root.bbox);
             return this.root.loadOctree().then(resolve);
         });
     }

--- a/src/Main.js
+++ b/src/Main.js
@@ -42,6 +42,7 @@ export { default as Layer, ImageryLayers } from 'Layer/Layer';
 export { default as ColorLayer } from 'Layer/ColorLayer';
 export { default as ElevationLayer } from 'Layer/ElevationLayer';
 export { default as GeometryLayer } from 'Layer/GeometryLayer';
+export { default as PointCloudLayer } from 'Layer/PointCloudLayer';
 export { default as PotreeLayer } from 'Layer/PotreeLayer';
 export { default as C3DTilesLayer } from 'Layer/C3DTilesLayer';
 export { default as TiledGeometryLayer } from 'Layer/TiledGeometryLayer';

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -29,21 +29,21 @@ function addPickingAttribute(points) {
 export default {
     executeCommand(command) {
         const layer = command.layer;
-        const potreeNode = command.requester;
+        const node = command.requester;
 
-        return potreeNode.load().then((geometry) => {
+        return node.load().then((geometry) => {
             const points = new THREE.Points(geometry, layer.material.clone());
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            points.position.copy(potreeNode.bbox.min);
+            points.position.copy(node.bbox.min);
             points.scale.copy(layer.scale);
             points.updateMatrix();
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
             points.layers.set(layer.threejsLayer);
             points.layer = layer;
-            points.extent = Extent.fromBox3(command.view.referenceCrs, potreeNode.bbox);
-            points.userData.potreeNode = potreeNode;
+            points.extent = Extent.fromBox3(command.view.referenceCrs, node.bbox);
+            points.userData.node = node;
             return points;
         });
     },

--- a/src/Source/PotreeSource.js
+++ b/src/Source/PotreeSource.js
@@ -65,16 +65,12 @@ class PotreeSource extends Source {
      * @constructor
      */
     constructor(source) {
-        if (!source.url) {
-            throw new Error('New PotreeSource: url is required');
-        }
         if (!source.file) {
             throw new Error('New PotreeSource: file is required');
         }
 
         super(source);
         this.file = source.file;
-        this.url = source.url;
         this.fetcher = Fetcher.arrayBuffer;
         this.extensionOctree = 'hrc';
 

--- a/test/unit/potree.js
+++ b/test/unit/potree.js
@@ -28,7 +28,8 @@ describe('Potree', function () {
                 networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
             }),
             onPointsCreated: () => {},
-        }, viewer);
+            crs: viewer.referenceCrs,
+        });
 
         context = {
             camera: viewer.camera,

--- a/test/unit/potreelayerparsing.js
+++ b/test/unit/potreelayerparsing.js
@@ -29,7 +29,7 @@ describe('Potree Provider', function () {
             cloud,
         });
 
-        const p1 = new PotreeLayer('pointsCloud1', { source }, view);
+        const p1 = new PotreeLayer('pointsCloud1', { source, crs: view.referenceCrs });
         ps.push(p1);
         p1.whenReady.then((l) => {
             const normalDefined = l.material.defines.NORMAL || l.material.defines.NORMAL_SPHEREMAPPED || l.material.defines.NORMAL_OCT16;
@@ -49,7 +49,7 @@ describe('Potree Provider', function () {
             },
         });
 
-        const p2 = new PotreeLayer('pointsCloud2', { source }, view);
+        const p2 = new PotreeLayer('pointsCloud2', { source, crs: view.referenceCrs });
         ps.push(p2);
         p2.whenReady.then((l) => {
             assert.ok(l.material.defines.NORMAL);
@@ -69,7 +69,7 @@ describe('Potree Provider', function () {
                 octreeDir: 'eglise_saint_blaise_arles',
             },
         });
-        const p3 = new PotreeLayer('pointsCloud3', { source }, view);
+        const p3 = new PotreeLayer('pointsCloud3', { source, crs: view.referenceCrs });
 
         ps.push(p3);
         p3.whenReady.then((l) => {
@@ -90,7 +90,7 @@ describe('Potree Provider', function () {
                 octreeDir: 'eglise_saint_blaise_arles',
             },
         });
-        const p4 = new PotreeLayer('pointsCloud4', { source }, view);
+        const p4 = new PotreeLayer('pointsCloud4', { source, crs: view.referenceCrs });
 
         ps.push(p4);
         p4.whenReady.then((l) => {

--- a/test/unit/potreelayerprocessing.js
+++ b/test/unit/potreelayerprocessing.js
@@ -1,54 +1,84 @@
 import assert from 'assert';
 import PotreeLayer from 'Layer/PotreeLayer';
+import PotreeNode from 'Core/PotreeNode';
 
 describe('preUpdate PotreeLayer', function () {
     const context = { camera: { height: 1, camera3D: { fov: 1 } } };
+    const layer = {
+        id: 'a',
+        source: { baseurl: 'server.geo' },
+        hierarchyStepSize: 1,
+    };
+    layer.root = new PotreeNode(4000, 0, layer);
+    layer.root.bbox.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+
+    layer.root.add(new PotreeNode(3000, 0, layer), 1, layer.root);
+    layer.root.children[0].obj = { layer, isPoints: true };
+    layer.root.add(new PotreeNode(3000, 0, layer), 2, layer.root);
+    layer.root.children[1].obj = { layer, isPoints: true };
+    layer.root.add(new PotreeNode(3000, 0, layer), 3, layer.root);
+    layer.root.children[2].obj = { layer, isPoints: true };
+
+    layer.root.children[0].add(new PotreeNode(2000, 0, layer), 1, layer.root);
+    layer.root.children[0].children[0].obj = { layer, isPoints: true };
+    layer.root.children[0].add(new PotreeNode(2000, 0, layer), 2, layer.root);
+    layer.root.children[0].children[1].obj = { layer, isPoints: true };
+    layer.root.children[1].add(new PotreeNode(2000, 0, layer), 1, layer.root);
+    layer.root.children[1].children[0].obj = { layer, isPoints: true };
+    layer.root.children[2].add(new PotreeNode(2000, 0, layer), 2, layer.root);
+    layer.root.children[2].children[0].obj = { layer, isPoints: true };
+    layer.root.children[2].add(new PotreeNode(2000, 0, layer), 3, layer.root);
+    layer.root.children[2].children[1].obj = { layer, isPoints: true };
+
+    layer.root.children[0].children[0].add(new PotreeNode(1000, 0, layer), 1, layer.root);
+    layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
+    layer.root.children[0].children[0].add(new PotreeNode(1000, 0, layer), 5, layer.root);
+    layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
+    layer.root.children[0].children[1].add(new PotreeNode(1000, 0, layer), 4, layer.root);
+    layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
+    layer.root.children[2].children[1].add(new PotreeNode(1000, 0, layer), 1, layer.root);
+    layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
+    layer.root.children[2].children[1].add(new PotreeNode(1000, 0, layer), 2, layer.root);
+    layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
+    layer.root.children[2].children[1].add(new PotreeNode(1000, 0, layer), 3, layer.root);
+    layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
+    layer.root.children[2].children[1].add(new PotreeNode(1000, 0, layer), 4, layer.root);
+    layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
 
     it('should return root if no change source', () => {
-        const layer = { root: {} };
         const sources = new Set();
-        assert.equal(
+        assert.deepStrictEqual(
             layer.root,
             PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
 
     it('should return root if no common ancestors', () => {
-        const layer = { root: {}, id: 'a' };
-        const elt1 = { name: '12', obj: { layer: 'a', isPoints: true } };
-        const elt2 = { name: '345', obj: { layer: 'a', isPoints: true } };
         const sources = new Set();
-        sources.add(elt1);
-        sources.add(elt2);
-        assert.equal(
+        sources.add(layer.root.children[0].children[0]);
+        sources.add(layer.root.children[2].children[1]);
+        assert.deepStrictEqual(
             layer.root,
             PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
 
     it('should return common ancestor', () => {
-        const layer = { root: {}, id: 'a' };
-        const elt1 = { name: '123', obj: { layer: 'a', isPoints: true } };
-        const elt2 = { name: '12567', obj: { layer: 'a', isPoints: true } };
-        const elt3 = { name: '122', obj: { layer: 'a', isPoints: true } };
         const sources = new Set();
-        sources.add(elt1);
-        sources.add(elt2);
-        sources.add(elt3);
-        layer.root.getChildByName = (name) => {
-            assert.equal('12', name);
-        };
-        PotreeLayer.prototype.preUpdate.call(layer, context, sources);
+        sources.add(layer.root.children[2].children[0]);
+        sources.add(layer.root.children[2].children[1]);
+        sources.add(layer.root.children[2].children[1].children[2]);
+        sources.add(layer.root.children[2].children[1].children[3]);
+        assert.deepStrictEqual(
+            layer.root.children[2],
+            PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
 
     it('should not search ancestors if layer are different root if no common ancestors', () => {
-        const layer = { root: {}, id: 'a' };
-        const elt1 = { name: '12', obj: { layer: 'a', isPoints: true } };
-        const elt2 = { name: '13', obj: { layer: 'b', isPoints: true } };
         const sources = new Set();
-        sources.add(elt1);
-        sources.add(elt2);
-        layer.root.getChildByName = (name) => {
-            assert.equal('12', name);
-        };
-        PotreeLayer.prototype.preUpdate.call(layer, context, sources);
+        sources.add(layer.root.children[2].children[0]);
+        sources.add(layer.root.children[2].children[1].children[3]);
+        layer.root.children[2].children[1].children[3].obj = { layer: {}, isPoints: true };
+        assert.deepStrictEqual(
+            layer.root.children[2].children[0],
+            PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
 });


### PR DESCRIPTION
## Description
Now, the Potree system is based on this new PointCloud system. It can now be used as a basis for other type of point clouds, like Entwine Point Tile.

**BREAKING CHANGE**: The signature of the `PotreeLayer` constructor has
changed.

## Motivation and Context
I am in the process of the integration of Entwine Point Tile format, and it is very similar to the current potree system we have. Instead of inheriting from it, I prefer to have a common point cloud basis to inherit from.