### PR TITLE
Fix remove layer with multi view

### DIFF
--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -32,6 +32,7 @@ const mfogDistance = ellipsoidSizes.x * 160.0;
 class Atmosphere extends GeometryLayer {
     constructor(id = 'atmosphere', options = {}) {
         super(id, new THREE.Object3D(), options);
+        this.isAtmosphere = true;
 
         const material = new THREE.ShaderMaterial({
             uniforms: {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -350,9 +350,16 @@ class View extends THREE.EventDispatcher {
                 }
             }
 
-            // remove unused cache
-            const sameSource = this.getLayers(l => l.source.uid == layer.source.uid && l.crs == layer.crs);
-            layer.source.onLayerRemoved({ unusedCrs: sameSource.length == 0 ? layer.crs : undefined });
+            // Remove unused cache in all viewers
+
+            // count of times the source is used in all viewer
+            let sharedSourceCount = 0;
+            for (const view of viewers) {
+                // add count of times the source is used in other layers
+                sharedSourceCount += view.getLayers(l => l.source.uid == layer.source.uid && l.crs == layer.crs).length;
+            }
+            // if sharedSourceCount equals to 0 so remove unused cache for this CRS
+            layer.source.onLayerRemoved({ unusedCrs: sharedSourceCount == 0 ? layer.crs : undefined });
 
             this.notifyChange(this.camera);
 

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -119,4 +119,13 @@ describe('Viewer', function () {
         renderer.context.getParameter = () => 32;
         assert.equal(getMaxColorSamplerUnitsCount(), 15);
     });
+
+    it('Dispose view', () => {
+        viewer.addLayer(globelayer);
+        assert.equal(viewer.getLayers().length, 1);
+        viewer.dispose();
+        assert.equal(Object.values(viewer._frameRequesters).length, 0);
+        assert.equal(viewer.getLayers().length, 0);
+        assert.equal(viewer._listeners, undefined);
+    });
 });


### PR DESCRIPTION
## Description

### fix(View): undefined cache after removing layer with multi-views.

### Add `View.dispose()` method.

Method dispose all viewer objects
 * remove control
 * remove all layers
 * remove all frame requester
 * remove all events

I add this method to manage of multi-views, which is a consequence of the fix.
