### PR TITLE
fix(source): move default format before calling parent constructor

### DIFF
--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -61,6 +61,8 @@ class TMSSource extends Source {
             throw new Error('New TMSSource/WMTSSource: crs projection is required');
         }
 
+        source.format = source.format || 'image/png';
+
         super(source);
 
         this.isTMSSource = true;
@@ -73,7 +75,6 @@ class TMSSource extends Source {
         this.zoom = source.zoom;
 
         this.isInverted = source.isInverted || false;
-        this.format = this.format || 'image/png';
         this.url = source.url;
         this.crs = CRS.formatToTms(source.crs);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -109,11 +109,13 @@ class WFSSource extends Source {
         if (!source.crs) {
             throw new Error('source.crs is required in wfs source');
         }
+
+        source.format = source.format || 'application/json';
+
         super(source);
 
         this.isWFSSource = true;
         this.typeName = source.typeName;
-        this.format = this.format || 'application/json';
         this.version = source.version || '2.0.2';
 
         this.url = `${source.url

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -87,12 +87,14 @@ class WMSSource extends Source {
         if (!source.crs && !source.projection) {
             throw new Error('source.crs is required');
         }
+
+        source.format = source.format || 'image/png';
+
         super(source);
 
         this.isWMSSource = true;
         this.name = source.name;
         this.zoom = source.zoom || { min: 0, max: 21 };
-        this.format = this.format || 'image/png';
         this.style = source.style || '';
 
         this.width = source.width || source.height || 256;


### PR DESCRIPTION
The default value was set, but it was making everything not working in the `Source` constructor.
