### PR TITLE
feature: add support to reassign all controls bindings in `GlobeView`

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -58,7 +58,8 @@
         "misc_camera_animation": "Camera animation",
         "misc_compare_25d_3d": "Compare 2.5D and 3D maps",
         "misc_georeferenced_images": "Georeferenced image",
-        "misc_orthographic_camera": "Orthographic camera"
+        "misc_orthographic_camera": "Orthographic camera",
+        "misc_custom_controls": "Define custom controls"
     },
 
     "Plugins": {

--- a/examples/misc_custom_controls.html
+++ b/examples/misc_custom_controls.html
@@ -1,0 +1,96 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Itowns - Custom controls</title>
+
+    <link rel="stylesheet" type="text/css" href="css/example.css">
+    <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+</head>
+<body>
+<div id="description">
+    Key bindings
+    <ul>
+        <li>Left-click + drag : rotate the globe</li>
+        <li>Wheel-click + drag : rotate the camera around its target</li>
+        <li>Ctrl + left-click + drag : rotate the camera around its position</li>
+        <li>Mouse wheel up/down : zoom in/out</li>
+        <li>Double left-click : zoom in</li>
+        <li>Double right-click : zoom out</li>
+        <li>Right-click + drag up/down : zoom in/out</li>
+    </ul>
+</div>
+<div id="viewerDiv"></div>
+
+<script src="../dist/itowns.js"></script>
+<script src="../dist/debug.js"></script>
+<script src="js/GUI/LoadingScreen.js"></script>
+<script src="js/GUI/GuiTools.js"></script>
+<script type="text/javascript">
+    /* global itowns, setupLoadingScreen, GuiTools, debug */
+
+    const viewerDiv = document.getElementById('viewerDiv');
+    const placement = {
+        coord: new itowns.Coordinates('EPSG:4326', 2.351323, 48.856712),
+        range: 25000000,
+    }
+    const view = new itowns.GlobeView(viewerDiv, placement);
+    setupLoadingScreen(viewerDiv, view);
+
+    // Add imagery and elevation layers
+    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function (config) {
+        config.source = new itowns.WMTSSource(config.source);
+        view.addLayer(
+            new itowns.ColorLayer('Ortho', config),
+        );
+    })
+    function addElevationLayerFromConfig(config) {
+        config.source = new itowns.WMTSSource(config.source);
+        view.addLayer(
+            new itowns.ElevationLayer(config.id, config),
+        );
+    }
+    itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+    itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+
+    const customControls = {
+        // Disable pan movement
+        PAN: {
+            enable: false,
+        },
+        // Change the key bindings for globe rotation
+        MOVE_GLOBE: {
+            enable: true,
+            mouseButton: itowns.THREE.MOUSE.LEFT,
+        },
+        // Change the key bindings for orbit movement (rotation around the camera target)
+        ORBIT: {
+            enable: true,
+            mouseButton: itowns.THREE.MOUSE.MIDDLE,
+        },
+        // Change the key bindings for dolly movement
+        DOLLY: {
+            enable: true,
+            mouseButton: itowns.THREE.MOUSE.RIGHT,
+        },
+        // Change the key bindings for panoramic movement (rotation around the camera position)
+        PANORAMIC: {
+            enable: true,
+            mouseButton: itowns.THREE.MOUSE.LEFT,
+            keyboard: 17,  // keyCode for the ctrl key
+        },
+        // Allow travel out movement when double right-clicking
+        TRAVEL_OUT: {
+            enable: true,
+            mouseButton: itowns.THREE.MOUSE.RIGHT,
+            double: true,
+        },
+    }
+
+    // Modify view's control to be set as the custom controls we just defined
+    view.controls.states.setFromOptions(customControls);
+</script>
+</body>
+</html>

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -174,7 +174,7 @@ class GlobeControls extends THREE.EventDispatcher {
         this.camera = view.camera.camera3D;
 
         // State control
-        this.states = new StateControl();
+        this.states = new StateControl(this.view);
         this.state = this.states.NONE;
 
         // Set to false to disable this control
@@ -242,7 +242,7 @@ class GlobeControls extends THREE.EventDispatcher {
         this._onMouseDown = this.onMouseDown.bind(this);
         this._onMouseWheel = this.onMouseWheel.bind(this);
         this._onContextMenuListener = this.onContextMenuListener.bind(this);
-        this._ondblclick = this.ondblclick.bind(this);
+        this._onTravel = this.travel.bind(this);
         this._onTouchStart = this.onTouchStart.bind(this);
         this._update = this.update.bind(this);
         this._onTouchMove = this.onTouchMove.bind(this);
@@ -253,11 +253,12 @@ class GlobeControls extends THREE.EventDispatcher {
         this.view.domElement.addEventListener('contextmenu', this._onContextMenuListener, false);
         this.view.domElement.addEventListener('mousedown', this._onMouseDown, false);
         this.view.domElement.addEventListener('mousewheel', this._onMouseWheel, false);
-        this.view.domElement.addEventListener('dblclick', this._ondblclick, false);
         this.view.domElement.addEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
         this.view.domElement.addEventListener('touchstart', this._onTouchStart, false);
         this.view.domElement.addEventListener('touchend', this._onMouseUp, false);
         this.view.domElement.addEventListener('touchmove', this._onTouchMove, false);
+
+        this.states.addEventListener('travel_in', this._onTravel, false);
 
         // refresh control for each animation's frame
         this.player.addEventListener('animation-frame', this._update);
@@ -675,10 +676,10 @@ class GlobeControls extends THREE.EventDispatcher {
         }
     }
 
-    ondblclick(event) {
-        if (this.enabled === false || currentKey) { return; }
+    travel(event) {
+        if (this.enabled === false) { return; }
         this.player.stop();
-        const point = this.view.getPickingPositionFromDepth(this.view.eventToViewCoords(event));
+        const point = this.view.getPickingPositionFromDepth(event.viewCoords);
         const range = this.getRange(point);
         if (point && range > this.minDistance) {
             return this.lookAtCoordinate({
@@ -910,11 +911,13 @@ class GlobeControls extends THREE.EventDispatcher {
         this.view.domElement.removeEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
         this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
         this.view.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
-        this.view.domElement.removeEventListener('dblclick', this._ondblclick, false);
 
         this.view.domElement.removeEventListener('touchstart', this._onTouchStart, false);
         this.view.domElement.removeEventListener('touchend', this._onMouseUp, false);
         this.view.domElement.removeEventListener('touchmove', this._onTouchMove, false);
+
+        this.states.dispose();
+        this.states.removeEventListener('travel_in', this._onTravel, false);
 
         this.player.removeEventListener('animation-frame', this._onKeyUp);
 

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -259,6 +259,7 @@ class GlobeControls extends THREE.EventDispatcher {
         this.view.domElement.addEventListener('touchmove', this._onTouchMove, false);
 
         this.states.addEventListener('travel_in', this._onTravel, false);
+        this.states.addEventListener('travel_out', this._onTravel, false);
 
         // refresh control for each animation's frame
         this.player.addEventListener('animation-frame', this._update);
@@ -684,7 +685,7 @@ class GlobeControls extends THREE.EventDispatcher {
         if (point && range > this.minDistance) {
             return this.lookAtCoordinate({
                 coord: new Coordinates('EPSG:4978', point),
-                range: range * 0.6,
+                range: range * (event.type === 'travel_out' ? 1 / 0.6 : 0.6),
                 time: 1500,
             });
         }
@@ -918,6 +919,7 @@ class GlobeControls extends THREE.EventDispatcher {
 
         this.states.dispose();
         this.states.removeEventListener('travel_in', this._onTravel, false);
+        this.states.removeEventListener('travel_out', this._onTravel, false);
 
         this.player.removeEventListener('animation-frame', this._onKeyUp);
 

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -13,64 +13,36 @@ const CONTROL_KEYS = {
 
 
 /**
- * @typedef {Object} state
- * @property {boolean} enable=true indicate whether the state is enable or not
- * @property {Number} [mouseButton] the mouse button to enter this state
- * @property {Number} [keyboard] the keyboard to enter this state
- * @property {Number} [finger] the number of fingers on the pad to enter this state
+ * @typedef {Object} StateControl~State
+ * @property {boolean} enable=true Indicate whether the state is enabled or not.
+ * @property {Number} [mouseButton] The mouse button bound to this state.
+ * @property {Number} [keyboard] The keyCode of the keyboard input bound to this state.
+ * @property {Number} [finger] The number of fingers on the pad bound to this state.
  */
 
 /**
  * It represents the control's states.
- * Each {@link state} is a control mode of the camera and how to interact with
+ * Each {@link State} is a control mode of the camera and how to interact with
  * the interface to activate this mode.
  * @class StateControl
  *
+ * @property {State}    NONE        {@link State} when camera is idle.
+ * @property {State}    ORBIT       {@link State} describing camera orbiting movement : the camera moves around its
+                                    * target at a constant distance from it.
+ * @property {State}    DOLLY       {@link State} describing camera dolly movement : the camera moves forward or
+                                    * backward from its target.
+ * @property {State}    PAN         {@link State} describing camera pan movement : the camera moves parallel to the
+                                    * current view plane.
+ * @property {State}    MOVE_GLOBE  {@link State} describing camera drag movement : the camera is moved around the view
+                                    * to give the feeling that the view is dragged under a static camera.
+ * @property {State}    PANORAMIC   {@link State} describing camera panoramic movement : the camera is rotated around
+                                    * its own position.
  */
 class StateControl {
-    constructor() {
+    constructor(options = {}) {
         this.NONE = {};
-        /**
-         * The camera loot at target and moves at a constant distance from it
-         */
-        this.ORBIT = {
-            mouseButton: THREE.MOUSE.LEFT,
-            keyboard: CONTROL_KEYS.CTRL,
-            enable: true,
-            finger: 2,
-        };
-        /**
-         * The camera loot at target and moves forward and backward from this point
-         */
-        this.DOLLY = {
-            mouseButton: THREE.MOUSE.MIDDLE,
-            enable: true,
-        };
-        /**
-         * the camera moves parallel to the current view plane
-         */
-        this.PAN = {
-            mouseButton: THREE.MOUSE.RIGHT,
-            up: CONTROL_KEYS.UP,
-            bottom: CONTROL_KEYS.BOTTOM,
-            left: CONTROL_KEYS.LEFT,
-            right: CONTROL_KEYS.RIGHT,
-            enable: true,
-            finger: 3,
-        };
-        this.MOVE_GLOBE = {
-            mouseButton: THREE.MOUSE.LEFT,
-            enable: true,
-            finger: 1,
-        };
-        /**
-         * the camera and target camera rotate around the globe
-         */
-        this.PANORAMIC = {
-            mouseButton: THREE.MOUSE.LEFT,
-            keyboard: CONTROL_KEYS.SHIFT,
-            enable: true,
-        };
+
+        this.setFromOptions(options);
     }
 
     /**
@@ -103,6 +75,55 @@ class StateControl {
             }
         }
         return this.NONE;
+    }
+
+    /**
+     * Set the current StateControl {@link State} properties to given values.
+     * @param {Object}  options     Object containing the `State` values to set current `StateControl` properties to.
+     *
+     * @example
+     * // Switch bindings for PAN and MOVE_GLOBE actions :
+     * view.controls.states.setFromOptions({
+     *     PAN: {
+     *        enable: true,
+     *        mouseButton: itowns.THREE.MOUSE.LEFT,
+     *     },
+     *     MOVE_GLOBE: {
+     *         enable: true,
+     *         mouseButton: itowns.THREE.MOUSE.RIGHT,
+     *     },
+     * };
+     */
+    setFromOptions(options) {
+        this.ORBIT = options.ORBIT || this.ORBIT || {
+            mouseButton: THREE.MOUSE.LEFT,
+            keyboard: CONTROL_KEYS.CTRL,
+            enable: true,
+            finger: 2,
+        };
+        this.DOLLY = options.DOLLY || this.DOLLY || {
+            mouseButton: THREE.MOUSE.MIDDLE,
+            enable: true,
+        };
+        this.PAN = options.PAN || this.PAN || {
+            mouseButton: THREE.MOUSE.RIGHT,
+            up: CONTROL_KEYS.UP,
+            bottom: CONTROL_KEYS.BOTTOM,
+            left: CONTROL_KEYS.LEFT,
+            right: CONTROL_KEYS.RIGHT,
+            enable: true,
+            finger: 3,
+        };
+        this.MOVE_GLOBE = options.MOVE_GLOBE || this.MOVE_GLOBE || {
+            mouseButton: THREE.MOUSE.LEFT,
+            enable: true,
+            finger: 1,
+        };
+        this.PANORAMIC = options.PANORAMIC || this.PANORAMIC || {
+            mouseButton: THREE.MOUSE.LEFT,
+            keyboard: CONTROL_KEYS.SHIFT,
+            enable: true,
+        };
     }
 }
 

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -58,6 +58,11 @@ function stateToTrigger(state) {
                                     * associated to this StateControl.
                                     * This state can only be associated to double click on mouse buttons (left or right)
                                     * or a keyboard key.
+ * @property {State}    TRAVEL_OUT  {@link State} describing camera travel out movement : the camera is zoomed out from
+                                    * a given position. The choice of the target position is made in the Controls
+                                    * associated to this StateControl.
+                                    * This state can only be associated to double click on mouse buttons (left or right)
+                                    * or a keyboard key. It is disabled by default.
  */
 class StateControl extends THREE.EventDispatcher {
     constructor(view, options = {}) {
@@ -72,6 +77,14 @@ class StateControl extends THREE.EventDispatcher {
             if (this.TRAVEL_IN === this.inputToState(event.button, event.keyCode, this.TRAVEL_IN.double)) {
                 this.dispatchEvent({
                     type: 'travel_in',
+                    viewCoords: this._view.eventToViewCoords(event),
+                });
+            }
+        };
+        this._handleTravelOutEvent = (event) => {
+            if (this.TRAVEL_OUT === this.inputToState(event.button, event.keyCode, this.TRAVEL_OUT.double)) {
+                this.dispatchEvent({
+                    type: 'travel_out',
                     viewCoords: this._view.eventToViewCoords(event),
                 });
             }
@@ -174,6 +187,13 @@ class StateControl extends THREE.EventDispatcher {
         this._domElement.removeEventListener(stateToTrigger(this.TRAVEL_IN), this._handleTravelInEvent, false);
         this._domElement.addEventListener(stateToTrigger(newTravelIn), this._handleTravelInEvent, false);
         this.TRAVEL_IN = newTravelIn;
+
+        const newTravelOut = options.TRAVEL_OUT || this.TRAVEL_OUT || {
+            enable: false,
+        };
+        this._domElement.removeEventListener(stateToTrigger(this.TRAVEL_OUT), this._handleTravelOutEvent, false);
+        this._domElement.addEventListener(stateToTrigger(newTravelOut), this._handleTravelOutEvent, false);
+        this.TRAVEL_OUT = newTravelOut;
     }
 
     /**
@@ -181,6 +201,7 @@ class StateControl extends THREE.EventDispatcher {
      */
     dispose() {
         this._domElement.removeEventListener(this.TRAVEL_IN.trigger, this._handleTravelInEvent, false);
+        this._domElement.removeEventListener(this.TRAVEL_OUT.trigger, this._handleTravelInEvent, false);
     }
 }
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -31,6 +31,14 @@ export const VIEW_EVENTS = {
     COLOR_LAYERS_ORDER_CHANGED,
 };
 
+/**
+ * Fired on current view's domElement when double right-clicking it. Copies all properties of the second right-click
+ * MouseEvent (such as cursor position).
+ * @event View#dblclick-right
+ * @property {string} type  dblclick-right
+ */
+
+
 const _syncGeometryLayerVisibility = function _syncGeometryLayerVisibility(layer, view) {
     if (layer.object3d) {
         layer.object3d.visible = layer.visible;
@@ -232,6 +240,19 @@ class View extends THREE.EventDispatcher {
         this.domElement.tabIndex = -1;
         // Set focus on view's domElement.
         this.domElement.focus();
+
+        // Create a custom `dblclick-right` event that is triggered when double right-clicking
+        let rightClickTimeStamp;
+        this.domElement.addEventListener('mouseup', (event) => {
+            if (event.button === 2) {  // If pressed mouse button is right button
+                // If time between two right-clicks is bellow 500 ms, triggers a `dblclick-right` event
+                if (rightClickTimeStamp && event.timeStamp - rightClickTimeStamp < 500) {
+                    this.domElement.dispatchEvent(new MouseEvent('dblclick-right', event));
+                }
+                rightClickTimeStamp = event.timeStamp;
+            }
+        });
+
 
         // push all viewer to keep source.cache
         viewers.push(this);

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -623,13 +623,13 @@ class View extends THREE.EventDispatcher {
     eventToViewCoords(event, target = _eventCoords, touchIdx = 0) {
         const br = this.domElement.getBoundingClientRect();
 
-        if (event.touches === undefined || !event.touches.length) {
+        if (event.touches && event.touches.length) {
+            return target.set(event.touches[touchIdx].clientX - br.x,
+                event.touches[touchIdx].clientY - br.y);
+        } else if (event.offsetX && event.offsetY) {
             const targetBoundingRect = event.target.getBoundingClientRect();
             return target.set(targetBoundingRect.x + event.offsetX - br.x,
                 targetBoundingRect.y + event.offsetY - br.y);
-        } else {
-            return target.set(event.touches[touchIdx].clientX - br.x,
-                event.touches[touchIdx].clientY - br.y);
         }
     }
 

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -194,10 +194,28 @@ describe('GlobeControls', function () {
         const startRange = controls.getRange();
         controls.travel({
             viewCoords: viewer.eventToViewCoords(event),
+            type: 'travel_in',
         }).then(() => {
             assert.ok(controls.getRange() < startRange);
             done();
         });
+    });
+
+    it('travel out', function (done) {
+        const startRange = controls.getRange();
+        controls.travel({
+            viewCoords: viewer.eventToViewCoords(event),
+            type: 'travel_out',
+        }).then(() => {
+            assert.ok(controls.getRange() > startRange);
+            done();
+        });
+    });
+
+    it('travel should not trigger if controls are disabled', function () {
+        controls.enabled = false;
+        assert.strictEqual(controls.travel(), undefined);
+        controls.enabled = true;
     });
 
     it('touch start', function () {

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -189,10 +189,12 @@ describe('GlobeControls', function () {
         assert.ok(controls.getRange() < startRange);
     });
 
-    it('mouse dblclick', function (done) {
+    it('travel in', function (done) {
         controls.setAnimationEnabled(false);
         const startRange = controls.getRange();
-        controls.ondblclick(event).then(() => {
+        controls.travel({
+            viewCoords: viewer.eventToViewCoords(event),
+        }).then(() => {
             assert.ok(controls.getRange() < startRange);
             done();
         });

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -3,6 +3,7 @@ import assert from 'assert';
 import GlobeView from 'Core/Prefab/GlobeView';
 import Coordinates from 'Core/Geographic/Coordinates';
 import { getLookAtFromMath, getRig } from 'Utils/CameraUtils';
+import StateControl from 'Controls/StateControl';
 import Renderer from './bootstrap';
 
 describe('GlobeControls', function () {
@@ -41,6 +42,10 @@ describe('GlobeControls', function () {
 
     it('instance GlobeControls', function () {
         assert.ok(controls);
+    });
+
+    it('should instantiate StateControl', function () {
+        assert(controls.states instanceof StateControl);
     });
 
     it('pickGeoPosition', function () {

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -1,9 +1,15 @@
 import { MOUSE } from 'three';
 import assert from 'assert';
-import StateControl from 'Controls/StateControl';
+import Coordinates from 'Core/Geographic/Coordinates';
+import GlobeView from 'Core/Prefab/GlobeView';
+import Renderer from './bootstrap';
 
 describe('StateControl', function () {
-    const states = new StateControl();
+    const renderer = new Renderer();
+
+    const placement = { coord: new Coordinates('EPSG:4326', 2.351323, 48.856712), range: 250000, proxy: false };
+    const viewer = new GlobeView(renderer.domElement, placement, { renderer });
+    const states = viewer.controls.states;
 
     it('inputToState should return the correct state', function () {
         assert.strictEqual(
@@ -44,6 +50,7 @@ describe('StateControl', function () {
             ORBIT: { enable: true, mouseButton: MOUSE.MIDDLE },
             DOLLY: { enable: true, mouseButton: MOUSE.RIGHT },
             PANORAMIC: { enable: true, mouseButton: MOUSE.LEFT, keyboard: 17 },
+            TRAVEL_IN: { enable: true, mouseButton: MOUSE.LEFT, double: true },
         };
         states.setFromOptions(options);
 
@@ -52,5 +59,10 @@ describe('StateControl', function () {
         assert.strictEqual(JSON.stringify(options.ORBIT), JSON.stringify(states.ORBIT));
         assert.strictEqual(JSON.stringify(options.DOLLY), JSON.stringify(states.DOLLY));
         assert.strictEqual(JSON.stringify(options.PANORAMIC), JSON.stringify(states.PANORAMIC));
+        assert.strictEqual(JSON.stringify(options.TRAVEL_IN), JSON.stringify(states.TRAVEL_IN));
+    });
+
+    it('should dispose event listeners', function () {
+        states.dispose();
     });
 });

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -1,0 +1,56 @@
+import { MOUSE } from 'three';
+import assert from 'assert';
+import StateControl from 'Controls/StateControl';
+
+describe('StateControl', function () {
+    const states = new StateControl();
+
+    it('inputToState should return the correct state', function () {
+        assert.strictEqual(
+            JSON.stringify(states.inputToState(MOUSE.LEFT, 17)),
+            JSON.stringify(states.ORBIT),
+        );
+    });
+
+    it('inputToState should return NONE state if matching state is disabled', function () {
+        states.ORBIT.enable = false;
+        assert.strictEqual(
+            JSON.stringify(states.inputToState(MOUSE.LEFT, 17)),
+            JSON.stringify(states.NONE),
+        );
+        states.ORBIT.enable = true;
+    });
+
+    it('touchToState should return the correct state', function () {
+        assert.strictEqual(
+            JSON.stringify(states.touchToState(3)),
+            JSON.stringify(states.PAN),
+        );
+    });
+
+    it('touchToState should return NONE state if matching state is disabled', function () {
+        states.PAN.enable = false;
+        assert.strictEqual(
+            JSON.stringify(states.touchToState(3)),
+            JSON.stringify(states.NONE),
+        );
+        states.PAN.enable = true;
+    });
+
+    it('setFromOptions should set states according to given options', function () {
+        const options = {
+            PAN: { enable: false },
+            MOVE_GLOBE: { enable: true, mouseButton: MOUSE.LEFT },
+            ORBIT: { enable: true, mouseButton: MOUSE.MIDDLE },
+            DOLLY: { enable: true, mouseButton: MOUSE.RIGHT },
+            PANORAMIC: { enable: true, mouseButton: MOUSE.LEFT, keyboard: 17 },
+        };
+        states.setFromOptions(options);
+
+        assert.strictEqual(JSON.stringify(options.PAN), JSON.stringify(states.PAN));
+        assert.strictEqual(JSON.stringify(options.MOVE_GLOBE), JSON.stringify(states.MOVE_GLOBE));
+        assert.strictEqual(JSON.stringify(options.ORBIT), JSON.stringify(states.ORBIT));
+        assert.strictEqual(JSON.stringify(options.DOLLY), JSON.stringify(states.DOLLY));
+        assert.strictEqual(JSON.stringify(options.PANORAMIC), JSON.stringify(states.PANORAMIC));
+    });
+});

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -51,6 +51,7 @@ describe('StateControl', function () {
             DOLLY: { enable: true, mouseButton: MOUSE.RIGHT },
             PANORAMIC: { enable: true, mouseButton: MOUSE.LEFT, keyboard: 17 },
             TRAVEL_IN: { enable: true, mouseButton: MOUSE.LEFT, double: true },
+            TRAVEL_OUT: { enable: true, mouseButton: MOUSE.RIGHT, double: true },
         };
         states.setFromOptions(options);
 
@@ -60,6 +61,7 @@ describe('StateControl', function () {
         assert.strictEqual(JSON.stringify(options.DOLLY), JSON.stringify(states.DOLLY));
         assert.strictEqual(JSON.stringify(options.PANORAMIC), JSON.stringify(states.PANORAMIC));
         assert.strictEqual(JSON.stringify(options.TRAVEL_IN), JSON.stringify(states.TRAVEL_IN));
+        assert.strictEqual(JSON.stringify(options.TRAVEL_OUT), JSON.stringify(states.TRAVEL_OUT));
     });
 
     it('should dispose event listeners', function () {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Add possibility to modify the `states` of a `GlobeControls` instance with a `StateControl.setFromOpions` method. This grant an easy reassigning of controls key/mouse bindings after creating a `GlobeView`.

- Refactorize double click event in `GlobeControls`. A travel animation which zoomed in on the mouse position was previously triggered with a `dblclick` event. Now, this travel animation is linked to a state (from `StateControls`). Therefore, it is now possible to modify the event which triggers the travel animation.

  For example, a user could have the travel animation triggered by pressing the `p` key instead of double-click by doing : 
```js
// Assuming `view` is an instance of `GlobeView` :
view.controls.states.setFromOptions({
    TRAVEL_IN: {
        enable: true,
        keyboard: 80,  // 80 is the keyCode for the `p` key
    },
});
```

- Add support in `GlobeControls` for a travel animation which zooms the camera out, linked to the state `StateControl.TRAVEL_OUT`. The event triggering this animation can be changed the same way as for the zoom-in travel. It is deactivated by default, but it can be activated with :
```js
view.controls.states.setFromOptions({
    TRAVEL_OUT: {
        enable: true,
        mouseButton: itowns.THREE.MOUSE.LEFT,  // for instance
        double: true,  // For state to be bound to double click
    },
});
```

- Add an example of a globe view where custom controls are defined.

## Important note

`TRAVEL_IN` and `TRAVEL_OUT` states can't yet be bound to single mouse click (right, left or middle) as it would require a complete refactoring of `GlobeControls`. Should a user try to do so, the travel animations would never occur.

## Left to do on this PR

- [x] Add unit tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Closes #978.
