### PR TITLE
chore(docs): add horizontal scroll on the doc content to see the full…

### DIFF
--- a/docs/static/styles/itowns.css
+++ b/docs/static/styles/itowns.css
@@ -9,7 +9,7 @@ html, body {
 }
 
 body {
-    overflow-x: hidden;
+    overflow-x: auto;
 }
 
 .scroll-section {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the overflow-x attribute for body element in docs/static/styles/itowns.css from hidden to auto.
This allows horizontal scroll on width reduced windows, so that one can see the full methods signature.

## Screenshot 

The following screenshot shows an example of a doc page where the methods signatures are not fully visible.

![Screenshot from 2020-10-28 18-11-24](https://user-images.githubusercontent.com/73115044/97471467-0d37cd80-1949-11eb-9ed0-7a0b500d1308.png)
