### PR TITLE
fix(LayeredMaterialNodeProcessing): prevent errors in layer update when removing layer

### DIFF
--- a/src/Process/handlerNodeError.js
+++ b/src/Process/handlerNodeError.js
@@ -2,6 +2,11 @@
 const MAX_RETRY = 4;
 
 export default function handlingError(err, node, layer, targetLevel, view) {
+    // Cancel error handling if the layer was removed between command scheduling and its execution
+    if (!node.layerUpdateState[layer.id]) {
+        return;
+    }
+
     if (err.isCancelledCommandException) {
         node.layerUpdateState[layer.id].success();
     } else if (err instanceof SyntaxError) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Prevent errors in `RasterLayer` update method that occured on removing a `RasterLayer` from the view.

When removing a `RasterLayer` from a `View`, it may delete cache for the layer data as well as the `LayerUpdateState` for the layer. As `RasterLayer` update tries to read those, it could cause errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

Closes #1286.
