### PR TITLE
fix(RasterColorTile): wrong getter name.

### DIFF
--- a/src/Renderer/RasterTile.js
+++ b/src/Renderer/RasterTile.js
@@ -105,7 +105,7 @@ class RasterTile extends THREE.EventDispatcher {
 export default RasterTile;
 
 export class RasterColorTile extends RasterTile {
-    get fx() {
+    get effect() {
         return this.layer.fx;
     }
 }


### PR DESCRIPTION
`fx` was wrong `RasterColorTile` getter.
