### PR TITLE
Fix npm install windows 10

### DIFF
--- a/config/prepare.js
+++ b/config/prepare.js
@@ -22,7 +22,9 @@ if (nodeMajorVersion < minNodeMajorVersion) {
     console.log(chalk.green('Node.js version :', process.versions.node));
 }
 
-const npmVersion = execSync('npm --version');
+const npmVersion = execSync('npm --version', {
+    encoding: 'utf8',
+});
 if (npmVersion) {
     console.log(chalk.green('Npm version :', npmVersion), '\n');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itowns",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itowns",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "A JS/WebGL framework for 3D geospatial data visualization",
   "main": "lib/Main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot",
     "debug": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot --env.noInline=true",
     "prepublishOnly": "npm run build && npm run transpile",
-    "prepare": "node ./config/prepare.js && node ./config/replace.config.js",
+    "prepare": "cross-env NO_UPDATE_NOTIFIER=true node ./config/prepare.js && node ./config/replace.config.js",
     "watch": "cross-env BABEL_DISABLE_CACHE=1 babel --watch src --out-dir lib"
   },
   "nyc": {

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,4 +1,4 @@
-export const REVISION = '2.28.0';
+export const REVISION = '2.28.1';
 
 // Geographic tools
 export { default as Extent } from 'Core/Geographic/Extent';


### PR DESCRIPTION
## Description
fix(install): prepare script spends a lot of time, to check npm version.

The issue is calling `npm --version` with nodejs `child_process.execSync`
The fix is set environment variable `NO_UPDATE_NOTIFIER=true`
With windows 10 behind proxy.
