### PR TITLE
Rename all Layer and Source properties 'projection' by 'crs'.

### DIFF
--- a/docs/tutorials/Display-a-geometry-layer.md
+++ b/docs/tutorials/Display-a-geometry-layer.md
@@ -97,7 +97,7 @@ instantiate the source.
 var geometrySource = new itowns.WFSSource({
     url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_indifferencie',
-    projection: 'EPSG:4326',
+    crs: 'EPSG:4326',
 });
 
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
@@ -142,7 +142,7 @@ function setAltitude(properties) {
 var geometrySource = new itowns.WFSSource({
     url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_indifferencie',
-    projection: 'EPSG:4326',
+    crs: 'EPSG:4326',
 });
 
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
@@ -213,7 +213,7 @@ function setExtrusion(properties) {
 var geometrySource = new itowns.WFSSource({
     url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_indifferencie',
-    projection: 'EPSG:4326',
+    crs: 'EPSG:4326',
 });
 
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
@@ -250,7 +250,7 @@ function setColor(properties) {
 var geometrySource = new itowns.WFSSource({
     url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_indifferencie',
-    projection: 'EPSG:4326',
+    crs: 'EPSG:4326',
 });
 
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
@@ -365,7 +365,7 @@ layer on a globe, and change some things on this layer. Here is the final code:
             var geometrySource = new itowns.WFSSource({
                 url: 'http://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_indifferencie',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
             });
 
             var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {

--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -16,7 +16,7 @@
         <script src="js/GUI/GuiTools.js"></script>
         <script src="js/3dTilesHelper.js"></script>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
             // Define geographic extent: CRS, min/max X, min/max Y
@@ -41,7 +41,7 @@
                 name: 'Ortho2009_vue_ensemble_16cm_CC46',
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 format: 'image/jpeg',
             });
 
@@ -61,7 +61,7 @@
                 extent: extent,
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 name: 'MNT2012_Altitude_10m_CC46',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',
             });

--- a/examples/js/plugins/DragNDrop.js
+++ b/examples/js/plugins/DragNDrop.js
@@ -6,7 +6,7 @@
  * displayed are stored in the plugin. Use the method `register` to declare the
  * way a file is read, parsed and displayed.
  *
- * Note: only files with the projection `EPSG:4326` can be projected correctly
+ * Note: only files with the crs projection `EPSG:4326` can be projected correctly
  * using this plugin.
  *
  * @module DragNDrop
