### PR TITLE
Update LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,7 +8,7 @@ iTowns V2 is licenced under both licences CeCILL-B Version 1.0 and MIT.
 
 iTowns is licensed under the CeCILL-B license, Version 1.0. You may obtain a copy of the License at
 
-http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+https://cecill.info/licences/Licence_CeCILL-B_V1-en.html
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 


### PR DESCRIPTION
## Description
Licence description website invalid url

## Motivation and Context
The link to the licence description was not working because it used http instead of https and the hostname changed

## Screenshots (if appropriate)
