### PR TITLE
Entwine Point Tile support

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -17,7 +17,9 @@
     "Pointcloud": {
         "potree_25d_map": "Potree 2.5D map",
         "potree_3d_map": "Potree 3D map",
-        "laz_dragndrop": "LAS/LAZ viewer"
+        "laz_dragndrop": "LAS/LAZ viewer",
+        "entwine_simple_loader": "Entwine loader",
+        "entwine_3d_loader": "Entwine 3D loader"
     },
 
     "Vector tiles": {

--- a/examples/entwine_3d_loader.html
+++ b/examples/entwine_3d_loader.html
@@ -1,0 +1,107 @@
+<html>
+    <head>
+        <title>Itowns - Entwine 3D loader</title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                left: 10px;
+            }
+        </style>
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="description">Specify the URL of a Entwine Point Tree to load:
+            <input type="text" id="ept_url" />
+            <button onclick="readEPTURL()">Load</button>
+            <p>If your dataset is not displaying at the right location,
+            check that it has been converted in <code>EPSG:4978</code>.</p>
+            <div id="share"></div>
+        </div>
+        <div id="viewerDiv">
+        </div>
+
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script type="text/javascript">
+            var debugGui = new dat.GUI();
+            var viewerDiv = document.getElementById('viewerDiv');
+
+            var view = new itowns.GlobeView(viewerDiv);
+
+            // Add one imagery layer to the scene and the miniView
+            // This layer is defined in a json file but it could be defined as a plain js
+            // object. See Layer* for more info.
+            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ColorLayer('Ortho', config);
+                view.addLayer(layer);
+            });
+            // Add two elevation layers.
+            // These will deform iTowns globe geometry to represent terrain elevation.
+            function addElevationLayerFromConfig(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ElevationLayer(config.id, config);
+                view.addLayer(layer);
+            }
+            itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+            itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+
+            var eptLayer, eptSource;
+
+            function onLayerReady() {
+                var lookAt = new itowns.THREE.Vector3();
+                eptLayer.root.bbox.getCenter(lookAt);
+                var coordLookAt = new itowns.Coordinates(view.referenceCrs, lookAt);
+
+                var size = new itowns.THREE.Vector3();
+                eptLayer.root.bbox.getSize(size);
+
+                view.controls.lookAtCoordinate({
+                    coord: coordLookAt,
+                    range: 2 * size.length(),
+                }, false);
+            }
+
+            function readEPTURL() {
+                var url = document.getElementById('ept_url').value || new URL(location.href).searchParams.get('ept');
+
+                if (url) {
+                    loadEPT(url);
+
+                    document.getElementById('share').innerHTML = '<a href="' +
+                        location.href.replace(location.search, '?ept=' + url) +
+                        '" target="_blank">Link to share this view</a>';
+                    document.getElementById('ept_url').value = url;
+                }
+            }
+
+            function loadEPT(url) {
+                eptSource = new itowns.EntwinePointTileSource({ url });
+
+                if (eptLayer) {
+                    view.removeLayer('ept');
+                    view.notifyChange();
+                }
+
+                eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', {
+                    source: eptSource,
+                    crs: view.referenceCrs,
+                });
+
+                itowns.View.prototype.addLayer.call(view, eptLayer).then(onLayerReady);
+
+                debug.PotreeDebug.initTools(view, eptLayer, debugGui);
+            }
+
+            readEPTURL();
+        </script>
+    </body>
+</html>

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -1,0 +1,118 @@
+<html>
+    <head>
+        <title>Itowns - Entwine simple loader</title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                left: 10px;
+            }
+        </style>
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="description">Specify the URL of a Entwine Point Tree to load:
+            <input type="text" id="ept_url" />
+            <button onclick="readEPTURL()">Load</button>
+            <button onclick="loadGrandLyon()">Load the Grand Lyon
+                dataset</button>
+            <div id="share"></div>
+        </div>
+        <div id="viewerDiv">
+        </div>
+
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script type="text/javascript">
+            var debugGui = new dat.GUI();
+            var viewerDiv = document.getElementById('viewerDiv');
+            viewerDiv.style.display = 'block';
+            var view = new itowns.View('EPSG:3946', viewerDiv);
+            view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
+
+            var controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
+            debugGui.add(controls.options, 'moveSpeed', 1, 10000).name('Movement speed');
+
+            var eptLayer, eptSource;
+
+            function onLayerReady() {
+                var camera = view.camera.camera3D;
+
+                var lookAt = new itowns.THREE.Vector3();
+                var size = new itowns.THREE.Vector3();
+                eptLayer.root.bbox.getSize(size);
+                eptLayer.root.bbox.getCenter(lookAt);
+
+                camera.far = 2.0 * size.length();
+
+                var position = eptLayer.root.bbox.min.clone().add(size.multiply({ x: 0, y: 0, z: size.x / size.z }));
+
+                camera.position.copy(position);
+                camera.lookAt(lookAt);
+
+                controls.options.moveSpeed = size.length();
+
+                view.notifyChange(camera);
+                controls.reset();
+            }
+
+            function readEPTURL() {
+                var url = document.getElementById('ept_url').value || new URL(location.href).searchParams.get('ept');
+
+                if (url) {
+                    loadEPT(url);
+
+                    document.getElementById('share').innerHTML = '<a href="' +
+                        location.href.replace(location.search, '?ept=' + url) +
+                        '" target="_blank">Link to share this view</a>';
+                    document.getElementById('ept_url').value = url;
+                }
+            }
+
+            function loadEPT(url) {
+                eptSource = new itowns.EntwinePointTileSource({ url });
+
+                if (eptLayer) {
+                    view.removeLayer('ept');
+                    view.notifyChange();
+                }
+
+                eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', {
+                    source: eptSource,
+                    crs: view.referenceCrs,
+                });
+
+                view.addLayer(eptLayer).then(onLayerReady);
+
+                debug.PotreeDebug.initTools(view, eptLayer, debugGui);
+
+                function dblClickHandler(event) {
+                    var pick = view.pickObjectsAt(event, 5, eptLayer);
+
+                    for (const p of pick) {
+                        console.info('Selected point #' + p.index + ' in position (' +
+                            p.object.position.x + ', ' +
+                            p.object.position.y + ', ' +
+                            p.object.position.z +
+                         ') - node ' + p.object.userData.node.id);
+                    }
+                }
+                view.domElement.addEventListener('dblclick', dblClickHandler);
+            }
+
+            function loadGrandLyon() {
+                document.getElementById('ept_url').value = 'https://download.data.grandlyon.com/files/grandlyon/imagerie/mnt2018/lidar/ept/';
+                readEPTURL();
+            }
+
+            readEPTURL();
+        </script>
+    </body>
+</html>

