### PR TITLE
feature(CameraUtils): add Extent to transformCameraToLookAtTarget params

### DIFF
--- a/examples/misc_orthographic_camera.html
+++ b/examples/misc_orthographic_camera.html
@@ -46,9 +46,11 @@
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             const viewerDiv = document.getElementById('viewerDiv');
 
-            // instantiate PlanarView with an orthographic camera
+            // instantiate PlanarView with an orthographic camera.
+            // The extent passed in `placement` is the area that will be displayed by camera.
             const view = new itowns.PlanarView(viewerDiv, extent, {
                 camera: { type: itowns.CAMERA_TYPE.ORTHOGRAPHIC },
+                placement: new itowns.Extent('EPSG:3946', 1838000, 1842000, 5172000, 5174000),
             });
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -32,6 +32,7 @@
             // but in case of orthographic we don't need this feature, so disable it
             var view = new itowns.PlanarView(viewerDiv, extent, { disableSkirt: true, maxSubdivisionLevel: 10,
                 camera: { type: itowns.CAMERA_TYPE.ORTHOGRAPHIC },
+                placement: new itowns.Extent('EPSG:3857', -20000000, 20000000, -8000000, 20000000),
                 controls: {
                     // Faster zoom in/out speed
                     zoomInFactor: 1,

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -89,7 +89,7 @@ class GlobeView extends View {
      *
      * @param {HTMLDivElement} viewerDiv - Where to attach the view and display it
      * in the DOM.
-     * @param {CameraTransformOptions} placement - An object to place view
+     * @param {CameraTransformOptions|Extent} placement - An object to place view
      * @param {object=} options - See options of {@link View}.
      */
     constructor(viewerDiv, placement = {}, options = {}) {
@@ -112,10 +112,12 @@ class GlobeView extends View {
         this.addLayer(tileLayer);
         this.tileLayer = tileLayer;
 
-        placement.coord = placement.coord || new Coordinates('EPSG:4326', 0, 0);
-        placement.tilt = placement.tilt || 89.5;
-        placement.heading = placement.heading || 0;
-        placement.range = placement.range || ellipsoidSizes.x * 2.0;
+        if (!placement.isExtent) {
+            placement.coord = placement.coord || new Coordinates('EPSG:4326', 0, 0);
+            placement.tilt = placement.tilt || 89.5;
+            placement.heading = placement.heading || 0;
+            placement.range = placement.range || ellipsoidSizes.x * 2.0;
+        }
 
         if (options.noControls) {
             CameraUtils.transformCameraToLookAtTarget(this, this.camera.camera3D, placement);

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -93,8 +93,6 @@ class Camera {
         * around.
      * @param   {Camera~CAMERA_TYPE}    [options.type=CAMERA_TYPE.PERSPECTIVE]  The type of the camera. See {@link
         * CAMERA_TYPE}.
-     * @param   {number}                [options.orthoExtent=50]                The height of the extent that a camera
-        * from type `CAMERA_TYPE.ORTHOGRAPHIC` must cover initially.
      * @constructor
      */
     constructor(crs, width, height, options = {}) {
@@ -107,19 +105,13 @@ class Camera {
         } else if (options.cameraThree) {
             this.camera3D = options.cameraThree;
         } else {
-            const orthoExtent = options.orthoExtent || 50;
-            const ratio = width / height;
-
             switch (options.type) {
                 case CAMERA_TYPE.ORTHOGRAPHIC:
-                    this.camera3D = new THREE.OrthographicCamera(
-                        orthoExtent * ratio / -2, orthoExtent * ratio / 2,
-                        orthoExtent / 2, orthoExtent / -2,
-                    );
+                    this.camera3D = new THREE.OrthographicCamera();
                     break;
                 case CAMERA_TYPE.PERSPECTIVE:
                 default:
-                    this.camera3D = new THREE.PerspectiveCamera(30, ratio);
+                    this.camera3D = new THREE.PerspectiveCamera(30);
                     break;
             }
         }

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -4,6 +4,8 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import Ellipsoid from 'Core/Math/Ellipsoid';
 import CameraUtils from 'Utils/CameraUtils';
 import DEMUtils from 'Utils/DEMUtils';
+import Camera, { CAMERA_TYPE } from 'Renderer/Camera';
+import Extent from 'Core/Geographic/Extent';
 
 function equalToFixed(value1, value2, toFixed) {
     return value1.toFixed(toFixed) === value2.toFixed(toFixed);
@@ -106,5 +108,49 @@ describe('Camera utils unit test', function () {
             assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
             assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
         });
+    });
+
+    it('should transform camera from given extent', function () {
+        view.isPlanarView = true;
+        view.isGlobeView = false;
+        const orthographicCamera = new Camera(view.referenceCrs, 60, 40, { type: CAMERA_TYPE.ORTHOGRAPHIC });
+        let camera3D = orthographicCamera.camera3D;
+
+        // let r the ratio width / height of the camera
+        // let R the ratio width / height if the extent
+
+        // case r > R (r = 1.5 and R = 0.75)
+        const subExtent = new Extent(view.referenceCrs, 0, 3, 0, 4);
+        CameraUtils.transformCameraToLookAtTarget(view, camera3D, subExtent);
+        assert.equal(
+            (camera3D.top - camera3D.bottom) / camera3D.zoom,
+            subExtent.dimensions().y,
+        );
+        assert.equal(
+            (camera3D.right - camera3D.left) / camera3D.zoom,
+            subExtent.dimensions().y * 1.5,
+        );
+
+        // case r < R (r = 1.5 and R = 2.0)
+        subExtent.set(0, 10, 0, 5);
+        CameraUtils.transformCameraToLookAtTarget(view, camera3D, subExtent);
+        assert.ok(
+            (camera3D.top - camera3D.bottom) / camera3D.zoom - subExtent.dimensions().x / 1.5 < Math.pow(10, -14),
+        );
+        assert.equal(
+            (camera3D.right - camera3D.left) / camera3D.zoom,
+            subExtent.dimensions().x,
+        );
+
+        const perspectiveCamera = new Camera(view.referenceCrs, 60, 40);
+        camera3D = perspectiveCamera.camera3D;
+
+        subExtent.set(0, 3, 0, 4);
+        CameraUtils.transformCameraToLookAtTarget(view, camera3D, subExtent);
+        camera3D.updateMatrixWorld(true);
+        assert.ok(
+            CameraUtils.getCameraTransformOptionsFromExtent(view, camera3D, subExtent).range -
+            subExtent.dimensions().y / (2 * Math.tan(THREE.Math.degToRad(camera3D.fov) / 2)) < Math.pow(10, -14),
+        );
     });
 });

--- a/test/unit/globeview.js
+++ b/test/unit/globeview.js
@@ -3,7 +3,10 @@ import assert from 'assert';
 import GlobeView from 'Core/Prefab/GlobeView';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import Coordinates from 'Core/Geographic/Coordinates';
+import Extent from 'Core/Geographic/Extent';
 import Renderer from './bootstrap';
+import CameraUtils from '../../src/Utils/CameraUtils';
+import OBB from '../../src/Renderer/OBB';
 
 function compareWithEpsilon(a, b, epsilon) {
     return a - epsilon < b && a + epsilon > b;
@@ -86,6 +89,23 @@ describe('GlobeView', function () {
         const pixels = 0.28;
         assert.ok(compareWithEpsilon(computed, pixels, 10e-4));
         assert.ok(compareWithEpsilon(computed, pixels, 10e-4));
+    });
+
+    it('should place camera at given extent', () => {
+        const extent = new Extent('EPSG:4326', 4.6315, 5.6315, 43.6756, 44.6756);
+        const extentViewer = new GlobeView(
+            renderer.domElement,
+            extent,
+            { renderer },
+        );
+        const camera3D = extentViewer.camera.camera3D;
+        const size = new THREE.Vector3();
+        new OBB().setFromExtent(extent).box3D.getSize(size);
+        assert.ok(
+            CameraUtils.getTransformCameraLookingAtTarget(extentViewer, camera3D).range -
+            size.x / (2 * Math.tan(THREE.Math.degToRad(camera3D.fov) / 2))
+            < Math.pow(10, -6),
+        );
     });
 });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add the possibility to pass an `Extent` as `params` in `CameraUtils.transformCameraToLookAtTarget(view, camera, params)` method. If so, the camera will be placed in a way that the entire given extent can be seen.
- Adapt `PlanarView` and `GlobeView` constructors so that they should be able to call `transformCameraToLookAtTarget` with an extent.
- The `pacement` parameter for `GlobeView` and the optional `options.placement` parameter for `PlanarView` can now be `Extents`.