### PR TITLE
fix(debug): update coordinates event on mouse move

### DIFF
--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -2,6 +2,7 @@ import { CameraHelper, Color, Vector3 } from 'three';
 import Coordinates from 'Core/Geographic/Coordinates';
 import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
 import OBB from 'Renderer/OBB';
+import * as THREE from 'three';
 import ThreeStatsChart from './charts/ThreeStatsChart';
 import { backgroundChartDiv, color_blue } from './charts/ChartConfig';
 import OBBHelper from './OBBHelper';
@@ -99,18 +100,23 @@ function Debug(view, datDebugTool, chartDivContainer) {
     let eventFolder;
     const controls = view.controls;
     initialPosition.crs = view.referenceCrs;
+    const cursorWorldPosition = new THREE.Vector3();
 
     const getCenter = (controls && controls.getCameraTargetPosition) ? controls.getCameraTargetPosition : () => view.camera.camera3D.position;
-    const cameraTargetListener = () => {
-        initialPosition.setFromVector3(getCenter()).as('EPSG:4326', geoPosition);
-        state.latitude = `${geoPosition.y.toFixed(6)}`;
-        state.longitude = `${geoPosition.x.toFixed(6)}`;
+    const cameraTargetListener = (event) => {
+        if (view.getPickingPositionFromDepth(view.eventToViewCoords(event), cursorWorldPosition)) {
+            initialPosition.setFromVector3(cursorWorldPosition).as('EPSG:4326', geoPosition);
+            state.latitude = `${geoPosition.y.toFixed(6)}`;
+            state.longitude = `${geoPosition.x.toFixed(6)}`;
+        } else {
+            state.latitude = '---------';
+            state.longitude = '---------';
+        }
         LatController.updateDisplay();
         LongController.updateDisplay();
     };
 
     gui.add(state, 'eventsDebug').name('Debug event').onChange((() => (newValue) => {
-        const listeners = [];
         if (newValue) {
             eventFolder = gui.addFolder('Events');
             eventFolder.open();
@@ -121,13 +127,9 @@ function Debug(view, datDebugTool, chartDivContainer) {
             LatController = eventFolder.add(state, 'latitude');
             LongController = eventFolder.add(state, 'longitude');
 
-            view.addFrameRequester(MAIN_LOOP_EVENTS.UPDATE_END, cameraTargetListener);
-            listeners.push({ type: MAIN_LOOP_EVENTS.UPDATE_END, stateName: 'cameraTargetUpdated', fn: cameraTargetListener });
+            view.domElement.addEventListener('mousemove', cameraTargetListener);
         } else {
-            for (const listener of listeners) {
-                controls.removeFrameRequester(listener.type, listener.fn);
-                delete state[listener.stateName];
-            }
+            view.domElement.removeEventListener('mousemove', cameraTargetListener);
             gui.removeFolder('Events');
         }
     })());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes the debug utility so that the `Event` tab in the `Debug Tools` menu displays the world coordinates under the mouse cursor. It previously used to display the world coordinates at the center of the screen.

Should the cursor be outside of the globe, the displayed longitude and latitude will be `0.000000`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Closes #935.
