### PR TITLE
Remove Source.extentsInsideLimit

### DIFF
--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -169,23 +169,16 @@ class LabelLayer extends Layer {
 
         if (!node.layerUpdateState[this.id].canTryUpdate()) {
             return;
+        } else if (!this.source.extentInsideLimit(node.extent, zoomDest)) {
+            node.layerUpdateState[this.id].noMoreUpdatePossible();
+            return;
         }
 
-
-        const extentsSource = [];
-        for (const extentDest of extentsDestination) {
-            const ext = this.source.crs == extentDest.crs ? extentDest : extentDest.as(this.source.crs);
-            if (!this.source.extentInsideLimit(ext)) {
-                node.layerUpdateState[this.id].noMoreUpdatePossible();
-                return;
-            }
-            extentsSource.push(extentDest);
-        }
         node.layerUpdateState[this.id].newTry();
 
         const command = {
             layer: this,
-            extentsSource,
+            extentsSource: extentsDestination,
             view: context.view,
             threejsLayer: this.threejsLayer,
             requester: node,

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -299,7 +299,7 @@ class TiledGeometryLayer extends GeometryLayer {
             if (zoom > e.zoom.max || zoom < e.zoom.min) {
                 continue;
             }
-            if (!e.frozen && e.ready && e.source.extentsInsideLimit(extents) && (!nodeLayer || nodeLayer.level < 0)) {
+            if (!e.frozen && e.ready && e.source.extentInsideLimit(node.extent, zoom) && (!nodeLayer || nodeLayer.level < 0)) {
                 // no stop subdivision in the case of a loading error
                 if (layerUpdateState[e.id] && layerUpdateState[e.id].inError()) {
                     continue;
@@ -322,7 +322,7 @@ class TiledGeometryLayer extends GeometryLayer {
                 continue;
             }
             nodeLayer = node.material.getLayer(c.id);
-            if (c.source.extentsInsideLimit(extents) && (!nodeLayer || nodeLayer.level < 0)) {
+            if (c.source.extentInsideLimit(node.extent, zoom) && (!nodeLayer || nodeLayer.level < 0)) {
                 return false;
             }
         }

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -1,9 +1,6 @@
 import Source from 'Source/Source';
 import Cache from 'Core/Scheduler/Cache';
-import Extent from 'Core/Geographic/Extent';
 import CRS from 'Core/Geographic/Crs';
-
-const ext = new Extent('EPSG:4326', [0, 0, 0, 0]);
 
 /**
  * @classdesc
@@ -150,7 +147,7 @@ class FileSource extends Source {
 
         this.whenReady.then(() => this.fetchedData);
 
-        this.zoom = source.zoom || { min: 0, max: Infinity };
+        this.zoom = { min: 0, max: Infinity };
     }
 
     urlFromExtent() {
@@ -190,10 +187,7 @@ class FileSource extends Source {
     }
 
     extentInsideLimit(extent) {
-        // Fix me => may be not
-        const localExtent = this.extent.crs == extent.crs ? extent : extent.as(this.extent.crs, ext);
-        return (extent.zoom == undefined || !(extent.zoom < this.zoom.min || extent.zoom > this.zoom.max)) &&
-            this.extent.intersectsExtent(localExtent);
+        return this.extent.intersectsExtent(extent);
     }
 }
 

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -225,22 +225,6 @@ class Source extends InformationsData {
     extentInsideLimit(extent) {
         throw new Error('In extented Source, you have to implement the method extentInsideLimit!');
     }
-
-    /**
-     * Tests if an array of extents is inside the source limits.
-     *
-     * @param {Array.<Extent>} extents - Array of extents to test.
-
-     * @return {boolean} True if all extents are inside, false otherwise.
-     */
-    extentsInsideLimit(extents) {
-        for (const extent of extents) {
-            if (!this.extentInsideLimit(extent)) {
-                return false;
-            }
-        }
-        return true;
-    }
 }
 
 export default Source;

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -1,7 +1,9 @@
 import Source from 'Source/Source';
 import URLBuilder from 'Provider/URLBuilder';
-import { globalExtentTMS } from 'Core/Geographic/Extent';
+import Extent, { globalExtentTMS } from 'Core/Geographic/Extent';
 import CRS from 'Core/Geographic/Crs';
+
+const extent = new Extent(CRS.tms_4326, 0, 0, 0);
 
 /**
  * @classdesc
@@ -20,8 +22,8 @@ import CRS from 'Core/Geographic/Crs';
  * or other system. See [this link]{@link
  * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/}
  * for more information.
- * @property {string} tileMatrixSet - Tile matrix set of the layer, used in the
- * generation of the coordinates to build the url. Default value is 'WGS84'.
+ * @property {Object} tileMatrixSetLimits - it describes the available tile for this layer
+ * @property {Object} extentSetlimits - these are the extents of the set of identical zoom tiles.
  * @property {Object} zoom - Object containing the minimum and maximum values of
  * the level, to zoom in the source.
  * @property {number} zoom.min - The minimum level of the source. Default value
@@ -38,7 +40,7 @@ import CRS from 'Core/Geographic/Crs';
  *         name: 'OpenStreetMap',
  *         url: 'http://www.openstreetmap.org/',
  *     },
- *     tileMatrixSet: 'PM',
+ *     crs: 'EPSG:3857',
  * });
  *
  * // Create the layer
@@ -78,6 +80,7 @@ class TMSSource extends Source {
         this.url = source.url;
         this.crs = CRS.formatToTms(source.crs);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;
+        this.extentSetlimits = {};
 
         if (!this.zoom) {
             if (this.tileMatrixSetLimits) {
@@ -91,7 +94,7 @@ class TMSSource extends Source {
                     max: maxZoom,
                 };
             } else {
-                this.zoom = { min: 0, max: 20 };
+                this.zoom = { min: 0, max: Infinity };
             }
         }
     }
@@ -100,16 +103,30 @@ class TMSSource extends Source {
         return URLBuilder.xyz(extent, this);
     }
 
-    extentInsideLimit(extent) {
+    onLayerAdded(options) {
+        super.onLayerAdded(options);
+        // Build extents of the set of identical zoom tiles.
+        const parent = options.out.parent;
+        // The extents crs is chosen to facilitate in raster tile process.
+        const crs = parent ? parent.extent.crs : options.out.crs;
+        if (this.tileMatrixSetLimits && !this.extentSetlimits[crs]) {
+            this.extentSetlimits[crs] = {};
+            extent.crs = this.crs;
+            for (let i = this.zoom.max; i >= this.zoom.min; i--) {
+                const tmsl = this.tileMatrixSetLimits[i];
+                const { west, north } = extent.set(i, tmsl.minTileRow, tmsl.minTileCol).as(crs);
+                const { east, south } = extent.set(i, tmsl.maxTileRow, tmsl.maxTileCol).as(crs);
+                this.extentSetlimits[crs][i] = new Extent(crs, west, east, south, north);
+            }
+        }
+    }
+
+    extentInsideLimit(extent, zoom) {
         // This layer provides data starting at level = layer.source.zoom.min
         // (the zoom.max property is used when building the url to make
         //  sure we don't use invalid levels)
-        return extent.zoom >= this.zoom.min && extent.zoom <= this.zoom.max &&
-                (this.tileMatrixSetLimits == undefined ||
-                (extent.row >= this.tileMatrixSetLimits[extent.zoom].minTileRow &&
-                    extent.row <= this.tileMatrixSetLimits[extent.zoom].maxTileRow &&
-                    extent.col >= this.tileMatrixSetLimits[extent.zoom].minTileCol &&
-                    extent.col <= this.tileMatrixSetLimits[extent.zoom].maxTileCol));
+        return zoom >= this.zoom.min && zoom <= this.zoom.max &&
+                (this.extentSetlimits[extent.crs] == undefined || this.extentSetlimits[extent.crs][zoom].intersectsExtent(extent));
     }
 }
 

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -125,7 +125,7 @@ class WFSSource extends Source {
         }&outputFormat=${this.format
         }&BBOX=%bbox,${this.crs}`;
 
-        this.zoom = source.zoom || { min: 0, max: Infinity };
+        this.zoom = { min: 0, max: Infinity };
 
         this.vendorSpecific = source.vendorSpecific;
         for (const name in this.vendorSpecific) {
@@ -162,8 +162,7 @@ class WFSSource extends Source {
     }
 
     extentInsideLimit(extent) {
-        return (extent.zoom == undefined || (extent.zoom >= this.zoom.min && extent.zoom <= this.zoom.max))
-            && this.extent.intersectsExtent(extent);
+        return this.extent.intersectsExtent(extent);
     }
 }
 

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -1,8 +1,6 @@
 import Source from 'Source/Source';
 import URLBuilder from 'Provider/URLBuilder';
-import Extent from 'Core/Geographic/Extent';
 
-const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
 /**
  * @classdesc
  * An object defining the source of images to get from a
@@ -94,7 +92,7 @@ class WMSSource extends Source {
 
         this.isWMSSource = true;
         this.name = source.name;
-        this.zoom = source.zoom || { min: 0, max: 21 };
+        this.zoom = { min: 0, max: Infinity };
         this.style = source.style || '';
 
         this.width = source.width || source.height || 256;
@@ -139,9 +137,7 @@ class WMSSource extends Source {
     }
 
     extentInsideLimit(extent) {
-        const localExtent = this.crs == extent.crs ? extent : extent.as(this.crs, _extent);
-        return (extent.zoom == undefined || !(extent.zoom < this.zoom.min || extent.zoom > this.zoom.max)) &&
-            this.extent.intersectsExtent(localExtent);
+        return this.extent.intersectsExtent(extent);
     }
 }
 

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -65,7 +65,6 @@ describe('updateLayeredMaterialNodeImagery', function () {
         };
         layer.visible = true;
 
-        source.extentsInsideLimit = () => true;
         source.extentInsideLimit = () => true;
         source.zoom = { min: 0, max: 10 };
         source.extent = { crs: 'EPSG:4326' };


### PR DESCRIPTION
## Description
`Source.extentsInsideLimit` was used for TMS Source, to check if tiles group intersects tile matrix set limits.
To replace the method by `Source.extentInsideLimit`, all extents array are reduced to one useful extent.

