### PR TITLE
fix(test): temporary disable the LabelLayer in wfs25d example

### DIFF
--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -281,7 +281,9 @@
             wfsCartoLayer.source = wfsCartoSource;
             wfsCartoLayer.style = wfsCartoStyle;
 
-            view.addLayer(wfsCartoLayer);
+            // TODO: enable this again when the stream became available
+            // Search for "zone_habitat" in this page https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?SERVICE=WFS&REQUEST=GetCapabilities
+            // view.addLayer(wfsCartoLayer);
 
             function picking(event) {
                 var htmlInfo = document.getElementById('info');


### PR DESCRIPTION
The stream associated to this layer is currently missing, and this
blocks PRs until we know what the problem is. This commit disables
adding the layer to the view, and then functional tests can pass.

See here for example https://travis-ci.com/github/iTowns/itowns/jobs/399543456#L901, for the PR #1471 