### PR TITLE
fix(Coordinates): rounds coordinates to prevent passing Infinite numbers to proj4

### DIFF
--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -230,7 +230,9 @@ class Coordinates {
                 this.y = THREE.MathUtils.clamp(this.y, -89.999999, 89.999999);
             }
 
-            target.setFromArray(proj4cache(this.crs, crs).forward([this.x, this.y, this.z]));
+            target.setFromArray(proj4cache(this.crs, crs).forward(
+                [this.x, this.y, this.z].map(coord => parseFloat(coord.toFixed(10))),
+            ));
         }
 
         target.crs = crs;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Rounds coordinates that are passed to proj4 when using transformation from one CRS to another. This prevents having infinite number error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Closes #1537.
