### PR TITLE
fix(CameraUtils): the camera rotation animation take the shortest angle

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -31,7 +31,7 @@
             var cameraCoord = new itowns.Coordinates('EPSG:3946', 1841980,
                 5175682, 3000)
             var view = new itowns.PlanarView(viewerDiv, extent, { placement: {
-                coord: cameraCoord, heading: -30, range: 4000, tilt: 30 } });
+                coord: cameraCoord, heading: 30, range: 4000, tilt: 30 } });
 
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/3dtiles_batch_table.html
+++ b/examples/3dtiles_batch_table.html
@@ -29,7 +29,7 @@
                 coord: new itowns.Coordinates('EPSG:4326', -75.61349, 40.044259),
                 range: 200,
                 tilt: 10,
-                heading: -145
+                heading: 145,
             };
 
             var viewerDiv = document.getElementById('viewerDiv');

--- a/examples/misc_camera_animation.html
+++ b/examples/misc_camera_animation.html
@@ -47,14 +47,14 @@
             atmosphere.setRealisticOn(true);
 
             pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 2.0889, 42.809), range: 100000, time: time * 0.2 });
-            pathTravel.push({ range: 13932, time: time * 0.2, tilt: 7.59, heading: -110.9 });
+            pathTravel.push({ range: 13932, time: time * 0.2, tilt: 7.59, heading: 110.9 });
             pathTravel.push({ tilt: 8, time: time * 0.2 });
-            pathTravel.push({ range: 70000, time: time * 0.2, tilt: 5, heading: -90 });
-            pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 7.0193, 43.991), tilt: 11.5, heading: -127.211, time: time });
+            pathTravel.push({ range: 70000, time: time * 0.2, tilt: 5, heading: 90 });
+            pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 7.0193, 43.991), tilt: 11.5, heading: 127.211, time: time });
             pathTravel.push({ range: 10414, time: time * 0.2 });
             pathTravel.push({ tilt: 8, time: time * 0.2 });
-            pathTravel.push({ range: 60000, heading: 40, time: time * 0.2 });
-            pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 9.114, 41.973), tilt: 15.92, heading: -13.18, time: time });
+            pathTravel.push({ range: 60000, heading: -40, time: time * 0.2 });
+            pathTravel.push({ coord: new itowns.Coordinates('EPSG:4326', 9.114, 41.973), tilt: 15.92, heading: 13.18, time: time });
             pathTravel.push({ range: 16601, time: time * 0.2 });
 
             function addLayerCb(layer) {

--- a/examples/source_file_gpx_raster.html
+++ b/examples/source_file_gpx_raster.html
@@ -24,7 +24,7 @@
                 coord: new itowns.Coordinates('EPSG:4326', 0.089, 42.8989),
                 range: 30000,
                 tilt: 20,
-                heading: 70,
+                heading: -70,
             }
 
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -56,7 +56,7 @@
             view = new itowns.PlanarView(viewerDiv, extent, {
                 placement: {
                     coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0),
-                    heading: -45,
+                    heading: 45,
                     range: 1800,
                     tilt: 30,
                 }

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -53,7 +53,7 @@
             viewerDiv = document.getElementById('viewerDiv');
 
             // Instanciate PlanarView*
-            view = new itowns.PlanarView(viewerDiv, extent, { placement: { heading: -49.6, range: 6200, tilt: 17 } });
+            view = new itowns.PlanarView(viewerDiv, extent, { placement: { heading: 49.6, range: 6200, tilt: 17 } });
             setupLoadingScreen(viewerDiv, view);
 
             // Add a WMS imagery source

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -215,6 +215,12 @@ class CameraRig extends THREE.Object3D {
 
         this.addPlaceTargetOnGround(view, camera, params.coord, factor);
         this.end.applyParams(view, params);
+        // compute the angle along z-axis between the starting position and the end position
+        const difference = this.end.target.rotation.z - this.start.target.rotation.z;
+        // if that angle is superior to 180°, recompute the rotation as the complementary angle.
+        if (Math.abs(difference) > Math.PI) {
+            this.end.target.rotation.z = this.start.target.rotation.z + difference - Math.sign(difference) * 2 * Math.PI;
+        }
 
         animations.push(new TWEEN.Tween(factor, tweenGroup).to({ t: 1 }, time)
             .easing(params.easing)

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -163,7 +163,7 @@ class CameraRig extends THREE.Object3D {
             this.target.rotation.x = THREE.MathUtils.degToRad(params.tilt);
         }
         if (params.heading != undefined) {
-            this.target.rotation.z = THREE.MathUtils.degToRad(wrapTo180(params.heading + 180));
+            this.target.rotation.z = THREE.MathUtils.degToRad(-wrapTo180(params.heading + 180));
         }
         if (params.range) {
             this.camera.position.set(0, params.range, 0);
@@ -313,7 +313,7 @@ class CameraRig extends THREE.Object3D {
 
     get tilt() { return THREE.MathUtils.radToDeg(this.target.rotation.x); }
 
-    get heading() { return wrapTo180((THREE.MathUtils.radToDeg(this.target.rotation.z) + 180)); }
+    get heading() { return -wrapTo180((THREE.MathUtils.radToDeg(this.target.rotation.z) + 180)); }
 
     get range() { return this.camera.position.y; }
 }

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -150,7 +150,7 @@ class CameraRig extends THREE.Object3D {
         const range = this.camera.position.length();
         this.target.rotation.x = Math.asin(this.camera.position.z / range);
         const cosPlanXY = THREE.MathUtils.clamp(this.camera.position.y / (Math.cos(this.target.rotation.x) * range), -1, 1);
-        this.target.rotation.z = Math.sign(-this.camera.position.x) * Math.acos(cosPlanXY);
+        this.target.rotation.z = Math.sign(-this.camera.position.x || 1) * Math.acos(cosPlanXY);
         this.camera.position.set(0, range, 0);
     }
 

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -149,7 +149,7 @@ describe('GlobeControls with globe example', function _() {
         const mouse = page.mouse;
         await mouse.move(middleWidth, middleHeight, { steps: 20 });
         await mouse.down();
-        await mouse.move((middleWidth) - 50, (middleHeight), { steps: 10 });
+        await mouse.move((middleWidth) + 50, (middleHeight), { steps: 10 });
         await mouse.up();
         await page.keyboard.up('Control');
         const endHeading = await page.evaluate(() => view.controls.getHeading());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Change the direction with which headings are counted : from anti-clockwise to clockwise (as navigation headings).
- Fix `CameraUtils` method  `animateCameraToLookAtTarget`. The animation when rotating the camera (by changing its heading) is now such as the rotation angle is the smallest possible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Before this PR, if one wanted to rotate the camera from heading 10° to heading 350°, the animation would rotate clockwise by almost a complete turn around (340°). With this PR, the animation shall rotate of only 20° counter-clockwise.

This PR closes #1517.

## BREAKING CHANGE
This PR introduces a breaking change : the given headings must now be counted clockwise. For instance, setting a heading to `90°` will now move the camera toward East instead of previously moving it toward West.