### PR TITLE
fix(3dTile): don't overload the b3dm material.

### DIFF
--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -193,7 +193,7 @@ export default {
                                     options.overrideMaterials.isMaterial) {
                                     mesh.material = options.overrideMaterials;
                                 } else {
-                                    mesh.material = new THREE.MeshLambertMaterial({ color: 0xffffff });
+                                    mesh.material.depthWrite = true;
                                 }
                             } else if (Capabilities.isLogDepthBufferSupported()
                                         && mesh.material.isRawShaderMaterial


### PR DESCRIPTION
* don't overload the b3dm material.
* set material.depthWrite to true.

fix #1559

![chrome-capture](https://user-images.githubusercontent.com/11291849/105528064-cd347c80-5ce4-11eb-8ba5-c52db283f358.jpg)
