### PR TITLE
fix(label): separate labels dom in layers

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -41,6 +41,8 @@ class TileMesh extends THREE.Mesh {
 
         this.layerUpdateState = {};
         this.isTileMesh = true;
+
+        this.domElements = {};
     }
 
     /**
@@ -102,9 +104,9 @@ class TileMesh extends THREE.Mesh {
         }
     }
 
-    findClosestDomElement() {
+    findClosestDomElement(id) {
         if (this.parent.isTileMesh) {
-            return this.parent.domElement || this.parent.findClosestDomElement();
+            return this.parent.domElements[id] || this.parent.findClosestDomElement(id);
         }
     }
 }

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -183,16 +183,24 @@ class Label2DRenderer {
     }
 
     hideNodeDOM(node) {
-        if (node.domElementVisible == true) {
-            node.domElement.style.display = 'none';
-            node.domElementVisible = false;
+        if (node.domElements) {
+            Object.values(node.domElements).forEach((domElement) => {
+                if (domElement.visible == true) {
+                    domElement.dom.style.display = 'none';
+                    domElement.visible = false;
+                }
+            });
         }
     }
 
     showNodeDOM(node) {
-        if (node.domElementVisible == false) {
-            node.domElement.style.display = 'block';
-            node.domElementVisible = true;
+        if (node.domElements) {
+            Object.values(node.domElements).forEach((domElement) => {
+                if (domElement.visible == false) {
+                    domElement.dom.style.display = 'block';
+                    domElement.visible = true;
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
If there was more than one `Layer` displaying labels, there was only one
DOM node rewritten everytime, and it was shared between layers.

Now it is two distinct `div`, with the id set to
`itowns-label-${layer.id}`.

This solves #1468 