### PR TITLE
fix(examples): fix key events in examples

### DIFF
--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -83,7 +83,7 @@ const defaultOptions = {
     minZenithAngle: 0,
     maxZenithAngle: 82.5,
     focusOnMouseOver: true,
-    focusOnMouseClick: false,
+    focusOnMouseClick: true,
     handleCollision: true,
     minDistanceCollision: 30,
     enableSmartTravel: true,

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -55,11 +55,11 @@ class PlanarView extends View {
         placement.heading = placement.heading || 0;
         placement.range = placement.range || max;
 
+        CameraUtils.transformCameraToLookAtTarget(this, camera3D, placement);
+
         if (!options.noControls) {
             this.controls = new PlanarControls(this, options.controls);
         }
-
-        CameraUtils.transformCameraToLookAtTarget(this, camera3D, placement);
 
         this.tileLayer = tileLayer;
     }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -200,7 +200,10 @@ class View extends THREE.EventDispatcher {
         this._fullSizeDepthBuffer = new Uint8Array(4 * this.camera.width * this.camera.height);
         this._pixelDepthBuffer = new Uint8Array(4);
 
-        // Focus needed to capture some key events.
+        // Indicates that view's domElement can be focused (the negative value indicates that domElement can't be
+        // focused sequentially using tab key). Focus is needed to capture some key events.
+        this.domElement.tabIndex = -1;
+        // Set focus on view's domElement.
         this.domElement.focus();
 
         // push all viewer to keep source.cache


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix key event in the following examples : 
- [2.5d map](http://www.itowns-project.org/itowns/examples/#view_25d_map)
- [Multiple globes](http://www.itowns-project.org/itowns/examples/#view_multiglobe)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Key event were not detected because of a focus issue on the view.
