### PR TITLE
refactor(Feature): FeatureCollection extends by Object3D and use local Matrix

### DIFF
--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -86,7 +86,9 @@ class LabelLayer extends Layer {
                 // NOTE: this only works because only POINT is supported, it
                 // needs more work for LINE and POLYGON
                 coord.setFromArray(f.vertices, g.size * g.indices[0].offset);
-                data.transformCoordinates(coord);
+                // Transform coordinate to data.crs projection
+                coord.applyMatrix4(data.matrixWorld);
+
                 if (f.size == 2) { coord.z = 0; }
                 if (!_extent.isPointInside(coord)) { return; }
 

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -118,8 +118,10 @@ function readPBF(file, options) {
     // TODO: verify if size is correct because is computed with only one feature (vFeature).
     const size = vFeature.extent * 2 ** z;
     const center = -0.5 * size;
-    collection.scale.set(size, -size, 1).divide(globalExtent);
-    collection.translation.set(-(vFeature.extent * x + center), -(vFeature.extent * y + center), 0).divide(collection.scale);
+
+    collection.scale.set(globalExtent.x / size, -globalExtent.y / size, 1);
+    collection.position.set(vFeature.extent * x + center, vFeature.extent * y + center, 0).multiply(collection.scale);
+    collection.updateMatrixWorld();
 
     sourceLayers.forEach((layer_id) => {
         if (!options.in.layers[layer_id]) { return; }
@@ -154,6 +156,7 @@ function readPBF(file, options) {
     // TODO verify if is needed to updateExtent for previous features.
     collection.updateExtent();
     collection.extent = file.extent;
+    collection.isInverted = options.in.isInverted;
     return Promise.resolve(collection);
 }
 

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -166,7 +166,12 @@ class FileSource extends Source {
             this._featuresCaches[options.out.crs].setByArray(features, [0]);
         }
         features.then((data) => {
-            this.extent = data.extent;
+            if (data.extent) {
+                this.extent = data.extent.clone();
+                // Transform local extent to data.crs projection.
+                this.extent.applyMatrix4(data.matrixWorld);
+            }
+
             if (data.isFeatureCollection) {
                 data.setParentStyle(options.out.style);
             }

--- a/test/unit/coordinate.js
+++ b/test/unit/coordinate.js
@@ -1,4 +1,5 @@
 import proj4 from 'proj4';
+import { Vector3, Matrix4, Quaternion } from 'three';
 import assert from 'assert';
 import Coordinates from 'Core/Geographic/Coordinates';
 
@@ -80,5 +81,20 @@ describe('Coordinates', function () {
         assert.equal(0, normal0.x);
         assert.equal(0, normal0.y);
         assert.equal(1, normal0.z);
+    });
+
+    it('should correctly apply Matrix4', function () {
+        const coord0 = new Coordinates('EPSG:3946', 1, 1);
+
+        const position = new Vector3(1, 2, 0);
+        const scale = new Vector3(2, 3, 1);
+        const quaternion = new Quaternion();
+        const matrix = new Matrix4().compose(position, quaternion, scale);
+
+        coord0.applyMatrix4(matrix);
+
+        assertFloatEqual(coord0.x, 3);
+        assertFloatEqual(coord0.y, 5);
+        assertFloatEqual(coord0.z, 0);
     });
 });

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { Box3, Vector3 } from 'three';
+import { Box3, Vector3, Matrix4, Quaternion } from 'three';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 import CRS from 'Core/Geographic/Crs';
@@ -290,11 +290,16 @@ describe('Extent', function () {
     it('should copy and transform extent', function () {
         const withValues = new Extent('EPSG:4326', [0, 0, 0, 0]);
         const extent = new Extent('EPSG:4326', [minX + 1, maxX - 1, maxY - 1, maxY + 2]);
-        withValues.transformedCopy({ x: 1, y: 2 }, { x: 2, y: -2 }, extent);
-        assert.equal(4, withValues.west);
-        assert.equal(20, withValues.east);
-        assert.equal(-14, withValues.south);
-        assert.equal(-8, withValues.north);
+        const position = new Vector3(1, 2, 0);
+        const scale = new Vector3(2, -2, 1);
+        const quaternion = new Quaternion();
+        const matrix = new Matrix4().compose(position, quaternion, scale);
+
+        withValues.copy(extent).applyMatrix4(matrix);
+        assert.equal(3, withValues.west);
+        assert.equal(19, withValues.east);
+        assert.equal(-8, withValues.south);
+        assert.equal(-2, withValues.north);
     });
 
     it('should get the right center for extrem cases', function () {

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -1,3 +1,4 @@
+import { Matrix4 } from 'three';
 import assert from 'assert';
 import Source from 'Source/Source';
 import Layer from 'Layer/Layer';
@@ -248,12 +249,12 @@ describe('Sources', function () {
         });
 
         it('should instance and use FileSource with features', function () {
+            const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
             const source = new FileSource({
-                features: { foo: 'bar', crs: 'EPSG:4326' },
+                features: { foo: 'bar', crs: 'EPSG:4326', extent, matrixWorld: new Matrix4() },
                 crs: 'EPSG:4326',
             });
             source.onLayerAdded({ out: { crs: source.crs } });
-            const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
             assert.ok(source.urlFromExtent(extent).startsWith('fake-file-url'));
             assert.ok(!source.fetchedData);
 


### PR DESCRIPTION
## Description
`FeatureCollection` uses local transform matrix. All data needs to be transformed to be  in `crs` projection.

The data (`extent` or `Coordinates`) are stored in a local system.
To use `Feature` vertices or `FeatureCollection/Feature` extent in crs projection,
it's necessary to apply `FeatureCollection.matrixWorld` on feature `Coordinates` or `Extent`.

## BREACKING CHANGES:
FeatureCollection/Feature/FeatureGeometry use local transform matrix.

## Motivation and Context
This PR makes the `FeatureCollection` transformations consistent. They are compatible with THREE js transformations.

In `Feature2Texture` the transformation of feature vertices to coordinates texture uses these transformation matrices.  It will be easier to switch from 2d canvas to 3d canvas.