### PR TITLE
refactor(PlanarView): implements PlanarControls in PlanarView constructor

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -76,10 +76,6 @@
 
             view.addLayer(wmsElevationLayer);
 
-            // instanciate controls
-            // eslint-disable-next-line no-new
-            new itowns.PlanarControls(view, {});
-
             // Add 3D Tiles layer
             // This 3D Tiles tileset uses the draco compression that is an
             // extension of gltf. We need to enable it.

--- a/examples/misc_compare_25d_3d.html
+++ b/examples/misc_compare_25d_3d.html
@@ -78,9 +78,6 @@
             var menuGlobe = new GuiTools('menuDiv', view);
             var overGlobe = true;
 
-            // eslint-disable-next-line
-            new itowns.PlanarControls(planarView, {});
-
             viewerDiv.addEventListener('mousemove', function _() {
                 overGlobe = true;
             }, false);

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -101,9 +101,6 @@
 
             view.addLayer(wmsElevationLayer);
 
-            // eslint-disable-next-line no-new
-            new itowns.PlanarControls(view, {});
-
             function setMaterialLineWidth(result) {
                 result.traverse(function _setLineWidth(mesh) {
                     if (mesh.material) {

--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -32,22 +32,20 @@
 
             // Instanciate PlanarView
             var view = new itowns.PlanarView(viewerDiv, extent, {
-                maxSubdivisionLevel: 20
+                maxSubdivisionLevel: 20,
+                controls: {
+                    // We do not want the user to zoom out too much
+                    maxAltitude: 40000000,
+                    // We want to keep the rotation disabled, to only have a view from the top
+                    enableRotation: false,
+                    // Faster zoom in/out speed
+                    zoomInFactor: 0.5,
+                    zoomOutFactor: 0.5,
+                    // Don't zoom too much on smart zoom
+                    smartZoomHeightMax: 100000,
+                },
             });
             var menuGlobe = new GuiTools('menuDiv', view, 300);
-
-            // eslint-disable-next-line no-new
-            new itowns.PlanarControls(view, {
-                // We do not want the user to zoom out too much
-                maxAltitude: 40000000,
-                // We want to keep the rotation disabled, to only have a view from the top
-                enableRotation: false,
-                // Faster zoom in/out speed
-                zoomInFactor: 0.5,
-                zoomOutFactor: 0.5,
-                // Don't zoom too much on smart zoom
-                smartZoomHeightMax: 100000,
-            });
 
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -96,9 +96,6 @@
             });
 
             view.addLayer(wmsElevationLayer);
-            // instanciate controls
-            // eslint-disable-next-line no-new
-            new itowns.PlanarControls(view, {});
 
             // Initialize scale :
             const initialScaleSize = 200;  // in pixel

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -30,19 +30,18 @@
             // Instanciate PlanarView
             // By default itowns' tiles geometry have a "skirt" (ie they have a height),
             // but in case of orthographic we don't need this feature, so disable it
-            var view = new itowns.PlanarView(viewerDiv, extent, { disableSkirt: true, maxSubdivisionLevel: 10, placement: { tilt: 90 } });
-
-            // eslint-disable-next-line no-new
-            new itowns.PlanarControls(view, {
-                // We do not want the user to zoom out too much
-                maxAltitude: 40000000,
-                // We want to keep the rotation disabled, to only have a view from the top
-                enableRotation: false,
-                // Faster zoom in/out speed
-                zoomInFactor: 0.5,
-                zoomOutFactor: 0.5,
-                // Don't zoom too much on smart zoom
-                smartZoomHeightMax: 100000,
+            var view = new itowns.PlanarView(viewerDiv, extent, { disableSkirt: true, maxSubdivisionLevel: 10, placement: { tilt: 90 },
+                controls: {
+                    // We do not want the user to zoom out too much
+                    maxAltitude: 40000000,
+                    // We want to keep the rotation disabled, to only have a view from the top
+                    enableRotation: false,
+                    // Faster zoom in/out speed
+                    zoomInFactor: 0.5,
+                    zoomOutFactor: 0.5,
+                    // Don't zoom too much on smart zoom
+                    smartZoomHeightMax: 100000,
+                },
             });
 
             setupLoadingScreen(viewerDiv, view);

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import View from 'Core/View';
 import CameraUtils from 'Utils/CameraUtils';
 
+import PlanarControls from 'Controls/PlanarControls';
 import PlanarLayer from './Planar/PlanarLayer';
 
 class PlanarView extends View {
@@ -24,6 +25,9 @@ class PlanarView extends View {
      * in the DOM.
      * @param {Extent} extent - The ground extent.
      * @param {object=} options - See options of {@link View}.
+     * @param {boolean} [options.noControls] - If true, no controls are associated to the view.
+     * @param {object=} [options.controls] - options for the PlanarControls associated to the view, if
+     * `options.noControls` is false.
      */
     constructor(viewerDiv, extent, options = {}) {
         THREE.Object3D.DefaultUp.set(0, 0, 1);
@@ -50,6 +54,10 @@ class PlanarView extends View {
         placement.tilt = placement.tilt || 90;
         placement.heading = placement.heading || 0;
         placement.range = placement.range || max;
+
+        if (!this.noControls) {
+            this.controls = new PlanarControls(this, options.controls);
+        }
 
         CameraUtils.transformCameraToLookAtTarget(this, camera3D, placement);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Refactor `PlanarView` constructor so that it can create an attribute that instantiate `PlanarControls` (like it is done with `GlobeView` and `GlobeControls`).
Also refactors examples that use `PlanarView` and `PlanarControls` to match the refactored `PlanarView`.