### PR TITLE
Fixes on labels

### DIFF
--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -47,9 +47,9 @@ class Label extends THREE.Object3D {
      * it can be accessed through `label.content.style`, but it is highly
      * discouraged to do so.
      */
-    constructor(content, coordinates, style = {}) {
-        if (content == undefined || coordinates == undefined) {
-            throw new Error('content and coordinates are mandatory to add a Label');
+    constructor(content = '', coordinates, style = {}) {
+        if (coordinates == undefined) {
+            throw new Error('coordinates are mandatory to add a Label');
         }
 
         super();
@@ -80,7 +80,7 @@ class Label extends THREE.Object3D {
         this.content.style.userSelect = 'none';
         this.content.style.position = 'absolute';
         if (typeof content == 'string') {
-            this.content.textContent = content || '';
+            this.content.textContent = content;
         } else {
             this.content.appendChild(content);
         }

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -28,7 +28,10 @@ if (document.documentElement.style.transform !== undefined) {
  * Label. Default is true. You should not change this, as it is used internally
  * for optimisation.
  * @property {Element} content - The DOM object that contains the content of the
- * label. The style and the position are applied on this object.
+ * label. The style and the position are applied on this object. All labels
+ * contain the `itowns-label` class, as well as a specific class related to the
+ * layer linked to it: `itowns-label-[layer-id]` (replace `[layer-id]` by the
+ * correct string).
  * @property {THREE.Vector3} position - The position in the 3D world of the
  * label.
  * @property {Coordinates} coordinates - The coordinates of the label.

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -108,9 +108,11 @@ class Label extends THREE.Object3D {
      * @param {number} y - Y coordinates in pixels, from top.
      */
     updateProjectedPosition(x, y) {
-        if (x != this.projectedPosition.x || y != this.projectedPosition.y) {
-            this.projectedPosition.x = x;
-            this.projectedPosition.y = y;
+        const X = Math.round(x);
+        const Y = Math.round(y);
+        if (X != this.projectedPosition.x || Y != this.projectedPosition.y) {
+            this.projectedPosition.x = X;
+            this.projectedPosition.y = Y;
 
             this.boundaries.left = x + this.offset.left;
             this.boundaries.right = x + this.offset.right;

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -72,10 +72,11 @@ function _preprocessLayer(view, layer, parentLayer) {
     if (layer.isLabelLayer) {
         view.mainLoop.gfxEngine.label2dRenderer.registerLayer(layer);
     } else if (layer.labelEnabled) {
-        const labelLayer = new LabelLayer(`${layer.id}-label`, view.referenceCrs);
-        labelLayer.source = source;
-        labelLayer.style = layer.style;
-        labelLayer.zoom = layer.zoom;
+        const labelLayer = new LabelLayer(`${layer.id}-label`, {
+            source,
+            style: layer.style,
+            zoom: layer.zoom,
+        });
 
         layer.addEventListener('visible-property-changed', () => {
             labelLayer.visible = layer.visible;

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -109,6 +109,7 @@ class LabelLayer extends Layer {
                 const label = new Label(content,
                     coord.clone(),
                     g.properties.style || f.style || this.style);
+                label.content.classList.add(`itowns-label-${this.id}`);
 
                 if (f.size == 2) {
                     label.needsAltitude = true;

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -19,14 +19,25 @@ const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
  * @property {boolean} isLabelLayer - Used to checkout whether this layer is a
  * LabelLayer.  Default is true. You should not change this, as it is used
  * internally for optimisation.
- * @property {string} crs - The crs of this layer.
  */
 class LabelLayer extends Layer {
-    constructor(id, crs) {
-        super(id);
+    /**
+     * @constructor
+     * @extends Layer
+     *
+     * @param {string} id - The id of the layer, that should be unique. It is
+     * not mandatory, but an error will be emitted if this layer is added a
+     * {@link View} that already has a layer going by that id.
+     * @param {Object} [config] - Optional configuration, all elements in it
+     * will be merged as is in the layer. For example, if the configuration
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name.
+     */
+    constructor(id, config = {}) {
+        super(id, config);
 
         this.isLabelLayer = true;
-        this.crs = crs;
         this.domElement = document.createElement('div');
         this.defineLayerProperty('visible', true, () => {
             this.domElement.style.display = this.visible ? 'block' : 'none';
@@ -139,7 +150,7 @@ class LabelLayer extends Layer {
         if (elevationLayer && node.layerUpdateState[elevationLayer.id].canTryUpdate()) {
             node.children.forEach((c) => {
                 if (c.isLabel && c.needsAltitude && c.updateElevationFromLayer(this.parent)) {
-                    c.update3dPosition(this.crs);
+                    c.update3dPosition(context.view.referenceCrs);
                 }
             });
         }
@@ -189,7 +200,7 @@ class LabelLayer extends Layer {
                     }
 
                     node.add(label);
-                    label.update3dPosition(this.crs);
+                    label.update3dPosition(context.view.referenceCrs);
 
                     labelsDiv.push(label.content);
                 });

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -8,7 +8,6 @@ import { FEATURE_TYPES } from 'Core/Feature';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
-let content;
 const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
 
 /**
@@ -84,9 +83,11 @@ class LabelLayer extends Layer {
                     || (this.style && this.style.zoom && this.style.zoom.min);
 
                 // Don't create a label if it is in-between two steps of zoom
-                if (!this.source.isFileSource) {
-                    if (data.extent.zoom != minzoom) { return; }
-                } else if (extent.zoom != minzoom) { return; }
+                if (minzoom !== undefined) {
+                    if (!this.source.isFileSource) {
+                        if (data.extent.zoom != minzoom) { return; }
+                    } else if (extent.zoom != minzoom) { return; }
+                }
 
                 // NOTE: this only works because only POINT is supported, it
                 // needs more work for LINE and POLYGON
@@ -96,8 +97,14 @@ class LabelLayer extends Layer {
                 if (!_extent.isPointInside(coord)) { return; }
 
                 const geometryField = g.properties.style && g.properties.style.text.field;
+                let content;
                 if (!geometryField && !featureField && !layerField) {
-                    return;
+                    // Check if there is an icon, with no text
+                    if (!(g.properties.style && g.properties.style.icon)
+                        && !(f.style && f.style.icon)
+                        && !(this.style && this.style.icon)) {
+                        return;
+                    }
                 } else if (geometryField) {
                     content = g.properties.style.getTextFromProperties(g.properties);
                 } else if (featureField) {

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -159,7 +159,7 @@ class Label2DRenderer {
             vector.setFromMatrixPosition(object.matrixWorld);
             vector.applyMatrix4(viewProjectionMatrix);
 
-            object.updateProjectedPosition(Math.round(vector.x * this.halfWidth + this.halfWidth), Math.round(-vector.y * this.halfHeight + this.halfHeight));
+            object.updateProjectedPosition(vector.x * this.halfWidth + this.halfWidth, -vector.y * this.halfHeight + this.halfHeight);
 
             // Are considered duplicates, labels that have the same screen
             // coordinates and the same base content.


### PR DESCRIPTION
A few fixes on labels:

- **fix(label): makes LabelLayer able to run alone**
Before, no configuration could be passed to it, like a source. This
fixes it.

- **feat(label): add a new class to Labels**
The class corresponds to `itowns-label-[layer-id]`. Documentation has
been added as well.

- **fix(label): allow label to only have an icon**

- **fix(label): labels don't jitter anymore**
There was a rounding that was done when comparing positions in the
renderer. This is still used for comparison, but the assigned value is
not the rounded one anymore.