### PR TITLE
fix(PlanarControls): prevent triggering new movement when already moving

### DIFF
--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -14,6 +14,7 @@ const mouseButtons = {
     MIDDLECLICK: THREE.MOUSE.MIDDLE,
     RIGHTCLICK: THREE.MOUSE.RIGHT,
 };
+let currentPressedButton;
 
 // starting camera position and orientation target
 const startPosition = new THREE.Vector3();
@@ -950,9 +951,10 @@ class PlanarControls extends THREE.EventDispatcher {
     onMouseDown(event) {
         event.preventDefault();
 
-        if (STATE.TRAVEL === this.state) {
+        if (STATE.NONE !== this.state) {
             return;
         }
+        currentPressedButton = event.button;
 
         this.updateMousePositionAndDelta(event);
 
@@ -992,7 +994,7 @@ class PlanarControls extends THREE.EventDispatcher {
     onMouseUp(event) {
         event.preventDefault();
 
-        if (STATE.TRAVEL !== this.state) {
+        if (STATE.TRAVEL !== this.state && currentPressedButton === event.button) {
             this.state = STATE.NONE;
         }
 
@@ -1023,7 +1025,7 @@ class PlanarControls extends THREE.EventDispatcher {
      * @ignore
      */
     onKeyDown(event) {
-        if (STATE.TRAVEL === this.state) {
+        if (STATE.NONE !== this.state) {
             return;
         }
         switch (event.keyCode) {

--- a/test/unit/planarControls.js
+++ b/test/unit/planarControls.js
@@ -71,6 +71,7 @@ describe('Planar Controls', function () {
         event.button = THREE.MOUSE.LEFT;
         controlsPerspective.onMouseDown(event);
         assert.equal(STATE.DRAG, controlsPerspective.state);
+        controlsPerspective.state = STATE.NONE;
     });
 
     it('ctrl + left-click should switch controls to ROTATE state, unless rotation is disabled', function () {
@@ -131,26 +132,32 @@ describe('Planar Controls', function () {
         controlsPerspective.state = STATE.TRAVEL;
         controlsPerspective.onMouseDown(event);
         assert.equal(controlsPerspective.state, STATE.TRAVEL);
+        controlsPerspective.state = STATE.NONE;
     });
 
     it('onMouseUp should switch controls to the relevant state', function () {
         // STATE.DRAG
-        controlsPerspective.state = STATE.DRAG;
+        event.button = THREE.MOUSE.LEFT;
+        controlsPerspective.onMouseDown(event);
         controlsPerspective.onMouseUp(event);
         assert.equal(STATE.NONE, controlsPerspective.state);
 
         // STATE.ROTATE
-        controlsPerspective.state = STATE.ROTATE;
+        event.ctrlKey = true;
+        controlsPerspective.onMouseDown(event);
         controlsPerspective.onMouseUp(event);
         assert.equal(STATE.NONE, controlsPerspective.state);
+        event.ctrlKey = false;
 
         // STATE.PAN
-        controlsPerspective.state = STATE.PAN;
+        event.button = THREE.MOUSE.RIGHT;
+        controlsPerspective.onMouseDown(event);
         controlsPerspective.onMouseUp(event);
         assert.equal(STATE.NONE, controlsPerspective.state);
 
         // STATE.TRAVEL
-        controlsPerspective.state = STATE.TRAVEL;
+        event.button = THREE.MOUSE.MIDDLE;
+        controlsPerspective.onMouseDown(event);
         controlsPerspective.onMouseUp(event);
         assert.equal(STATE.TRAVEL, controlsPerspective.state);
         controlsPerspective.state = STATE.NONE;


### PR DESCRIPTION
This PR fixes issue #1603, implementing the following behavior in a planar context :

- if a user triggers a second movement while already in movement, the second movement is ignored.