@@ -78,7 +78,7 @@ var DragNDrop = (function _() {
 
                     var source = new itowns.FileSource({
                         parsedData: result,
-                        projection: 'EPSG:4326',
+                        crs: 'EPSG:4326',
                     });
 
                     var randomColor = Math.round(Math.random() * 0xffffff);

--- a/examples/layers/JSONLayers/Administrative.json
+++ b/examples/layers/JSONLayers/Administrative.json
@@ -5,7 +5,7 @@
   "opacity": 1,
   "transparent": true,
   "source": {
-    "projection": "EPSG:3857",
+    "crs": "EPSG:3857",
     "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
     "format": "image/png",
     "name": "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",

--- a/examples/layers/JSONLayers/Cada.json
+++ b/examples/layers/JSONLayers/Cada.json
@@ -6,7 +6,7 @@
   "transparent": true,
   "source": {
     "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
-    "projection": "EPSG:3857",
+    "crs": "EPSG:3857",
     "networkOptions": {
       "crossOrigin": "omit"
     },

--- a/examples/layers/JSONLayers/Cassini.json
+++ b/examples/layers/JSONLayers/Cassini.json
@@ -2,7 +2,7 @@
     "id":         "Cassini",
     "source": {
         "url": "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
         "networkOptions": {
             "crossOrigin": "anonymous"
         },

--- a/examples/layers/JSONLayers/DARK.json
+++ b/examples/layers/JSONLayers/DARK.json
@@ -1,7 +1,7 @@
 {
     "id": "DARK",
     "source": {
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
 	    "networkOptions": { "crossOrigin" : "anonymous" },
         "format": "image/png",
         "url": "http://a.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png",

--- a/examples/layers/JSONLayers/Denomination.json
+++ b/examples/layers/JSONLayers/Denomination.json
@@ -6,7 +6,7 @@
   "transparent": true,
   "source": {
     "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
-    "projection": "EPSG:3857",
+    "crs": "EPSG:3857",
     "tileMatrixSet": "PM",
     "format": "image/png",
     "name": "GEOGRAPHICALNAMES.NAMES",

--- a/examples/layers/JSONLayers/EtatMajor.json
+++ b/examples/layers/JSONLayers/EtatMajor.json
@@ -3,7 +3,7 @@
     "opacity": 1,
     "transparent": true,
     "source": {
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
         "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
         "networkOptions": {
             "crossOrigin": "anonymous"

--- a/examples/layers/JSONLayers/GeoidMNT.json
+++ b/examples/layers/JSONLayers/GeoidMNT.json
@@ -8,7 +8,7 @@
     "source": {
         "url": "https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/geoid/geoid/bil/%TILEMATRIX/geoid_%COL_%ROW.bil",
         "format": "image/x-bil;bits=32",
-        "projection": "EPSG:4326",
+        "crs": "EPSG:4326",
         "tileMatrixSet": "WGS84G",
         "tileMatrixSetLimits": {
             "0": {

--- a/examples/layers/JSONLayers/IGN_MNT.json
+++ b/examples/layers/JSONLayers/IGN_MNT.json
@@ -9,7 +9,7 @@
     },
     "source": {
         "url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
-        "projection": "EPSG:4326",
+        "crs": "EPSG:4326",
         "format": "image/x-bil;bits=32",
         "attribution" : {
             "name":"IGN",

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -9,7 +9,7 @@
 	},
 	"source": {
 		"url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
-        "projection": "EPSG:4326",
+        "crs": "EPSG:4326",
 		"format": "image/x-bil;bits=32",
 		"attribution" : {
 			"name":"IGN",

--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -1,7 +1,7 @@
 {
     "id": "OPENSM",
     "source": {
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
         "isInverted": true,
         "format": "image/png",
         "url": "http://osm.oslandia.io/styles/klokantech-basic/${z}/${x}/${y}.png",

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -2,7 +2,7 @@
     "id":   "Ortho",
     "source": {
         "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
         "networkOptions": {
             "crossOrigin": "anonymous"
         },

--- a/examples/layers/JSONLayers/Railways.json
+++ b/examples/layers/JSONLayers/Railways.json
@@ -5,7 +5,7 @@
   "opacity": 1,
   "transparent": true,
   "source": {
-    "projection": "EPSG:3857",
+    "crs": "EPSG:3857",
     "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
     "format": "image/png",
     "networkOptions": {

--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -9,7 +9,7 @@
         "version"   : "1.3.0",
         "name"      : "REGIONS.2017",
         "style"      : "",
-        "projection" : "EPSG:3857",
+        "crs" : "EPSG:3857",
         "extent": {
             "west": "-6880639.13669047",
             "east": "6215707.87640867",

--- a/examples/layers/JSONLayers/ScanEX.json
+++ b/examples/layers/JSONLayers/ScanEX.json
@@ -2,7 +2,7 @@
     "id":         "ScanEX",
     "fx" :        2.5,
     "source": {
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
         "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "format": "image/jpeg",
         "name": "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD",

--- a/examples/layers/JSONLayers/Top25.json
+++ b/examples/layers/JSONLayers/Top25.json
@@ -1,11 +1,11 @@
 {
     "id":         "Top25",
     "source": {
-        "projection": "EPSG:3857",
+        "crs": "EPSG:3857",
         "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
         "networkOptions": {
             "crossOrigin": "anonymous"
-        },    
+        },
         "format": "image/jpeg",
         "attribution" : {
             "name":"IGN",

--- a/examples/layers/JSONLayers/Transport.json
+++ b/examples/layers/JSONLayers/Transport.json
@@ -5,7 +5,7 @@
   "opacity": 1,
   "transparent": true,
   "source": {
-    "projection": "EPSG:3857",
+    "crs": "EPSG:3857",
     "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
     "format": "image/png",
     "networkOptions": {

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -10,7 +10,7 @@
     },
     "source": {
         "format": "image/x-bil;bits=32",
-        "projection": "EPSG:4326",
+        "crs": "EPSG:4326",
         "url":        "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
         "name": "ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3",
         "tileMatrixSet": "WGS84G",

--- a/examples/misc_compare_25d_3d.html
+++ b/examples/misc_compare_25d_3d.html
@@ -54,7 +54,7 @@
         <script src="../dist/itowns.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
             /* global itowns, document, GuiTools, Promise */
             var placement = {
@@ -140,7 +140,7 @@
                 name: 'Ortho2009_vue_ensemble_16cm_CC46',
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 format: 'image/jpeg',
             });
 

--- a/examples/plugins_drag_n_drop.html
+++ b/examples/plugins_drag_n_drop.html
@@ -12,7 +12,7 @@
         <div id="viewerDiv">
             <div id="description">Drag and drop a Geojson or Gpx file onto the
                 viewer, and see it loaded as a ColorLayer. Only files with the
-                projection <b>EPSG:4326</b> can be projected correctly in this
+                crs projection <b>EPSG:4326</b> can be projected correctly in this
                 demo. More information about the plugin used <a
                  href="http://www.itowns-project.org/itowns/docs/#api/Plugins/DragNDrop"
                  target="_blank">in the documentation.</a></div>

--- a/examples/plugins_pyramidal_tiff.html
+++ b/examples/plugins_pyramidal_tiff.html
@@ -37,7 +37,7 @@
             var tiffSource = new itowns.TMSSource({
                 url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/geoid/localcolors/tiff/${z}/localcolors_${x}_${y}.tif',
                 tileMatrixSet: 'WGS84G',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 parser: TIFFParser.parse,
                 fetcher: itowns.Fetcher.arrayBuffer,
                 zoom: { min: 0, max: 4 },

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -61,7 +61,7 @@
                     source: new itowns.PotreeSource({
                         file: 'eglise_saint_blaise_arles.js',
                         url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/eglise_saint_blaise_arles',
-                        projection: view.referenceCrs,
+                        crs: view.referenceCrs,
                     }),
                 });
 

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -65,7 +65,7 @@
                 source: new itowns.PotreeSource({
                     file: 'eglise_saint_blaise_arles.js',
                     url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
-                    projection: view.referenceCrs,
+                    crs: view.referenceCrs,
                 }),
             });
 

--- a/examples/source_file_geojson_3d.html
+++ b/examples/source_file_geojson_3d.html
@@ -51,7 +51,7 @@
                 // Use a FileSource to load a single file once
                 source: new itowns.FileSource({
                     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/multipolygon.geojson',
-                    projection: 'EPSG:4326',
+                    crs: 'EPSG:4326',
                     format: 'application/json',
                 }),
                 zoom: { min: 10 },

--- a/examples/source_file_gpx_raster.html
+++ b/examples/source_file_gpx_raster.html
@@ -82,7 +82,7 @@
 
                     var gpxSource = new itowns.FileSource({
                         fetchedData: gpx,
-                        projection: 'EPSG:4326',
+                        crs: 'EPSG:4326',
                         parser: itowns.GpxParser.parse,
                     });
 

--- a/examples/source_file_kml_raster.html
+++ b/examples/source_file_kml_raster.html
@@ -59,7 +59,7 @@
             // Fetch, Parse and Convert by iTowns
             var kmlSource = new itowns.FileSource({
                 url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 fetcher: itowns.Fetcher.xml,
                 parser: itowns.KMLParser.parse,
             });

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -28,7 +28,7 @@
         <script src="../dist/itowns.js"></script>
         <script src="js/GUI/LoadingScreen.js"></script>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
             /* global itowns,document, setupLoadingScreen, window */
 
@@ -68,7 +68,7 @@
                 networkOptions: { crossOrigin: 'anonymous' },
                 version: '1.3.0',
                 name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 extent: extent,
                 format: 'image/jpeg',
             });
@@ -86,7 +86,7 @@
                 extent: extent,
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 name: 'MNT2012_Altitude_10m_CC46',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',
             });
@@ -152,7 +152,7 @@
                 version: '2.0.0',
                 id: 'tcl_bus',
                 typeName: 'tcl_sytral.tcllignebus',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 extent: {
                     west: 1822174.60,
                     east: 1868247.07,
@@ -219,7 +219,7 @@
                 url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 ipr: 'IGN',
                 format: 'application/json',
                 extent: {
@@ -243,7 +243,7 @@
                 },
                 filter: acceptFeature,
                 overrideAltitudeInToZero: true,
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 source: wfsBuildingSource,
                 zoom: { min: 4 },
             });
@@ -254,7 +254,7 @@
                 url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDCARTO_BDD_WLD_WGS84G:zone_habitat',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 ipr: 'IGN',
                 format: 'application/json',
                 extent: {
@@ -277,7 +277,7 @@
             });
 
             var wfsCartoLayer = new itowns.LabelLayer('wfsCarto', 'EPSG:3946');
-            wfsCartoLayer.projection = 'EPSG:3946';
+            wfsCartoLayer.crs = 'EPSG:3946';
             wfsCartoLayer.source = wfsCartoSource;
             wfsCartoLayer.style = wfsCartoStyle;
 

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -21,7 +21,7 @@
             </ul>
         </div>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
             // # Simple Globe viewer
 
@@ -100,7 +100,7 @@
                 url: 'https://download.data.grandlyon.com/wfs/rdata?',
                 version: '2.0.0',
                 typeName: 'tcl_sytral.tcllignebus',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 extent: {
                     west: 1822174.60,
                     east: 1868247.07,
@@ -167,7 +167,7 @@
                 url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 ipr: 'IGN',
                 format: 'application/json',
                 extent: {

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -63,7 +63,7 @@
                 url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 extent: {
                     west: 4.568,
                     east: 5.18,

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -28,7 +28,7 @@
         <script src="../dist/debug.js"></script>
         <script src="js/GUI/GuiTools.js"></script>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
             /* global itowns, setupLoadingScreen, GuiTools, debug */
             // # Planar (EPSG:3946) viewer
@@ -59,7 +59,7 @@
                 name: 'Ortho2009_vue_ensemble_16cm_CC46',
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 format: 'image/jpeg',
             });
 
@@ -79,7 +79,7 @@
                 extent: extent,
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
                 name: 'MNT2012_Altitude_10m_CC46',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',
             });

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -51,7 +51,7 @@
                 url: 'http://c.tile.stamen.com/watercolor/${z}/${x}/${y}.jpg',
                 networkOptions: { crossOrigin: 'anonymous' },
                 extent,
-                projection: 'EPSG:3857',
+                crs: 'EPSG:3857',
                 attribution: {
                     name: 'OpenStreetMap',
                     url: 'http://www.openstreetmap.org/',

--- a/examples/view_immersive.html
+++ b/examples/view_immersive.html
@@ -22,7 +22,7 @@
         <script src="js/GUI/GuiTools.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/2154, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/2154, Proj4js section)
             itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
             // Define initial camera position
@@ -104,7 +104,7 @@
                 // Radius in meter of the sphere used as a background.
                 backgroundDistance: 1200,
                 source: orientedImageSource,
-                projection: view.referenceCrs,
+                crs: view.referenceCrs,
                 useMask: false,
                 onPanoChanged: (e) => {
                     view.controls.setPreviousPosition(e.previousPanoPosition);
@@ -121,7 +121,7 @@
                     url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?',
                     version: '2.0.0',
                     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable,BDTOPO_BDD_WLD_WGS84G:bati_indifferencie,BDTOPO_BDD_WLD_WGS84G:bati_industriel',
-                    projection: 'EPSG:4326',
+                    crs: 'EPSG:4326',
                     ipr: 'IGN',
                     format: 'application/json',
                     extent: {

--- a/examples/view_multi_25d.html
+++ b/examples/view_multi_25d.html
@@ -17,7 +17,7 @@
         </script>
         <script src="https://unpkg.com/three@0.86.0/examples/js/controls/OrbitControls.js"></script>
         <script type="text/javascript">
-            // Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
             itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
             // # Planar (EPSG:3946) viewer
 
@@ -100,7 +100,7 @@
                 extent,
                 version: '1.3.0',
                 name: 'MNT2012_Altitude_10m_CC46',
-                projection: 'EPSG:3946',
+                crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
@@ -125,7 +125,7 @@
                     url: 'https://download.data.grandlyon.com/wms/grandlyon',
                     version: '1.3.0',
                     name: wms,
-                    projection: 'EPSG:3946',
+                    crs: 'EPSG:3946',
                     format: 'image/jpeg',
                     extent,
                 });

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -1084,7 +1084,7 @@ class GlobeControls extends THREE.EventDispatcher {
      *
      * @deprecated Use View#getScale instead.
      */
-    getScale(pitch) {
+    getScale(pitch) /* istanbul ignore next */ {
         console.warn('Deprecated, use View#getScale instead.');
         return this.view.getScale(pitch);
     }
@@ -1097,7 +1097,7 @@ class GlobeControls extends THREE.EventDispatcher {
      *
      * @deprecated Use `View#getPixelsToMeters` instead.
      */
-    pixelsToMeters(pixels, pixelPitch = 0.28) {
+    pixelsToMeters(pixels, pixelPitch = 0.28) /* istanbul ignore next */ {
         console.warn('Deprecated use View#getPixelsToMeters instead.');
         const scaled = this.getScale(pixelPitch);
         const size = pixels * pixelPitch;
@@ -1113,7 +1113,7 @@ class GlobeControls extends THREE.EventDispatcher {
      * @deprecated Use `View#getPixelsToMeters` and `GlobeControls#metersToDegrees`
      * instead.
      */
-    pixelsToDegrees(pixels, pixelPitch = 0.28) {
+    pixelsToDegrees(pixels, pixelPitch = 0.28) /* istanbul ignore next */ {
         console.warn('Deprecated, use View#getPixelsToMeters and GlobeControls#getMetersToDegrees instead.');
         const chord = this.pixelsToMeters(pixels, pixelPitch);
         return THREE.MathUtils.radToDeg(2 * Math.asin(chord / (2 * ellipsoidSizes.x)));
@@ -1127,7 +1127,7 @@ class GlobeControls extends THREE.EventDispatcher {
      *
      * @deprecated Use `View#getMetersToPixels` instead.
      */
-    metersToPixels(value, pixelPitch = 0.28) {
+    metersToPixels(value, pixelPitch = 0.28) /* istanbul ignore next */ {
         console.warn('Deprecated, use View#getMetersToPixels instead.');
         const scaled = this.getScale(pixelPitch);
         pixelPitch /= 1000;

--- a/src/Converter/textureConverter.js
+++ b/src/Converter/textureConverter.js
@@ -27,7 +27,7 @@ export default {
                 new THREE.Color(backgroundLayer.paint['background-color']) :
                 undefined;
 
-            extentDestination.as(CRS.formatToEPSG(layer.projection), extentTexture);
+            extentDestination.as(CRS.formatToEPSG(layer.crs), extentTexture);
             texture = Feature2Texture.createTextureFromFeature(data, extentTexture, 256, layer.style, backgroundColor);
             texture.parsedData = data;
             texture.extent = extentDestination;

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -194,7 +194,7 @@ class Feature {
         this.crs = crs;
         this.size = options.withAltitude ? 3 : 2;
         if (options.buildExtent) {
-            // this.crs is final projection, is out projection.
+            // this.crs is final crs projection, is out projection.
             // If the extent crs is the same then we use output coordinate (coordOut) to expand it.
             this.extent = defaultExtent(crs != 'EPSG:4978' ?  crs : options.crsIn);
             this.useCrsOut = this.crs == this.extent.crs;

--- a/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
+++ b/src/Core/Prefab/Globe/BuilderEllipsoidTile.js
@@ -24,8 +24,8 @@ class BuilderEllipsoidTile {
             dimension: new THREE.Vector2(),
         };
 
-        this.projection = options.projection;
-        // Order projection on tiles
+        this.crs = options.crs;
+        // Order crs projection on tiles
         this.uvCount = options.uvCount;
 
         this.computeUvs = [
@@ -68,7 +68,7 @@ class BuilderEllipsoidTile {
     // get center tile in cartesian 3D
     center(extent) {
         return extent.center(this.tmp.coords[0])
-            .as(this.projection, this.tmp.coords[1]).toVector3();
+            .as(this.crs, this.tmp.coords[1]).toVector3();
     }
 
     // get position 3D cartesian
@@ -77,7 +77,7 @@ class BuilderEllipsoidTile {
             params.projected.longitude,
             params.projected.latitude);
 
-        this.tmp.coords[0].as(this.projection, this.tmp.coords[1]).toVector3(this.tmp.position);
+        this.tmp.coords[0].as(this.crs, this.tmp.coords[1]).toVector3(this.tmp.position);
         return this.tmp.position;
     }
 

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -61,7 +61,7 @@ class GlobeLayer extends TiledGeometryLayer {
             CRS.tms_3857,
         ];
         const uvCount = config.tileMatrixSets.length;
-        const builder = new BuilderEllipsoidTile({ projection: 'EPSG:4978', uvCount });
+        const builder = new BuilderEllipsoidTile({ crs: 'EPSG:4978', uvCount });
 
         super(id, object3d || new THREE.Group(), schemeTile, builder, config);
 
@@ -100,10 +100,10 @@ class GlobeLayer extends TiledGeometryLayer {
     countColorLayersTextures(...layers) {
         let occupancy = 0;
         for (const layer of layers) {
-            const projection = layer.projection || layer.source.projection;
+            const crs = layer.crs || layer.source.crs;
             // 'EPSG:3857' occupies the maximum 3 textures on tiles
             // 'EPSG:4326' occupies 1 textures on tile
-            occupancy += projection == 'EPSG:3857' ? 3 : 1;
+            occupancy += crs == 'EPSG:3857' ? 3 : 1;
         }
         return occupancy;
     }

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -142,11 +142,11 @@ class GlobeView extends View {
             return Promise.reject(new Error('Add Layer type object'));
         }
         if (layer.isColorLayer) {
-            if (!this.tileLayer.tileMatrixSets.includes(CRS.formatToTms(layer.source.projection))) {
+            if (!this.tileLayer.tileMatrixSets.includes(CRS.formatToTms(layer.source.crs))) {
                 return layer._reject(`Only ${this.tileLayer.tileMatrixSets} tileMatrixSet are currently supported for color layers`);
             }
         } else if (layer.isElevationLayer) {
-            if (CRS.formatToTms(layer.source.projection) !== this.tileLayer.tileMatrixSets[0]) {
+            if (CRS.formatToTms(layer.source.crs) !== this.tileLayer.tileMatrixSets[0]) {
                 return layer._reject(`Only ${this.tileLayer.tileMatrixSets[0]} tileMatrixSet is currently supported for elevation layers`);
             }
         }

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -41,11 +41,11 @@ class PlanarLayer extends TiledGeometryLayer {
         const tms = CRS.formatToTms(extent.crs);
         const tileMatrixSets = [tms];
         if (!globalExtentTMS.get(extent.crs)) {
-            // Add new global extent for this new projection.
+            // Add new global extent for this new crs projection.
             globalExtentTMS.set(extent.crs, extent);
         }
         config.tileMatrixSets = tileMatrixSets;
-        super(id, object3d || new THREE.Group(), [extent], new PlanarTileBuilder({ projection: extent.crs }), config);
+        super(id, object3d || new THREE.Group(), [extent], new PlanarTileBuilder({ crs: extent.crs }), config);
         this.isPlanarLayer = true;
         this.extent = extent;
         this.minSubdivisionLevel = this.minSubdivisionLevel == undefined ? 0 : this.minSubdivisionLevel;

--- a/src/Core/Prefab/Planar/PlanarTileBuilder.js
+++ b/src/Core/Prefab/Planar/PlanarTileBuilder.js
@@ -7,10 +7,15 @@ const center = new THREE.Vector3();
 
 class PlanarTileBuilder {
     constructor(options = {}) {
+        /* istanbul ignore next */
         if (options.projection) {
-            this.projection = options.projection;
+            console.warn('PlanarTileBuilder projection parameter is deprecated, use crs instead.');
+            options.crs = options.crs || options.projection;
+        }
+        if (options.crs) {
+            this.crs = options.crs;
         } else {
-            throw new Error('options.projection is mandatory for PlanarTileBuilder');
+            throw new Error('options.crs is mandatory for PlanarTileBuilder');
         }
         this.tmp = {
             coords: new Coordinates('EPSG:4326', 0, 0),

--- a/src/Core/Prefab/TileBuilder.js
+++ b/src/Core/Prefab/TileBuilder.js
@@ -10,7 +10,7 @@ const cacheTile = new Cache();
 export default function newTileGeometry(builder, params) {
     const { sharableExtent, quaternion, position } = builder.computeSharableExtent(params.extent);
     const south = sharableExtent.south.toFixed(6);
-    const bufferKey = `${builder.projection}_${params.disableSkirt ? 0 : 1}_${params.segment}`;
+    const bufferKey = `${builder.crs}_${params.disableSkirt ? 0 : 1}_${params.segment}`;
     let promiseGeometry = cacheTile.get(south, params.level, bufferKey);
 
     // build geometry if doesn't exist

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -67,8 +67,8 @@ class TileMesh extends THREE.Mesh {
         }
     }
 
-    getExtentsByProjection(projection) {
-        return this._tms.get(CRS.formatToTms(projection));
+    getExtentsByProjection(crs) {
+        return this._tms.get(CRS.formatToTms(crs));
     }
 
     /**

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -146,7 +146,7 @@ class LabelLayer extends Layer {
             return;
         }
 
-        const extentsDestination = node.getExtentsByProjection(this.source.projection) || [node.extent];
+        const extentsDestination = node.getExtentsByProjection(this.source.crs) || [node.extent];
         const zoomDest = extentsDestination[0].zoom;
 
         if (zoomDest < layer.zoom.min || zoomDest > layer.zoom.max) {
@@ -173,7 +173,7 @@ class LabelLayer extends Layer {
 
         const extentsSource = [];
         for (const extentDest of extentsDestination) {
-            const ext = this.source.projection == extentDest.crs ? extentDest : extentDest.as(this.source.projection);
+            const ext = this.source.crs == extentDest.crs ? extentDest : extentDest.as(this.source.crs);
             if (!this.source.extentInsideLimit(ext)) {
                 node.layerUpdateState[this.id].noMoreUpdatePossible();
                 return;

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -75,6 +75,11 @@ class Layer extends THREE.EventDispatcher {
      * layerToListen.addEventListener('opacity-property-changed', (event) => console.log(event));
      */
     constructor(id, config = {}) {
+        /* istanbul ignore next */
+        if (config.projection) {
+            console.warn('Layer projection parameter is deprecated, use crs instead.');
+            config.crs = config.crs || config.projection;
+        }
         super();
         this.isLayer = true;
 
@@ -123,7 +128,7 @@ class Layer extends THREE.EventDispatcher {
             this.parsingOptions.styles = this.source.styles;
             this.parsingOptions.isInverted = this.source.isInverted;
             this.parsingOptions.layers = this.source.layers;
-            this.parsingOptions.crsOut = this.projection || this.crs;
+            this.parsingOptions.crsOut = this.crs;
             this.ready = true;
             this.source.onLayerAdded(this.parsingOptions);
             return this;
@@ -135,7 +140,7 @@ class Layer extends THREE.EventDispatcher {
 
         // [Draft]: tempory parsing options
         this.parsingOptions = {
-            crsIn: this.source.projection,
+            crsIn: this.source.crs,
             overrideAltitudeInToZero: this.overrideAltitudeInToZero,
             filter: this.filter || this.source.filter,
             mergeFeatures: config.mergeFeatures === undefined ? true : config.mergeFeatures,

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -93,7 +93,7 @@ class OrientedImageLayer extends GeometryLayer {
      * @param { Object } config - configuration of the layer
      * @param { number } config.backgroundDistance - Radius in meter of the sphere used as a background
      * @param { function } config.onPanoChanged - callback fired when current panoramic changes
-     * @param { string } config.projection - projection of the view
+     * @param { string } config.crs - crs projection of the view
      * @param { string } config.orientation - Json object, using GeoJSon format to represent points,
      * it's a set of panoramic position and orientation.
      * @param { string } config.calibrations - Json object, representing a set of camera. see [CameraCalibrationParser]{@link module:CameraCalibrationParser}
@@ -101,6 +101,11 @@ class OrientedImageLayer extends GeometryLayer {
      * a tecture is need for each camera, for each panoramic.
      */
     constructor(id, config = {}) {
+        /* istanbul ignore next */
+        if (config.projection) {
+            console.warn('OrientedImageLayer projection parameter is deprecated, use crs instead.');
+            config.crs = config.crs || config.projection;
+        }
         super(id, new THREE.Group(), config);
 
         this.background = config.background || createBackground(config.backgroundDistance);
@@ -125,11 +130,11 @@ class OrientedImageLayer extends GeometryLayer {
         // for each point, there is a position and a quaternion attribute.
         this.source.whenReady.then(metadata => GeoJsonParser.parse(config.orientation || metadata.orientation, {
             mergeFeatures: false,
-            crsOut: config.projection }).then((orientation) =>  {
+            crsOut: config.crs }).then((orientation) =>  {
             this.panos = orientation.features;
 
             const crsIn = orientation.optionsFeature.crsIn;
-            const crsOut = config.projection;
+            const crsOut = config.crs;
             const crs2crs = OrientationUtils.quaternionFromCRSToCRS(crsIn, crsOut);
             const quat = new THREE.Quaternion();
 

--- a/src/Layer/PotreeLayer.js
+++ b/src/Layer/PotreeLayer.js
@@ -66,7 +66,7 @@ class PotreeLayer extends PointCloudLayer {
             this.root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
             this.root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
 
-            this.extent = Extent.fromBox3(this.source.projection || 'EPSG:4326', this.root.bbox);
+            this.extent = Extent.fromBox3(this.source.crs || 'EPSG:4326', this.root.bbox);
             return this.root.loadOctree().then(resolve);
         });
     }

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -293,7 +293,7 @@ class TiledGeometryLayer extends GeometryLayer {
         let nodeLayer = node.material.getElevationLayer();
 
         for (const e of context.elevationLayers) {
-            const extents = node.getExtentsByProjection(e.projection);
+            const extents = node.getExtentsByProjection(e.crs);
             const zoom = extents[0].zoom;
             if (zoom > e.zoom.max || zoom < e.zoom.min) {
                 continue;
@@ -311,7 +311,7 @@ class TiledGeometryLayer extends GeometryLayer {
             if (c.frozen || !c.visible || !c.ready) {
                 continue;
             }
-            const extents = node.getExtentsByProjection(c.projection);
+            const extents = node.getExtentsByProjection(c.crs);
             const zoom = extents[0].zoom;
             if (zoom > c.zoom.max || zoom < c.zoom.min) {
                 continue;

--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -51,7 +51,7 @@ export default {
      * geometry.
      * @param {ArrayBuffer} data.dbf - Columnar attributes for each shape, in
      * [dBase]{@link https://en.wikipedia.org/wiki/DBase} IV format.
-     * @param {string} [data.prj] - The coordinate system and projection
+     * @param {string} [data.prj] - The coordinate system and crs projection
      * information.
      * @param {geojsonParserOptions} [options]
      *

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -277,7 +277,7 @@ export function init3dTilesLayer(view, scheduler, layer, rootTile) {
             tile.updateMatrixWorld();
             layer.tileset.tiles[tile.tileId].loaded = true;
             layer.root = tile;
-            layer.extent = boundingVolumeToExtent(layer.projection || view.referenceCrs,
+            layer.extent = boundingVolumeToExtent(layer.crs || view.referenceCrs,
                 tile.boundingVolume, tile.matrixWorld);
             layer.onTileContentLoaded(tile);
         });

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -67,7 +67,7 @@ export default {
             return features;
         }
 
-        const extentsDestination = node.getExtentsByProjection(layer.source.projection) || [node.extent];
+        const extentsDestination = node.getExtentsByProjection(layer.source.crs) || [node.extent];
 
         const zoomDest = extentsDestination[0].zoom;
 
@@ -78,7 +78,7 @@ export default {
 
         const extentsSource = [];
         for (const extentDest of extentsDestination) {
-            const ext = layer.source.projection == extentDest.crs ? extentDest : extentDest.as(layer.source.projection);
+            const ext = layer.source.crs == extentDest.crs ? extentDest : extentDest.as(layer.source.crs);
             ext.zoom = extentDest.zoom;
             if (extentInsideSource(ext, layer.source)) {
                 node.layerUpdateState[layer.id].noMoreUpdatePossible();

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -47,7 +47,7 @@ export function updateLayeredMaterialNodeImagery(context, layer, node, parent) {
     if (!parent || !material) {
         return;
     }
-    const extentsDestination = node.getExtentsByProjection(layer.projection);
+    const extentsDestination = node.getExtentsByProjection(layer.crs);
 
     const zoom = extentsDestination[0].zoom;
     if (zoom > layer.zoom.max || zoom < layer.zoom.min) {
@@ -178,7 +178,7 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
     // Elevation is currently handled differently from color layers.
     // This is caused by a LayeredMaterial limitation: only 1 elevation texture
     // can be used (where a tile can have N textures x M layers)
-    const extentsDestination = node.getExtentsByProjection(layer.projection);
+    const extentsDestination = node.getExtentsByProjection(layer.crs);
     const zoom = extentsDestination[0].zoom;
     if (zoom > layer.zoom.max || zoom < layer.zoom.min) {
         return;

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -79,7 +79,7 @@ export default {
      *
      * @example
      * extent = new Extent('EPSG:4326', 12, 14, 35, 46);
-     * source.projection = 'EPSG:4326';
+     * source.crs = 'EPSG:4326';
      * source.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
      * url = URLBuilder.bbox(extent, source);
      *
@@ -92,8 +92,8 @@ export default {
      * @return {string} the formed url
      */
     bbox: function bbox(bbox, source) {
-        const precision = source.projection == 'EPSG:4326' ? 9 : 2;
-        bbox.as(source.projection, extent);
+        const precision = source.crs == 'EPSG:4326' ? 9 : 2;
+        bbox.as(source.crs, extent);
         const w = extent.west.toFixed(precision);
         const s = extent.south.toFixed(precision);
         const e = extent.east.toFixed(precision);

--- a/src/Renderer/MaterialLayer.js
+++ b/src/Renderer/MaterialLayer.js
@@ -23,9 +23,9 @@ class MaterialLayer {
     constructor(material, layer) {
         this.id = layer.id;
         this.textureOffset = 0; // will be updated in updateUniforms()
-        this.crs = layer.parent.tileMatrixSets.indexOf(CRS.formatToTms(layer.projection));
+        this.crs = layer.parent.tileMatrixSets.indexOf(CRS.formatToTms(layer.crs));
         if (this.crs == -1) {
-            console.error('Unknown crs:', layer.projection);
+            console.error('Unknown crs:', layer.crs);
         }
 
         // Define color properties

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -5,7 +5,7 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import CRS from 'Core/Geographic/Crs';
 
 // get oriented bounding box of tile
-const builder = new BuilderEllipsoidTile({ projection: 'EPSG:4978', uvCount: 1 });
+const builder = new BuilderEllipsoidTile({ crs: 'EPSG:4978', uvCount: 1 });
 const size = new THREE.Vector3();
 const dimension = new THREE.Vector2();
 const center = new THREE.Vector3();

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -32,7 +32,7 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
  * care of everything.</caption>
  * const kmlSource = new itowns.FileSource({
  *     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/croquis.kml',
- *     projection: 'EPSG:4326',
+ *     crs: 'EPSG:4326',
  *     fetcher: itowns.Fetcher.xml,
  *     parser: itowns.KMLParser.parse,
  * });
@@ -40,7 +40,7 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
  * const kmlLayer = new itowns.ColorLayer('Kml', {
  *     name: 'kml',
  *     transparent: true,
- *     projection: view.tileLayer.extent.crs,
+ *     crs: view.tileLayer.extent.crs,
  *     source: kmlSource,
  * });
  *
@@ -53,7 +53,7 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
  *     .then(function _(gpx) {
  *         const gpxSource = new itowns.FileSource({
  *             data: gpx,
- *             projection: 'EPSG:4326',
+ *             crs: 'EPSG:4326',
  *             parser: itowns.GpxParser.parse,
  *         });
  *
@@ -90,7 +90,7 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
  *         });
  *     }).then(function _(parsedData) {
  *         ariege.source = new itowns.FileSource({
- *             projection: 'EPSG:4326',
+ *             crs: 'EPSG:4326',
  *             parsedData,
  *         });
  *
@@ -100,19 +100,22 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
 class FileSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * FileSource and {@link Source}. Only `projection` is mandatory, but if it
-     * presents in `parsedData` under the property `projection` or `crs`, it is
-     * fine.
-     * @param {string} crsOut - The projection of the output data after parsing.
+     * FileSource and {@link Source}. Only `crs` is mandatory, but if it
+     * presents in `parsedData` under the property `crs`, it is fine.
      *
      * @constructor
      */
     constructor(source) {
-        if (!source.projection) {
-            if (source.parsedData && (source.parsedData.crs || source.parsedData.projection)) {
-                source.projection = source.parsedData.crs || source.parsedData.projection;
+        /* istanbul ignore next */
+        if (source.projection) {
+            console.warn('FileSource projection parameter is deprecated, use crs instead.');
+            source.crs = source.crs || source.projection;
+        }
+        if (!source.crs) {
+            if (source.parsedData && source.parsedData.crs) {
+                source.crs = source.parsedData.crs;
             } else {
-                throw new Error('source.projection is required in FileSource');
+                throw new Error('source.crs is required in FileSource');
             }
         }
 

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -57,16 +57,17 @@ class TMSSource extends Source {
      * @constructor
      */
     constructor(source) {
-        if (!source.projection) {
-            throw new Error('New TMSSource: projection is required');
+        if (!source.crs && !source.projection) {
+            throw new Error('New TMSSource/WMTSSource: crs projection is required');
         }
+
         super(source);
 
         this.isTMSSource = true;
 
         if (!source.extent) {
             // default to the global extent
-            this.extent = globalExtentTMS.get(source.projection);
+            this.extent = globalExtentTMS.get(source.crs);
         }
 
         this.zoom = source.zoom;
@@ -74,7 +75,7 @@ class TMSSource extends Source {
         this.isInverted = source.isInverted || false;
         this.format = this.format || 'image/png';
         this.url = source.url;
-        this.projection = CRS.formatToTms(source.projection);
+        this.crs = CRS.formatToTms(source.crs);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;
 
         if (!this.zoom) {

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -43,7 +43,7 @@ class VectorTilesSource extends TMSSource {
      */
     constructor(source) {
         source.format = 'application/x-protobuf;type=mapbox-vector';
-        source.projection = 'EPSG:3857';
+        source.crs = 'EPSG:3857';
         source.isInverted = true;
         source.url = source.url || '.';
         super(source);

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -37,7 +37,7 @@ import CRS from 'Core/Geographic/Crs';
  *     url: 'http://wxs.fr/wfs',
  *     version: '2.0.0',
  *     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable',
- *     projection: 'EPSG:4326',
+ *     crs: 'EPSG:4326',
  *     extent: {
  *         west: 4.568,
  *         east: 5.18,
@@ -68,7 +68,7 @@ import CRS from 'Core/Geographic/Crs';
  *     url: 'http://wxs.fr/wfs',
  *     version: '2.0.0',
  *     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable',
- *     projection: 'EPSG:4326',
+ *     crs: 'EPSG:4326',
  *     extent: {
  *         west: 4.568,
  *         east: 5.18,
@@ -92,18 +92,22 @@ import CRS from 'Core/Geographic/Crs';
 class WFSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
-     * WFSSource and {@link Source}. `url`, `typeName` and `projection` are
+     * WFSSource and {@link Source}. `url`, `typeName` and `crs` are
      * mandatory.
      *
      * @constructor
      */
     constructor(source) {
+        if (source.projection) {
+            console.warn('WFSSource projection parameter is deprecated, use crs instead.');
+            source.crs = source.crs || source.projection;
+        }
         if (!source.typeName) {
             throw new Error('source.typeName is required in wfs source.');
         }
 
-        if (!source.projection) {
-            throw new Error('source.projection is required in wfs source');
+        if (!source.crs) {
+            throw new Error('source.crs is required in wfs source');
         }
         super(source);
 
@@ -115,9 +119,9 @@ class WFSSource extends Source {
         this.url = `${source.url
         }SERVICE=WFS&REQUEST=GetFeature&typeName=${this.typeName
         }&VERSION=${this.version
-        }&SRSNAME=${this.projection
+        }&SRSNAME=${this.crs
         }&outputFormat=${this.format
-        }&BBOX=%bbox,${this.projection}`;
+        }&BBOX=%bbox,${this.crs}`;
 
         this.zoom = source.zoom || { min: 0, max: Infinity };
 

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -49,7 +49,7 @@ const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
  *     version: '1.3.0',
  *     name: 'REGION.2016',
  *     style: '',
- *     projection: 'EPSG:3857',
+ *     crs: 'EPSG:3857',
  *     extent: {
  *         west: '-6880639.13557728',
  *         east: '6215707.87974825',
@@ -70,7 +70,7 @@ const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
 class WMSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of
-     * WMSSource and {@link Source}. `url`, `name`, `extent` and `projection`
+     * WMSSource and {@link Source}. `url`, `name`, `extent` and `crs`
      * are mandatory.
      *
      * @constructor
@@ -84,8 +84,8 @@ class WMSSource extends Source {
             throw new Error('source.extent is required');
         }
 
-        if (!source.projection) {
-            throw new Error('source.projection is required');
+        if (!source.crs && !source.projection) {
+            throw new Error('source.crs is required');
         }
         super(source);
 
@@ -102,7 +102,7 @@ class WMSSource extends Source {
 
         if (!source.axisOrder) {
         // 4326 (lat/long) axis order depends on the WMS version used
-            if (source.projection == 'EPSG:4326') {
+            if (this.crs == 'EPSG:4326') {
             // EPSG 4326 x = lat, long = y
             // version 1.1.0 long/lat while version 1.3.0 mandates xy (so lat,long)
                 this.axisOrder = (this.version === '1.1.0' ? 'wsen' : 'swne');
@@ -121,7 +121,8 @@ class WMSSource extends Source {
             this.format}&TRANSPARENT=${
             this.transparent}&BBOX=%bbox&${
             crsPropName}=${
-            this.projection}&WIDTH=${this.width}&HEIGHT=${this.height}`;
+            this.crs}&WIDTH=${this.width}&HEIGHT=${this.height}`;
+
 
         this.vendorSpecific = source.vendorSpecific;
         for (const name in this.vendorSpecific) {
@@ -136,7 +137,7 @@ class WMSSource extends Source {
     }
 
     extentInsideLimit(extent) {
-        const localExtent = this.projection == extent.crs ? extent : extent.as(this.projection, _extent);
+        const localExtent = this.crs == extent.crs ? extent : extent.as(this.crs, _extent);
         return (extent.zoom == undefined || !(extent.zoom < this.zoom.min || extent.zoom > this.zoom.max)) &&
             this.extent.intersectsExtent(localExtent);
     }

--- a/src/Source/WMTSSource.js
+++ b/src/Source/WMTSSource.js
@@ -17,7 +17,7 @@ import TMSSource from 'Source/TMSSource';
  * Default value is '1.0.0'.
  * @property {string} style - The style to query on the WMTS server. Default
  * value is 'normal'.
- * @property {string} projection - The projection in which to fetch the data. If
+ * @property {string} crs - The crs projection in which to fetch the data. If
  * not specified, it is deduced from `tileMatrixSet`. Default value is
  * 'EPSG:3857'.
  * @property {string} tileMatrixSet - Tile matrix set of the layer, used in the
@@ -67,10 +67,6 @@ class WMTSSource extends TMSSource {
     constructor(source) {
         if (!source.name) {
             throw new Error('New WMTSSource: name is required');
-        }
-
-        if (!source.projection) {
-            throw new Error('New WMTSSource: projection is required');
         }
 
         super(source);

--- a/src/Utils/placeObjectOnGround.js
+++ b/src/Utils/placeObjectOnGround.js
@@ -51,6 +51,7 @@ function _updateVector3(layer, method, nodes, vecCRS, vec, offset, matrices = {}
  *
  * @return {boolean} true if successful, false if we couldn't lookup the elevation at the given coords
  */
+/* istanbul ignore next */
 function placeObjectOnGround(layer, crs, obj, options = {}, tileHint) {
     console.warn('placeObjectOnGround has been deprecated because it needs review and test');
     let tiles;

--- a/test/unit/coordinate.js
+++ b/test/unit/coordinate.js
@@ -2,7 +2,7 @@ import proj4 from 'proj4';
 import assert from 'assert';
 import Coordinates from 'Core/Geographic/Coordinates';
 
-// Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+// Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 // Assert two float number are equals, with 5 digits precision.

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -56,11 +56,11 @@ describe('Provide in Sources', function () {
     };
 
     const planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
-    const colorlayer = new ColorLayer('color', { projection: 'EPSG:3857' });
-    const elevationlayer = new ElevationLayer('elevation', { projection: 'EPSG:3857' });
+    const colorlayer = new ColorLayer('color', { crs: 'EPSG:3857' });
+    const elevationlayer = new ElevationLayer('elevation', { crs: 'EPSG:3857' });
 
-    colorlayer.parsingOptions.crsOut = colorlayer.projection;
-    elevationlayer.parsingOptions.crsOut = elevationlayer.projection;
+    colorlayer.parsingOptions.crsOut = colorlayer.crs;
+    elevationlayer.parsingOptions.crsOut = elevationlayer.crs;
 
     planarlayer.attach(colorlayer);
     planarlayer.attach(elevationlayer);
@@ -73,10 +73,10 @@ describe('Provide in Sources', function () {
 
     const featureLayer = new GeometryLayer('geom', new THREE.Group());
     featureLayer.update = FeatureProcessing.update;
-    featureLayer.projection = 'EPSG:4978';
+    featureLayer.crs = 'EPSG:4978';
     featureLayer.mergeFeatures = false;
     featureLayer.parsingOptions.crsIn = 'EPSG:3857';
-    featureLayer.parsingOptions.crsOut = featureLayer.projection;
+    featureLayer.parsingOptions.crsOut = featureLayer.crs;
     featureLayer.parsingOptions.filteringExtent = true;
 
     featureLayer.zoom.min = 10;
@@ -93,7 +93,7 @@ describe('Provide in Sources', function () {
         typeName: 'name',
         format: `${formatTag}application/json`,
         extent: globalExtent,
-        projection: 'EPSG:3857',
+        crs: 'EPSG:3857',
     });
 
     let featureCountByCb = 0;
@@ -118,7 +118,7 @@ describe('Provide in Sources', function () {
             name: 'name',
             format: `${formatTag}image/png`,
             tileMatrixSet: 'PM',
-            projection: 'EPSG:3857',
+            crs: 'EPSG:3857',
             extent: globalExtent,
             zoom: {
                 min: 0,
@@ -126,7 +126,7 @@ describe('Provide in Sources', function () {
             },
         });
 
-        colorlayer.source.onLayerAdded({ crsOut: colorlayer.projection });
+        colorlayer.source.onLayerAdded({ crsOut: colorlayer.crs });
 
         const tile = new TileMesh(geom, material, planarlayer, extent);
         material.visible = true;
@@ -148,14 +148,14 @@ describe('Provide in Sources', function () {
             name: 'name',
             format: `${formatTag}image/png`,
             tileMatrixSet: 'PM',
-            projection: 'EPSG:3857',
+            crs: 'EPSG:3857',
             zoom: {
                 min: 0,
                 max: 12,
             },
         });
 
-        elevationlayer.source.onLayerAdded({ crsOut: elevationlayer.projection });
+        elevationlayer.source.onLayerAdded({ crsOut: elevationlayer.crs });
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
         nodeLayerElevation.level = EMPTY_TEXTURE_ZOOM;
@@ -176,14 +176,14 @@ describe('Provide in Sources', function () {
             name: 'name',
             format: `${formatTag}image/png`,
             extent: globalExtent,
-            projection: 'EPSG:3857',
+            crs: 'EPSG:3857',
             zoom: {
                 min: 0,
                 max: 12,
             },
         });
         // May be move in layer Constructor
-        colorlayer.source.onLayerAdded({ crsOut: colorlayer.projection });
+        colorlayer.source.onLayerAdded({ crsOut: colorlayer.crs });
 
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
@@ -226,7 +226,7 @@ describe('Provide in Sources', function () {
         featureLayer.parsingOptions.mergeFeatures = false;
         tile.layerUpdateState = { test: new LayerUpdateState() };
 
-        featureLayer.source.onLayerAdded({ crsOut: featureLayer.projection });
+        featureLayer.source.onLayerAdded({ crsOut: featureLayer.crs });
 
         featureLayer.update(context, featureLayer, tile);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((features) => {
@@ -248,7 +248,7 @@ describe('Provide in Sources', function () {
         featureLayer.parsingOptions.mergeFeatures = true;
         featureLayer.cache.data.clear();
         featureLayer.source._parsedDatasCaches = {};
-        featureLayer.source.onLayerAdded({ crsOut: featureLayer.projection });
+        featureLayer.source.onLayerAdded({ crsOut: featureLayer.crs });
         featureLayer.update(context, featureLayer, tile);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((features) => {
             assert.ok(features[0].children[0].isMesh);
@@ -271,7 +271,7 @@ describe('Provide in Sources', function () {
         nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.material.visible = true;
         featureLayer.source.uid = 22;
-        const colorlayerWfs = new ColorLayer('color', { projection: 'EPSG:3857',
+        const colorlayerWfs = new ColorLayer('color', { crs: 'EPSG:3857',
             source: featureLayer.source,
             style: {
                 fill: {
@@ -288,9 +288,9 @@ describe('Provide in Sources', function () {
                 },
             },
         });
-        colorlayerWfs.parsingOptions.crsOut = colorlayerWfs.projection;
+        colorlayerWfs.parsingOptions.crsOut = colorlayerWfs.crs;
         colorlayerWfs.parsingOptions.style = colorlayerWfs.style;
-        colorlayerWfs.source.onLayerAdded({ crsOut: colorlayerWfs.projection });
+        colorlayerWfs.source.onLayerAdded({ crsOut: colorlayerWfs.crs });
         updateLayeredMaterialNodeImagery(context, colorlayerWfs, tile, tile.parent);
         updateLayeredMaterialNodeImagery(context, colorlayerWfs, tile, tile.parent);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((textures) => {
@@ -306,7 +306,7 @@ describe('Provide in Sources', function () {
             name: 'name',
             format: `${formatTag}image/png`,
             tileMatrixSet: 'PM',
-            projection: 'EPSG:3857',
+            crs: 'EPSG:3857',
             extent: globalExtent,
             zoom: {
                 min: 0,

--- a/test/unit/demutils.js
+++ b/test/unit/demutils.js
@@ -21,7 +21,7 @@ describe('DemUtils', function () {
 
     const source = new WMTSSource({
         format: 'image/x-bil;bits=32',
-        projection: 'EPSG:4326',
+        crs: 'EPSG:4326',
         url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts',
         name: 'ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3',
         tileMatrixSet: 'WGS84G',

--- a/test/unit/featureprocess.js
+++ b/test/unit/featureprocess.js
@@ -28,7 +28,7 @@ describe('Layer with Feature process', function () {
 
     const source = new FileSource({
         url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
-        projection: 'EPSG:4326',
+        crs: 'EPSG:4326',
         format: 'application/json',
         networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
     });

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -32,13 +32,13 @@ describe('updateLayeredMaterialNodeImagery', function () {
 
     const source = new Source({
         url: 'http://',
-        projection: 'EPSG:4326',
+        crs: 'EPSG:4326',
         extent,
     });
 
     const layer = new Layer('foo', {
         source,
-        projection: 'EPSG:4326',
+        crs: 'EPSG:4326',
         info: { update: () => {} },
         tileMatrixSets: [
             'TMS:4326',

--- a/test/unit/layerupdatestrategy.js
+++ b/test/unit/layerupdatestrategy.js
@@ -34,14 +34,14 @@ describe('Handling no data source error', function () {
 
     const source = new Source({
         url: 'http://',
-        projection: 'EPSG:4326',
+        crs: 'EPSG:4326',
         extent,
     });
     source.zoom = { max: 20, min: 0 };
 
     const layer = new Layer('foo', {
         source,
-        projection: 'EPSG:4326',
+        crs: 'EPSG:4326',
         info: { update: () => {} },
         tileMatrixSets: [
             'TMS:4326',

--- a/test/unit/obb.js
+++ b/test/unit/obb.js
@@ -44,7 +44,7 @@ describe('OBB', function () {
 });
 
 
-// Define projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+// Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
 proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 function assertVerticesAreInOBB(builder, extent) {
     const params = {
@@ -73,7 +73,7 @@ function assertVerticesAreInOBB(builder, extent) {
 }
 
 describe('Planar tiles OBB computation', function () {
-    const builder = new PlanarTileBuilder({ projection: 'EPSG:3946', uvCount: 1 });
+    const builder = new PlanarTileBuilder({ crs: 'EPSG:3946', uvCount: 1 });
 
     it('should compute OBB correctly', function () {
         const extent = new Extent('EPSG:3946', -100, 100, -50, 50);
@@ -81,7 +81,7 @@ describe('Planar tiles OBB computation', function () {
     });
 });
 describe('Ellipsoid tiles OBB computation', function () {
-    const builder = new BuilderEllipsoidTile({ projection: 'EPSG:4978', uvCount: 1 });
+    const builder = new BuilderEllipsoidTile({ crs: 'EPSG:4978', uvCount: 1 });
 
     it('should compute globe-level 0 OBB correctly', function () {
         const extent = new Extent('EPSG:4326', -180, 0, -90, 90);

--- a/test/unit/orientedimagelayer.js
+++ b/test/unit/orientedimagelayer.js
@@ -38,7 +38,7 @@ describe('Oriented Image Layer', function () {
         // Radius in meter of the sphere used as a background.
         backgroundDistance: 1200,
         source: orientedImageSource,
-        projection: viewer.referenceCrs,
+        crs: viewer.referenceCrs,
         useMask: false,
     });
 

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -22,7 +22,7 @@ describe('URL creations', function () {
 
     it('should correctly replace %bbox by 12,35,14,46', function () {
         const extent = new Extent('EPSG:4978', 12, 14, 35, 46);
-        layer.projection = 'EPSG:4978';
+        layer.crs = 'EPSG:4978';
         layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
         const result = URLBuilder.bbox(extent, layer);
         assert.equal(result, 'http://server.geo/wms/BBOX=12.00,35.00,14.00,46.00&FORMAT=jpg&SERVICE=WMS');
@@ -30,7 +30,7 @@ describe('URL creations', function () {
 
     it('should correctly replace %bbox by 12,14,35,46', function () {
         const extent = new Extent('EPSG:4326', 12, 14, 35, 46);
-        layer.projection = 'EPSG:4326';
+        layer.crs = 'EPSG:4326';
         layer.axisOrder = 'wesn';
         layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
         const result = URLBuilder.bbox(extent, layer);
@@ -39,7 +39,7 @@ describe('URL creations', function () {
 
     it('shouldn\'t use the scientific notation', function () {
         const extent = new Extent('EPSG:4326', 1 / 9999999999, 14, 35, 46);
-        layer.projection = 'EPSG:4326';
+        layer.crs = 'EPSG:4326';
         layer.axisOrder = 'wesn';
         layer.url = 'http://bla/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
         const result = URLBuilder.bbox(extent, layer);

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -41,7 +41,7 @@ describe('Sources', function () {
         const paramsWFS = {
             url: 'http://',
             typeName: 'test',
-            projection: 'EPSG:4326',
+            crs: 'EPSG:4326',
         };
 
         it('should instance and use WFSSource', function () {
@@ -91,7 +91,7 @@ describe('Sources', function () {
         const paramsWMTS = {
             url: 'http://',
             name: 'name',
-            projection: 'EPSG:4326',
+            crs: 'EPSG:4326',
         };
 
         it('should throw an error for having no name', function () {
@@ -131,7 +131,7 @@ describe('Sources', function () {
             url: 'http://',
             name: 'name',
             extent: [-90, 90, -45, 45],
-            projection: 'EPSG:4326',
+            crs: 'EPSG:4326',
         };
 
         it('should throw an error for having no required parameters', function () {
@@ -150,10 +150,10 @@ describe('Sources', function () {
         });
 
         it('should set the correct axisOrder', function () {
-            paramsWMS.projection = 'EPSG:3857';
+            paramsWMS.crs = 'EPSG:3857';
             const source = new WMSSource(paramsWMS);
             assert.strictEqual(source.axisOrder, 'wsen');
-            paramsWMS.projection = 'EPSG:4326';
+            paramsWMS.crs = 'EPSG:4326';
         });
 
         it('should use vendor specific parameters for the creation of the WMS url', function () {
@@ -196,7 +196,7 @@ describe('Sources', function () {
     describe('TMSSource', function () {
         const paramsTMS = {
             url: 'http://',
-            projection: 'EPSG:3857',
+            crs: 'EPSG:3857',
         };
 
         it('should instance and use TMSSource', function () {
@@ -215,7 +215,7 @@ describe('Sources', function () {
         it('should instance FileSource and fetch file', function (done) {
             const source = new FileSource({
                 url: urlGeojson,
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
                 format: 'application/json',
                 extent: new Extent('EPSG:4326', 0, 20, 0, 20),
                 zoom: { min: 0, max: 21 },
@@ -241,7 +241,7 @@ describe('Sources', function () {
             const source = new FileSource({
                 fetchedData,
                 format: 'application/json',
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
             });
 
             assert.ok(!source.parsedData);
@@ -249,8 +249,8 @@ describe('Sources', function () {
             assert.ok(source.fetchedData);
             assert.ok(source.isFileSource);
 
-            const layer = new Layer('09-ariege', { projection: 'EPSG:4326', source });
-            layer.parsingOptions.crsOut = layer.projection;
+            const layer = new Layer('09-ariege', { crs: 'EPSG:4326', source });
+            layer.parsingOptions.crsOut = layer.crs;
             layer.parsingOptions.withAltitude = false;
             layer.source.onLayerAdded(layer.parsingOptions);
 
@@ -267,9 +267,9 @@ describe('Sources', function () {
         it('should instance and use FileSource with parsedData', function () {
             const source = new FileSource({
                 parsedData: { foo: 'bar', crs: 'EPSG:4326' },
-                projection: 'EPSG:4326',
+                crs: 'EPSG:4326',
             });
-            source.onLayerAdded({ crsOut: source.projection });
+            source.onLayerAdded({ crsOut: source.crs });
             const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
             assert.ok(source.urlFromExtent(extent).startsWith('fake-file-url'));
             assert.ok(!source.fetchedData);
@@ -279,22 +279,22 @@ describe('Sources', function () {
 
         it('should throw an error for having no required parameters', function () {
             assert.throws(() => new FileSource({}), Error);
-            assert.throws(() => new FileSource({ projection: 'EPSG:4326' }), Error);
+            assert.throws(() => new FileSource({ crs: 'EPSG:4326' }), Error);
         });
 
-        describe('should set the projection from parsedData', function () {
+        describe('should set the crs projection from parsedData', function () {
             it('with the crs', function () {
                 const source = new FileSource({
                     parsedData: { crs: 'EPSG:4326' },
                 });
-                assert.strictEqual(source.projection, 'EPSG:4326');
+                assert.strictEqual(source.crs, 'EPSG:4326');
             });
 
-            it('with the projection', function () {
+            it('with the crs projection', function () {
                 const source = new FileSource({
-                    parsedData: { projection: 'EPSG:4326' },
+                    parsedData: { crs: 'EPSG:4326' },
                 });
-                assert.strictEqual(source.projection, 'EPSG:4326');
+                assert.strictEqual(source.crs, 'EPSG:4326');
             });
         });
     });

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -22,10 +22,10 @@ describe('Viewer', function () {
         globelayer = new GlobeLayer('globe', new THREE.Group());
         source = new FileSource({
             parsedData: { crs: 'EPSG:4326' },
-            projection: 'EPSG:4326',
+            crs: 'EPSG:4326',
         });
 
-        colorLayer = new ColorLayer('l0', { source, labelEnabled: true, projection: 'EPSG:4326' });
+        colorLayer = new ColorLayer('l0', { source, labelEnabled: true, crs: 'EPSG:4326' });
         colorLayer2 = new ColorLayer('l1', { source });
     });
 


### PR DESCRIPTION
## Description
Rename all **`Layer`** and **`Source`** properties `projection` by **`crs`**.

**Deprecated**: **`Source.projection`** and **`Layer.projection`** properties are deprecated.
- Use **`crs`** instead of **`projection`**.
## Motivation
Have same **`crs`** projection property for : **`Extent, Coordinates, Features, Layer and Source`**

