### PR TITLE
fix(PlanarControls): prevent freezing zoom when clicking while zooming with an orthographic camera

### DIFF
--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -1037,7 +1037,13 @@ class PlanarControls extends THREE.EventDispatcher {
     onMouseUp(event) {
         event.preventDefault();
 
-        if (STATE.TRAVEL !== this.state && currentPressedButton === event.button) {
+        // Does not interrupt ongoing camera action if state is TRAVEL or CAMERA_OTHO. This prevents interrupting a zoom
+        // movement or a smart travel by pressing any movement key.
+        // The camera action is also uninterrupted if the released button does not match the button triggering the
+        // ongoing action. This prevents for instance exiting drag mode when right-clicking while dragging the view.
+        if (STATE.TRAVEL !== this.state
+            && STATE.ORTHO_ZOOM !== this.state
+            && currentPressedButton === event.button) {
             this.state = STATE.NONE;
         }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
While zooming in or out using mousewheel with an orthographic camera in a `PlanarControls` context, the zoom action is freezed if a key is released. Thus, the camera `zoom` property does not reach the final value computed while initializing the zoom action, causing inconsistency between zoom value and `zoomFactor` parameter.

To fix this, a test is performed when releasing a key : if the controls are in a `ZOOM_ORTHO` state (i.e. the camera is zooming), releasing a key has no consequences.

This issue was not present when zooming with a perspective camera. In this case, the zoom would switch the controls in `TRAVEL` state, and the test added for `ZOOM_ORTHO` state already existed for `TRAVEL` state.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Closes #1634.
