### PR TITLE
refacto(material): mutualize common uniform/define methods

### DIFF
--- a/src/Renderer/CommonMaterial.js
+++ b/src/Renderer/CommonMaterial.js
@@ -1,0 +1,34 @@
+import * as THREE from 'three';
+
+export default {
+    setDefineMapping(object, PROPERTY, mapping) {
+        Object.keys(mapping).forEach((key) => {
+            object.defines[`${PROPERTY}_${key}`] = mapping[key];
+        });
+    },
+
+    setDefineProperty(object, property, PROPERTY, initValue) {
+        object.defines[PROPERTY] = initValue;
+        Object.defineProperty(object, property, {
+            get: () => object.defines[PROPERTY],
+            set: (value) => {
+                if (object.defines[PROPERTY] != value) {
+                    object.defines[PROPERTY] = value;
+                    object.needsUpdate = true;
+                }
+            },
+        });
+    },
+
+    setUniformProperty(object, property, initValue) {
+        object.uniforms[property] = new THREE.Uniform(initValue);
+        Object.defineProperty(object, property, {
+            get: () => object.uniforms[property].value,
+            set: (value) => {
+                if (object.uniforms[property].value != value) {
+                    object.uniforms[property].value = value;
+                }
+            },
+        });
+    },
+};

--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -5,6 +5,7 @@ import ShaderUtils from 'Renderer/Shader/ShaderUtils';
 import Capabilities from 'Core/System/Capabilities';
 import RenderMode from 'Renderer/RenderMode';
 import MaterialLayer from 'Renderer/MaterialLayer';
+import CommonMaterial from 'Renderer/CommonMaterial';
 
 const identityOffsetScale = new THREE.Vector4(0.0, 0.0, 1.0, 1.0);
 
@@ -55,37 +56,6 @@ function updateLayersUniforms(uniforms, olayers, max) {
     textureCount.value = count;
 }
 
