### PR TITLE
fix(test): switch latest node version from 15 to 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "lts/*"
-  - "node"
+  - "14"
 after_success:
   - npm install coveralls && nyc report --reporter=text-lcov | coveralls
   - openssl aes-256-cbc -K $encrypted_db2ce12ff441_key -iv $encrypted_db2ce12ff441_iv -in deploy_key.enc -out deploy_key -d


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I modified the .travis.yml file so that the latest node version used for test switches from 15 to 14.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
There is an issue using iTowns with node 15.
