### PR TITLE
fix(FeatureToolTip): avoid undefined layer on move.

### DIFF
--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -48,6 +48,9 @@ var FeatureToolTip = (function _() {
             }
 
             layer = layers[layersId.indexOf(layerId)];
+            if (!layer) {
+                continue;
+            }
             if (typeof layer.options.filterGeometries == 'function') {
                 features[layerId] = layer.options.filterGeometries(features[layerId], layer.layer) || [];
             }


### PR DESCRIPTION
## Description
Avoid `undefined` layer on mouse move.