-function setDefineMapping(object, PROPERTY, mapping) {
-    Object.keys(mapping).forEach((key) => {
-        object.defines[`${PROPERTY}_${key}`] = mapping[key];
-    });
-}
-
-function setDefineProperty(object, property, PROPERTY, initValue) {
-    object.defines[PROPERTY] = initValue;
-    Object.defineProperty(object, property, {
-        get: () => object.defines[PROPERTY],
-        set: (value) => {
-            if (object.defines[PROPERTY] != value) {
-                object.defines[PROPERTY] = value;
-                object.needsUpdate = true;
-            }
-        },
-    });
-}
-
-function setUniformProperty(object, property, initValue) {
-    object.uniforms[property] = new THREE.Uniform(initValue);
-    Object.defineProperty(object, property, {
-        get: () => object.uniforms[property].value,
-        set: (value) => {
-            if (object.uniforms[property].value != value) {
-                object.uniforms[property].value = value;
-            }
-        },
-    });
-}
-
 export const ELEVATION_MODES = {
     RGBA: 0,
     COLOR: 1,
@@ -105,9 +75,9 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         this.defines.USE_FOG = 1;
         this.defines.NUM_CRS = crsCount;
 
-        setDefineMapping(this, 'ELEVATION', ELEVATION_MODES);
-        setDefineMapping(this, 'MODE', RenderMode.MODES);
-        setDefineProperty(this, 'mode', 'MODE', RenderMode.MODES.FINAL);
+        CommonMaterial.setDefineMapping(this, 'ELEVATION', ELEVATION_MODES);
+        CommonMaterial.setDefineMapping(this, 'MODE', RenderMode.MODES);
+        CommonMaterial.setDefineProperty(this, 'mode', 'MODE', RenderMode.MODES.FINAL);
 
         if (__DEBUG__) {
             this.defines.DEBUG = 1;
@@ -115,9 +85,9 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
             if (crsCount > 1) {
                 outlineColors.push(new THREE.Vector3(1.0, 0.5, 0.0));
             }
-            setUniformProperty(this, 'showOutline', true);
-            setUniformProperty(this, 'outlineWidth', 0.008);
-            setUniformProperty(this, 'outlineColors', outlineColors);
+            CommonMaterial.setUniformProperty(this, 'showOutline', true);
+            CommonMaterial.setUniformProperty(this, 'outlineWidth', 0.008);
+            CommonMaterial.setUniformProperty(this, 'outlineColors', outlineColors);
         }
 
         if (Capabilities.isLogDepthBufferSupported()) {
@@ -130,25 +100,25 @@ class LayeredMaterial extends THREE.RawShaderMaterial {
         this.fragmentShader = fragmentShader[crsCount];
 
         // Color uniforms
-        setUniformProperty(this, 'diffuse', new THREE.Color(0.04, 0.23, 0.35));
-        setUniformProperty(this, 'opacity', this.opacity);
+        CommonMaterial.setUniformProperty(this, 'diffuse', new THREE.Color(0.04, 0.23, 0.35));
+        CommonMaterial.setUniformProperty(this, 'opacity', this.opacity);
 
         // Lighting uniforms
-        setUniformProperty(this, 'lightingEnabled', false);
-        setUniformProperty(this, 'lightPosition', new THREE.Vector3(-0.5, 0.0, 1.0));
+        CommonMaterial.setUniformProperty(this, 'lightingEnabled', false);
+        CommonMaterial.setUniformProperty(this, 'lightPosition', new THREE.Vector3(-0.5, 0.0, 1.0));
 
         // Misc properties
-        setUniformProperty(this, 'fogDistance', 1000000000.0);
-        setUniformProperty(this, 'fogColor', new THREE.Color(0.76, 0.85, 1.0));
-        setUniformProperty(this, 'overlayAlpha', 0);
-        setUniformProperty(this, 'overlayColor', new THREE.Color(1.0, 0.3, 0.0));
-        setUniformProperty(this, 'objectId', 0);
+        CommonMaterial.setUniformProperty(this, 'fogDistance', 1000000000.0);
+        CommonMaterial.setUniformProperty(this, 'fogColor', new THREE.Color(0.76, 0.85, 1.0));
+        CommonMaterial.setUniformProperty(this, 'overlayAlpha', 0);
+        CommonMaterial.setUniformProperty(this, 'overlayColor', new THREE.Color(1.0, 0.3, 0.0));
+        CommonMaterial.setUniformProperty(this, 'objectId', 0);
 
         // > 0 produces gaps,
         // < 0 causes oversampling of textures
         // = 0 causes sampling artefacts due to bad estimation of texture-uv gradients
         // best is a small negative number
-        setUniformProperty(this, 'minBorderDistance', -0.01);
+        CommonMaterial.setUniformProperty(this, 'minBorderDistance', -0.01);
 
         // LayeredMaterialLayers
         this.layers = [];

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -5,7 +5,7 @@
 #endif
 
 varying vec4 vColor;
-uniform bool pickingMode;
+uniform bool picking;
 void main() {
     #include <logdepthbuf_fragment>
     // circular point rendering
@@ -15,7 +15,7 @@ void main() {
 
 #if defined(USE_TEXTURES_PROJECTIVE)
     vec4 color = vColor;
-    if (!pickingMode) {
+    if (!picking) {
         #pragma unroll_loop
         for (int i = 0; i < ORIENTED_IMAGES_COUNT; i++) {
             color = projectiveTextureColor(projectiveTextureCoords[ ORIENTED_IMAGES_COUNT - 1 - i ], projectiveTextureDistortion[ ORIENTED_IMAGES_COUNT - 1 - i ], projectiveTexture[ ORIENTED_IMAGES_COUNT - 1 - i ], mask[ORIENTED_IMAGES_COUNT - 1 - i], color);

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -8,7 +8,7 @@
 
 uniform float size;
 
-uniform bool pickingMode;
+uniform bool picking;
 uniform int mode;
 uniform float opacity;
 uniform vec4 overlayColor;
@@ -69,7 +69,7 @@ void main() {
     vec3 normal = color;
 #endif
 
-    if (pickingMode) {
+    if (picking) {
         vColor = unique_id;
     } else if (mode == MODE_INTENSITY) {
         vColor = vec4(intensity, intensity, intensity, opacity);


### PR DESCRIPTION
The update of uniforms in `PointsMaterial` was archaic, but by using
methods available in `LayeredMaterial`, things became a little better.

I didn't touch `OrientedImageMaterial` as the example is currently not working, and I think it needs to be fixed in another PR before using `CommonMaterial` too.