### PR TITLE
Fix TMS projection/ crs

### DIFF
--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -61,9 +61,15 @@ export default {
      * @return {string} the formed url
      */
     xyz: function xyz(coords, source) {
-        return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
-            .replace(/(\$\{y\}|%ROW)/, coords.row)
-            .replace(/(\$\{x\}|%COL)/, coords.col));
+        if (source.isInverted) {
+            return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
+                .replace(/(\$\{y\}|%ROW)/, Math.pow(2, coords.zoom) - coords.row - 1) // .replace(/(\$\{y\}|%ROW)/, coords.row)
+                .replace(/(\$\{x\}|%COL)/, coords.col));
+        } else {
+            return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
+                .replace(/(\$\{y\}|%ROW)/, coords.row)
+                .replace(/(\$\{x\}|%COL)/, coords.col));
+        }
     },
 
     /**

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -61,15 +61,9 @@ export default {
      * @return {string} the formed url
      */
     xyz: function xyz(coords, source) {
-        if (source.isInverted) {
-            return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
-                .replace(/(\$\{y\}|%ROW)/, Math.pow(2, coords.zoom) - coords.row - 1) // .replace(/(\$\{y\}|%ROW)/, coords.row)
-                .replace(/(\$\{x\}|%COL)/, coords.col));
-        } else {
-            return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
-                .replace(/(\$\{y\}|%ROW)/, coords.row)
-                .replace(/(\$\{x\}|%COL)/, coords.col));
-        }
+        return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
+            .replace(/(\$\{y\}|%ROW)/, coords.row)
+            .replace(/(\$\{x\}|%COL)/, coords.col));
     },
 
     /**

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -57,7 +57,7 @@ class TMSSource extends Source {
      * @constructor
      */
     constructor(source) {
-        if (!source.projection && !source.crs) {
+        if (!source.projection) {
             throw new Error('New TMSSource: projection or crs is required');
         }
         super(source);
@@ -74,7 +74,7 @@ class TMSSource extends Source {
         this.isInverted = source.isInverted || false;
         this.format = this.format || 'image/png';
         this.url = source.url;
-        this.projection = CRS.formatToTms(source.projection || source.crs);
+        this.projection = CRS.formatToTms(source.projection);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;
 
         if (!this.zoom) {

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -66,7 +66,7 @@ class TMSSource extends Source {
 
         if (!source.extent) {
             // default to the global extent
-            this.extent = globalExtentTMS.get(source.projection);
+            this.extent = globalExtentTMS.get(source.projection || source.crs);
         }
 
         this.zoom = source.zoom;

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -57,7 +57,7 @@ class TMSSource extends Source {
      * @constructor
      */
     constructor(source) {
-        if (!source.projection) {
+        if (!source.projection && !source.crs) {
             throw new Error('New TMSSource: projection or crs is required');
         }
         super(source);
@@ -74,7 +74,7 @@ class TMSSource extends Source {
         this.isInverted = source.isInverted || false;
         this.format = this.format || 'image/png';
         this.url = source.url;
-        this.projection = CRS.formatToTms(source.projection);
+        this.projection = CRS.formatToTms(source.projection || source.crs);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;
 
         if (!this.zoom) {

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -57,26 +57,24 @@ class TMSSource extends Source {
      * @constructor
      */
     constructor(source) {
-        if (!source.crs && !source.projection) {
-            throw new Error('New TMSSource/WMTSSource: crs projection is required');
+        if (!source.projection && !source.crs) {
+            throw new Error('New TMSSource: projection or crs is required');
         }
-
-        source.format = source.format || 'image/png';
-
         super(source);
 
         this.isTMSSource = true;
 
         if (!source.extent) {
             // default to the global extent
-            this.extent = globalExtentTMS.get(source.crs);
+            this.extent = globalExtentTMS.get(source.projection);
         }
 
         this.zoom = source.zoom;
 
         this.isInverted = source.isInverted || false;
+        this.format = this.format || 'image/png';
         this.url = source.url;
-        this.crs = CRS.formatToTms(source.crs);
+        this.projection = CRS.formatToTms(source.projection || source.crs);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;
 
         if (!this.zoom) {
@@ -98,6 +96,10 @@ class TMSSource extends Source {
 
     urlFromExtent(extent) {
         return URLBuilder.xyz(extent, this);
+    }
+
+    handlingError(err) {
+        console.warn(`err ${this.url}`, err);
     }
 
     extentInsideLimit(extent) {


### PR DESCRIPTION
## Description
Changed TMSSource.js to accept both "source.projection" and "source.crs" as input key value

## Motivation and Context

The example source layers JSON had keys named "crs",
but TMSSource.js (and the other sources on which it's based) expects "projection"

TMSSource now accepts both "source.projection" and "source.crs",
if both "source.projection" and "source.crs" are null,
it still throws the error that a crs/ projection is required.
If "source.projection" is available it is used, otherwise "source.crs" is used.