--- a/src/Core/EntwinePointTileNode.js
+++ b/src/Core/EntwinePointTileNode.js
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+import Fetcher from 'Provider/Fetcher';
+import PointCloudNode from 'Core/PointCloudNode';
+
+const size = new THREE.Vector3();
+const position = new THREE.Vector3();
+const translation = new THREE.Vector3();
+
+function buildId(depth, x, y, z) {
+    return `${depth}-${x}-${y}-${z}`;
+}
+
+/**
+ * @extends PointCloudNode
+ *
+ * @property {boolean} isEntwinePointTileNode - Used to checkout whether this
+ * node is a EntwinePointTileNode. Default is `true`. You should not change
+ * this, as it is used internally for optimisation.
+ * @property {number} depth - The depth of the node in the tree - see the
+ * [Entwine
+ * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+ * @property {number} x - The x coordinate of the node in the tree - see the
+ * [Entwine
+ * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+ * @property {number} y - The x coordinate of the node in the tree - see the
+ * [Entwine
+ * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+ * @property {number} z - The x coordinate of the node in the tree - see the
+ * [Entwine
+ * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+ * @property {string} id - The id of the node, constituted of the four
+ * components: `depth-x-y-z`.
+ */
+class EntwinePointTileNode extends PointCloudNode {
+    /**
+     * Constructs a new instance of EntwinePointTileNode.
+     *
+     * @constructor
+     *
+     * @param {number} depth - The depth of the node in the tree - see the
+     * [Entwine
+     * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+     * @param {number} x - The x coordinate of the node in the tree - see the
+     * [Entwine
+     * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+     * @param {number} y - The x coordinate of the node in the tree - see the
+     * [Entwine
+     * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+     * @param {number} z - The x coordinate of the node in the tree - see the
+     * [Entwine
+     * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
+     * @param {EntwinePointTileLayer} layer - The layer the node is attached to.
+     * @param {number} [numPoints=0] - The number of points in this node. If
+     * `-1`, it means that the octree hierarchy associated to this node needs to
+     * be loaded.
+     */
+    constructor(depth, x, y, z, layer, numPoints = 0) {
+        super(numPoints, layer);
+
+        this.isEntwinePointTileNode = true;
+
+        this.depth = depth;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+
+        this.id = buildId(depth, x, y, z);
+
+        this.url = `${this.layer.source.url}/ept-data/${this.id}.${this.layer.source.extension}`;
+    }
+
+    createChildAABB(node) {
+        // factor to apply, based on the depth difference (can be > 1)
+        const f = 2 ** (node.depth - this.depth);
+
+        // size of the child node bbox (Vector3), based on the size of the
+        // parent node, and divided by the factor
+        this.bbox.getSize(size).divideScalar(f);
+
+        // initialize the child node bbox at the location of the parent node bbox
+        node.bbox.min.copy(this.bbox.min);
+
+        // position of the parent node, if it was at the same depth than the
+        // child, found by multiplying the tree position by the factor
+        position.copy(this).multiplyScalar(f);
+
+        // difference in position between the two nodes, at child depth, and
+        // scale it using the size
+        translation.subVectors(node, position).multiply(size);
+
+        // apply the translation to the child node bbox
+        node.bbox.min.add(translation);
+
+        // use the size computed above to set the max
+        node.bbox.max.copy(node.bbox.min).add(size);
+    }
+
+    get octreeIsLoaded() {
+        return this.numPoints >= 0;
+    }
+
+    loadOctree() {
+        return Fetcher.json(`${this.layer.source.url}/ept-hierarchy/${this.id}.json`, this.layer.source.networkOptions).then((hierarchy) => {
+            this.numPoints = hierarchy[this.id];
+
+            const stack = [];
+            stack.push(this);
+
+            while (stack.length) {
+                const node = stack.shift();
+                const depth = node.depth + 1;
+                const x = node.x * 2;
+                const y = node.y * 2;
+                const z = node.z * 2;
+
+                node.findAndCreateChild(depth, x,     y,     z,     hierarchy, stack);
+                node.findAndCreateChild(depth, x + 1, y,     z,     hierarchy, stack);
+                node.findAndCreateChild(depth, x,     y + 1, z,     hierarchy, stack);
+                node.findAndCreateChild(depth, x + 1, y + 1, z,     hierarchy, stack);
+                node.findAndCreateChild(depth, x,     y,     z + 1, hierarchy, stack);
+                node.findAndCreateChild(depth, x + 1, y,     z + 1, hierarchy, stack);
+                node.findAndCreateChild(depth, x,     y + 1, z + 1, hierarchy, stack);
+                node.findAndCreateChild(depth, x + 1, y + 1, z + 1, hierarchy, stack);
+            }
+        });
+    }
+
+    findAndCreateChild(depth, x, y, z, hierarchy, stack) {
+        const id = buildId(depth, x, y, z);
+        const numPoints = hierarchy[id];
+
+        if (typeof numPoints == 'number') {
+            const child = new EntwinePointTileNode(depth, x, y, z, this.layer, numPoints);
+            this.add(child);
+            stack.push(child);
+        }
+    }
+}
+
+export default EntwinePointTileNode;

