### PR TITLE
fix: standardize zoom factor in PlanarControls and GlobeControls

### DIFF
--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -38,9 +38,6 @@
                     maxAltitude: 40000000,
                     // We want to keep the rotation disabled, to only have a view from the top
                     enableRotation: false,
-                    // Faster zoom in/out speed
-                    zoomInFactor: 0.5,
-                    zoomOutFactor: 0.5,
                     // Don't zoom too much on smart zoom
                     smartTravelHeightMax: 100000,
                 },

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -35,8 +35,8 @@
                 placement: new itowns.Extent('EPSG:3857', -20000000, 20000000, -8000000, 20000000),
                 controls: {
                     // Faster zoom in/out speed
-                    zoomInFactor: 1,
-                    zoomOutFactor: 0.5,
+                    zoomInFactor: 3,
+                    zoomOutFactor: 0.3,
                 },
             });
 

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -35,8 +35,7 @@
                 placement: new itowns.Extent('EPSG:3857', -20000000, 20000000, -8000000, 20000000),
                 controls: {
                     // Faster zoom in/out speed
-                    zoomInFactor: 3,
-                    zoomOutFactor: 0.3,
+                    zoomFactor: 3,
                 },
             });
 

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -84,8 +84,8 @@ const defaultOptions = {
     minPanSpeed: 0.05,
     maxPanSpeed: 15,
     zoomTravelTime: 0.2,  // must be a number
-    zoomInFactor: 0.5,
-    zoomOutFactor: 0.45,
+    zoomInFactor: 2,
+    zoomOutFactor: 0.5,
     maxAltitude: 50000000,
     groundLevel: 200,
     autoTravelTimeMin: 1.5,
@@ -132,10 +132,8 @@ export const PLANAR_CONTROL_EVENT = {
  * @param   {number}        [options.maxPanSpeed=15]            Pan speed when close to maxAltitude.
  * @param   {number}        [options.minPanSpeed=0.05]          Pan speed when close to the ground.
  * @param   {number}        [options.zoomTravelTime=0.2]        Animation time when zooming.
- * @param   {number}        [options.zoomInFactor=0.025]        Zoom movement is equal to the distance to the zoom
- * target, multiplied by this factor when zooming in.
- * @param   {number}        [options.zoomOutFactor=0.4]         Zoom movement is equal to the distance to the zoom
- * target, multiplied by this factor when zooming out.
+ * @param   {number}        [options.zoomInFactor=2]            The factor the scale is multiplied by when zooming in.
+ * @param   {number}        [options.zoomOutFactor=2]           The factor the scale is multiplied by when zooming out.
  * @param   {number}        [options.maxAltitude=12000]         Maximum altitude reachable when panning or zooming out.
  * @param   {number}        [options.groundLevel=200]           Minimum altitude reachable when panning.
  * @param   {number}        [options.autoTravelTimeMin=1.5]     Minimum duration for animated travels with the `auto`
@@ -492,7 +490,7 @@ class PlanarControls extends THREE.EventDispatcher {
         const newPos = new THREE.Vector3();
 
         if (delta > 0 || (delta < 0 && this.maxAltitude > this.camera.position.z)) {
-            const zoomFactor = delta > 0 ? this.zoomInFactor : -1 * this.zoomOutFactor;
+            const zoomFactor = delta > 0 ? this.zoomInFactor : this.zoomOutFactor;
 
             // change the camera field of view if the camera is orthographic
             if (this.camera.isOrthographicCamera) {
@@ -503,7 +501,7 @@ class PlanarControls extends THREE.EventDispatcher {
                 // camera zoom at the beginning of zoom movement
                 startZoom = this.camera.zoom;
                 // camera zoom at the end of zoom movement
-                endZoom = startZoom * (1 + zoomFactor);
+                endZoom = startZoom * zoomFactor;
                 // the altitude of the target must be the same as camera's
                 pointUnderCursor.z = this.camera.position.z;
 
@@ -515,7 +513,7 @@ class PlanarControls extends THREE.EventDispatcher {
                 newPos.lerpVectors(
                     this.camera.position,
                     pointUnderCursor,
-                    zoomFactor,
+                    (1 - 1 / zoomFactor),
                 );
                 // initiate travel
                 this.initiateTravel(

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -84,8 +84,7 @@ const defaultOptions = {
     minPanSpeed: 0.05,
     maxPanSpeed: 15,
     zoomTravelTime: 0.2,  // must be a number
-    zoomInFactor: 2,
-    zoomOutFactor: 0.5,
+    zoomFactor: 2,
     maxAltitude: 50000000,
     groundLevel: 200,
     autoTravelTimeMin: 1.5,
@@ -132,8 +131,8 @@ export const PLANAR_CONTROL_EVENT = {
  * @param   {number}        [options.maxPanSpeed=15]            Pan speed when close to maxAltitude.
  * @param   {number}        [options.minPanSpeed=0.05]          Pan speed when close to the ground.
  * @param   {number}        [options.zoomTravelTime=0.2]        Animation time when zooming.
- * @param   {number}        [options.zoomInFactor=2]            The factor the scale is multiplied by when zooming in.
- * @param   {number}        [options.zoomOutFactor=2]           The factor the scale is multiplied by when zooming out.
+ * @param   {number}        [options.zoomFactor=2]              The factor the scale is multiplied by when zooming
+ * in and divided by when zooming out. This factor can't be null.
  * @param   {number}        [options.maxAltitude=12000]         Maximum altitude reachable when panning or zooming out.
  * @param   {number}        [options.groundLevel=200]           Minimum altitude reachable when panning.
  * @param   {number}        [options.autoTravelTimeMin=1.5]     Minimum duration for animated travels with the `auto`
@@ -200,8 +199,20 @@ class PlanarControls extends THREE.EventDispatcher {
         }
 
         // zoom movement is equal to the distance to the zoom target, multiplied by zoomFactor
-        this.zoomInFactor = options.zoomInFactor || defaultOptions.zoomInFactor;
-        this.zoomOutFactor = options.zoomOutFactor || defaultOptions.zoomOutFactor;
+        if (options.zoomInFactor) {
+            console.warn('Controls zoomInFactor parameter is deprecated. Use zoomFactor instead.');
+            options.zoomFactor = options.zoomFactor || options.zoomInFactor;
+        }
+        if (options.zoomOutFactor) {
+            console.warn('Controls zoomOutFactor parameter is deprecated. Use zoomFactor instead.');
+            options.zoomFactor = options.zoomFactor || options.zoomInFactor || 1 / options.zoomOutFactor;
+        }
+        if (options.zoomFactor === 0) {
+            console.warn('Controls zoomFactor parameter can not be equal to 0. Its value will be set to default.');
+            options.zoomFactor = defaultOptions.zoomFactor;
+        }
+        this.zoomInFactor = options.zoomFactor || defaultOptions.zoomFactor;
+        this.zoomOutFactor = 1 / (options.zoomFactor || defaultOptions.zoomFactor);
 
         // approximate ground altitude value. Camera altitude is clamped above groundLevel
         this.groundLevel = options.groundLevel || defaultOptions.groundLevel;

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -152,13 +152,11 @@ describe('GlobeControls', function () {
     });
 
     it('dolly', function () {
-        controls.dollyIn(10);
+        controls.dolly(1);
         controls.state = controls.states.ORBIT;
         controls.update();
-        controls.dollyOut(10);
+        controls.dolly(-1);
         controls.state = controls.states.NONE;
-        controls.dollyOut();
-        controls.dollyIn();
     });
 
     it('mouse down + crtl', function () {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fix issue #1586 regarding inconsistent values of zoom factors for an orthographic camera and a perspective camera in a planar context.
- Refacor the zoom factor parameters both in `PlanarControls` and `GlobeControls` : the user shall now only give a single `zoomFactor` parameter instead of the previous two factors (`zoomInFactor` and `zoomOutFactor`) in planar and `zoomSpeed` in globe.

## Motivation

- Standardize code and usage between `GlobeControls` and `PlanarControls`.
- Give more relevance to the values of zoomFactor.