### PR TITLE
Refactor Feature and Parser

### DIFF
--- a/examples/js/plugins/CSVnVRTParser.js
+++ b/examples/js/plugins/CSVnVRTParser.js
@@ -83,6 +83,8 @@ var CSVnVRTParser = (function _() {
     }
 
     function OGRVRTLayer2Feature(layer, data, crs, options) {
+        var collection = new itowns.FeatureCollection(options.out);
+
         var _crs = (layer.LayerSRS && layer.LayerSRS.value) || crs;
 
         var type = itowns.FEATURE_TYPES.POINT;
@@ -90,7 +92,7 @@ var CSVnVRTParser = (function _() {
             type = getGeometryType(layer.GeometryType.value);
         }
 
-        var feature = new itowns.Feature(type, options.out.crs, options.out);
+        var feature = collection.requestFeatureByType(type);
 
         if (layer.Field) {
             if (!layer.Field.length) {
@@ -138,7 +140,9 @@ var CSVnVRTParser = (function _() {
             }
         }
 
-        return feature;
+        collection.updateExtent();
+
+        return collection;
     }
 
     // eslint-disable-next-line no-unused-vars
@@ -153,10 +157,7 @@ var CSVnVRTParser = (function _() {
 
     function readLayer(layer, data, options, crs) {
         if (layer.OGRVRTLayer) {
-            var collection = new itowns.FeatureCollection(options.out.crs, options.out);
-            var feature = OGRVRTLayer2Feature(layer.OGRVRTLayer, data, layer.TargetSRS.value, options);
-            collection.pushFeature(feature);
-            return collection;
+            return OGRVRTLayer2Feature(layer.OGRVRTLayer, data, layer.TargetSRS.value, options);
         } else if (layer.OGRVRTWarpedLayer) {
             return OGRVRTWarpedLayer2Feature(layer, data, options, crs);
         } else if (layer.OGRVRTUnionLayer) {

--- a/examples/js/plugins/DragNDrop.js
+++ b/examples/js/plugins/DragNDrop.js
@@ -74,8 +74,7 @@ var DragNDrop = (function _() {
                         crs: (extension.mode == _GEOMETRY ? _view.referenceCrs : _view.tileLayer.extent.crs),
                         buildExtent: true,
                         mergeFeatures: true,
-                        withNormal: (extension.mode == _GEOMETRY),
-                        withAltitude: (extension.mode == _GEOMETRY),
+                        structure: (extension.mode == _GEOMETRY ? '3d' : '2d'),
                     },
                 }).then(function _(features) {
                     var dimensions = features.extent.dimensions();

--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -64,8 +64,7 @@
                     crs: view.tileLayer.extent.crs,
                     buildExtent: true,
                     mergeFeatures: true,
-                    withNormal: false,
-                    withAltitude: false,
+                    structure: '2d',
                 }
             };
 

--- a/examples/source_file_gpx_3d.html
+++ b/examples/source_file_gpx_3d.html
@@ -74,6 +74,7 @@
                             crs: view.referenceCrs,
                             buildExtent: true,
                             mergeFeatures: true,
+                            structure: '3d',
                         }
                     }))
                     .then(collection => itowns.Feature2Mesh.convert({

--- a/src/Core/Deprecated/Undeprecator.js
+++ b/src/Core/Deprecated/Undeprecator.js
@@ -13,15 +13,25 @@ export const deprecatedParsingOptionsToNewOne = (options) => {
         newOptions.out.mergeFeatures = options.mergeFeatures;
         newOptions.out.withNormal = options.withNormal;
         newOptions.out.withAltitude = options.withAltitude;
-        newOptions.out.buildExtent = options.buildExtent;
+        if (options.out.withAltitude && options.out.withNormal) {
+            newOptions.structure = '3d';
+        } else {
+            newOptions.structure = '2d';
+        }
         newOptions.out.filteringExtent = options.filteringExtent;
         newOptions.out.style = options.style;
         newOptions.out.overrideAltitudeInToZero = options.overrideAltitudeInToZero;
         newOptions.out.filter = options.filter;
         return newOptions;
-    } else {
-        return options;
+    } else if (options.out && (options.out.withAltitude !== undefined || options.out.withNormal !== undefined)) {
+        console.warn('Parsing options out.withAltitude and out.withNormal are deprecates, use out.structure: 2d or 3d.');
+        if (options.out.withAltitude && options.out.withNormal) {
+            options.structure = '3d';
+        } else {
+            options.structure = '2d';
+        }
     }
+    return options;
 };
 
 export default {};

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import Extent from 'Core/Geographic/Extent';
 import Coordinates from 'Core/Geographic/Coordinates';
+import CRS from 'Core/Geographic/Crs';
 import Style from 'Core/Style';
 
 function defaultExtent(crs) {
@@ -275,8 +276,7 @@ export class FeatureCollection {
      */
     constructor(crs, options) {
         this.isFeatureCollection = true;
-        // TODO: Replace crs parameter by CRS.formatToEPSG(options.crs)
-        this.crs = crs;
+        this.crs = CRS.formatToEPSG(options.crs);
         this.features = [];
         this.optionsFeature = options || {};
         if (this.optionsFeature.buildExtent) {

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -216,7 +216,7 @@ class Feature {
         this.crs = crs;
         this.normals = structure3d ? [] : undefined;
         this.size = structure3d ? 3 : 2;
-        if (options.buildExtent) {
+        if (options.extent) {
             // this.crs is final crs projection, is out projection.
             // If the extent crs is the same then we use output coordinate (coordOut) to expand it.
             this.extent = defaultExtent(options.forcedExtentCrs || this.crs);
@@ -279,9 +279,7 @@ export class FeatureCollection {
         this.crs = CRS.formatToEPSG(options.crs);
         this.features = [];
         this.optionsFeature = options || {};
-        if (this.optionsFeature.buildExtent) {
-            this.extent = defaultExtent(options.forcedExtentCrs || this.crs);
-        }
+        this.extent = options.buildExtent ? defaultExtent(options.forcedExtentCrs || this.crs) : undefined;
         this.translation = new THREE.Vector3();
         this.scale = new THREE.Vector3(1, 1, 1);
     }

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -27,10 +27,9 @@ const defaultNormal = new THREE.Vector3(0, 0, 1);
  * @property {string} forcedExtentCrs - force feature extent crs if buildExtent is true.
  * @property {function} [filter] - Filter function to remove features
  * @property {boolean} [mergeFeatures=true] - If true all geometries are merged by type and multi-type
- * @property {boolean} [withNormal=true] - If true each coordinate normal is computed.
- * True if the layer inherits from {@link GeometryLayer}
- * @property {boolean} [withAltitude=true] - If true each coordinate altitude is kept
- * True if the layer inherits from {@link GeometryLayer}
+ * @property {string} [structure='2d'] - data structure type : 2d or 3d.
+ * If the structure is 3d, the feature have 3 dimensions by vertices positions and
+ * a normal for each vertices.
  * @property {boolean} [overrideAltitudeInToZero=false] - If true, the altitude of the source data isn't taken into account for 3D geometry convertions.
  * the altitude will be override to 0. This can be useful if you don't have a DEM or provide a new one when converting (with Layer.convert).
  * @property {Style} style - The style to inherit when creating
@@ -198,8 +197,9 @@ class Feature {
      * @param {string} crs Geographic or Geocentric coordinates system.
      * @param {FeatureBuildingOptions} [options={}] options to build feature.
      * @param {boolean} [options.buildExtent] Build extent and update when adding new vertice.
-     * @param {boolean} [options.withAltitude] Set vertice altitude when adding new vertice.
-     * @param {boolean} [options.withNormal] Set vertice normal when adding new vertice.
+     * @property {string} [options.structure='3d'] - data structure type : `2d` or `3d`.
+     * If the structure is `3d`, the feature have 3 dimensions by vertice position and
+     * a normal for each vertices. The structure `3d` it is adapted to convert in 3d mesh.
      * @param {Style} [options.style] The style to inherit when creating a new
      * style for this feature.
      */
@@ -209,11 +209,12 @@ class Feature {
         } else {
             throw new Error(`Unsupported Feature type: ${type}`);
         }
+        const structure3d = options.structure == '3d';
         this.geometries = [];
         this.vertices = [];
-        this.normals = options.withNormal ? [] : undefined;
         this.crs = crs;
-        this.size = options.withAltitude ? 3 : 2;
+        this.normals = structure3d ? [] : undefined;
+        this.size = structure3d ? 3 : 2;
         if (options.buildExtent) {
             // this.crs is final crs projection, is out projection.
             // If the extent crs is the same then we use output coordinate (coordOut) to expand it.

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -81,8 +81,7 @@ class ColorLayer extends RasterLayer {
 
         // Feature options
         this.buildExtent = true;
-        this.withNormal = false;
-        this.withAltitude = false;
+        this.structure = '2d';
     }
 
     /**

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -135,8 +135,7 @@ class GeometryLayer extends Layer {
 
         // Feature options
         this.filteringExtent = !this.source.isFileSource;
-        this.withNormal = true;
-        this.withAltitude = true;
+        this.structure = '3d';
     }
 
     // Attached layers expect to receive the visual representation of a

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -1,5 +1,5 @@
 import Coordinates from 'Core/Geographic/Coordinates';
-import Feature, { FeatureCollection, FEATURE_TYPES } from 'Core/Feature';
+import { FeatureCollection, FEATURE_TYPES } from 'Core/Feature';
 import Style from 'Core/Style';
 import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
 
@@ -31,9 +31,12 @@ const firstPtIsOut = (extent, aCoords, crs) => {
     return !extent.isPointInside(coord);
 };
 const toFeature = {
-    populateGeometry(crsIn, coordinates, geometry, setAltitude = true, feature) {
+    populateGeometry(crsIn, coordinates, geometry, collection, feature) {
         geometry.startSubGeometry(coordinates.length, feature);
-        const useAlti = setAltitude && typeof coordinates[0][2] == 'number';
+
+        const useAlti = !collection.overrideAltitudeInToZero &&
+                        collection.size == 3 &&
+                        typeof coordinates[0][2] == 'number';
 
         // coordinates is a list of pair [[x1, y1], [x2, y2], ..., [xn, yn]]
         for (const pair of coordinates) {
@@ -43,23 +46,23 @@ const toFeature = {
         }
         geometry.updateExtent();
     },
-    point(feature, crsIn, coordsIn, filteringExtent, setAltitude, properties) {
-        this.default(feature, crsIn, [coordsIn], filteringExtent, setAltitude, properties);
+    point(feature, crsIn, coordsIn, collection, properties) {
+        this.default(feature, crsIn, [coordsIn], collection, properties);
     },
-    default(feature, crsIn, coordsIn, filteringExtent, setAltitude, properties) {
-        if (filteringExtent && firstPtIsOut(filteringExtent, coordsIn, crsIn)) {
+    default(feature, crsIn, coordsIn, collection, properties) {
+        if (collection.filterExtent && firstPtIsOut(collection.filterExtent, coordsIn, crsIn)) {
             return;
         }
 
         const geometry = feature.bindNewGeometry();
         geometry.properties = properties;
         geometry.properties.style = new Style({}, feature.style).setFromGeojsonProperties(properties, feature.type);
-        this.populateGeometry(crsIn, coordsIn, geometry, setAltitude, feature);
+        this.populateGeometry(crsIn, coordsIn, geometry, collection, feature);
         feature.updateExtent(geometry);
     },
-    polygon(feature, crsIn, coordsIn, filteringExtent, setAltitude, properties) {
+    polygon(feature, crsIn, coordsIn, collection, properties) {
         // filtering
-        if (filteringExtent && firstPtIsOut(filteringExtent, coordsIn[0], crsIn)) {
+        if (collection.filterExtent && firstPtIsOut(collection.filterExtent, coordsIn[0], crsIn)) {
             return;
         }
         const geometry = feature.bindNewGeometry();
@@ -68,33 +71,33 @@ const toFeature = {
 
         // Then read contour and holes
         for (let i = 0; i < coordsIn.length; i++) {
-            this.populateGeometry(crsIn, coordsIn[i], geometry, setAltitude, feature);
+            this.populateGeometry(crsIn, coordsIn[i], geometry, collection, feature);
         }
         feature.updateExtent(geometry);
     },
-    multi(type, feature, crsIn, coordsIn, filteringExtent, setAltitude, properties) {
+    multi(type, feature, crsIn, coordsIn, collection, properties) {
         for (const coords of coordsIn) {
-            this[type](feature, crsIn, coords, filteringExtent, setAltitude, properties);
+            this[type](feature, crsIn, coords, collection, properties);
         }
     },
 };
 
-function coordinatesToFeature(type, feature, crsIn, coordinates, filteringExtent, setAltitude, properties) {
+function coordinatesToFeature(type, feature, crsIn, coordinates, collection, properties) {
     if (coordinates.length == 0) {
         return;
     }
     switch (type) {
         case 'point':
         case 'linestring':
-            return toFeature.default(feature, crsIn, coordinates, filteringExtent, setAltitude, properties);
+            return toFeature.default(feature, crsIn, coordinates, collection, properties);
         case 'multipoint':
-            return toFeature.multi('point', feature, crsIn, coordinates, filteringExtent, setAltitude, properties);
+            return toFeature.multi('point', feature, crsIn, coordinates, collection, properties);
         case 'multilinestring':
-            return toFeature.multi('default', feature, crsIn, coordinates, filteringExtent, setAltitude, properties);
+            return toFeature.multi('default', feature, crsIn, coordinates, collection, properties);
         case 'polygon':
-            return toFeature.polygon(feature, crsIn, coordinates, filteringExtent, setAltitude, properties);
+            return toFeature.polygon(feature, crsIn, coordinates, collection, properties);
         case 'multipolygon':
-            return toFeature.multi('polygon', feature, crsIn, coordinates, filteringExtent, setAltitude, properties);
+            return toFeature.multi('polygon', feature, crsIn, coordinates, collection, properties);
         case 'geometrycollection':
         default:
             throw new Error(`Unhandled geojson type ${feature.type}`);
@@ -120,17 +123,11 @@ function toFeatureType(jsonType) {
 
 const keyProperties = ['type', 'geometry', 'properties'];
 
-function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, collection) {
-    if (options.filter && !options.filter(json.properties, json.geometry)) {
-        return;
-    }
-
+function jsonFeatureToFeature(crsIn, json, collection) {
     const jsonType = json.geometry.type.toLowerCase();
     const featureType = toFeatureType(jsonType);
-    const feature = options.mergeFeatures ? collection.requestFeatureByType(featureType) : new Feature(featureType, crsOut, options);
-    const geometryCount = feature.geometryCount;
+    const feature = collection.requestFeatureByType(featureType);
     const coordinates = jsonType != 'point' ? json.geometry.coordinates : [json.geometry.coordinates];
-    const setAltitude = !options.overrideAltitudeInToZero && options.structure == '3d';
     const properties = json.properties || {};
 
     // copy other properties
@@ -143,29 +140,24 @@ function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, col
         }
     }
 
-    coordinatesToFeature(jsonType, feature, crsIn, coordinates, filteringExtent, setAltitude, properties);
-
-    if (feature.geometryCount == geometryCount) {
-        return;
-    }
+    coordinatesToFeature(jsonType, feature, crsIn, coordinates, collection, properties);
 
     return feature;
 }
 
-function jsonFeaturesToFeatures(crsIn, crsOut, jsonFeatures, filteringExtent, options) {
-    const collection = new FeatureCollection(crsOut, options);
+function jsonFeaturesToFeatures(crsIn, jsonFeatures, options) {
+    const collection = new FeatureCollection(options);
+
+    const filter = options.filter || (() => true);
 
     for (const jsonFeature of jsonFeatures) {
-        const feature = jsonFeatureToFeature(crsIn, crsOut, jsonFeature, filteringExtent, options, collection);
-        if (feature && !options.mergeFeatures) {
-            collection.pushFeature(feature);
+        if (filter(jsonFeature.properties, jsonFeature.geometry)) {
+            jsonFeatureToFeature(crsIn, jsonFeature, collection);
         }
     }
 
-    if (options.mergeFeatures) {
-        collection.removeEmptyFeature();
-        collection.updateExtent();
-    }
+    collection.removeEmptyFeature();
+    collection.updateExtent();
 
     return collection;
 }
@@ -198,23 +190,20 @@ export default {
         }
 
         _in.crs = _in.crs || readCRS(json);
-        out.mergeFeatures = out.mergeFeatures == undefined ? true : out.mergeFeatures;
-        out.structure = out.structure == undefined ? '3d' : out.structure;
 
-        let filteringExtent;
         if (out.filteringExtent) {
             if (typeof out.filteringExtent == 'boolean') {
-                filteringExtent = json.extent.as(_in.crs);
+                out.filterExtent = json.extent.as(_in.crs);
             } else if (out.filteringExtent.isExtent) {
-                filteringExtent = out.filteringExtent;
+                out.filterExtent = out.filteringExtent;
             }
         }
 
         switch (json.type.toLowerCase()) {
             case 'featurecollection':
-                return Promise.resolve(jsonFeaturesToFeatures(_in.crs, out.crs, json.features, filteringExtent, out));
+                return Promise.resolve(jsonFeaturesToFeatures(_in.crs, json.features, out));
             case 'feature':
-                return Promise.resolve(jsonFeaturesToFeatures(_in.crs, out.crs, [json], filteringExtent, out));
+                return Promise.resolve(jsonFeaturesToFeatures(_in.crs, [json], out));
             default:
                 throw new Error(`Unsupported GeoJSON type: '${json.type}`);
         }

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -130,7 +130,7 @@ function jsonFeatureToFeature(crsIn, crsOut, json, filteringExtent, options, col
     const feature = options.mergeFeatures ? collection.requestFeatureByType(featureType) : new Feature(featureType, crsOut, options);
     const geometryCount = feature.geometryCount;
     const coordinates = jsonType != 'point' ? json.geometry.coordinates : [json.geometry.coordinates];
-    const setAltitude = !options.overrideAltitudeInToZero && options.withAltitude;
+    const setAltitude = !options.overrideAltitudeInToZero && options.structure == '3d';
     const properties = json.properties || {};
 
     // copy other properties
@@ -199,8 +199,7 @@ export default {
 
         _in.crs = _in.crs || readCRS(json);
         out.mergeFeatures = out.mergeFeatures == undefined ? true : out.mergeFeatures;
-        out.withNormal = out.withNormal == undefined ? true : out.withNormal;
-        out.withAltitude = out.withAltitude == undefined ? true : out.withAltitude;
+        out.structure = out.structure == undefined ? '3d' : out.structure;
 
         let filteringExtent;
         if (out.filteringExtent) {

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -110,8 +110,7 @@ function readPBF(file, options) {
 
     options.out.buildExtent = true;
     options.out.mergeFeatures = true;
-    options.out.withAltitude = false;
-    options.out.withNormal = false;
+    options.out.structure = '2d';
 
     const collection = new FeatureCollection('EPSG:3857', options.out);
 

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -112,7 +112,7 @@ function readPBF(file, options) {
     options.out.mergeFeatures = true;
     options.out.structure = '2d';
 
-    const collection = new FeatureCollection('EPSG:3857', options.out);
+    const collection = new FeatureCollection(options.out);
 
     const vFeature = vectorTile.layers[sourceLayers[0]];
     // TODO: verify if size is correct because is computed with only one feature (vFeature).

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -84,8 +84,7 @@ import CRS from 'Core/Geographic/Crs';
      *             crs: view.tileLayer.extent.crs,
      *             buildExtent: true,
      *             mergeFeatures: true,
-     *             withNormal: false,
-     *             withAltitude: false,
+     *             structure: '2d',
  *             },
  *         });
  *     }).then(function _(features) {

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -4,8 +4,7 @@ import Coordinates from 'Core/Geographic/Coordinates';
 
 describe('Feature', function () {
     const options_A = {
-        withNormal: true,
-        withAltitude: true,
+        structure: '3d',
         buildExtent: true,
     };
 

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -1,11 +1,12 @@
 import assert from 'assert';
-import Feature, { FEATURE_TYPES } from 'Core/Feature';
+import Feature, { FeatureCollection, FEATURE_TYPES } from 'Core/Feature';
 import Coordinates from 'Core/Geographic/Coordinates';
 
 describe('Feature', function () {
     const options_A = {
         structure: '3d',
         buildExtent: true,
+        crs: 'EPSG:4326',
     };
 
     const coord = new Coordinates('EPSG:4326', 0, 0, 0);
@@ -26,8 +27,11 @@ describe('Feature', function () {
     });
 
     it('Should instance Features with options', function () {
-        const featureLine_A = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326', options_A);
-        const featureLine_B = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');
+        const collection_A = new FeatureCollection(options_A);
+        const collection_B = new FeatureCollection({ crs: 'EPSG:4326' });
+
+        const featureLine_A = collection_A.requestFeatureByType(FEATURE_TYPES.LINE);
+        const featureLine_B = collection_B.requestFeatureByType(FEATURE_TYPES.LINE);
 
         assert.equal(featureLine_A.size, 3);
         assert.ok(featureLine_A.normals);
@@ -39,7 +43,9 @@ describe('Feature', function () {
     });
 
     it('Should push Coordinates in Feature Geometry', function () {
-        const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:3857', options_A);
+        const collection_A = new FeatureCollection({ crs: 'EPSG:3857', buildExtent: true, structure: '3d' });
+
+        const featureLine = collection_A.requestFeatureByType(FEATURE_TYPES.LINE);
         const geometry = featureLine.bindNewGeometry();
 
         coord.setFromValues(-10, -10, 0);

--- a/test/unit/feature2mesh.js
+++ b/test/unit/feature2mesh.js
@@ -27,8 +27,8 @@ function computeAreaOfMesh(mesh) {
 }
 
 describe('Feature2Mesh', function () {
-    const parsed = GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false } });
-    const parsed2 = GeoJsonParser.parse(geojson2, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false } });
+    const parsed = GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false, structure: '3d' } });
+    const parsed2 = GeoJsonParser.parse(geojson2, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false, structure: '3d' } });
 
     it('rect mesh area should match geometry extent', () =>
         parsed.then((collection) => {

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -7,7 +7,7 @@ import { FEATURE_TYPES } from 'Core/Feature';
 const geojson = require('../data/geojson/simple.geojson.json');
 
 describe('FeaturesUtils', function () {
-    const options = { out: { crs: 'EPSG:4326', buildExtent: true, mergeFeatures: false, withAltitude: false, withNormal: false } };
+    const options = { out: { crs: 'EPSG:4326', buildExtent: true, mergeFeatures: false, structure: '3d' } };
     const promise = GeoJsonParser.parse(geojson, options);
     it('should correctly parse geojson', () =>
         promise.then((collection) => {

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -62,28 +62,17 @@ describe('GeoJsonParser', function () {
         }).then((collection) => {
             assert.ok(collection.features.length == 3);
         }));
-    it('should return an collection without altitude', () =>
+    it('should return an collection without altitude and normal', () =>
         GeoJsonParser.parse(holes, {
             in: {
                 crs: 'EPSG:3946',
             },
             out: {
                 crs: 'EPSG:3946',
-                withAltitude: false,
+                structure: '2d',
             },
         }).then((collection) => {
             assert.ok(collection.features[0].vertices.length == 32);
-        }));
-    it('should return an collection without normal', () =>
-        GeoJsonParser.parse(holes, {
-            in: {
-                crs: 'EPSG:3946',
-            },
-            out: {
-                crs: 'EPSG:3946',
-                withNormal: false,
-            },
-        }).then((collection) => {
             assert.ok(collection.features[0].normals == undefined);
         }));
 

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -11,7 +11,7 @@ proj4.defs('EPSG:3946',
     '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 function parse(geojson) {
-    return GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true } });
+    return GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, structure: '3d' } });
 }
 
 describe('GeoJsonParser', function () {

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -23,7 +23,7 @@ describe('LabelLayer', function () {
         };
         layer.style.text.field = 'content';
 
-        collection = new FeatureCollection('EPSG:4326', { crs: 'EPSG:4326', buildExtent: true });
+        collection = new FeatureCollection({ crs: 'EPSG:4326', buildExtent: true });
         const feature = collection.requestFeatureByType(FEATURE_TYPES.POINT);
         const geometry = feature.bindNewGeometry();
         geometry.startSubGeometry(0, feature);

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -234,7 +234,7 @@ describe('Sources', function () {
             assert.ok(source.fetchedData);
             assert.ok(source.isFileSource);
 
-            const layer = new Layer('09-ariege', { crs: 'EPSG:4326', source, withAltitude: false });
+            const layer = new Layer('09-ariege', { crs: 'EPSG:4326', source, structure: '2d' });
             layer.source.onLayerAdded({ out: layer });
 
             layer.whenReady.then(() => {

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -18,6 +18,9 @@ describe('Vector tiles', function () {
                 layers,
                 styles: [[]],
             },
+            out: {
+                crs: 'EPSG:3857',
+            },
         });
     }
 


### PR DESCRIPTION
## Description
* replace parsing options `withNormal` and `withAltitude` by `structure`.
* simplify build extent check in `Feature`.
* normalize crs projection `FeatureCollection`.
* remove `optionsFeature` from `FeatureCollection`.
* simplify  `FeatureCollection` and `Feature` constructor.

## BREAKING CHANGE

`FeatureCollection` and `Feature` signature constructor are changed.

## DEPRECATED

Parsing options `withNormal` and `withAltitude` are deprecated, use `structure` (`2d` or `3d`) instead of.



