### PR TITLE
release 2.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itowns",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itowns",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "A JS/WebGL framework for 3D geospatial data visualization",
   "main": "lib/Main.js",
   "scripts": {


### PR DESCRIPTION
A new release had to be done, because the previous one got the wrong version of THREE.

This could be avoided if we didn't included THREE inside iTowns.