### PR TITLE
Refactoring parsing options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,7 +103,7 @@ module.exports = {
         'no-console': ['warn', { allow: ['warn', 'error'] }],
         'class-methods-use-this': 'off',
         'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
-        'max-classes-per-file': ['error', 3],
+        'max-classes-per-file': ['error', 4],
     },
     globals: {
         __DEBUG__: false,

--- a/docs/config.json
+++ b/docs/config.json
@@ -12,6 +12,7 @@
                 "Feature",
                 "FeatureGeometry",
                 "FeatureCollection",
+                "FeatureBuildingOptions",
                 "Style",
                 "Label"
             ],
@@ -49,6 +50,8 @@
             ],
 
             "Source": [
+                "InformationsData",
+                "ParsingOptions",
                 "Source",
                 "WMTSSource",
                 "WMSSource",

--- a/examples/js/plugins/CSVnVRTParser.js
+++ b/examples/js/plugins/CSVnVRTParser.js
@@ -17,9 +17,10 @@
  *     text: ['csv']
  * }).then(function _(res) {
  *     res.csv = Papa.parse(res.csv.trim()).data;
- *     return CSVnVRTParser.parse(res, {
- *         buildExtent: true,
- *         crsOut: 'EPSG:4326'
+ *     return CSVnVRTParser.parse(res, { out: {
+ *              buildExtent: true,
+ *              crs: 'EPSG:4326'
+ *          }
  *     });
  * }).then(function _(features) {
  *     var source = new itowns.FileSource({ features });
@@ -89,7 +90,7 @@ var CSVnVRTParser = (function _() {
             type = getGeometryType(layer.GeometryType.value);
         }
 
-        var feature = new itowns.Feature(type, options.crsOut, options);
+        var feature = new itowns.Feature(type, options.out.crs, options.out);
 
         if (layer.Field) {
             if (!layer.Field.length) {
@@ -152,7 +153,7 @@ var CSVnVRTParser = (function _() {
 
     function readLayer(layer, data, options, crs) {
         if (layer.OGRVRTLayer) {
-            var collection = new itowns.FeatureCollection(options.crsOut, options);
+            var collection = new itowns.FeatureCollection(options.out.crs, options.out);
             var feature = OGRVRTLayer2Feature(layer.OGRVRTLayer, data, layer.TargetSRS.value, options);
             collection.pushFeature(feature);
             return collection;

--- a/examples/js/plugins/DragNDrop.js
+++ b/examples/js/plugins/DragNDrop.js
@@ -67,12 +67,16 @@ var DragNDrop = (function _() {
                 }
 
                 extension.parser(data, {
-                    buildExtent: true,
-                    crsIn: 'EPSG:4326',
-                    crsOut: (extension.mode == _GEOMETRY ? _view.referenceCrs : _view.tileLayer.extent.crs),
-                    mergeFeatures: true,
-                    withNormal: (extension.mode == _GEOMETRY),
-                    withAltitude: (extension.mode == _GEOMETRY),
+                    in: {
+                        crs: 'EPSG:4326',
+                    },
+                    out: {
+                        crs: (extension.mode == _GEOMETRY ? _view.referenceCrs : _view.tileLayer.extent.crs),
+                        buildExtent: true,
+                        mergeFeatures: true,
+                        withNormal: (extension.mode == _GEOMETRY),
+                        withAltitude: (extension.mode == _GEOMETRY),
+                    },
                 }).then(function _(features) {
                     var dimensions = features.extent.dimensions();
 

--- a/examples/plugins_vrt.html
+++ b/examples/plugins_vrt.html
@@ -49,10 +49,10 @@
                 text: ['csv'],
             }).then(function _(res) {
                 res.csv = Papa.parse(res.csv.trim()).data;
-                return CSVnVRTParser.parse(res, {
+                return CSVnVRTParser.parse(res, { out: {
                     buildExtent: true,
-                    crsOut: view.tileLayer.extent.crs,
-                });
+                    crs: view.tileLayer.extent.crs,
+                }});
             }).then(function _(features) {
                 var velibSource = new itowns.FileSource({ features });
 

--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -57,12 +57,16 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
 
             var optionsGeoJsonParser = {
-                buildExtent: true,
-                crsIn: 'EPSG:4326',
-                crsOut: view.tileLayer.extent.crs,
-                mergeFeatures: true,
-                withNormal: false,
-                withAltitude: false,
+                in: {
+                    crs: 'EPSG:4326',
+                },
+                out: {
+                    crs: view.tileLayer.extent.crs,
+                    buildExtent: true,
+                    mergeFeatures: true,
+                    withNormal: false,
+                    withAltitude: false,
+                }
             };
 
             // Convert by iTowns

--- a/examples/source_file_gpx_3d.html
+++ b/examples/source_file_gpx_3d.html
@@ -67,10 +67,14 @@
                 console.info('Globe initialized');
                 itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
                     .then(gpx => itowns.GpxParser.parse(gpx, {
-                        buildExtent: true,
-                        crsIn: 'EPSG:4326',
-                        crsOut: view.referenceCrs,
-                        mergeFeatures: true,
+                        in: {
+                            crs: 'EPSG:4326',
+                        },
+                        out: {
+                            crs: view.referenceCrs,
+                            buildExtent: true,
+                            mergeFeatures: true,
+                        }
                     }))
                     .then(collection => itowns.Feature2Mesh.convert({
                         color: new itowns.THREE.Color(0xff0000),

--- a/examples/source_file_shapefile.html
+++ b/examples/source_file_shapefile.html
@@ -48,8 +48,10 @@
                 text: ['prj'],
             }).then(function _(res) {
                 return itowns.ShapefileParser.parse(res, {
-                    buildExtent: true,
-                    crsOut: view.tileLayer.extent.crs,
+                    out: {
+                        crs: view.tileLayer.extent.crs,
+                        buildExtent: true,
+                    }
                 });
             }).then(function _(features) {
                 var velibSource = new itowns.FileSource({ features });

--- a/src/Core/Deprecated/Undeprecator.js
+++ b/src/Core/Deprecated/Undeprecator.js
@@ -1,0 +1,29 @@
+export const deprecatedParsingOptionsToNewOne = (options) => {
+    /* istanbul ignore next */
+    if (options.crsOut || options.crsIn) {
+        console.warn('Parsing options with crsIn and crsOut are deprecates, use { in, out } structure.');
+        const newOptions = { in: {}, out: {} };
+        newOptions.in.crs = options.crsIn;
+        newOptions.in.isInverted = options.isInverted;
+        newOptions.in.styles = options.styles;
+        newOptions.in.layers = options.layers;
+        newOptions.in.filter = options.filter;
+
+        newOptions.out.crs = options.crsOut;
+        newOptions.out.mergeFeatures = options.mergeFeatures;
+        newOptions.out.withNormal = options.withNormal;
+        newOptions.out.withAltitude = options.withAltitude;
+        newOptions.out.buildExtent = options.buildExtent;
+        newOptions.out.filteringExtent = options.filteringExtent;
+        newOptions.out.style = options.style;
+        newOptions.out.overrideAltitudeInToZero = options.overrideAltitudeInToZero;
+        newOptions.out.filter = options.filter;
+        return newOptions;
+    } else {
+        return options;
+    }
+};
+
+export default {};
+
+

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -196,8 +196,8 @@ class Feature {
         if (options.buildExtent) {
             // this.crs is final crs projection, is out projection.
             // If the extent crs is the same then we use output coordinate (coordOut) to expand it.
-            this.extent = defaultExtent(crs != 'EPSG:4978' ?  crs : options.crsIn);
-            this.useCrsOut = this.crs == this.extent.crs;
+            this.extent = defaultExtent(options.forcedExtentCrs || this.crs);
+            this.useCrsOut = !options.forceExtentCrs;
         }
         this._pos = 0;
         this._pushValues = (this.size === 3 ? push3DValues : push2DValues).bind(this);
@@ -247,11 +247,12 @@ export default Feature;
 export class FeatureCollection {
     constructor(crs, options) {
         this.isFeatureCollection = true;
+        // TODO: Replace crs parameter by CRS.formatToEPSG(options.crs)
         this.crs = crs;
         this.features = [];
         this.optionsFeature = options || {};
         if (this.optionsFeature.buildExtent) {
-            this.extent = defaultExtent(crs != 'EPSG:4978' ?  crs : options.crsIn);
+            this.extent = defaultExtent(options.forcedExtentCrs || this.crs);
         }
         this.translation = new THREE.Vector3();
         this.scale = new THREE.Vector3(1, 1, 1);

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -18,6 +18,28 @@ const coordOut = new Coordinates('EPSG:4326', 0, 0, 0);
 const defaultNormal = new THREE.Vector3(0, 0, 1);
 
 /**
+ * @property {string} crs - The CRS to convert the input coordinates to.
+ * @property {Extent|boolean} [filteringExtent=undefined] - Optional filter to reject
+ * features outside of extent. Extent filetring is file extent if filteringExtent is true.
+ * @property {boolean} [buildExtent=false] - If true the geometry will
+ * have an extent property containing the area covered by the geometry.
+ * True if the layer does not inherit from {@link GeometryLayer}.
+ * @property {string} forcedExtentCrs - force feature extent crs if buildExtent is true.
+ * @property {function} [filter] - Filter function to remove features
+ * @property {boolean} [mergeFeatures=true] - If true all geometries are merged by type and multi-type
+ * @property {boolean} [withNormal=true] - If true each coordinate normal is computed.
+ * True if the layer inherits from {@link GeometryLayer}
+ * @property {boolean} [withAltitude=true] - If true each coordinate altitude is kept
+ * True if the layer inherits from {@link GeometryLayer}
+ * @property {boolean} [overrideAltitudeInToZero=false] - If true, the altitude of the source data isn't taken into account for 3D geometry convertions.
+ * the altitude will be override to 0. This can be useful if you don't have a DEM or provide a new one when converting (with Layer.convert).
+ * @property {Style} style - The style to inherit when creating
+ * style for all new features.
+ *
+*/
+export class FeatureBuildingOptions {}
+
+/**
  * @property {Extent} extent - The 2D extent containing all the points
  * composing the geometry.
  * @property {Object[]} indices - Contains the indices that define the geometry.
@@ -168,14 +190,13 @@ export const FEATURE_TYPES = {
  * FeatureGeometry}.
  * @property {Extent?} extent - The extent containing all the geometries
  * composing the feature.
- * @property {Style} style - The style of the Feature.
  */
 class Feature {
     /**
      *
      * @param {string} type type of Feature. It can be 'point', 'line' or 'polygon'.
      * @param {string} crs Geographic or Geocentric coordinates system.
-     * @param {Object} [options={}] options to build feature.
+     * @param {FeatureBuildingOptions} [options={}] options to build feature.
      * @param {boolean} [options.buildExtent] Build extent and update when adding new vertice.
      * @param {boolean} [options.withAltitude] Set vertice altitude when adding new vertice.
      * @param {boolean} [options.withNormal] Set vertice normal when adding new vertice.
@@ -245,6 +266,12 @@ export default Feature;
  * An object regrouping a list of [features]{@link Feature} and the extent of this collection.
  */
 export class FeatureCollection {
+    /**
+     * Constructs a new instance.
+     *
+     * @param      {string}  crs      The crs projection.
+     * @param      {FeatureBuildingOptions|Layer}  options  The building options .
+     */
     constructor(crs, options) {
         this.isFeatureCollection = true;
         // TODO: Replace crs parameter by CRS.formatToEPSG(options.crs)

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -74,6 +74,8 @@ function _preprocessLayer(view, layer, parentLayer) {
     if (layer.isLabelLayer) {
         view.mainLoop.gfxEngine.label2dRenderer.registerLayer(layer);
     } else if (layer.labelEnabled) {
+        // Because the features are shared between layer and labelLayer.
+        layer.buildExtent = true;
         const labelLayer = new LabelLayer(`${layer.id}-label`, {
             source,
             style: layer.style,

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -67,9 +67,10 @@ class ColorLayer extends Layer {
         this.transparent = config.transparent || (this.opacity < 1.0);
         this.noTextureParentOutsideLimit = config.source ? config.source.isFileSource : false;
 
-        this.parsingOptions.buildExtent = true;
-        this.parsingOptions.withNormal = false;
-        this.parsingOptions.withAltitude = false;
+        // Feature options
+        this.buildExtent = true;
+        this.withNormal = false;
+        this.withAltitude = false;
     }
 
     update(context, layer, node, parent) {

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -132,9 +132,11 @@ class GeometryLayer extends Layer {
             value: Infinity,
             writable: false,
         });
-        this.parsingOptions.filteringExtent = !this.source.isFileSource;
-        this.parsingOptions.withNormal = true;
-        this.parsingOptions.withAltitude = true;
+
+        // Feature options
+        this.filteringExtent = !this.source.isFileSource;
+        this.withNormal = true;
+        this.withAltitude = true;
     }
 
     // Attached layers expect to receive the visual representation of a

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -44,7 +44,7 @@ class LabelLayer extends Layer {
             this.domElement.style.display = this.visible ? 'block' : 'none';
         });
 
-        this.parsingOptions.buildExtent = true;
+        this.buildExtent = true;
     }
 
     /**

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -133,6 +133,8 @@ class Layer extends THREE.EventDispatcher {
         this.cache = new Cache(config.cacheLifeTime);
 
         this.mergeFeatures = this.mergeFeatures === undefined ? true : config.mergeFeatures;
+
+        // TODO: verify but this.source.filter seems be always undefined.
         this.filter = this.filter || this.source.filter;
     }
 
@@ -225,7 +227,7 @@ class Layer extends THREE.EventDispatcher {
      * Determines whether the specified feature is valid data.
      *
      * @param      {Feature}  feature  The feature
-     * @returns the feature is returned if it's valided
+     * @returns {Feature} the feature is returned if it's valided
      */
     // eslint-disable-next-line
     isValidData(feature) {}

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -123,14 +123,8 @@ class Layer extends THREE.EventDispatcher {
             this._resolve = re;
             this._reject = rj;
         }).then(() => {
-            // [Draft]: tempory parsing options
-            this.parsingOptions.style = this.style;
-            this.parsingOptions.styles = this.source.styles;
-            this.parsingOptions.isInverted = this.source.isInverted;
-            this.parsingOptions.layers = this.source.layers;
-            this.parsingOptions.crsOut = this.crs;
             this.ready = true;
-            this.source.onLayerAdded(this.parsingOptions);
+            this.source.onLayerAdded({ out: this });
             return this;
         });
 
@@ -138,14 +132,8 @@ class Layer extends THREE.EventDispatcher {
 
         this.cache = new Cache(config.cacheLifeTime);
 
-        // [Draft]: tempory parsing options
-        this.parsingOptions = {
-            crsIn: this.source.crs,
-            overrideAltitudeInToZero: this.overrideAltitudeInToZero,
-            filter: this.filter || this.source.filter,
-            mergeFeatures: config.mergeFeatures === undefined ? true : config.mergeFeatures,
-            isInverted: this.source.isInverted,
-        };
+        this.mergeFeatures = this.mergeFeatures === undefined ? true : config.mergeFeatures;
+        this.filter = this.filter || this.source.filter;
     }
 
     addInitializationStep() {
@@ -222,7 +210,7 @@ class Layer extends THREE.EventDispatcher {
             if (feature) {
                 data = Promise.resolve(this.convert(feature, to));
             } else {
-                data = this.source.loadData(from, this.parsingOptions)
+                data = this.source.loadData(from, this)
                     .then(feat => this.convert(feat, to), (err) => {
                         throw err;
                     });

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -126,14 +126,18 @@ class OrientedImageLayer extends GeometryLayer {
 
         const resolve = this.addInitializationStep();
 
+        this.mergeFeatures = false;
+        this.filteringExtent = false;
+        const options = { out: this };
+
         // panos is an array of feature point, representing many panoramics.
         // for each point, there is a position and a quaternion attribute.
-        this.source.whenReady.then(metadata => GeoJsonParser.parse(config.orientation || metadata.orientation, {
-            mergeFeatures: false,
-            crsOut: config.crs }).then((orientation) =>  {
+        this.source.whenReady.then(metadata => GeoJsonParser.parse(config.orientation || metadata.orientation, options).then((orientation) =>  {
             this.panos = orientation.features;
 
-            const crsIn = orientation.optionsFeature.crsIn;
+            // the crs input is parsed in geojson parser
+            // and returned in options.in
+            const crsIn = options.in.crs;
             const crsOut = config.crs;
             const crs2crs = OrientationUtils.quaternionFromCRSToCRS(crsIn, crsOut);
             const quat = new THREE.Quaternion();

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -176,29 +176,11 @@ function jsonFeaturesToFeatures(crsIn, crsOut, jsonFeatures, filteringExtent, op
  */
 export default {
     /**
-     * @typedef {Object} GeoJsonParserOptions
-     * @property {string} crsOut - The CRS to convert the input coordinates
-     * to.
-     * @property {string} crsIn - Override the data CRS.
-     * @property {Extent|boolean} [filteringExtent=undefined] - Optional filter to reject
-     * features outside of extent. Extent filetring is file extent if filteringExtent is true.
-     * @property {boolean} [buildExtent=false] - If true the geometry will
-     * have an extent property containing the area covered by the geom
-     * @property {function} [filter] - Filter function to remove features
-     * @property {boolean} [mergeFeatures=true] - If true all geometries are merged by type and multi-type
-     * @property {boolean} [withNormal=true] - If true each coordinate normal is computed
-     * @property {boolean} [withAltitude=true] - If true each coordinate altitude is kept
-     * @property {boolean} [overrideAltitudeInToZero=false] - If true, the altitude of the source data isn't taken into account for 3D geometry convertions.
-     * the altitude will be override to 0. This can be useful if you don't have a DEM or provide a new one when converting (with Layer.convert).
-     */
-
-    /**
      * Parse a GeoJSON file content and return a [FeatureCollection]{@link FeatureCollection}.
      *
      * @param {string} json - The GeoJSON file content to parse.
-     * @param {GeoJsonParser~GeoJsonParserOptions} options - Options controlling
-     * the parsing.
-     *
+     * @param {ParsingOptions} options - Options controlling the parsing.
+
      * @return {Promise} A promise resolving with a [FeatureCollection]{@link FeatureCollection}.
      */
     parse(json, options = {}) {

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -15,7 +15,7 @@ export default {
      * module:GeoJsonParser~FeatureCollection}.
      *
      * @param {XMLDocument} gpxFile - The GPX file content to parse.
-     * @param {GeoJsonParser~GeoJsonParserOptions} options - Options controlling the parsing.
+     * @param {ParsingOptions} options - Options controlling the parsing.
      *
      * @return {Promise} A promise resolving with a [FeatureCollection]{@link
      * module:GeoJsonParser~FeatureCollection}.

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -1,5 +1,6 @@
 import { gpx } from '@tmcw/togeojson';
 import GeoJsonParser from 'Parser/GeoJsonParser';
+import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
 
 /**
  * The GpxParser module provides a [parse]{@link module:GpxParser.parse}
@@ -20,6 +21,7 @@ export default {
      * module:GeoJsonParser~FeatureCollection}.
      */
     parse(gpxFile, options) {
+        options = deprecatedParsingOptionsToNewOne(options);
         return GeoJsonParser.parse(gpx(gpxFile), options);
     },
 };

--- a/src/Parser/KMLParser.js
+++ b/src/Parser/KMLParser.js
@@ -1,5 +1,6 @@
 import { kml } from '@tmcw/togeojson';
 import GeoJsonParser from 'Parser/GeoJsonParser';
+import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
 
 /**
  * The KMLParser module provides a [parse]{@link module:KMLParser.parse}
@@ -20,6 +21,7 @@ export default {
      * module:GeoJsonParser~FeatureCollection}.
      */
     parse(kmlFile, options) {
+        options = deprecatedParsingOptionsToNewOne(options);
         return GeoJsonParser.parse(kml(kmlFile), options);
     },
 };

--- a/src/Parser/KMLParser.js
+++ b/src/Parser/KMLParser.js
@@ -15,7 +15,7 @@ export default {
      * module:GeoJsonParser~FeatureCollection}.
      *
      * @param {XMLDocument} kmlFile - The KML file content to parse.
-     * @param {GeoJsonParser~GeoJsonParserOptions} options - Options controlling the parsing.
+     * @param {ParsingOptions} options - Options controlling the parsing.
      *
      * @return {Promise} A promise resolving with a [FeatureCollection]{@link
      * module:GeoJsonParser~FeatureCollection}.

--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -58,10 +58,9 @@ export default {
      * [dBase]{@link https://en.wikipedia.org/wiki/DBase} IV format.
      * @param {string} [data.prj] - The coordinate system and crs projection
      * information.
-     * @param {geojsonParserOptions} [options]
+     * @param {ParsingOptions} [options]
      *
-     * @return {Promise} A promise resolving with a [FeatureCollection]{@link
-     * module:GeoJsonParser~FeatureCollection}.
+     * @return {Promise} A promise resolving with a {@link FeatureCollection}.
      */
     parse(data, options = {}) {
         options = deprecatedParsingOptionsToNewOne(options);

--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -1,6 +1,7 @@
 import proj4 from 'proj4';
 import shp from 'shpjs';
 import GeoJsonParser from 'Parser/GeoJsonParser';
+import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
 
 /**
  * The ShapefileParser module provides a [parse]{@link
@@ -26,9 +27,13 @@ import GeoJsonParser from 'Parser/GeoJsonParser';
  *         shx: res[2],
  *         prj: res[3],
  *     }, {
- *         buildExtent: true,
- *         crsIn: 'EPSG:4326',
- *         crsOut: view.tileLayer.extent.crs,
+ *            in: {
+ *              crs: 'EPSG:4326',
+ *         },
+ *         out: {
+ *             crs: view.tileLayer.extent.crs,
+ *             buildExtent: true,
+ *         }
  *     });
  * }).then(function _(geojson) {
  *     var source = new FileSource({ features: geojson });
@@ -59,6 +64,7 @@ export default {
      * module:GeoJsonParser~FeatureCollection}.
      */
     parse(data, options = {}) {
+        options = deprecatedParsingOptionsToNewOne(options);
         let result;
 
         // If a zip is present, don't read anything else
@@ -71,7 +77,8 @@ export default {
             ]).then(shp.combine);
         }
 
-        options.crsIn = data.prj ? proj4(data.prj).oProj.datumName : undefined;
+        options.in = options.in || {};
+        options.in.crs = data.prj ? proj4(data.prj).oProj.datumName : undefined;
 
         return Promise.resolve(result).then(res => GeoJsonParser.parse(res, options));
     },

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -173,27 +173,19 @@ export default {
      * [Mapbox Vector Tile]{@link https://www.mapbox.com/vector-tiles/specification/}.
      *
      * @param {ArrayBuffer} file - The vector tile file to parse.
-     * @param {Object} options - Options controlling the parsing.
-     * @param {Extent} options.extent - The Extent to convert the input coordinates to.
-     * @param {Extent=} options.filteringExtent - Optional filter to reject features
-     * outside of this extent.
-     * @param {boolean} [options.mergeFeatures=true] - If true all geometries are merged by type and multi-type
-     * @param {boolean} [options.withNormal=true] - If true each coordinate normal is computed
-     * @param {boolean} [options.withAltitude=true] - If true each coordinate altitude is kept
-     * @param {function=} options.filter - Filter function to remove features.
-     * @param {Object} options.Styles - Object containing subobject with
+     *
+     * @param {ParsingOptions} options - Options controlling the parsing {@link ParsingOptions}.
+     *
+     * @param {InformationsData} options.in - Object containing all styles,
+     * layers and informations data, see {@link InformationsData}.
+     *
+     * @param {Object} options.in.Styles - Object containing subobject with
      * informations on a specific style layer. Styles available is by `layer.id` and by zoom.
-     * @param {Object} options.layers - Object containing subobject with
-     * informations on a specific layer. Informations available is `id`,
-     * `filterExpression`, `zoom.min` and `zoom.max`. See {@link
-     * VectorTilesSource} for more precision. The key of each information is the
-     * `source-layer` property of the layer.
-     * @param {string=} options.isInverted - This option is to be set to the
-     * correct value, true or false (default being false), if the computation of
-     * the coordinates needs to be inverted to same scheme as OSM, Google Maps
-     * or other system. See [this link]{@link
-     * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates}
-     * for more informations.
+     *
+     * @param {Object} options.in.layers - Object containing subobject with
+     *
+     * @param {FeatureBuildingOptions} options.out - options indicates how the features should be built,
+     * see {@link FeatureBuildingOptions}.
      *
      * @return {Promise} A Promise resolving with a Feature or an array a
      * Features.

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -82,12 +82,14 @@ const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
  * itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson')
  *     .then(function _(geojson) {
  *         return itowns.GeoJsonParser.parse(geojson, {
- *             buildExtent: true,
- *             crsIn: 'EPSG:4326',
- *             crsOut: view.tileLayer.extent.crs,
- *             mergeFeatures: true,
- *             withNormal: false,
- *             withAltitude: false,
+ *             in: { in: 'EPSG:4326' },
+ *             out: {
+     *             crs: view.tileLayer.extent.crs,
+     *             buildExtent: true,
+     *             mergeFeatures: true,
+     *             withNormal: false,
+     *             withAltitude: false,
+ *             },
  *         });
  *     }).then(function _(features) {
  *         ariege.source = new itowns.FileSource({
@@ -180,7 +182,7 @@ class FileSource extends Source {
      * The loaded data is a Feature or Texture.
      *
      * @param      {Extent}  extent   extent requested parsed data.
-     * @param      {Object}  out     The feature returned options
+     * @param      {FeatureBuildingOptions|Layer}  out  The feature returned options
      * @return     {FeatureCollection|Texture}  The parsed data.
      */
     loadData(extent, out) {

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -161,16 +161,16 @@ class Source {
      * The loaded data is a Feature or Texture.
      *
      * @param      {Extent}  extent   extent requested parsed data.
-     * @param      {Object}  options  The parsing options
+     * @param      {Object}  out     The feature returned options
      * @return     {FeatureCollection|Texture}  The parsed data.
      */
-    loadData(extent, options) {
-        const cache = this._featuresCaches[options.crsOut];
+    loadData(extent, out) {
+        const cache = this._featuresCaches[out.crs];
         // try to get parsed data from cache
         let features = cache.getByArray(this.requestToKey(extent));
         if (!features) {
             // otherwise fetch/parse the data
-            features = cache.setByArray(fetchSourceData(this, extent).then(fetchedData => this.parser(fetchedData, options),
+            features = cache.setByArray(fetchSourceData(this, extent).then(file => this.parser(file, { out, in: this }),
                 err => this.handlingError(err)), this.requestToKey(extent));
             /* istanbul ignore next */
             if (this.onParsedFile) {
@@ -191,8 +191,8 @@ class Source {
      */
     onLayerAdded(options) {
         // Added new cache by crs
-        if (!this._featuresCaches[options.crsOut]) {
-            this._featuresCaches[options.crsOut] = new Cache();
+        if (!this._featuresCaches[options.out.crs]) {
+            this._featuresCaches[options.out.crs] = new Cache();
         }
     }
 

--- a/test/functional/source_file_geojson_raster.js
+++ b/test/functional/source_file_geojson_raster.js
@@ -15,7 +15,7 @@ describe('source_file_geojson_raster', function _() {
             const promises = [];
             const layers = view.getLayers(l => l.source && l.source.isFileSource);
             for (let i = 0; i < layers.length; i++) {
-                promises.push(layers[i].source.loadData({}, { crsOut: 'EPSG:4326' }));
+                promises.push(layers[i].source.loadData({}, { crs: 'EPSG:4326' }));
             }
 
             return Promise.all(promises);
@@ -30,7 +30,7 @@ describe('source_file_geojson_raster', function _() {
             const promises = [];
             const layers = view.getLayers(l => l.source && l.source.isFileSource);
             for (let i = 0; i < layers.length; i++) {
-                promises.push(layers[i].source.loadData({}, { crsOut: 'EPSG:4326' }));
+                promises.push(layers[i].source.loadData({}, { crs: 'EPSG:4326' }));
             }
 
             return Promise.all(promises).then(fa => fa.filter(f => itowns

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -59,9 +59,6 @@ describe('Provide in Sources', function () {
     const colorlayer = new ColorLayer('color', { crs: 'EPSG:3857' });
     const elevationlayer = new ElevationLayer('elevation', { crs: 'EPSG:3857' });
 
-    colorlayer.parsingOptions.crsOut = colorlayer.crs;
-    elevationlayer.parsingOptions.crsOut = elevationlayer.crs;
-
     planarlayer.attach(colorlayer);
     planarlayer.attach(elevationlayer);
 
@@ -75,11 +72,8 @@ describe('Provide in Sources', function () {
     featureLayer.update = FeatureProcessing.update;
     featureLayer.crs = 'EPSG:4978';
     featureLayer.mergeFeatures = false;
-    featureLayer.parsingOptions.crsIn = 'EPSG:3857';
-    featureLayer.parsingOptions.crsOut = featureLayer.crs;
-    featureLayer.parsingOptions.filteringExtent = true;
-
     featureLayer.zoom.min = 10;
+
     function extrude() {
         return 5000;
     }
@@ -126,7 +120,7 @@ describe('Provide in Sources', function () {
             },
         });
 
-        colorlayer.source.onLayerAdded({ crsOut: colorlayer.crs });
+        colorlayer.source.onLayerAdded({ out: colorlayer });
 
         const tile = new TileMesh(geom, material, planarlayer, extent);
         material.visible = true;
@@ -155,7 +149,7 @@ describe('Provide in Sources', function () {
             },
         });
 
-        elevationlayer.source.onLayerAdded({ crsOut: elevationlayer.crs });
+        elevationlayer.source.onLayerAdded({ out: elevationlayer });
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
         nodeLayerElevation.level = EMPTY_TEXTURE_ZOOM;
@@ -183,7 +177,7 @@ describe('Provide in Sources', function () {
             },
         });
         // May be move in layer Constructor
-        colorlayer.source.onLayerAdded({ crsOut: colorlayer.crs });
+        colorlayer.source.onLayerAdded({ out: colorlayer });
 
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
         material.visible = true;
@@ -223,10 +217,10 @@ describe('Provide in Sources', function () {
         material.visible = true;
         nodeLayer.level = EMPTY_TEXTURE_ZOOM;
         tile.parent = { pendingSubdivision: false };
-        featureLayer.parsingOptions.mergeFeatures = false;
+        featureLayer.mergeFeatures = false;
         tile.layerUpdateState = { test: new LayerUpdateState() };
 
-        featureLayer.source.onLayerAdded({ crsOut: featureLayer.crs });
+        featureLayer.source.onLayerAdded({ out: featureLayer });
 
         featureLayer.update(context, featureLayer, tile);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((features) => {
@@ -245,10 +239,10 @@ describe('Provide in Sources', function () {
         tile.material.visible = true;
         tile.parent = { pendingSubdivision: false };
         featureLayer.source.uid = 8;
-        featureLayer.parsingOptions.mergeFeatures = true;
+        featureLayer.mergeFeatures = true;
         featureLayer.cache.data.clear();
         featureLayer.source._featuresCaches = {};
-        featureLayer.source.onLayerAdded({ crsOut: featureLayer.crs });
+        featureLayer.source.onLayerAdded({ out: featureLayer });
         featureLayer.update(context, featureLayer, tile);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((features) => {
             assert.ok(features[0].children[0].isMesh);
@@ -288,9 +282,7 @@ describe('Provide in Sources', function () {
                 },
             },
         });
-        colorlayerWfs.parsingOptions.crsOut = colorlayerWfs.crs;
-        colorlayerWfs.parsingOptions.style = colorlayerWfs.style;
-        colorlayerWfs.source.onLayerAdded({ crsOut: colorlayerWfs.crs });
+        colorlayerWfs.source.onLayerAdded({ out: colorlayerWfs });
         updateLayeredMaterialNodeImagery(context, colorlayerWfs, tile, tile.parent);
         updateLayeredMaterialNodeImagery(context, colorlayerWfs, tile, tile.parent);
         DataSourceProvider.executeCommand(context.scheduler.commands[0]).then((textures) => {

--- a/test/unit/feature2mesh.js
+++ b/test/unit/feature2mesh.js
@@ -27,8 +27,8 @@ function computeAreaOfMesh(mesh) {
 }
 
 describe('Feature2Mesh', function () {
-    const parsed = GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, mergeFeatures: false });
-    const parsed2 = GeoJsonParser.parse(geojson2, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true, mergeFeatures: false });
+    const parsed = GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false } });
+    const parsed2 = GeoJsonParser.parse(geojson2, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false } });
 
     it('rect mesh area should match geometry extent', () =>
         parsed.then((collection) => {

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -7,8 +7,8 @@ import { FEATURE_TYPES } from 'Core/Feature';
 const geojson = require('../data/geojson/simple.geojson.json');
 
 describe('FeaturesUtils', function () {
-    const promise = GeoJsonParser.parse(geojson, { crsOut: 'EPSG:4326', buildExtent: true, mergeFeatures: false, withAltitude: false, withNormal: false });
-
+    const options = { out: { crs: 'EPSG:4326', buildExtent: true, mergeFeatures: false, withAltitude: false, withNormal: false } };
+    const promise = GeoJsonParser.parse(geojson, options);
     it('should correctly parse geojson', () =>
         promise.then((collection) => {
             assert.equal(collection.features.length, 3);

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -11,7 +11,7 @@ proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 function parse(geojson) {
-    return GeoJsonParser.parse(geojson, { crsIn: 'EPSG:3946', crsOut: 'EPSG:3946', buildExtent: true });
+    return GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true } });
 }
 
 describe('GeoJsonParser', function () {
@@ -27,55 +27,75 @@ describe('GeoJsonParser', function () {
 
     it('should return an empty collection', () =>
         GeoJsonParser.parse(holes, {
-            crsIn: 'EPSG:3946',
-            crsOut: 'EPSG:3946',
-            buildExtent: true,
-            filteringExtent: new Extent('EPSG:3946', 10, 20, 10, 20),
+            in: {
+                crs: 'EPSG:3946',
+            },
+            out: {
+                crs: 'EPSG:3946',
+                buildExtent: true,
+                filteringExtent: new Extent('EPSG:3946', 10, 20, 10, 20),
+            },
         }).then((collection) => {
             assert.ok(collection.features.length == 0);
         }));
     it('should return an merged collection', () =>
         GeoJsonParser.parse(holes, {
-            crsIn: 'EPSG:3946',
-            crsOut: 'EPSG:3946',
-            mergeFeatures: true,
-
+            in: {
+                crs: 'EPSG:3946',
+            },
+            out: {
+                crs: 'EPSG:3946',
+                mergeFeatures: true,
+            },
         }).then((collection) => {
             assert.ok(collection.features.length == 1);
         }));
     it('should return an no merged collection', () =>
         GeoJsonParser.parse(holes, {
-            crsIn: 'EPSG:3946',
-            crsOut: 'EPSG:3946',
-            mergeFeatures: false,
-
+            in: {
+                crs: 'EPSG:3946',
+            },
+            out: {
+                crs: 'EPSG:3946',
+                mergeFeatures: false,
+            },
         }).then((collection) => {
             assert.ok(collection.features.length == 3);
         }));
     it('should return an collection without altitude', () =>
         GeoJsonParser.parse(holes, {
-            crsIn: 'EPSG:3946',
-            crsOut: 'EPSG:3946',
-            withAltitude: false,
-
+            in: {
+                crs: 'EPSG:3946',
+            },
+            out: {
+                crs: 'EPSG:3946',
+                withAltitude: false,
+            },
         }).then((collection) => {
             assert.ok(collection.features[0].vertices.length == 32);
         }));
     it('should return an collection without normal', () =>
         GeoJsonParser.parse(holes, {
-            crsIn: 'EPSG:3946',
-            crsOut: 'EPSG:3946',
-            withNormal: false,
-
+            in: {
+                crs: 'EPSG:3946',
+            },
+            out: {
+                crs: 'EPSG:3946',
+                withNormal: false,
+            },
         }).then((collection) => {
             assert.ok(collection.features[0].normals == undefined);
         }));
 
     it('parses Point and MultiPoint', () =>
         GeoJsonParser.parse(points, {
-            crsIn: 'EPSG:4326',
-            crsOut: 'EPSG:4326',
-            mergeFeatures: false,
+            in: {
+                crs: 'EPSG:4326',
+            },
+            out: {
+                crs: 'EPSG:4326',
+                mergeFeatures: false,
+            },
         }).then((collection) => {
             assert.equal(collection.features.length, 3);
             assert.equal(collection.features[0].geometries.length, 1);

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -14,7 +14,7 @@ describe('LabelLayer', function () {
     let extent;
 
     before('init LabelLayer and a FeatureCollection like', function () {
-        layer = new LabelLayer('layer', 'EPSG:4978');
+        layer = new LabelLayer('labels');
         layer.source = {};
         layer.style = new Style();
         layer.style.zoom = {
@@ -23,7 +23,7 @@ describe('LabelLayer', function () {
         };
         layer.style.text.field = 'content';
 
-        collection = new FeatureCollection('EPSG:4326', { buildExtent: true });
+        collection = new FeatureCollection('EPSG:4326', { crs: 'EPSG:4326', buildExtent: true });
         const feature = collection.requestFeatureByType(FEATURE_TYPES.POINT);
         const geometry = feature.bindNewGeometry();
         geometry.startSubGeometry(0, feature);

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -249,13 +249,11 @@ describe('Sources', function () {
             assert.ok(source.fetchedData);
             assert.ok(source.isFileSource);
 
-            const layer = new Layer('09-ariege', { crs: 'EPSG:4326', source });
-            layer.parsingOptions.crsOut = layer.crs;
-            layer.parsingOptions.withAltitude = false;
-            layer.source.onLayerAdded(layer.parsingOptions);
+            const layer = new Layer('09-ariege', { crs: 'EPSG:4326', source, withAltitude: false });
+            layer.source.onLayerAdded({ out: layer });
 
             layer.whenReady.then(() => {
-                const promise = source.loadData([], layer.parsingOptions);
+                const promise = source.loadData([], layer);
                 promise.then((featureCollection) => {
                     assert.equal(featureCollection.features[0].vertices.length, 3536);
                     done();
@@ -269,7 +267,7 @@ describe('Sources', function () {
                 features: { foo: 'bar', crs: 'EPSG:4326' },
                 crs: 'EPSG:4326',
             });
-            source.onLayerAdded({ crsOut: source.crs });
+            source.onLayerAdded({ out: { crs: source.crs } });
             const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
             assert.ok(source.urlFromExtent(extent).startsWith('fake-file-url'));
             assert.ok(!source.fetchedData);

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -13,8 +13,10 @@ describe('Vector tiles', function () {
 
     function parse(pbf, layers) {
         return VectorTileParser.parse(pbf, {
-            layers,
-            styles: [[]],
+            in: {
+                layers,
+                styles: [[]],
+            },
         });
     }
 


### PR DESCRIPTION
## Description
Simplify parsing options construction: 
   - parsing options will have two properties `in` and `out`
     - `in` will be data specification for **in data**.
     - `out` will be data specification for **out feature**.
  - in and out could be set, respectively, by `Source` and `Layer`.
```js 
// custom parsing  option to convert 'EPSG:4326' data to 'EPSG:4978' `Feature`.
const parsingOptions = { 
   in: { crs: 'EPSG:4326'  },
   out: { crs: 'EPSG:4978'  },
};
// For a layer the options will be
const parsingOptionsForLayer = { 
   in: layer.source,
   out: layer,
};
```

fix  #1480

