### PR TITLE
Some labels fixes (see 1473)

### DIFF
--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -155,7 +155,14 @@ class Label extends THREE.Object3D {
         const elevation = DEMUtils.getElevationValueAt(layer, this.coordinates, DEMUtils.FAST_READ_Z);
         if (elevation && elevation != this.coordinates.z) {
             this.coordinates.z = elevation;
+            this.updateHorizonCullingPoint();
             return true;
+        }
+    }
+
+    updateHorizonCullingPoint() {
+        if (this.horizonCullingPoint) {
+            this.getWorldPosition(this.horizonCullingPoint);
         }
     }
 }

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -92,6 +92,8 @@ class Label extends THREE.Object3D {
                 this.content.classList.add('itowns-stroke-single');
             }
             style.applyToHTML(this.content);
+        } else {
+            this.anchor = [0, 0];
         }
 
         this.zoom = {

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -35,6 +35,8 @@ if (document.documentElement.style.transform !== undefined) {
  * @property {THREE.Vector3} position - The position in the 3D world of the
  * label.
  * @property {Coordinates} coordinates - The coordinates of the label.
+ * @property {number} order - Order of the label that will be read from the
+ * style. It helps sorting and prioritizing a Label during render.
  */
 class Label extends THREE.Object3D {
     /**
@@ -100,6 +102,8 @@ class Label extends THREE.Object3D {
             min: style.zoom && style.zoom.min != undefined ? style.zoom.min : 2,
             max: style.zoom && style.zoom.max != undefined ? style.zoom.max : 24,
         };
+
+        this.order = style.order || 0;
     }
 
     /**
@@ -116,10 +120,12 @@ class Label extends THREE.Object3D {
             this.projectedPosition.x = X;
             this.projectedPosition.y = Y;
 
-            this.boundaries.left = x + this.offset.left;
-            this.boundaries.right = x + this.offset.right;
-            this.boundaries.top = y + this.offset.top;
-            this.boundaries.bottom = y + this.offset.bottom;
+            // 2 is a padding value, to avoid labels being too close to each
+            // other. This value has been choosen arbitrarily.
+            this.boundaries.left = x + this.offset.left - 2;
+            this.boundaries.right = x + this.offset.right + 2;
+            this.boundaries.top = y + this.offset.top - 2;
+            this.boundaries.bottom = y + this.offset.bottom + 2;
         }
     }
 

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -117,8 +117,12 @@ class GlobeLayer extends TiledGeometryLayer {
             return false;
         }
 
+        return this.horizonCulling(node.horizonCullingPointElevationScaled);
+    }
+
+    horizonCulling(point) {
         // see https://cesiumjs.org/2013/04/25/Horizon-culling/
-        scaledHorizonCullingPoint.copy(node.horizonCullingPointElevationScaled).applyMatrix4(worldToScaledEllipsoid);
+        scaledHorizonCullingPoint.copy(point).applyMatrix4(worldToScaledEllipsoid);
         scaledHorizonCullingPoint.sub(cameraPosition);
 
         const vtMagnitudeSquared = scaledHorizonCullingPoint.lengthSq();

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -113,6 +113,8 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * - `point` is for all points
  * - `text` contains all {@link Label} related things
  *
+ * @property {number} order - Order of the features that will be associated to
+ * the style. It can helps sorting and prioritizing features if needed.
  * @property {Object} fill - Polygons and fillings style.
  * @property {string} fill.color - Defines the main color of the filling. Can be
  * any [valid color
@@ -226,6 +228,8 @@ class Style {
      */
     constructor(params = {}, parent) {
         this.isStyle = true;
+
+        this.order = 0;
 
         this.parent = parent || {
             zoom: {},
@@ -351,12 +355,15 @@ class Style {
      * set Style from vector tile layer properties.
      * @param {object} layer vector tile layer.
      * @param {Object} sprites vector tile layer.
+     * @param {number} [order=0]
      * @param {boolean} [symbolToCircle=false]
      * @returns {Style}
      */
-    setFromVectorTileLayer(layer, sprites, symbolToCircle = false) {
+    setFromVectorTileLayer(layer, sprites, order = 0, symbolToCircle = false) {
         layer.layout = layer.layout || {};
         layer.paint = layer.paint || {};
+
+        this.order = order;
 
         const zoom = this.zoom.min || 0;
 

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -455,7 +455,6 @@ class Style {
         domElement.style.fontSize = `${this.text.size}px`;
         domElement.style.fontFamily = this.text.font.join(',');
 
-        domElement.style.overflowWrap = 'break-word';
         domElement.style.textTransform = this.text.transform;
         domElement.style.letterSpacing = `${this.text.spacing}em`;
         domElement.style.textAlign = this.text.justify;
@@ -529,7 +528,7 @@ class Style {
      * @return {string} The formatted string.
      */
     getTextFromProperties(properties) {
-        return this.text.field.replace(/\{(.+?)\}/g, (a, b) => (properties[b] || ''));
+        return this.text.field.replace(/\{(.+?)\}/g, (a, b) => (properties[b] || '')).trim();
     }
 }
 

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import Layer from 'Layer/Layer';
@@ -209,6 +210,11 @@ class LabelLayer extends Layer {
 
                     node.add(label);
                     label.update3dPosition(context.view.referenceCrs);
+
+                    if (node.level < 4) {
+                        label.horizonCullingPoint = new THREE.Vector3();
+                        label.updateHorizonCullingPoint();
+                    }
 
                     labelsDiv.push(label.content);
                 });

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -139,11 +139,9 @@ class Label2DRenderer {
             if (!object.visible) {
                 this.hideNodeDOM(object);
                 return;
-            }
-
             // Don't go further if the node can't be in the screen space (it
             // does not need to be rendered to continue the culling)
-            if (object.extent && !object.extent.intersectsExtent(extent)) {
+            } else if (object.extent && !object.extent.intersectsExtent(extent)) {
                 this.hideNodeDOM(object);
                 return;
             }
@@ -184,12 +182,17 @@ class Label2DRenderer {
 
     hideNodeDOM(node) {
         if (node.domElements) {
-            Object.values(node.domElements).forEach((domElement) => {
-                if (domElement.visible == true) {
-                    domElement.dom.style.display = 'none';
-                    domElement.visible = false;
-                }
-            });
+            const domElements = Object.values(node.domElements);
+            if (domElements.length > 0) {
+                domElements.forEach((domElement) => {
+                    if (domElement.visible == true) {
+                        domElement.dom.style.display = 'none';
+                        domElement.visible = false;
+                    }
+                });
+            } else {
+                node.children.filter(n => n.isTileMesh).forEach(n => this.hideNodeDOM(n));
+            }
         }
     }
 

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -153,6 +153,10 @@ class Label2DRenderer {
         // visible extent, we can filter more labels.
         } else if (object.zoom.max <= currentMaxZoom || !extent.isPointInside(object.coordinates)) {
             this.grid.hidden.push(object);
+        // Do some horizon culling (if possible) if the tiles level is small
+        // enough. The chosen value of 4 seems to provide a good result.
+        } else if (object.parent.level < 4 && object.parent.layer.horizonCulling && object.parent.layer.horizonCulling(object.horizonCullingPoint)) {
+            this.grid.hidden.push(object);
         } else {
             vector.setFromMatrixPosition(object.matrixWorld);
             vector.applyMatrix4(viewProjectionMatrix);

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -109,7 +109,7 @@ class VectorTilesSource extends TMSSource {
                         const style = new Style();
                         style.zoom.min = stops[i];
                         style.zoom.max = stops[i + 1];
-                        style.setFromVectorTileLayer(layer, this.sprites, this.symbolToCircle);
+                        style.setFromVectorTileLayer(layer, this.sprites, order, this.symbolToCircle);
                         this.styles[layer.id].push(style);
                     }
 

--- a/test/unit/style.js
+++ b/test/unit/style.js
@@ -30,7 +30,6 @@ describe('Style', function () {
         assert.equal(dom.style.color, '#000000');
         assert.equal(dom.style.fontSize, '16px');
         assert.equal(dom.style.fontFamily, 'Open Sans Regular,Arial Unicode MS Regular,sans-serif');
-        assert.equal(dom.style.overflowWrap, 'break-word');
         assert.equal(dom.style.textTransform, 'none');
         assert.equal(dom.style.letterSpacing, '0em');
         assert.equal(dom.style.textAlign, 'center');


### PR DESCRIPTION
Three commits, to solve three problems listed in #1473 

- **fix(label): breaks word correctly**
It does not break in the middle of it anymore.

- **fix(label): correctly hide dom**
There was a problem for a specific situation. Let's consider that there
is a level 2 node, with four level 3 nodes. The L2 node contains no
DOM elements, while there are some in the L3 nodes. So the DOM in L3
have no parents, they are the first in the hierarchy.  So if we find L2
hidden, we don't go further, and thus inside L3 nodes, and don't hide
the DOM.
This commit fixes this behaviour, by allowing to go further in the
hierarchy until DOM elements are found.

- **fix(label): horizon culling**
Add a proper horizon culling mechanism, by splitting the GlobeLayer
culling to use it.


- **fix(label): reduce flickering by ordering label**
    It is not perfect yet, but the flickering has been reduced by taking into
    account the order the labels have.

- **test(label): add test for `Label2DRenderer`**