### PR TITLE
New fx option (-1 -> contour)

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -47,7 +47,8 @@
         "effects_postprocessing": "Post processing",
         "effects_split": "Splitted rendering",
         "effects_stereo": "Stereo effects",
-        "mars": "Mars atmosphere"
+        "mars": "Mars atmosphere",
+        "contour_render": "Contour render"
     },
 
     "Miscellaneous": {

--- a/examples/contour_render.html
+++ b/examples/contour_render.html
@@ -1,0 +1,146 @@
+<html>
+    <head>
+        <title>Itowns - Globe</title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv"></div>
+        <span id="divScaleWidget"> Scale </span>
+        <div id="miniDiv"></div>
+
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script type="text/javascript">
+            // # Simple Globe viewer
+            // Define initial camera position
+            var placement = {
+                coord: new itowns.Coordinates('EPSG:4326', 2.351323, 48.856712),
+                range: 25000000,
+            }
+            var miniView;
+            var minDistance = 10000000;
+            var maxDistance = 30000000;
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            var viewerDiv = document.getElementById('viewerDiv');
+            var miniDiv = document.getElementById('miniDiv');
+
+            // Instanciate iTowns GlobeView*
+            var view = new itowns.GlobeView(viewerDiv, placement);
+            setupLoadingScreen(viewerDiv, view);
+
+            // Dont' instance mini viewer if it's Test env
+            miniView = new itowns.GlobeView(miniDiv, placement, {
+                // `limit globe' subdivision level:
+                // we're don't need a precise globe model
+                // since the mini globe will always be seen from a far point of view (see minDistance above)
+                maxSubdivisionLevel: 2,
+                // Don't instance default controls since miniview's camera will be synced
+                // on the main view's one (see view.addFrameRequester)
+                noControls: true,
+            });
+
+            // Set a 0 alpha clear value (instead of the default '1')
+            // because we want a transparent background for the miniglobe view to be able
+            // to see the main view "behind"
+            miniView.mainLoop.gfxEngine.renderer.setClearColor(0x000000, 0);
+
+            // update miniview's camera with the view's camera position
+            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, function updateMiniView() {
+                // clamp distance camera from globe
+                var distanceCamera = view.camera.camera3D.position.length();
+                var distance = Math.min(Math.max(distanceCamera * 1.5, minDistance), maxDistance);
+                var camera = miniView.camera.camera3D;
+                var cameraTargetPosition = view.controls.getCameraTargetPosition();
+                // Update target miniview's camera
+                camera.position.copy(cameraTargetPosition).setLength(distance);
+                camera.lookAt(cameraTargetPosition);
+                miniView.notifyChange(camera);
+            });
+
+
+            // Add one imagery layer to the scene and the miniView
+            // This layer is defined in a json file but it could be defined as a plain js
+            // object. See Layer* for more info.
+            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ColorLayer('Ortho', config);
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+
+                var miniLayer = new itowns.ColorLayer('OrthoMini', config);
+                miniView.addLayer(miniLayer);
+            });
+            itowns.Fetcher.json('./layers/JSONLayers/PlanIGNV2.json').then(function _(config) {
+                config.opacity = 0.5;
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ColorLayer('PlanIGNV2', config);
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+            });
+            itowns.Fetcher.json('./layers/JSONLayers/PlanIGNV2.json').then(function _(config) {
+                console.log(config);
+                config.fx = -1.0;
+                // config.source.format = "image/png";
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ColorLayer('PlanIGNV2 Contour', config);
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+            });
+            // Add two elevation layers.
+            // These will deform iTowns globe geometry to represent terrain elevation.
+            function addElevationLayerFromConfig(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ElevationLayer(config.id, config);
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+            }
+            itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+            itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+
+            var menuGlobe = new GuiTools('menuDiv', view);
+            var divScaleWidget = document.getElementById('divScaleWidget');
+
+            function updateScaleWidget() {
+                var value = view.getPixelsToMeters(200);
+                value = Math.floor(value);
+                var digit = Math.pow(10, value.toString().length - 1);
+                value = Math.round(value / digit) * digit;
+                var pix = view.getMetersToPixels(value);
+                var unit = 'm';
+                if (value >= 1000) {
+                    value /= 1000;
+                    unit = 'km';
+                }
+                divScaleWidget.innerHTML = `${value} ${unit}`;
+                divScaleWidget.style.width = `${pix}px`;
+            }
+
+            // Listen for globe full initialisation event
+            view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
+                // eslint-disable-next-line no-console
+                console.info('Globe initialized');
+                updateScaleWidget();
+            });
+            view.controls.addEventListener(itowns.CONTROL_EVENTS.RANGE_CHANGED, () => {
+                updateScaleWidget();
+            });
+
+            const atmosphere = view.getLayerById('atmosphere');
+            atmosphere.setRealisticOn(!view.isDebugMode);
+
+            const cRL = menuGlobe.addGUI('RealisticLighting', !view.isDebugMode, function (v) {
+                atmosphere.setRealisticOn(v);
+                view.notifyChange(atmosphere);
+            });
+
+            window.addEventListener('resize', updateScaleWidget);
+
+            debug.createTileDebugUI(menuGlobe.gui, view);
+        </script>
+    </body>
+</html>

