### PR TITLE
feature(PlanarControls): add resolution interval parameters to limit zoom

### DIFF
--- a/examples/misc_orthographic_camera.html
+++ b/examples/misc_orthographic_camera.html
@@ -51,6 +51,11 @@
             const view = new itowns.PlanarView(viewerDiv, extent, {
                 camera: { type: itowns.CAMERA_TYPE.ORTHOGRAPHIC },
                 placement: new itowns.Extent('EPSG:3946', 1838000, 1842000, 5172000, 5174000),
+                controls: {
+                    // limit the zoom to a resolution interval
+                    maxResolution: 0.01,  // a pixel shall not represent a metric size smaller than 1 cm
+                    minResolution: 100, // a pixel shall not represent a metric size larger than 100m
+                }
             });
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -36,6 +36,8 @@
                 controls: {
                     // Faster zoom in/out speed
                     zoomFactor: 3,
+                    // prevent from zooming in too much
+                    maxResolution: 0.005  // a pixel shall not represent a metric size smaller than 5 mm
                 },
             });
 

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -96,6 +96,8 @@ const defaultOptions = {
     maxPanSpeed: 15,
     zoomTravelTime: 0.2,  // must be a number
     zoomFactor: 2,
+    maxResolution: 1 / Infinity,
+    minResolution: Infinity,
     maxAltitude: 50000000,
     groundLevel: 200,
     autoTravelTimeMin: 1.5,
@@ -144,6 +146,10 @@ export const PLANAR_CONTROL_EVENT = {
  * @param   {number}        [options.zoomTravelTime=0.2]        Animation time when zooming.
  * @param   {number}        [options.zoomFactor=2]              The factor the scale is multiplied by when zooming
  * in and divided by when zooming out. This factor can't be null.
+ * @param   {number}        [options.maxResolution=0]           The smallest size in meters a pixel at the center of the
+ * view can represent.
+ * @param   {number}        [options.minResolution=Infinity]    The biggest size in meters a pixel at the center of the
+ * view can represent.
  * @param   {number}        [options.maxAltitude=12000]         Maximum altitude reachable when panning or zooming out.
  * @param   {number}        [options.groundLevel=200]           Minimum altitude reachable when panning.
  * @param   {number}        [options.autoTravelTimeMin=1.5]     Minimum duration for animated travels with the `auto`
@@ -224,6 +230,10 @@ class PlanarControls extends THREE.EventDispatcher {
         }
         this.zoomInFactor = options.zoomFactor || defaultOptions.zoomFactor;
         this.zoomOutFactor = 1 / (options.zoomFactor || defaultOptions.zoomFactor);
+
+        // the maximum and minimum size (in meters) a pixel at the center of the view can represent
+        this.maxResolution = options.maxResolution || defaultOptions.maxResolution;
+        this.minResolution = options.minResolution || defaultOptions.minResolution;
 
         // approximate ground altitude value. Camera altitude is clamped above groundLevel
         this.groundLevel = options.groundLevel || defaultOptions.groundLevel;
@@ -514,6 +524,12 @@ class PlanarControls extends THREE.EventDispatcher {
 
         if (delta > 0 || (delta < 0 && this.maxAltitude > this.camera.position.z)) {
             const zoomFactor = delta > 0 ? this.zoomInFactor : this.zoomOutFactor;
+
+            // do not zoom if the resolution after the zoom is outside resolution limits
+            const endResolution = this.view.getPixelsToMeters() / zoomFactor;
+            if (this.maxResolution > endResolution || endResolution > this.minResolution) {
+                return;
+            }
 
             // change the camera field of view if the camera is orthographic
             if (this.camera.isOrthographicCamera) {

--- a/test/unit/planarControls.js
+++ b/test/unit/planarControls.js
@@ -268,6 +268,23 @@ describe('Planar Controls', function () {
         controlsOrtho.state = STATE.NONE;
     });
 
+    it('resolution limits on zoom', function () {
+        const orthoScale = viewOrtho.getPixelsToMeters();
+        controlsOrtho.minResolution = orthoScale;
+        controlsOrtho.maxResolution = orthoScale;
+
+        // wheel in
+        wheelMouse(controlsOrtho, cameraOrtho, 10);
+        // camera has not moved
+        assert.ok(cameraOrtho.position.equals(cameraInitialPosition));
+        // zoom has not changed
+        assert.equal(cameraOrtho.zoom, cameraInitialZoom);
+        // reset controls
+        controlsOrtho.minResolution = Infinity;
+        controlsOrtho.maxResolution = 0;
+        controlsOrtho.state = STATE.NONE;
+    });
+
     it('smart travel for a perspective camera', function () {
         event.button = THREE.MOUSE.MIDDLE;
 


### PR DESCRIPTION
## Description
Add maximum and minimum resolution optional parameters to `PlanarControls`.

- The `maxResolution` parameter defines the maximum resolution the view can reach -- i.e. the smallest size in meters a pixel at the center of the view can represent.
- The `minResolution` parameter defines the minimum resolution the view can reach -- i.e. the largest size in meters a pixel at the center of the view can represent.

Usage of these parameters is added in examples :

- http://www.itowns-project.org/itowns/examples/#view_2d_map where a maximum resolution limit is set to prevent from zooming in too much ;
- http://www.itowns-project.org/itowns/examples/#misc_orthographic_camera where a maximum and a minimum resolution limits are set to prevent from zooming outside a given scale interval.

## Motivation and Context
Bring a solution to issue #1611.