### PR TITLE
Fix Feature issues

### DIFF
--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -226,7 +226,7 @@ class Feature {
             // this.crs is final crs projection, is out projection.
             // If the extent crs is the same then we use output coordinate (coordOut) to expand it.
             this.extent = defaultExtent(collection.extent.crs);
-            this.useCrsOut = !collection.forceExtentCrs;
+            this.useCrsOut = this.extent.crs == this.crs;
         }
         this._pos = 0;
         this._pushValues = (this.size === 3 ? push3DValues : push2DValues).bind(this);
@@ -300,8 +300,6 @@ export default Feature;
 
 export class FeatureCollection extends THREE.Object3D {
     /**
-     * Constructs a new instance.
-     *
      * @param      {FeatureBuildingOptions|Layer}  options  The building options .
      */
     constructor(options) {

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -283,7 +283,13 @@ export default Feature;
  * @property {Feature[]} features - The array of features composing the
  * collection.
  * @property {Extent?} extent - The 2D extent containing all the features
- * composing the collection.
+ * composing the collection. The extent projection is the same local projection `FeatureCollection`.
+ * To transform `FeatureCollection.extent` to `FeatureCollection.crs` projection, the transformation matrix must be applied.
+ *
+ * **WARNING** if crs is `EPSG:4978` because the 3d geocentric system doesn't work with 2D `Extent`,
+ * The FeatureCollection.extent projection is the original projection.
+ * In this case, there isn't need to transform the extent.
+ *
  * @property {string} crs - Geographic or Geocentric coordinates system.
  * @property {boolean} isFeatureCollection - Used to check whether this is FeatureCollection.
  * @property {number} size - The size structure, it's 3 for 3d and 2 for 2d.

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -108,10 +108,6 @@ function readPBF(file, options) {
     // Only if the layer.origin is top
     const y = options.in.isInverted ? file.extent.row : (1 << z) - file.extent.row - 1;
 
-    options.out.buildExtent = true;
-    options.out.mergeFeatures = true;
-    options.out.structure = '2d';
-
     const collection = new FeatureCollection(options.out);
 
     const vFeature = vectorTile.layers[sourceLayers[0]];

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -169,7 +169,9 @@ class FileSource extends Source {
             if (data.extent) {
                 this.extent = data.extent.clone();
                 // Transform local extent to data.crs projection.
-                this.extent.applyMatrix4(data.matrixWorld);
+                if (this.extent.crs == data.crs) {
+                    this.extent.applyMatrix4(data.matrixWorld);
+                }
             }
 
             if (data.isFeatureCollection) {


### PR DESCRIPTION
## Description
This PR fixes some little issues:
* Wrong condition to choose `Feature` extent crs projection.
* Remove unnecessary `Feature` parameters in `VectorTileParser`
* Transform extent `FileSource` if is needed.

