### PR TITLE
refactor(Layer): Layer constructor parameter needs Source.

### DIFF
--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -11,11 +11,11 @@
  *
  * // Add layers
  * var wfsSource = new itowns.WFSSource(...);
- * var wfsLayer = new itowns.ColorLayer(wfsSource...);
+ * var wfsLayer = new itowns.ColorLayer('id_wfs', { source: wfsSource });
  * view.addLayer(wfsLayer);
  *
  * var fileSource = new itowns.FileSource(...);
- * var fileLayer = new itowns.GeometryLayer(fileSource...);
+ * var fileLayer = new itowns.GeometryLayer('id_myFile', { source: fileSource});
  * view.addLayer(fileLayer);
  *
  * FeatureToolTip.addLayer(wfsLayer);

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -273,10 +273,11 @@
                 },
             });
 
-            var wfsCartoLayer = new itowns.LabelLayer('wfsCarto', 'EPSG:3946');
-            wfsCartoLayer.crs = 'EPSG:3946';
-            wfsCartoLayer.source = wfsCartoSource;
-            wfsCartoLayer.style = wfsCartoStyle;
+            var wfsCartoLayer = new itowns.LabelLayer('wfsCarto', {
+                crs: 'EPSG:3946',
+                source: wfsCartoSource,
+                style: wfsCartoStyle,
+            });
 
             // TODO: enable this again when the stream became available
             // Search for "zone_habitat" in this page https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wfs?SERVICE=WFS&REQUEST=GetCapabilities

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -31,6 +31,7 @@ const mfogDistance = ellipsoidSizes.x * 160.0;
 
 class Atmosphere extends GeometryLayer {
     constructor(id = 'atmosphere', options = {}) {
+        options.source = false;
         super(id, new THREE.Object3D(), options);
         this.isAtmosphere = true;
 

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -46,11 +46,14 @@ class Layer extends THREE.EventDispatcher {
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
      * {@link View} that already has a layer going by that id.
-     * @param {Object} [config] - Optional configuration, all elements in it
+     * @param {Object} config - configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
-     * contains three elements `name, protocol, extent`, these elements will be
+     * contains three elements `name, extent`, these elements will be
      * available using `layer.name` or something else depending on the property
      * name.
+     * @param {Source|boolean} config.source - instantiated Source specifies data source to display.
+     * if config.source is a boolean, it can only be false. if config.source is false,
+     * the layer doesn't need Source (like debug Layer or procedural layer).
      * @param {number} [config.cacheLifeTime=Infinity] - set life time value in cache.
      * This value is used for [Cache]{@link Cache} expiration mechanism.
      *
@@ -79,6 +82,10 @@ class Layer extends THREE.EventDispatcher {
         if (config.projection) {
             console.warn('Layer projection parameter is deprecated, use crs instead.');
             config.crs = config.crs || config.projection;
+        }
+
+        if (config.source === undefined || config.source === true) {
+            throw new Error(`Layer ${id} needs Source`);
         }
         super();
         this.isLayer = true;

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -62,6 +62,7 @@ class TiledGeometryLayer extends GeometryLayer {
     constructor(id, object3d, schemeTile, builder, config) {
         // cacheLifeTime = CACHE_POLICIES.INFINITE because the cache is handled by the builder
         config.cacheLifeTime = CACHE_POLICIES.INFINITE;
+        config.source = false;
         super(id, object3d, config);
 
         this.isTiledGeometryLayer = true;

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -56,8 +56,8 @@ describe('Provide in Sources', function () {
     };
 
     const planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
-    const colorlayer = new ColorLayer('color', { crs: 'EPSG:3857' });
-    const elevationlayer = new ElevationLayer('elevation', { crs: 'EPSG:3857' });
+    const colorlayer = new ColorLayer('color', { crs: 'EPSG:3857', source: false });
+    const elevationlayer = new ElevationLayer('elevation', { crs: 'EPSG:3857', source: false });
 
     planarlayer.attach(colorlayer);
     planarlayer.attach(elevationlayer);
@@ -68,7 +68,7 @@ describe('Provide in Sources', function () {
     const nodeLayer = material.getLayer(colorlayer.id);
     const nodeLayerElevation = material.getLayer(elevationlayer.id);
 
-    const featureLayer = new GeometryLayer('geom', new THREE.Group());
+    const featureLayer = new GeometryLayer('geom', new THREE.Group(), { source: false });
     featureLayer.update = FeatureProcessing.update;
     featureLayer.crs = 'EPSG:4978';
     featureLayer.mergeFeatures = false;

--- a/test/unit/geometrylayer.js
+++ b/test/unit/geometrylayer.js
@@ -4,8 +4,8 @@ import GeometryLayer from 'Layer/GeometryLayer';
 import ColorLayer from 'Layer/ColorLayer';
 
 describe('GeometryLayer', function () {
-    const geometry = new GeometryLayer('geometry', new THREE.Group());
-    const color = new ColorLayer('color');
+    const geometry = new GeometryLayer('geometry', new THREE.Group(), { source: false });
+    const color = new ColorLayer('color', { source: false });
 
     it('should attached a color layer', function () {
         geometry.attach(color);

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -14,7 +14,7 @@ describe('LabelLayer', function () {
     let extent;
 
     before('init LabelLayer and a FeatureCollection like', function () {
-        layer = new LabelLayer('labels');
+        layer = new LabelLayer('labels', { source: false });
         layer.source = {};
         layer.style = new Style();
         layer.style.zoom = {

--- a/test/unit/layer.js
+++ b/test/unit/layer.js
@@ -4,7 +4,7 @@ import ColorLayer from 'Layer/ColorLayer';
 
 describe('Layer', function () {
     it('should emit an event on property changed', function () {
-        const layer = new Layer('testId');
+        const layer = new Layer('testId', { source: false });
         layer.defineLayerProperty('test', 0);
         layer.addEventListener('test-property-changed', (e) => {
             assert.equal(e.type, 'test-property-changed');
@@ -17,10 +17,10 @@ describe('Layer', function () {
 
 describe('ImageryLayers', function () {
     const layers = [
-        new ColorLayer('l0'),
-        new ColorLayer('l1'),
-        new ColorLayer('l2'),
-        new ColorLayer('l3'),
+        new ColorLayer('l0', { source: false }),
+        new ColorLayer('l1', { source: false }),
+        new ColorLayer('l2', { source: false }),
+        new ColorLayer('l3', { source: false }),
     ];
 
     layers[0].sequence = 0;
@@ -61,5 +61,9 @@ describe('ImageryLayers', function () {
         assert.equal(res[1], 'l1');
         assert.equal(res[2], 'l2');
         assert.equal(res[3], 'l0');
+    });
+
+    it('throws error when instance layer without Source', function () {
+        assert.throws(() => new ColorLayer('id'), /^Error: Layer id needs Source$/);
     });
 });

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -94,6 +94,7 @@ export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) 
         update: debugIdUpdate,
         visible: false,
         cacheLifeTime: Infinity,
+        source: false,
     });
 
     View.prototype.addLayer.call(view, obbLayer, _3dTileslayer).then((l) => {

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -189,6 +189,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
         update: debugIdUpdate,
         visible: false,
         cacheLifeTime: Infinity,
+        source: false,
     });
 
     View.prototype.addLayer.call(view, obbLayer, layer).then((l) => {
@@ -201,6 +202,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
         update: debugIdUpdate,
         visible: false,
         cacheLifeTime: Infinity,
+        source: false,
     });
 
     View.prototype.addLayer.call(view, sbLayer, layer).then((l) => {


### PR DESCRIPTION
## Description
If a `Layer` is instantiated without Source, it breaks asynchronous events handling (like internal fetching).
For this reason, parameter `Source` is mandatory in parameters `Layer` constructor.