### PR TITLE
feature(VectorTilesSource): store parsed vector tile style as class property

### DIFF
--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -63,6 +63,7 @@ class VectorTilesSource extends TMSSource {
         }
 
         this.whenReady = promise.then((style) => {
+            this.jsonStyle = style;
             const baseurl = source.sprite || style.sprite;
             if (baseurl) {
                 return Fetcher.json(`${baseurl}.json`, this.networkOptions).then((sprites) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
After `VectorTilesSource` constructor parses `source.style`, store the result in a `jsonStyle` class attribute.
Resolves issue #1520.
