### PR TITLE
fix(Extent): forgetting zoom property copy, in Extent.as().

### DIFF
--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -212,6 +212,7 @@ class Extent {
             }
 
             target.crs = crs;
+            target.zoom = this.zoom;
             target.set(this.west, this.east, this.south, this.north);
 
             return target;


### PR DESCRIPTION
## Description
Fix target copy in `Extent.as` Method.
