### PR TITLE
fix(GeojsonParser): prevent properties from being overriden

### DIFF
--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -173,10 +173,10 @@
             view.addLayer(lyonTclBusLayer);
 
             function colorBuildings(properties) {
-                if (properties.id.indexOf('bati_remarquable') === 0) {
+                if (properties.geojson.id.indexOf('bati_remarquable') === 0) {
                     return color.set(0x5555ff);
                 }
-                if (properties.id.indexOf('bati_industriel') === 0) {
+                if (properties.geojson.id.indexOf('bati_industriel') === 0) {
                     return color.set(0xff5555);
                 }
                 return color.set(0xeeeeee);

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -124,9 +124,9 @@
             view.addLayer(lyonTclBusLayer);
 
             function colorBuildings(properties) {
-                if (properties.id.indexOf('bati_remarquable') === 0) {
+                if (properties.geojson.id.indexOf('bati_remarquable') === 0) {
                     return color.set(0x5555ff);
-                } else if (properties.id.indexOf('bati_industriel') === 0) {
+                } else if (properties.geojson.id.indexOf('bati_industriel') === 0) {
                     return color.set(0xff5555);
                 }
                 return color.set(0xeeeeee);

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -136,7 +136,10 @@ function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, col
     // copy other properties
     for (const key of Object.keys(json)) {
         if (!keyProperties.includes(key.toLowerCase())) {
-            properties[key] = json[key];
+            // create `geojson` key if it does not exist yet
+            properties.geojson = properties.geojson || {};
+            // add key defined property to `geojson` property
+            properties.geojson[key] = json[key];
         }
     }
 

--- a/test/functional/source_stream_wfs_25d.js
+++ b/test/functional/source_stream_wfs_25d.js
@@ -13,7 +13,7 @@ describe('source_stream_wfs_25d', function _() {
     it('should pick the correct building', async () => {
         // test picking
         const buildingId = await page.evaluate(() => picking({ x: 97, y: 213 }));
-        assert.equal(buildingId.id, 'bati_indifferencie.5266051');
+        assert.equal(buildingId.geojson.id, 'bati_indifferencie.5266051');
     });
     it('should remove GeometryLayer', async () => {
         const countGeometryLayerStart = await page.evaluate(() => view.getLayers(l => l.isGeometryLayer).length);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As mentioned by #1406, some properties present in geojson features may also be present in those features `properties` property. In that case, the properties present in geojson features would override those appearing under the `properties` key in geojson features.

With this PR, properties that are defined in a feature and are also present in this feature `properties` property are now stored under the `geojson` property. They can thus still be stored without overriding other properties anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Closes #1406.