### PR TITLE
fix(PlanarControls): fix zoom movement with an orthographic camera

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -656,12 +656,13 @@ class View extends THREE.EventDispatcher {
     /**
      * Convert view coordinates to normalized coordinates (NDC)
      * @param {THREE.Vector2} viewCoords (in pixels, 0-0 = top-left of the View)
+     * @param {THREE.Vector2} target
      * @return {THREE.Vector2} - NDC coordinates (x and y are [-1, 1])
      */
-    viewToNormalizedCoords(viewCoords) {
-        _eventCoords.x = 2 * (viewCoords.x / this.camera.width) - 1;
-        _eventCoords.y = -2 * (viewCoords.y / this.camera.height) + 1;
-        return _eventCoords;
+    viewToNormalizedCoords(viewCoords, target = _eventCoords) {
+        target.x = 2 * (viewCoords.x / this.camera.width) - 1;
+        target.y = -2 * (viewCoords.y / this.camera.height) + 1;
+        return target;
     }
 
     /**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Correct an issue with `PlanarControl` in an orthographic camera context.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Before PR, zooming in and out with an orthographic camera in a `PlanarView` would not target cursor position. With this PR, the zoom targets cursor position.