### PR TITLE
feat(point): add an intensity range for point clouds

### DIFF
--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -61,6 +61,12 @@ function markForDeletion(elt) {
     }
 }
 
+function changeIntensityRange(layer) {
+    if (layer.material.intensityRange) {
+        layer.material.intensityRange.set(layer.minIntensityRange, layer.maxIntensityRange);
+    }
+}
+
 /**
  * The basis for all point clouds related layers.
  *
@@ -86,6 +92,12 @@ function markForDeletion(elt) {
  * `PointsMaterial`.
  * @property {number} [mode=MODE.COLOR] - The displaying mode of the points.
  * Values are specified in `PointsMaterial`.
+ * @property {number} [minIntensityRange=0] - The minimal intensity of the
+ * layer. Changing this value will affect the material, if it has the
+ * corresponding uniform. The value is normalized between 0 and 1.
+ * @property {number} [maxIntensityRange=1] - The maximal intensity of the
+ * layer. Changing this value will affect the material, if it has the
+ * corresponding uniform. The value is normalized between 0 and 1.
  */
 class PointCloudLayer extends GeometryLayer {
     /**
@@ -122,9 +134,18 @@ class PointCloudLayer extends GeometryLayer {
         this.pointBudget = config.pointBudget || 2000000;
         this.pointSize = config.pointSize === 0 || !isNaN(config.pointSize) ? config.pointSize : 4;
         this.sseThreshold = config.sseThreshold || 2;
+
+        this.defineLayerProperty('minIntensityRange', config.minIntensityRange || 0, changeIntensityRange);
+        this.defineLayerProperty('maxIntensityRange', config.maxIntensityRange || 1, changeIntensityRange);
+
         this.material = config.material || {};
-        this.material = this.material.isMaterial ? config.material : new PointsMaterial(config.material);
+        if (!this.material.isMaterial) {
+            config.material = config.material || {};
+            config.material.intensityRange = new THREE.Vector2(this.minIntensityRange, this.maxIntensityRange);
+            this.material = new PointsMaterial(config.material);
+        }
         this.material.defines = this.material.defines || {};
+
         this.mode = config.mode || MODE.COLOR;
     }
 

--- a/src/Parser/LASParser.js
+++ b/src/Parser/LASParser.js
@@ -40,7 +40,7 @@ export default {
             const positionBuffer = new THREE.BufferAttribute(parsedData.attributes.POSITION.value, 3, false);
             geometry.setAttribute('position', positionBuffer);
 
-            const intensityBuffer = new THREE.BufferAttribute(parsedData.attributes.intensity.value, 1, false);
+            const intensityBuffer = new THREE.BufferAttribute(parsedData.attributes.intensity.value, 1, true);
             geometry.setAttribute('intensity', intensityBuffer);
 
             const classificationBuffer = new THREE.BufferAttribute(parsedData.attributes.classification.value, 1, false);

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -18,7 +18,7 @@ const POINT_ATTTRIBUTES = {
         numElements: 1,
         numByte: 2,
         // using Float32Array because Float16Array doesn't exist
-        arrayType: Float32Array,
+        arrayType: Uint16Array,
         attributeName: 'intensity',
         normalized: true,
     },

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -28,7 +28,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
         CommonMaterial.setUniformProperty(this, 'picking', false);
         CommonMaterial.setUniformProperty(this, 'opacity', this.opacity);
         CommonMaterial.setUniformProperty(this, 'overlayColor', options.overlayColor || new THREE.Vector4(0, 0, 0, 0));
-
+        CommonMaterial.setUniformProperty(this, 'intensityRange', options.intensityRange || new THREE.Vector2(0, 1));
 
         if (oiMaterial) {
             this.uniforms.projectiveTextureAlphaBorder = oiMaterial.uniforms.projectiveTextureAlphaBorder;
@@ -93,6 +93,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
         this.picking = source.picking;
         this.scale = source.scale;
         this.overlayColor.copy(source.overlayColor);
+        this.intensityRange.copy(source.intensityRange);
         Object.assign(this.defines, source.defines);
         return this;
     }

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -13,6 +13,7 @@ uniform bool picking;
 uniform int mode;
 uniform float opacity;
 uniform vec4 overlayColor;
+uniform vec2 intensityRange;
 attribute vec3 color;
 attribute vec4 unique_id;
 attribute float intensity;
@@ -73,7 +74,9 @@ void main() {
     if (picking) {
         vColor = unique_id;
     } else if (mode == MODE_INTENSITY) {
-        vColor = vec4(intensity, intensity, intensity, opacity);
+        // adapt the grayscale knowing the range
+        float i = (intensity - intensityRange.x) / (intensityRange.y - intensityRange.x);
+        vColor = vec4(i, i, i, opacity);
     } else if (mode == MODE_NORMAL) {
         vColor = vec4(abs(normal), opacity);
     } else {

--- a/test/unit/potreeBinParser.js
+++ b/test/unit/potreeBinParser.js
@@ -52,7 +52,7 @@ describe('PotreeBinParser', function () {
             assert.deepStrictEqual(posAttr.array, Float32Array.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14));
             // check intensity
             assert.equal(intensityAttr.itemSize, 1);
-            assert.deepStrictEqual(intensityAttr.array, Float32Array.of(100, 101, 102, 103, 104));
+            assert.deepStrictEqual(intensityAttr.array, Uint16Array.of(100, 101, 102, 103, 104));
             // check colors
             assert.equal(colorAttr.itemSize, 4);
             assert.deepStrictEqual(colorAttr.array, Uint8Array.of(

--- a/utils/debug/PotreeDebug.js
+++ b/utils/debug/PotreeDebug.js
@@ -33,6 +33,7 @@ export default {
         var styleUI = layer.debugUI.addFolder('Styling');
         if (layer.material.mode != undefined) {
             styleUI.add(layer.material, 'mode', MODE).name('Display mode').onChange(update);
+            styleUI.add(layer, 'maxIntensityRange', 0, 1).name('Intensity max').onChange(update);
         }
         styleUI.add(layer, 'opacity', 0, 1).name('Layer Opacity').onChange(update);
         styleUI.add(layer, 'pointSize', 0, 15).name('Point Size').onChange(update);


### PR DESCRIPTION
It is possible to specify the min and the max of the intensity range,
while updating the material in the same time to reflect those changes.