### PR TITLE
Refactoring data loading

### DIFF
--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -54,7 +54,9 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
             function isValidData(data) {
-                return data.features[0].geometries.length < 1000;
+                if(data.features[0].geometries.length < 1000) {
+                    return data;
+                }
             }
 
             var wfsBuildingSource = new itowns.WFSSource({

--- a/examples/vector_tile_dragndrop.html
+++ b/examples/vector_tile_dragndrop.html
@@ -48,7 +48,6 @@
                 var source = new itowns.VectorTilesSource({ style });
 
                 var layer = new itowns.ColorLayer(style.name + ' ' + id, {
-                    isValidData: function v() { return false },
                     source,
                     noTextureParentOutsideLimit: true,
                     labelEnabled: true,

--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -51,14 +51,6 @@
 
             setupLoadingScreen(viewerDiv, view);
 
-
-            // Add a vector tile layer
-            function isValidData(data, extentDestination) {
-                // re-use the same vector tiles by interval 4
-                // var z = extentDestination.zoom - 2;
-                return false;
-            }
-
             var mvtSource = new itowns.VectorTilesSource({
                 style: 'https://raw.githubusercontent.com/Oslandia/postile-openmaptiles/master/style.json',
                 // eslint-disable-next-line no-template-curly-in-string
@@ -74,7 +66,6 @@
             });
 
             var mvtLayer = new itowns.ColorLayer('MVT', {
-                isValidData: isValidData,
                 source: mvtSource,
                 labelEnabled: true,
             });

--- a/examples/vector_tile_raster_3d.html
+++ b/examples/vector_tile_raster_3d.html
@@ -52,11 +52,6 @@
                 return z - (z % 5);
             }
 
-            function isValidData(data, extentDestination) {
-                const isValid = inter(extentDestination.zoom) == inter(data.extent.zoom);
-                return isValid;
-            }
-
             var mvtSource = new itowns.VectorTilesSource({
                 style: 'https://raw.githubusercontent.com/Oslandia/postile-openmaptiles/master/style.json',
                 // eslint-disable-next-line no-template-curly-in-string
@@ -72,7 +67,6 @@
             });
 
             var mvtLayer = new itowns.ColorLayer('MVT', {
-                isValidData: isValidData,
                 source: mvtSource,
                 fx: 2.5,
                 labelEnabled: true,

--- a/examples/view_multi_25d.html
+++ b/examples/view_multi_25d.html
@@ -96,6 +96,15 @@
             parent.updateMatrixWorld(true);
 
             view.scene.add(parent);
+            var elevationSource = new itowns.WMSSource({
+                extent,
+                version: '1.3.0',
+                name: 'MNT2012_Altitude_10m_CC46',
+                projection: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+            });
 
             for (index = 0; index < wmsLayers.length; index++) {
                 wms = wmsLayers[index];
@@ -124,22 +133,13 @@
                     source: colorSource,
                 });
                 view.addLayer(colorLayer, tileLayer);
-
-                var elevationSource = new itowns.WMSSource({
-                    extent,
-                    version: '1.3.0',
-                    name: 'MNT2012_Altitude_10m_CC46',
-                    projection: 'EPSG:3946',
-                    width: 256,
-                    format: 'image/jpeg',
-                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                });
                 var elevationLayer = new itowns.ElevationLayer('wms_elevation' + wms + index, {
                     source: elevationSource,
                     useColorTextureElevation: true,
                     colorTextureElevationMinZ: 144,
                     colorTextureElevationMaxZ: 622,
                 });
+
                 view.addLayer(elevationLayer, tileLayer);
             }
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -76,6 +76,7 @@ function _preprocessLayer(view, layer, parentLayer) {
             source,
             style: layer.style,
             zoom: layer.zoom,
+            crs: view.referenceCrs,
         });
 
         layer.addEventListener('visible-property-changed', () => {
@@ -305,6 +306,10 @@ class View extends THREE.EventDispatcher {
                     }
                 }
             }
+
+            // remove unused cache
+            const sameSource = this.getLayers(l => l.source.uid == layer.source.uid && l.projection == layer.projection);
+            layer.source.onLayerRemoved({ unusedCrs: sameSource.length == 0 ? layer.projection : undefined });
 
             this.notifyChange(this.camera);
 

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -66,6 +66,10 @@ class ColorLayer extends Layer {
         this.defineLayerProperty('sequence', 0);
         this.transparent = config.transparent || (this.opacity < 1.0);
         this.noTextureParentOutsideLimit = config.source ? config.source.isFileSource : false;
+
+        this.parsingOptions.buildExtent = true;
+        this.parsingOptions.withNormal = false;
+        this.parsingOptions.withAltitude = false;
     }
 
     update(context, layer, node, parent) {

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -132,6 +132,9 @@ class GeometryLayer extends Layer {
             value: Infinity,
             writable: false,
         });
+        this.parsingOptions.filteringExtent = !this.source.isFileSource;
+        this.parsingOptions.withNormal = true;
+        this.parsingOptions.withAltitude = true;
     }
 
     // Attached layers expect to receive the visual representation of a

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -43,6 +43,8 @@ class LabelLayer extends Layer {
         this.defineLayerProperty('visible', true, () => {
             this.domElement.style.display = this.visible ? 'block' : 'none';
         });
+
+        this.parsingOptions.buildExtent = true;
     }
 
     /**

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -128,7 +128,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     const destinationLevel = extentsDestination[0].zoom || node.level;
     const targetLevel = chooseNextLevelToFetch(layer.updateStrategy.type, node, destinationLevel, nodeLayer.level, layer, failureParams);
 
-    if (targetLevel <= nodeLayer.level || targetLevel > destinationLevel) {
+    if ((!layer.source.isVectorSource && targetLevel <= nodeLayer.level) || targetLevel > destinationLevel) {
         if (failureParams.lowestLevelError != Infinity) {
             // this is the highest level found in case of error.
             node.layerUpdateState[layer.id].noMoreUpdatePossible();
@@ -152,7 +152,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     }
 
     node.layerUpdateState[layer.id].newTry();
-    const parsedData = nodeLayer.textures.map(t => t.parsedData);
+    const parsedData = nodeLayer.textures.map(t => layer.isValidData(t.parsedData));
     const command = buildCommand(context.view, layer, extentsSource, extentsDestination, node, parsedData);
 
     return context.scheduler.execute(command).then(

--- a/src/Provider/DataSourceProvider.js
+++ b/src/Provider/DataSourceProvider.js
@@ -1,89 +1,10 @@
-function isValidData(data, extentDestination, validFn) {
-    if (data && (!validFn || validFn(data, extentDestination))) {
-        return data;
-    }
-}
-
-const error = (err, source) => {
-    source.handlingError(err);
-    throw err;
-};
-
-export function parseSourceData(data, layer) {
-    const source = layer.source;
-
-    const options = {
-        buildExtent: source.isFileSource || !layer.isGeometryLayer,
-        crsIn: source.projection,
-        crsOut: layer.projection,
-        filteringExtent: !source.isFileSource && layer.isGeometryLayer,
-        overrideAltitudeInToZero: layer.overrideAltitudeInToZero,
-        filter: layer.filter || source.filter,
-        isInverted: source.isInverted,
-        mergeFeatures: layer.mergeFeatures === undefined ? true : layer.mergeFeatures,
-        withNormal: layer.isGeometryLayer !== undefined,
-        withAltitude: layer.isGeometryLayer !== undefined,
-        layers: source.layers,
-        styles: source.styles,
-        style: layer.style,
-    };
-
-    return source.parser(data, options).then(parsedFile => source.onParsedFile(parsedFile));
-}
-
-function fetchSourceData(extSrc, layer) {
-    const source = layer.source;
-    // If source, we must fetch and convert data
-    // URL of the resource you want to fetch
-    const url = source.urlFromExtent(extSrc);
-
-    // Fetch data
-    return source.fetcher(url, source.networkOptions).then((f) => {
-        f.extent = extSrc;
-        return f;
-    });
-}
-
 export default {
     executeCommand(command) {
-        const promises = [];
         const layer = command.layer;
-        const source = layer.source;
-        const extentsSource = command.extentsSource;
-        const extentsDestination = command.extentsDestination || extentsSource;
-        const parsedData = command.parsedData || [];
+        const features = command.parsedData || [];
+        const src = command.extentsSource;
+        const dst = command.extentsDestination || src;
 
-        for (let i = 0, max = extentsSource.length; i < max; i++) {
-            const extSource = extentsSource[i];
-            const extDest = extentsDestination[i];
-
-            // Tag to Cache data
-            const tag = source.requestToKey(source.isVectorSource ? extDest : extSource);
-
-            let convertedSourceData = layer.cache.getByArray(tag);
-
-            // If data isn't in cache
-            if (!convertedSourceData) {
-                // Already fetched and parsed data that can be used
-                const validedParsedData = isValidData(parsedData[i], extDest, layer.isValidData) || source.parsedData;
-                if (validedParsedData) {
-                    // Convert
-                    convertedSourceData = layer.convert(validedParsedData, extDest, layer);
-                } else {
-                    // Fetch, parse and convert
-                    convertedSourceData = fetchSourceData(extSource, layer)
-                        .then(fetchedData => parseSourceData(fetchedData, layer), err => error(err, source))
-                        .then(parsedData => layer.convert(parsedData, extDest, layer), err => error(err, source));
-                }
-                // Put converted data in cache
-                layer.cache.setByArray(convertedSourceData, tag);
-            }
-
-            // Verify some command is resolved
-            // See old WFSProvider : command.resolve(result)
-            promises.push(convertedSourceData);
-        }
-
-        return Promise.all(promises);
+        return Promise.all(src.map((from, i) => (layer.getData(from, dst[i], features[i]))));
     },
 };

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -250,23 +250,29 @@ describe('Sources', function () {
             assert.ok(source.isFileSource);
 
             const layer = new Layer('09-ariege', { projection: 'EPSG:4326', source });
+            layer.parsingOptions.crsOut = layer.projection;
+            layer.source.onLayerAdded({ crsOut: layer.projection });
+
             layer.whenReady.then(() => {
-                assert.equal(source.parsedData.features[0].vertices.length, 3536);
-                done();
+                const promise = source.loadData([], { crsOut: layer.projection });
+                promise.then((featureCollection) => {
+                    assert.equal(featureCollection.features[0].vertices.length, 5304);
+                    done();
+                });
             });
             layer._resolve();
         });
 
         it('should instance and use FileSource with parsedData', function () {
             const source = new FileSource({
-                parsedData: { foo: 'bar' },
+                parsedData: { foo: 'bar', crs: 'EPSG:4326' },
                 projection: 'EPSG:4326',
             });
-
+            source.onLayerAdded({ crsOut: source.projection });
             const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
             assert.ok(source.urlFromExtent(extent).startsWith('fake-file-url'));
             assert.ok(!source.fetchedData);
-            assert.ok(source.parsedData);
+
             assert.ok(source.isFileSource);
         });
 

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -251,12 +251,13 @@ describe('Sources', function () {
 
             const layer = new Layer('09-ariege', { projection: 'EPSG:4326', source });
             layer.parsingOptions.crsOut = layer.projection;
-            layer.source.onLayerAdded({ crsOut: layer.projection });
+            layer.parsingOptions.withAltitude = false;
+            layer.source.onLayerAdded(layer.parsingOptions);
 
             layer.whenReady.then(() => {
-                const promise = source.loadData([], { crsOut: layer.projection });
+                const promise = source.loadData([], layer.parsingOptions);
                 promise.then((featureCollection) => {
-                    assert.equal(featureCollection.features[0].vertices.length, 5304);
+                    assert.equal(featureCollection.features[0].vertices.length, 3536);
                     done();
                 });
             });

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -21,11 +21,11 @@ describe('Viewer', function () {
 
         globelayer = new GlobeLayer('globe', new THREE.Group());
         source = new FileSource({
-            parsedData: {},
+            parsedData: { crs: 'EPSG:4326' },
             projection: 'EPSG:4326',
         });
 
-        colorLayer = new ColorLayer('l0', { source, labelEnabled: true });
+        colorLayer = new ColorLayer('l0', { source, labelEnabled: true, projection: 'EPSG:4326' });
         colorLayer2 = new ColorLayer('l1', { source });
     });
 


### PR DESCRIPTION
## Refactoring data loading
Move the fetching, the parsing and the converting to `Source` and `Layer` classes.

* `Source` handles the fetching and the parsing in `loadData` method;
* `Parsed datas caches` are added  in `Source`;
* the parsing options are temporary moved in `Layer` class. the objective is to delete it in a other PR;

## Motivation and Context
* reduce `DataSourceProvider`;
* approach the architecture by layer node ([see project](https://github.com/iTowns/itowns/projects/7));
* go mile stone  `simplify parsing options construction`;

## Future
1. rename `projection` property by `crs` in `Layer` and `Source` classes;
2. simplify parsing options construction: #1480 
   - parsing options will have two properties `in` and `out`
     - `in` will be data specification for **in data**.
     - `out` will be data specification for **out feature**.
  - in and out could be set, respectively, by `Source` and `Layer`.
```js 
// custom parsing  option to convert 'EPSG:4326' data to 'EPSG:4978' `Feature`.
const parsingOptions = { 
   in: { crs: 'EPSG:4326'  },
   out: { crs: 'EPSG:4978'  },
};
// For a layer the options will be
const parsingOptionsForLayer = { 
   in: layer.source,
   out: layer,
};
```
3.  move loading data in a new node layer