--- a/src/Core/PointCloudNode.js
+++ b/src/Core/PointCloudNode.js
@@ -24,7 +24,8 @@ class PointCloudNode extends THREE.EventDispatcher {
             this.loadOctree();
         }
 
-        return this.layer.source.fetcher(this.url, this.layer.source.networkOptions).then(this.layer.source.parse);
+        return this.layer.source.fetcher(this.url, this.layer.source.networkOptions)
+            .then(file => this.layer.source.parse(file, { out: this.layer, in: this.layer.source }));
     }
 
     findCommonAncestor(node) {

--- a/src/Layer/EntwinePointTileLayer.js
+++ b/src/Layer/EntwinePointTileLayer.js
@@ -1,0 +1,67 @@
+import * as THREE from 'three';
+import EntwinePointTileNode from 'Core/EntwinePointTileNode';
+import PointCloudLayer from 'Layer/PointCloudLayer';
+import Extent from 'Core/Geographic/Extent';
+
+const bboxMesh = new THREE.Mesh();
+const box3 = new THREE.Box3();
+bboxMesh.geometry.boundingBox = box3;
+
+/**
+ * @property {boolean} isEntwinePointTileLayer - Used to checkout whether this
+ * layer is a EntwinePointTileLayer. Default is `true`. You should not change
+ * this, as it is used internally for optimisation.
+ */
+class EntwinePointTileLayer extends PointCloudLayer {
+    /**
+     * Constructs a new instance of Entwine Point Tile layer.
+     *
+     * @constructor
+     * @extends PointCloudLayer
+     *
+     * @example
+     * // Create a new point cloud layer
+     * const points = new EntwinePointTileLayer('EPT',
+     *  {
+     *      source: new EntwinePointTileSource({
+     *          url: 'https://server.geo/ept-dataset',
+     *      }
+     *  });
+     *
+     * View.prototype.addLayer.call(view, points);
+     *
+     * @param {string} id - The id of the layer, that should be unique. It is
+     * not mandatory, but an error will be emitted if this layer is added a
+     * {@link View} that already has a layer going by that id.
+     * @param {Object} config - Configuration, all elements in it
+     * will be merged as is in the layer. For example, if the configuration
+     * contains three elements `name, protocol, extent`, these elements will be
+     * available using `layer.name` or something else depending on the property
+     * name. See the list of properties to know which one can be specified.
+     * @param {string} [config.crs=ESPG:4326] - The CRS of the {@link View} this
+     * layer will be attached to. This is used to determine the extent of this
+     * layer. Default to `EPSG:4326`.
+     * @param {number} [config.skip=1] - Read one point from every `skip` points
+     * - see {@link LASParser}.
+     */
+    constructor(id, config) {
+        super(id, config);
+        this.isEntwinePointTileLayer = true;
+
+        const resolve = this.addInitializationStep();
+        this.whenReady = this.source.whenReady.then(() => {
+            this.root = new EntwinePointTileNode(0, 0, 0, 0, this, -1);
+            this.root.bbox.min.fromArray(this.source.boundsConforming, 0);
+            this.root.bbox.max.fromArray(this.source.boundsConforming, 3);
+
+            this.extent = Extent.fromBox3(config.crs || 'EPSG:4326', this.root.bbox);
+            return this.root.loadOctree().then(resolve);
+        });
+    }
+
+    get spacing() {
+        return this.source.spacing;
+    }
+}
+
+export default EntwinePointTileLayer;

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -217,7 +217,7 @@ class PointCloudLayer extends GeometryLayer {
         point.copy(context.camera.camera3D.position).sub(this.object3d.position);
 
         // only load geometry if this elements has points
-        if (elt.numPoints > 0) {
+        if (elt.numPoints !== 0) {
             if (elt.obj) {
                 if (elt.obj.material.update) {
                     elt.obj.material.update(this.material);

--- a/src/Main.js
+++ b/src/Main.js
@@ -53,6 +53,7 @@ export { default as ColorLayersOrdering } from 'Renderer/ColorLayersOrdering';
 export { default as GlobeLayer } from 'Core/Prefab/Globe/GlobeLayer';
 export { default as PlanarLayer } from 'Core/Prefab/Planar/PlanarLayer';
 export { default as LabelLayer } from 'Layer/LabelLayer';
+export { default as EntwinePointTileLayer } from 'Layer/EntwinePointTileLayer';
 
 // Sources provided by default in iTowns
 // A custom source should at least implements Source
@@ -67,6 +68,7 @@ export { default as VectorTilesSource } from 'Source/VectorTilesSource';
 export { default as OrientedImageSource } from 'Source/OrientedImageSource';
 export { default as PotreeSource } from 'Source/PotreeSource';
 export { default as C3DTilesSource } from 'Source/C3DTilesSource';
+export { default as EntwinePointTileSource } from 'Source/EntwinePointTileSource';
 
 // Parsers provided by default in iTowns
 // Custom parser can be implemented as wanted, as long as the main function

--- a/src/Parser/LASParser.js
+++ b/src/Parser/LASParser.js
@@ -22,18 +22,24 @@ export default {
      *
      * @param {ArrayBuffer} data - The file content to parse.
      * @param {Object} [options] - Options to give to the parser.
-     * @param {number|string} [options.colorDepth='auto'] - Does the color
+     * @param {number|string} [options.in.colorDepth='auto'] - Does the color
      * encoding is known ? Is it `8` or `16` bits ? By default it is to
      * `'auto'`, but it will be more performant if a specific value is set.
+     * @param {number} [options.out.skip=1] - Read one point from every `skip`
+     * points.
      *
      * @return {Promise} A promise resolving with a `THREE.BufferGeometry`. The
      * header of the file is contained in `userData`.
      */
     parse(data, options = {}) {
-        options.colorDepth = options.colorDepth || 'auto';
-        options.skip = 1;
-
-        return LASLoader.parse(data, { las: options }).then((parsedData) => {
+        options.in = options.in || {};
+        options.out = options.out || {};
+        return LASLoader.parse(data, {
+            las: {
+                colorDepth: options.in.colorDepth || 'auto',
+                skip: options.out.skip || 1,
+            },
+        }).then((parsedData) => {
             const geometry = new THREE.BufferGeometry();
             geometry.userData = parsedData.loaderData.header;
 

--- a/src/Parser/PotreeBinParser.js
+++ b/src/Parser/PotreeBinParser.js
@@ -66,11 +66,12 @@ export default {
     /** Parse .bin PotreeConverter format and convert to a THREE.BufferGeometry
      * @function parse
      * @param {ArrayBuffer} buffer - the bin buffer.
-     * @param {Object} pointAttributes - the point attributes information contained in cloud.js
+     * @param {Object} options
+     * @param {string[]} options.in.pointAttributes - the point attributes information contained in cloud.js
      * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      *
      */
-    parse: function parse(buffer, pointAttributes) {
+    parse: function parse(buffer, options) {
         if (!buffer) {
             throw new Error('No array buffer provided.');
         }
@@ -78,7 +79,7 @@ export default {
         const view = new DataView(buffer);
         // Format: X1,Y1,Z1,R1,G1,B1,A1,[...],XN,YN,ZN,RN,GN,BN,AN
         let pointByteSize = 0;
-        for (const potreeName of pointAttributes) {
+        for (const potreeName of options.in.pointAttributes) {
             pointByteSize += POINT_ATTTRIBUTES[potreeName].byteSize;
         }
         const numPoints = Math.floor(buffer.byteLength / pointByteSize);
@@ -86,7 +87,7 @@ export default {
         const geometry = new THREE.BufferGeometry();
         let elemOffset = 0;
         let attrOffset = 0;
-        for (const potreeName of pointAttributes) {
+        for (const potreeName of options.in.pointAttributes) {
             const attr = POINT_ATTTRIBUTES[potreeName];
             const arrayLength = attr.numElements * numPoints;
             const array = new attr.arrayType(arrayLength);

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -36,8 +36,10 @@ export default {
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            points.position.copy(node.bbox.min);
-            points.scale.copy(layer.scale);
+            if (!layer.isEntwinePointTileLayer) {
+                points.position.copy(node.bbox.min);
+                points.scale.copy(layer.scale);
+            }
             points.updateMatrix();
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
             points.layers.set(layer.threejsLayer);

--- a/src/Source/EntwinePointTileSource.js
+++ b/src/Source/EntwinePointTileSource.js
@@ -1,0 +1,73 @@
+import proj4 from 'proj4';
+import LASParser from 'Parser/LASParser';
+import PotreeBinParser from 'Parser/PotreeBinParser';
+import Fetcher from 'Provider/Fetcher';
+import Source from 'Source/Source';
+
+/**
+ * @classdesc
+ * An object defining the source of Entwine Point Tile data. It fetches and
+ * parses the main configuration file of Entwine Point Tile format,
+ * [`ept.json`](https://entwine.io/entwine-point-tile.html#ept-json).
+ *
+ * @extends Source
+ *
+ * @property {boolean} isEntwinePointTileSource - Used to checkout whether this
+ * source is a EntwinePointTileSource. Default is true. You should not change
+ * this, as it is used internally for optimisation.
+ * @property {string} url - The URL of the directory containing the whole
+ * Entwine Point Tile structure.
+ */
+class EntwinePointTileSource extends Source {
+    /**
+     * @constructor
+     *
+     * @param {Object} config - The configuration, see {@link Source} for
+     * available values.
+     * @param {number|string} [config.colorDepth='auto'] - Does the color
+     * encoding is known ? Is it `8` or `16` bits ? By default it is to
+     * `'auto'`, but it will be more performant if a specific value is set.
+     */
+    constructor(config) {
+        super(config);
+
+        this.isEntwinePointTileSource = true;
+        this.colorDepth = config.colorDepth;
+
+        // Necessary because we use the url without the ept.json part as a base
+        this.url = this.url.replace('/ept.json', '');
+
+        // https://entwine.io/entwine-point-tile.html#ept-json
+        this.whenReady = Fetcher.json(`${this.url}/ept.json`, this.networkOptions).then((metadata) => {
+            // Set parser and its configuration from schema
+            this.parse = metadata.dataType === 'laszip' ? LASParser.parse : PotreeBinParser.parse;
+            this.extension = metadata.dataType === 'laszip' ? 'laz' : 'bin';
+
+            if (metadata.srs && metadata.srs.authority && metadata.srs.horizontal) {
+                this.crs = `${metadata.srs.authority}:${metadata.srs.horizontal}`;
+                if (!proj4.defs(this.crs)) {
+                    proj4.defs(this.crs, metadata.srs.wkt);
+                }
+
+                if (metadata.srs.vertical && metadata.srs.vertical !== metadata.srs.horizontal) {
+                    console.warn('EntwinePointTileSource: Vertical coordinates system code is not yet supported.');
+                }
+            }
+
+            // NOTE: this spacing is kinda arbitrary here, we take the width and
+            // length (height can be ignored), and we divide by the specified
+            // span in ept.json. This needs improvements.
+            this.spacing = (Math.abs(metadata.boundsConforming[3] - metadata.boundsConforming[0])
+                + Math.abs(metadata.boundsConforming[4] - metadata.boundsConforming[1])) / (2 * metadata.span);
+
+            this.boundsConforming = metadata.boundsConforming;
+            this.span = metadata.span;
+
+            return this;
+        });
+
+        this.fetcher = Fetcher.arrayBuffer;
+    }
+}
+
+export default EntwinePointTileSource;

--- a/src/Source/PotreeSource.js
+++ b/src/Source/PotreeSource.js
@@ -78,11 +78,10 @@ class PotreeSource extends Source {
         // https://github.com/PropellerAero/potree-propeller-private/blob/master/docs/file_format.md#cloudjs
         this.whenReady = (source.cloud ? Promise.resolve(source.cloud) : Fetcher.json(`${this.url}/${this.file}`, this.networkOptions))
             .then((cloud) => {
+                this.pointAttributes = cloud.pointAttributes;
                 this.baseurl = `${this.url}/${cloud.octreeDir}/r`;
                 this.extension = cloud.pointAttributes === 'CIN' ? 'cin' : 'bin';
-                this.parse = this.extension === 'cin' ?
-                    buffer => PotreeCinParser.parse(buffer) :
-                    buffer => PotreeBinParser.parse(buffer, cloud.pointAttributes);
+                this.parse = this.extension === 'cin' ? PotreeCinParser.parse : PotreeBinParser.parse;
 
                 return cloud;
             });

--- a/test/unit/entwine.js
+++ b/test/unit/entwine.js
@@ -1,0 +1,115 @@
+import assert from 'assert';
+import HttpsProxyAgent from 'https-proxy-agent';
+import View from 'Core/View';
+import GlobeView from 'Core/Prefab/GlobeView';
+import Coordinates from 'Core/Geographic/Coordinates';
+import EntwinePointTileSource from 'Source/EntwinePointTileSource';
+import EntwinePointTileLayer from 'Layer/EntwinePointTileLayer';
+import EntwinePointTileNode from 'Core/EntwinePointTileNode';
+import Renderer from './bootstrap';
+
+describe('Entwine Point Tile', function () {
+    const source = new EntwinePointTileSource({
+        url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/entwine',
+        networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+    });
+
+    it('loads the EPT structure', (done) => {
+        source.whenReady.then(() => {
+            done();
+        });
+    });
+
+    describe('Layer', function () {
+        let renderer;
+        let placement;
+        let view;
+        let layer;
+        let context;
+
+        before(function (done) {
+            renderer = new Renderer();
+            placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
+            view = new GlobeView(renderer.domElement, placement, { renderer });
+            layer = new EntwinePointTileLayer('test', { source }, view);
+
+            context = {
+                camera: view.camera,
+                engine: view.mainLoop.gfxEngine,
+                scheduler: view.mainLoop.scheduler,
+                geometryLayer: layer,
+                view,
+            };
+
+            View.prototype.addLayer.call(view, layer).then(() => {
+                done();
+            });
+        });
+
+        it('pre updates and finds the root', () => {
+            const element = layer.preUpdate(context, new Set([layer]));
+            assert.strictEqual(element.length, 1);
+            assert.deepStrictEqual(element[0], layer.root);
+        });
+
+        it('tries to update on the root and fails', function () {
+            layer.update(context, layer, layer.root);
+            assert.strictEqual(layer.root.promise, undefined);
+        });
+
+        it('tries to update on the root and succeeds', function (done) {
+            view.controls.lookAtCoordinate({
+                coord: source.center,
+                range: 250,
+            }, false).then(() => {
+                layer.update(context, layer, layer.root);
+                layer.root.promise.then(() => {
+                    done();
+                });
+            });
+        });
+
+        it('post updates', function () {
+            layer.postUpdate(context, layer);
+        });
+    });
+
+    describe('Node', function () {
+        const layer = { source: { url: 'http://server.geo', extension: 'laz' } };
+        const root = new EntwinePointTileNode(0, 0, 0, 0, layer, 4000);
+        root.bbox.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+
+        root.add(new EntwinePointTileNode(1, 0, 0, 0, layer, 3000));
+        root.add(new EntwinePointTileNode(1, 0, 0, 1, layer, 3000));
+        root.add(new EntwinePointTileNode(1, 0, 1, 1, layer, 3000));
+
+        root.children[0].add(new EntwinePointTileNode(2, 0, 0, 0, layer, 2000));
+        root.children[0].add(new EntwinePointTileNode(2, 0, 1, 0, layer, 2000));
+        root.children[1].add(new EntwinePointTileNode(2, 0, 1, 3, layer, 2000));
+        root.children[2].add(new EntwinePointTileNode(2, 0, 2, 2, layer, 2000));
+        root.children[2].add(new EntwinePointTileNode(2, 0, 3, 3, layer, 2000));
+
+        root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 0, 0, layer, 1000));
+        root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 1, 0, layer, 1000));
+        root.children[1].children[0].add(new EntwinePointTileNode(3, 0, 2, 7, layer, 1000));
+        root.children[2].children[0].add(new EntwinePointTileNode(3, 0, 5, 4, layer, 1000));
+        root.children[2].children[1].add(new EntwinePointTileNode(3, 1, 6, 7, layer));
+
+        it('finds the common ancestor of two nodes', () => {
+            let ancestor = root.children[2].children[1].children[0].findCommonAncestor(root.children[2].children[0].children[0]);
+            assert.deepStrictEqual(ancestor, root.children[2]);
+
+            ancestor = root.children[0].children[0].children[0].findCommonAncestor(root.children[0].children[0].children[1]);
+            assert.deepStrictEqual(ancestor, root.children[0].children[0]);
+
+            ancestor = root.children[0].children[1].findCommonAncestor(root.children[2].children[1].children[0]);
+            assert.deepStrictEqual(ancestor, root);
+
+            ancestor = root.children[1].findCommonAncestor(root.children[1].children[0].children[0]);
+            assert.deepStrictEqual(ancestor, root.children[1]);
+
+            ancestor = root.children[2].children[0].findCommonAncestor(root.children[2]);
+            assert.deepStrictEqual(ancestor, root.children[2]);
+        });
+    });
+});

--- a/test/unit/potreeBinParser.js
+++ b/test/unit/potreeBinParser.js
@@ -8,7 +8,14 @@ describe('PotreeBinParser', function () {
         for (let i = 0; i < 12; i++) {
             dv.setInt32(i * 4, i * 2, true);
         }
-        return PotreeBinParser.parse(buffer, ['POSITION_CARTESIAN']).then((geom) => {
+
+        const options = {
+            in: {
+                pointAttributes: ['POSITION_CARTESIAN'],
+            },
+        };
+
+        return PotreeBinParser.parse(buffer, options).then((geom) => {
             const posAttr = geom.getAttribute('position');
             assert.equal(posAttr.itemSize, 3);
             assert.ok(posAttr.array instanceof Float32Array);
@@ -41,7 +48,13 @@ describe('PotreeBinParser', function () {
             dv.setUint8(i * numbyte + 18, i * 3);
         }
 
-        return PotreeBinParser.parse(buffer, ['POSITION_CARTESIAN', 'INTENSITY', 'COLOR_PACKED', 'CLASSIFICATION']).then(function (geom) {
+        const options = {
+            in: {
+                pointAttributes: ['POSITION_CARTESIAN', 'INTENSITY', 'COLOR_PACKED', 'CLASSIFICATION'],
+            },
+        };
+
+        return PotreeBinParser.parse(buffer, options).then(function (geom) {
             const posAttr = geom.getAttribute('position');
             const intensityAttr = geom.getAttribute('intensity');
             const colorAttr = geom.getAttribute('color');


### PR DESCRIPTION
A first view on the implementation of the [Entwine format.](entwine.io)

- feat: add Entwine Point Tile support
Based on the PointCloud basis, it is now possible to use
EntwinePointTileSource and EntwinePointTileLayer to display data from
Entwine. See https://entwine.io/ for more information on this format.
- examples: add two Entwine Point Tile examples 

I have a few things to add before review, like some documentation and the verification of the `bin` parser.