--- a/examples/layers/JSONLayers/PlanIGNV2.json
+++ b/examples/layers/JSONLayers/PlanIGNV2.json
@@ -1,0 +1,130 @@
+{
+    "id":         "PlanIGNV2",
+    "source": {
+        "crs": "EPSG:3857",
+        "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "format": "image/png",
+        "name": "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
+        "attribution" : {
+            "name":"IGN",
+            "url":"http://www.ign.fr/"
+        },
+        "tileMatrixSet": "PM",
+        "tileMatrixSetLimits": {
+            "0": {
+                "minTileRow": 0,
+                "maxTileRow": 0,
+                "minTileCol": 0,
+                "maxTileCol": 1
+            },
+            "1": {
+                "minTileRow": 0,
+                "maxTileRow": 1,
+                "minTileCol": 0,
+                "maxTileCol": 2
+            },
+            "2": {
+                "minTileRow": 0,
+                "maxTileRow": 3,
+                "minTileCol": 0,
+                "maxTileCol": 4
+            },
+            "3": {
+                "minTileRow": 0,
+                "maxTileRow": 7,
+                "minTileCol": 0,
+                "maxTileCol": 8
+            },
+            "4": {
+                "minTileRow": 0,
+                "maxTileRow": 15,
+                "minTileCol": 0,
+                "maxTileCol": 16
+            },
+            "5": {
+                "minTileRow": 0,
+                "maxTileRow": 30,
+                "minTileCol": 0,
+                "maxTileCol": 32
+            },
+            "6": {
+                "minTileRow": 0,
+                "maxTileRow": 62,
+                "minTileCol": 0,
+                "maxTileCol": 64
+            },
+            "7": {
+                "minTileRow": 0,
+                "maxTileRow": 124,
+                "minTileCol": 0,
+                "maxTileCol": 128
+            },
+            "8": {
+                "minTileRow": 85,
+                "maxTileRow": 143,
+                "minTileCol": 81,
+                "maxTileCol": 167
+            },
+            "9": {
+                "minTileRow": 170,
+                "maxTileRow": 287,
+                "minTileCol": 163,
+                "maxTileCol": 335
+            },
+            "10": {
+                "minTileRow": 340,
+                "maxTileRow": 574,
+                "minTileCol": 331,
+                "maxTileCol": 671
+            },
+            "11": {
+                "minTileRow": 681,
+                "maxTileRow": 114,
+                "minTileCol": 663,
+                "maxTileCol": 134
+            },
+            "12": {
+                "minTileRow": 1363,
+                "maxTileRow": 2298,
+                "minTileCol": 1326,
+                "maxTileCol": 2684
+            },
+            "13": {
+                "minTileRow": 2726,
+                "maxTileRow": 4596,
+                "minTileCol": 2653,
+                "maxTileCol": 5368
+            },
+            "14": {
+                "minTileRow": 5452,
+                "maxTileRow": 9204,
+                "minTileCol": 5311,
+                "maxTileCol": 1074
+            },
+            "15": {
+                "minTileRow": 10944,
+                "maxTileRow": 18381,
+                "minTileCol": 10632,
+                "maxTileCol": 21467
+            },
+            "16": {
+                "minTileRow": 21889,
+                "maxTileRow": 36763,
+                "minTileCol": 21264,
+                "maxTileCol": 42934
+            },
+            "17": {
+                "minTileRow": 43778,
+                "maxTileRow": 73526,
+                "minTileCol": 42528,
+                "maxTileCol": 85869
+            },
+            "18": {
+                "minTileRow": 87557,
+                "maxTileRow": 147052,
+                "minTileCol": 85058,
+                "maxTileCol": 171738
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Add a new option in the color layer shader to view contours (fx = -1)
- Add a new layer (PanIGNV2) in the JSONLayers folder (a PNG wmts source is needed for the example)
- Add a new example (contour_render.html)

The shader compare a pixel with its 4 neighbors (up/down/left/right), it renders red (1, 0, 0, 1) if there is differences and transparent (r, g, b, 0) otherwise. It's important to check the image limits so as not to create false contour. It's also important to only used un-interpolated color to obtain clear contours.

## Motivation and Context

This feature is necessary to display the outlines of a mosaic graph from an image containing one color per area.

## Screenshots (if appropriate)
![Capture-1](https://user-images.githubusercontent.com/15654110/114369759-01e70000-9b7f-11eb-91a4-74c999a53061.PNG)
![Capture-2](https://user-images.githubusercontent.com/15654110/114369778-07444a80-9b7f-11eb-9aa1-3bad5d20f969.PNG)
