### PR TITLE
FeatureCollection local system and Style GeometryLayer.

### DIFF
--- a/docs/tutorials/Display-a-geometry-layer.md
+++ b/docs/tutorials/Display-a-geometry-layer.md
@@ -123,9 +123,9 @@ There is a few differences though:
   called to update the layer each time the rendering loop is called. For now
   let's simply put `itowns.FeatureProcessing.update` and don't touch this
   method.
-- the third parameter is `convert`, that is more interesting to us. It is the
-  method that will tell how to use the data to convert it to meshes, and do
-  other operations on it.
+- `Convert` method to convert `FeatureCollection` to `THREE.Mesh`.
+- the third parameter is `Style`, that is more interesting to us. It is the
+  Object that will tell how to use the data to stylize the meshes.
 
 Trying this code will result in... nothing visually ! The data was processed and
 displayed, but it is hidden under the elevation layer. If we remove the
@@ -137,7 +137,7 @@ have indeed been added. So let's place the data on the elevation layer !
 ## Placing the data on the ground
 
 To achieve the positionning relative to the elevation layer, we will need to add
-a parameter to the `convert` property: `altitude`, a method that will help us.
+a parameter to the `Style` property: `base_altitude`, a method that will help us.
 
 ```js
 function setAltitude(properties) {
@@ -153,8 +153,11 @@ var geometrySource = new itowns.WFSSource({
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
     source: geometrySource,
     update: itowns.FeatureProcessing.update,
-    convert: itowns.Feature2Mesh.convert({
-        altitude: setAltitude
+    convert: itowns.Feature2Mesh.convert(),
+    style: new itowns.Style({
+        fill: {
+            base_altitude: setAltitude,
+        }
     }),
     zoom: { min: 14 },
 });
@@ -207,8 +210,8 @@ But now we can't see completely our buildings again. What can we do about that
 
 ## Extruding the data
 
-Like the altitude, the volume of a building can be changed using the `extrude`
-parameter of the `convert` property.
+Like the altitude, the volume of a building can be changed using the `extrusion_height`
+parameter of the `Style` property.
 
 ```js
 function setExtrusion(properties) {
@@ -224,9 +227,12 @@ var geometrySource = new itowns.WFSSource({
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
     source: geometrySource,
     update: itowns.FeatureProcessing.update,
-    convert: itowns.Feature2Mesh.convert({
-        altitude: setAltitude,
-        extrude: setExtrusion,
+    convert: itowns.Feature2Mesh.convert(),
+    style: new itowns.Style({
+        fill: {
+            base_altitude: setAltitude,
+            extrusion_height: setExtrusion,
+        }
     }),
     zoom: { min: 14 },
 });
@@ -245,7 +251,7 @@ nice view of our buildings:
 
 We are not yet touching the color of the buildings. This results in every
 building being randomly colored at each time. To solve this, as we did before,
-we can add a `color` parameter to the `convert` property.
+we can add a `color` parameter to the `Style` property.
 
 ```js
 function setColor(properties) {
@@ -261,10 +267,13 @@ var geometrySource = new itowns.WFSSource({
 var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
     source: geometrySource,
     update: itowns.FeatureProcessing.update,
-    convert: itowns.Feature2Mesh.convert({
-        altitude: setAltitude,
-        extrude: setExtrusion,
-        color: setColor
+    convert: itowns.Feature2Mesh.convert(),
+    style: new itowns.Style({
+        fill: {
+            color: setColor
+            base_altitude: setAltitude,
+            extrusion_height: setExtrusion,
+        },
     }),
     zoom: { min: 14 },
 });
@@ -381,10 +390,13 @@ layer on a globe, and change some things on this layer. Here is the final code:
             var geometryLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
                 source: geometrySource,
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
-                    altitude: setAltitude,
-                    extrude: setExtrusion,
-                    color: setColor
+                convert: itowns.Feature2Mesh.convert(),
+                style: new itowns.Style({
+                    fill: {
+                        color: setColor
+                        base_altitude: setAltitude,
+                        extrusion_height: setExtrusion,
+                    },
                 }),
                 zoom: { min: 14 },
             });

--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -64,6 +64,10 @@ var FeatureToolTip = (function _() {
         }
     }
 
+    function getGeometryProperties(geometry) {
+        return function properties() { return geometry.properties; };
+    }
+
     function fillToolTip(features, layer, options) {
         var content = '';
         var feature;
@@ -76,9 +80,10 @@ var FeatureToolTip = (function _() {
 
         for (var p = 0; p < features.length; p++) {
             feature = features[p];
-
             geometry = feature.geometry;
             style = (geometry.properties && geometry.properties.style) || feature.style || layer.style;
+            var context = { globals: {}, properties: getGeometryProperties(geometry) };
+            style = style.drawingStylefromContext(context);
             fill = style.fill.color;
             stroke = '1.25px ' + style.stroke.color;
 

--- a/examples/source_file_geojson_3d.html
+++ b/examples/source_file_geojson_3d.html
@@ -54,15 +54,18 @@
                     crs: 'EPSG:4326',
                     format: 'application/json',
                 }),
+                update: itowns.FeatureProcessing.update,
+                convert: itowns.Feature2Mesh.convert(),
+                transparent: true,
+                opacity: 0.7,
                 zoom: { min: 10 },
+                style: new itowns.Style({
+                    fill: {
+                        color: new itowns.THREE.Color(0xbbffbb),
+                        extrusion_height: 80,
+                    }
+                })
             });
-            marne.update = itowns.FeatureProcessing.update;
-            marne.convert = itowns.Feature2Mesh.convert({
-                color: new itowns.THREE.Color(0xbbffbb),
-                extrude: 80 });
-            marne.transparent = true;
-            marne.opacity = 0.7;
-
 
             view.addLayer(marne).then(function menu(layer) {
                 var gui = debug.GeometryDebug.createGeometryDebugUI(menuGlobe.gui, view, layer);

--- a/examples/source_file_gpx_3d.html
+++ b/examples/source_file_gpx_3d.html
@@ -62,7 +62,6 @@
             var waypointGeometry = new itowns.THREE.BoxGeometry(1, 1, 80);
             var waypointMaterial = new itowns.THREE.MeshBasicMaterial({ color: 0xffffff });
             // Listen for globe full initialisation event
-            var waypoints = [];
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
                 itowns.Fetcher.xml('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/ULTRA2009.gpx')
@@ -72,38 +71,36 @@
                         },
                         out: {
                             crs: view.referenceCrs,
-                            buildExtent: true,
-                            mergeFeatures: true,
                             structure: '3d',
+                            style: new itowns.Style({
+                                stroke : {
+                                    color: 'red',
+                                    width: 2,
+                                },
+                                point : {
+                                    color: 'white',
+                                }
+                            })
                         }
                     }))
-                    .then(collection => itowns.Feature2Mesh.convert({
-                        color: new itowns.THREE.Color(0xff0000),
-                    })(collection))
+                    .then(itowns.Feature2Mesh.convert())
                     .then(function (mesh) {
                         if (mesh) {
+                            mesh.updateMatrixWorld();
                             mesh.traverse((m) => {
-                                if (m.type == 'Line') {
-                                    m.material.linewidth = 5;
-                                }
-
                                 if (m.type == 'Points') {
                                     var vertices = m.feature.vertices;
-                                    for (var i = 0; i < vertices.length; i++) {
+                                    for (var i = 0; i < vertices.length; i += 3) {
                                         var waypoint = new itowns.THREE.Mesh(waypointGeometry, waypointMaterial);
-                                        waypoint.position.set(
-                                            vertices[i * 3],
-                                            vertices[i * 3 + 1],
-                                            vertices[i * 3 + 2]);
-                                        waypoint.lookAt(0, 0, 0);
+                                        waypoint.position.fromArray(vertices, i);
+                                        waypoint.lookAt(mesh.worldToLocal(new itowns.THREE.Vector3()));
                                         waypoint.onBeforeRender = updatePointScale;
+                                        waypoint.updateMatrix();
+                                        mesh.add(waypoint);
                                         waypoint.updateMatrixWorld();
-                                        waypoints.push(waypoint);
                                     }
                                 }
                             });
-                            mesh.add(...waypoints);
-                            mesh.updateMatrixWorld();
                             view.scene.add(mesh);
                             view.notifyChange();
                         }

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -235,8 +235,10 @@
                     altitude: altitudeBuildings,
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {
-                    mesh.scale.z = 0.01;
-                    meshes.push(mesh);
+                    mesh.children.forEach(c => {
+                        c.scale.z = 0.01;
+                        meshes.push(c);
+                    })
                 },
                 filter: acceptFeature,
                 overrideAltitudeInToZero: true,

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -101,18 +101,6 @@
 
             view.addLayer(wmsElevationLayer);
 
-            function setMaterialLineWidth(result) {
-                result.traverse(function _setLineWidth(mesh) {
-                    if (mesh.material) {
-                        mesh.material.linewidth = 5;
-                    }
-                });
-            }
-
-            function colorLine(properties) {
-                return color.set(Math.round(Math.random() * 0xffffff));
-            }
-
             var tile;
             var linesBus = [];
 
@@ -161,13 +149,17 @@
 
             var lyonTclBusLayer = new itowns.GeometryLayer('lyon_tcl_bus', new itowns.THREE.Group(), {
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
-                    color: colorLine,
-                    altitude: altitudeLine }),
-                onMeshCreated: setMaterialLineWidth,
+                convert: itowns.Feature2Mesh.convert(),
                 filter: acceptFeatureBus,
                 source: lyonTclBusSource,
                 zoom: { min: 2 },
+
+                style: new itowns.Style({
+                    stroke: {
+                        base_altitude: altitudeLine,
+                        width: 5,
+                    }
+                })
             });
 
             view.addLayer(lyonTclBusLayer);
@@ -230,10 +222,8 @@
             var wfsBuildingLayer = new itowns.GeometryLayer('wfsBuilding', new itowns.THREE.Group(), {
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
-                    color: colorBuildings,
-                    batchId: function (property, featureId) { return featureId; },
-                    altitude: altitudeBuildings,
-                    extrude: extrudeBuildings }),
+                    batchId: function (property, featureId) { return featureId; }
+                }),
                 onMeshCreated: function scaleZ(mesh) {
                     mesh.children.forEach(c => {
                         c.scale.z = 0.01;
@@ -241,10 +231,17 @@
                     })
                 },
                 filter: acceptFeature,
-                overrideAltitudeInToZero: true,
                 crs: 'EPSG:3946',
                 source: wfsBuildingSource,
                 zoom: { min: 4 },
+
+                style: new itowns.Style({
+                    fill: {
+                        color: colorBuildings,
+                        base_altitude: altitudeBuildings,
+                        extrusion_height: extrudeBuildings,
+                    }
+                })
             });
 
             view.addLayer(wfsBuildingLayer);

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -186,8 +186,10 @@
                     altitude: altitudeBuildings,
                     extrude: extrudeBuildings }),
                 onMeshCreated: function scaleZ(mesh) {
-                    mesh.scale.z = 0.01;
-                    meshes.push(mesh);
+                    mesh.children.forEach(c => {
+                        c.scale.z = 0.01;
+                        meshes.push(c);
+                    })
                 },
                 filter: acceptFeature,
                 overrideAltitudeInToZero: true,

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -113,13 +113,18 @@
             var lyonTclBusLayer = new itowns.GeometryLayer('WFS Bus lines', new itowns.THREE.Group(), {
                 name: 'lyon_tcl_bus',
                 update: itowns.FeatureProcessing.update,
-                convert: itowns.Feature2Mesh.convert({
-                    color: colorLine,
-                    altitude: altitudeLine }),
-                linewidth: 5,
+                convert: itowns.Feature2Mesh.convert(),
                 filter: acceptFeatureBus,
                 source: lyonTclBusSource,
                 zoom: { min: 9 },
+
+                style: new itowns.Style({
+                    stroke: {
+                        color: colorLine,
+                        base_altitude: altitudeLine,
+                        width: 5,
+                    }
+                })
             });
             view.addLayer(lyonTclBusLayer);
 
@@ -181,10 +186,8 @@
             var wfsBuildingLayer = new itowns.GeometryLayer('WFS Building', new itowns.THREE.Group(), {
                 update: itowns.FeatureProcessing.update,
                 convert: itowns.Feature2Mesh.convert({
-                    color: colorBuildings,
                     batchId: function (property, featureId) { return featureId; },
-                    altitude: altitudeBuildings,
-                    extrude: extrudeBuildings }),
+                }),
                 onMeshCreated: function scaleZ(mesh) {
                     mesh.children.forEach(c => {
                         c.scale.z = 0.01;
@@ -192,9 +195,16 @@
                     })
                 },
                 filter: acceptFeature,
-                overrideAltitudeInToZero: true,
                 source: wfsBuildingSource,
                 zoom: { min: 14 },
+
+                style: new itowns.Style({
+                    fill: {
+                        color: colorBuildings,
+                        base_altitude: altitudeBuildings,
+                        extrusion_height: extrudeBuildings,
+                    }
+                })
             });
             view.addLayer(wfsBuildingLayer);
 

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -78,11 +78,27 @@
                 transparent: true,
                 style: {
                     fill: {
-                        color: 'red',
-                        opacity: 0.5
+                        color: p => {
+                            if (p.geojson.id.indexOf('bati_remarquable') === 0) {
+                                return '#5555ff';
+                            }
+                            if (p.geojson.id.indexOf('bati_industriel') === 0) {
+                                return '#ff5555';
+                            }
+                            return '#eeeeee';
+                        },
+                        opacity: 0.7
                     },
                     stroke: {
-                        color: 'white',
+                        color: p => {
+                            if (p.geojson.id.indexOf('bati_remarquable') === 0) {
+                                return '#8888ff';
+                            }
+                            if (p.geojson.id.indexOf('bati_industriel') === 0) {
+                                return '#ff8888';
+                            }
+                            return '#ffffff';
+                        },
                         width: 2.0,
                     },
                 },

--- a/examples/view_immersive.html
+++ b/examples/view_immersive.html
@@ -135,14 +135,16 @@
                 // create geometry layer for the buildings
                 var wfsBuildingLayer = new itowns.GeometryLayer('Buildings', new itowns.THREE.Group(), {
                     update: itowns.FeatureProcessing.update,
-                    convert: itowns.Feature2Mesh.convert({
-                        altitude: altitudeBuildings,
-                        extrude: extrudeBuildings }),
-
+                    convert: itowns.Feature2Mesh.convert(),
+                    style: new itowns.Style({
+                        fill: {
+                            base_altitude: altitudeBuildings,
+                            extrusion_height: extrudeBuildings,
+                        }
+                    }),
                     // when a building is created, it get the projective texture mapping, from oriented image layer.
                     onMeshCreated: (mesh) => mesh.traverse(object => object.material = orientedImageLayer.material),
                     source: wfsBuildingSource,
-                    overrideAltitudeInToZero: true,
                     zoom: { min: 15 },
                 });
 

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -31,6 +31,8 @@ function updateSurfaces(surfaces, position, norm) {
 
 // vector use in the pick method
 const target = new THREE.Vector3();
+const normal = new THREE.Vector3();
+const normalMatrix = new THREE.Matrix3();
 const up = new THREE.Vector3();
 const startQuaternion = new THREE.Quaternion();
 
@@ -45,7 +47,9 @@ function pick(event, view, buildingsLayer, pickGround = () => {}, pickObject = (
     // to detect pick on building, compare first picked building distance to ground distance
     if (buildings.length && buildings[0].distance < distanceToGround) { // pick buildings
         // callback
-        pickObject(buildings[0].point, buildings[0].face.normal);
+        normalMatrix.getNormalMatrix(buildings[0].object.matrixWorld);
+        normal.copy(buildings[0].face.normal).applyNormalMatrix(normalMatrix);
+        pickObject(buildings[0].point, normal);
     } else if (view.tileLayer) {
         const far = view.camera.camera3D.far * 0.95;
         if (distanceToGround < far) {

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -1,31 +1,20 @@
 import * as THREE from 'three';
 import Earcut from 'earcut';
-import Coordinates from 'Core/Geographic/Coordinates';
 import { FEATURE_TYPES } from 'Core/Feature';
+import { deprecatedFeature2MeshOptions } from 'Core/Deprecated/Undeprecator';
 
-function getProperty(name, options, defaultValue, ...args) {
-    const property = options[name];
+const _color = new THREE.Color();
 
-    if (property) {
-        if (typeof property === 'function') {
-            const p = property(...args);
-            if (p) {
-                return p;
-            }
+function toColor(color) {
+    if (color) {
+        if (color.type == 'Color') {
+            return color;
         } else {
-            return property;
+            return _color.set(color);
         }
+    } else {
+        return _color.set(Math.random() * 0xffffff);
     }
-
-    if (typeof defaultValue === 'function') {
-        return defaultValue(...args);
-    }
-
-    return defaultValue;
-}
-
-function randomColor() {
-    return new THREE.Color(Math.random() * 0xffffff);
 }
 
 function fillColorArray(colors, length, color, offset = 0) {
@@ -50,37 +39,23 @@ function fillBatchIdArray(batchId, batchIdArray, start, end) {
  * @param      {number[]} ptsIn - Coordinates of a feature.
  * @param      {number[]} normals - Coordinates of a feature.
  * @param      {number[]} target - Target to copy result.
- * @param      {(Function|number)}  altitude - Altitude of feature or function to get altitude.
- * @param      {number} extrude - The extrude amount to apply at each point
+ * @param      {number}  zTranslation - Translation on Z axe.
  * @param      {number} offsetOut - The offset array value to copy on target
  * @param      {number} countIn - The count of coordinates to read in ptsIn
  * @param      {number} startIn - The offser array to strat reading in ptsIn
  */
-const coord = new Coordinates('EPSG:4326', 0, 0);
-function coordinatesToVertices(ptsIn, normals, target, altitude = 0, extrude = 0, offsetOut = 0, countIn = ptsIn.length / 3, startIn = offsetOut) {
+function coordinatesToVertices(ptsIn, normals, target, zTranslation, offsetOut = 0, countIn = ptsIn.length / 3, startIn = offsetOut) {
     startIn *= 3;
     countIn *= 3;
     offsetOut *= 3;
     const endIn = startIn + countIn;
-    let fnAltitude;
-    if (!isNaN(altitude)) {
-        fnAltitude = () => altitude;
-    } else if (Array.isArray(altitude)) {
-        fnAltitude = id => altitude[(id - startIn) / 3];
-    } else {
-        fnAltitude = id => altitude({}, coord.setFromArray(ptsIn, id));
-    }
 
     for (let i = startIn, j = offsetOut; i < endIn; i += 3, j += 3) {
         // move the vertex following the normal, to put the point on the good altitude
-        const t = fnAltitude(i) + (Array.isArray(extrude) ? extrude[(i - startIn) / 3] : extrude);
-        if (target.minAltitude) {
-            target.minAltitude = Math.min(t, target.minAltitude);
-        }
         // fill the vertices array at the offset position
-        target[j] = ptsIn[i] + normals[i] * t;
-        target[j + 1] = ptsIn[i + 1] + normals[i + 1] * t;
-        target[j + 2] = ptsIn[i + 2] + normals[i + 2] * t;
+        target[j] = ptsIn[i] + normals[i] * zTranslation;
+        target[j + 1] = ptsIn[i + 1] + normals[i + 1] * zTranslation;
+        target[j + 2] = ptsIn[i + 2] + normals[i + 2] * zTranslation;
     }
 }
 
@@ -136,18 +111,21 @@ function featureToPoint(feature, options) {
     let featureId = 0;
 
     let vertices;
-    if (options.altitude !== 0) {
+    const zTranslation = options.GlobalZTrans - feature.altitude.min;
+    if (zTranslation !== 0) {
         vertices = new Float32Array(ptsIn.length);
-        coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
+        coordinatesToVertices(ptsIn, normals, vertices, zTranslation);
     } else {
         vertices = new Float32Array(ptsIn);
     }
-
+    const globals = { point: true };
     for (const geometry of feature.geometries) {
-        const color = getProperty('color', options, randomColor, geometry.properties);
+        const context = { globals, properties: () => geometry.properties };
+        const style = feature.style.drawingStylefromContext(context);
+
         const start = geometry.indices[0].offset;
         const count = geometry.indices[0].count;
-        fillColorArray(colors, count, color, start);
+        fillColorArray(colors, count, toColor(style.point.color), start);
 
         if (batchIds) {
             const id = options.batchId(geometry.properties, featureId);
@@ -161,9 +139,9 @@ function featureToPoint(feature, options) {
     geom.setAttribute('color', new THREE.BufferAttribute(colors, 3, true));
     if (batchIds) { geom.setAttribute('batchId', new THREE.BufferAttribute(batchIds, 1)); }
 
-    const points = new THREE.Points(geom, pointMaterial);
-    points.minAltitude = 0;
-    return points;
+    pointMaterial.size = feature.style.point.radius;
+
+    return new THREE.Points(geom, pointMaterial);
 }
 
 var lineMaterial = new THREE.LineBasicMaterial();
@@ -177,9 +155,10 @@ function featureToLine(feature, options) {
     let featureId = 0;
 
     let vertices;
-    if (options.altitude !== 0) {
+    const zTranslation =  options.GlobalZTrans - feature.altitude.min;
+    if (zTranslation != 0) {
         vertices = new Float32Array(ptsIn.length);
-        coordinatesToVertices(ptsIn, normals, vertices, options.altitude);
+        coordinatesToVertices(ptsIn, normals, vertices, zTranslation);
     } else {
         vertices = new Float32Array(ptsIn);
     }
@@ -188,13 +167,18 @@ function featureToLine(feature, options) {
 
     let lines;
 
+    // TODO CREATE material for each feature
+    lineMaterial.linewidth = feature.style.stroke.width;
+    const globals = { stroke: true };
     if (feature.geometries.length > 1) {
         const countIndices = (count - feature.geometries.length) * 2;
         const indices = new Uint16Array(countIndices);
         let i = 0;
         // Multi line case
         for (const geometry of feature.geometries) {
-            const color = getProperty('color', options, randomColor, geometry.properties);
+            const context = { globals, properties: () => geometry.properties };
+            const style = feature.style.drawingStylefromContext(context);
+
             const start = geometry.indices[0].offset;
             // To avoid integer overflow with indice value (16 bits)
             if (start > 0xffff) {
@@ -203,7 +187,7 @@ function featureToLine(feature, options) {
             }
             const count = geometry.indices[0].count;
             const end = start + count;
-            fillColorArray(colors, count, color, start);
+            fillColorArray(colors, count, toColor(style.stroke.color), start);
             for (let j = start; j < end - 1; j++) {
                 if (j < 0xffff) {
                     indices[i++] = j;
@@ -223,8 +207,10 @@ function featureToLine(feature, options) {
         geom.setIndex(new THREE.BufferAttribute(indices, 1));
         lines = new THREE.LineSegments(geom, lineMaterial);
     } else {
-        const color = getProperty('color', options, randomColor, feature.geometries[0].properties);
-        fillColorArray(colors, count, color);
+        const context = { globals, properties: () => feature.geometries[0].properties };
+        const style = feature.style.drawingStylefromContext(context);
+
+        fillColorArray(colors, count, toColor(style.stroke.color));
         geom.setAttribute('color', new THREE.BufferAttribute(colors, 3, true));
         if (batchIds) {
             const id = options.batchId(feature.geometries[0].properties, featureId);
@@ -233,21 +219,28 @@ function featureToLine(feature, options) {
         }
         lines = new THREE.Line(geom, lineMaterial);
     }
-    lines.minAltitude = 0;
     return lines;
 }
 
-const color = new THREE.Color();
 const material = new THREE.MeshBasicMaterial();
 function featureToPolygon(feature, options) {
     const ptsIn = feature.vertices;
     const normals = feature.normals;
-    const vertices = new Float32Array(ptsIn);
+
+    let vertices;
+    const zTranslation = options.GlobalZTrans - feature.altitude.min;
+    if (zTranslation != 0) {
+        vertices = new Float32Array(ptsIn.length);
+        coordinatesToVertices(ptsIn, normals, vertices, zTranslation);
+    } else {
+        vertices = new Float32Array(ptsIn);
+    }
+
     const colors = new Uint8Array(ptsIn.length);
     const indices = [];
-    vertices.minAltitude = Infinity;
 
     const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
+    const globals = { fill: true };
     let featureId = 0;
 
     for (const geometry of feature.geometries) {
@@ -257,15 +250,14 @@ function featureToPolygon(feature, options) {
             console.warn('Feature to Polygon: integer overflow, too many points in polygons');
             break;
         }
-        const color = getProperty('color', options, randomColor, geometry.properties);
+        const context = { globals, properties: () => geometry.properties };
+        const style = feature.style.drawingStylefromContext(context);
+
         const lastIndice = geometry.indices.slice(-1)[0];
         const end = lastIndice.offset + lastIndice.count;
         const count = end - start;
-        const altitude = getProperty('altitude', options, 0, geometry.properties);
-        if (altitude !== 0) {
-            coordinatesToVertices(ptsIn, normals, vertices, altitude, 0, start, count);
-        }
-        fillColorArray(colors, count, color, start);
+
+        fillColorArray(colors, count, toColor(style.fill.color), start);
 
         const geomVertices = vertices.slice(start * 3, end * 3);
         const holesOffsets = geometry.indices.map(i => i.offset - start).slice(1);
@@ -292,9 +284,7 @@ function featureToPolygon(feature, options) {
 
     geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
 
-    const mesh = new THREE.Mesh(geom, material);
-    mesh.minAltitude = isNaN(vertices.minAltitude) ? 0 : vertices.minAltitude;
-    return mesh;
+    return new THREE.Mesh(geom, material);
 }
 
 function area(contour, offset, count) {
@@ -309,6 +299,7 @@ function area(contour, offset, count) {
     return a * 0.5;
 }
 
+const bottomColor = new THREE.Color();
 function featureToExtrudedPolygon(feature, options) {
     const ptsIn = feature.vertices;
     const offset = feature.geometries[0].indices[0].offset;
@@ -321,31 +312,34 @@ function featureToExtrudedPolygon(feature, options) {
     const indices = [];
     const totalVertices = ptsIn.length / 3;
 
-    vertices.minAltitude = Infinity;
-
     const batchIds = options.batchId ?  new Uint32Array(vertices.length / 3) : undefined;
     let featureId = 0;
 
-    for (const geometry of feature.geometries) {
-        const altitude = getProperty('altitude', options, 0, geometry.properties);
-        const extrude = getProperty('extrude', options, 0, geometry.properties);
+    const z = options.GlobalZTrans - feature.altitude.min;
+    const globals = { fill: true };
 
-        const colorTop = getProperty('color', options, randomColor, geometry.properties);
-        color.copy(colorTop);
-        color.multiplyScalar(0.6);
+    for (const geometry of feature.geometries) {
+        const context = { globals, properties: () => geometry.properties };
+        const style = feature.style.drawingStylefromContext(context);
+
+        // topColor is assigned to the top of extruded polygon
+        const topColor = toColor(style.fill.color);
+        // bottomColor is assigned to the bottom of extruded polygon
+        bottomColor.copy(topColor);
+        bottomColor.multiplyScalar(0.5);
 
         const start = geometry.indices[0].offset;
         const lastIndice = geometry.indices.slice(-1)[0];
         const end = lastIndice.offset + lastIndice.count;
         const count = end - start;
 
-        coordinatesToVertices(ptsIn, normals, vertices, altitude, 0, start, count);
-        fillColorArray(colors, count, color, start);
+        coordinatesToVertices(ptsIn, normals, vertices, z, start, count);
+        fillColorArray(colors, count, bottomColor, start);
 
         const startTop = start + totalVertices;
         const endTop = end + totalVertices;
-        coordinatesToVertices(ptsIn, normals, vertices, altitude, extrude, startTop, count, start);
-        fillColorArray(colors, count, colorTop, startTop);
+        coordinatesToVertices(ptsIn, normals, vertices, z + style.fill.extrusion_height, startTop, count, start);
+        fillColorArray(colors, count, topColor, startTop);
 
         const geomVertices = vertices.slice(startTop * 3, endTop * 3);
         const holesOffsets = geometry.indices.map(i => i.offset - start).slice(1);
@@ -383,7 +377,6 @@ function featureToExtrudedPolygon(feature, options) {
     geom.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
 
     const mesh = new THREE.Mesh(geom, material);
-    mesh.minAltitude = isNaN(vertices.minAltitude) ? 0 : vertices.minAltitude;
     return mesh;
 }
 
@@ -392,9 +385,6 @@ function featureToExtrudedPolygon(feature, options) {
  *
  * @param {Feature} feature - the feature to convert
  * @param {Object} options - options controlling the conversion
- * @param {number|function} options.altitude - define the base altitude of the mesh
- * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
- * @param {object|function} options.color - define per feature color
  * @return {THREE.Mesh} mesh
  */
 function featureToMesh(feature, options) {
@@ -411,7 +401,7 @@ function featureToMesh(feature, options) {
             mesh = featureToLine(feature, options);
             break;
         case FEATURE_TYPES.POLYGON:
-            if (options.extrude) {
+            if (feature.style.fill.extrusion_height) {
                 mesh = featureToExtrudedPolygon(feature, options);
             } else {
                 mesh = featureToPolygon(feature, options);
@@ -425,6 +415,8 @@ function featureToMesh(feature, options) {
     mesh.material.color = new THREE.Color(0xffffff);
 
     mesh.feature = feature;
+    mesh.position.z = feature.altitude.min - options.GlobalZTrans;
+
     return mesh;
 }
 
@@ -437,9 +429,6 @@ export default {
      * a THREE.Group.
      *
      * @param {Object} options - options controlling the conversion
-     * @param {number|function} options.altitude - define the base altitude of the mesh
-     * @param {number|function} options.extrude - if defined, polygons will be extruded by the specified amount
-     * @param {object|function} options.color - define per feature color
      * @param {function} [options.batchId] - optional function to create batchId attribute. It is passed the feature property and the feature index. As the batchId is using an unsigned int structure on 32 bits, the batchId could be between 0 and 4,294,967,295.
      * @return {function}
      * @example <caption>Example usage of batchId with featureId.</caption>
@@ -448,14 +437,8 @@ export default {
      *     type: 'geometry',
      *     update: itowns.FeatureProcessing.update,
      *     convert: itowns.Feature2Mesh.convert({
-     *         color: colorBuildings,
      *         batchId: (property, featureId) => featureId,
-     *         altitude: altitudeBuildings,
-     *         extrude: extrudeBuildings }),
-     *     onMeshCreated: function scaleZ(mesh) {
-     *         mesh.scale.z = 0.01;
-     *         meshes.push(mesh);
-     *     },
+     *     }),
      *     filter: acceptFeature,
      *     source,
      * });
@@ -466,19 +449,14 @@ export default {
      *     type: 'geometry',
      *     update: itowns.FeatureProcessing.update,
      *     convert: itowns.Feature2Mesh.convert({
-     *         color: colorBuildings,
      *         batchId: (property, featureId) => property.house ? 10 : featureId,
-     *         altitude: altitudeBuildings,
-     *         extrude: extrudeBuildings }),
-     *     onMeshCreated: function scaleZ(mesh) {
-     *         mesh.scale.z = 0.01;
-     *         meshes.push(mesh);
-     *     },
+     *         }),
      *     filter: acceptFeature,
      *     source,
      * });
      */
     convert(options = {}) {
+        deprecatedFeature2MeshOptions(options);
         return function _convert(collection) {
             if (!collection) { return; }
 

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -428,29 +428,6 @@ function featureToMesh(feature, options) {
     return mesh;
 }
 
-function featuresToThree(features, options) {
-    if (!features || features.length == 0) { return; }
-
-    if (features.length == 1) {
-        coord.crs = features[0].crs;
-        coord.setFromValues(0, 0, 0);
-        return featureToMesh(features[0], options);
-    }
-
-    const group = new THREE.Group();
-    group.minAltitude = Infinity;
-
-    for (const feature of features) {
-        coord.crs = feature.crs;
-        coord.setFromValues(0, 0, 0);
-        const mesh = featureToMesh(feature, options);
-        group.add(mesh);
-        group.minAltitude = Math.min(mesh.minAltitude, group.minAltitude);
-    }
-
-    return group;
-}
-
 /**
  * @module Feature2Mesh
  */
@@ -505,7 +482,19 @@ export default {
         return function _convert(collection) {
             if (!collection) { return; }
 
-            return featuresToThree(collection.features, options);
+            const features = collection.features;
+
+            if (!features || features.length == 0) { return; }
+
+            const group = new THREE.Group();
+            options.GlobalZTrans = collection.center.z;
+
+            features.forEach(feature => group.add(featureToMesh(feature, options)));
+
+            group.quaternion.copy(collection.quaternion);
+            group.position.copy(collection.position);
+
+            return group;
         };
     },
 };

--- a/src/Core/Deprecated/Undeprecator.js
+++ b/src/Core/Deprecated/Undeprecator.js
@@ -17,7 +17,7 @@ export const deprecatedColorLayerOptions = (options) => {
 export const deprecatedParsingOptionsToNewOne = (options) => {
     /* istanbul ignore next */
     if (options.crsOut || options.crsIn) {
-        console.warn('Parsing options with crsIn and crsOut are deprecates, use { in, out } structure.');
+        console.warn('Parsing options with crsIn and crsOut are deprecated, use { in, out } structure.');
         const newOptions = { in: {}, out: {} };
         newOptions.in.crs = options.crsIn;
         newOptions.in.isInverted = options.isInverted;
@@ -27,29 +27,51 @@ export const deprecatedParsingOptionsToNewOne = (options) => {
 
         newOptions.out.crs = options.crsOut;
         newOptions.out.mergeFeatures = options.mergeFeatures;
-        newOptions.out.withNormal = options.withNormal;
-        newOptions.out.withAltitude = options.withAltitude;
-        if (options.out.withAltitude && options.out.withNormal) {
-            newOptions.structure = '3d';
+        if (options.withAltitude && options.withNormal) {
+            console.warn('Parsing options withAltitude and withNormal is deprecated, use out.structure: 2d or 3d.');
+            newOptions.out.structure = '3d';
         } else {
-            newOptions.structure = '2d';
+            newOptions.out.structure = '2d';
         }
         newOptions.out.filteringExtent = options.filteringExtent;
         newOptions.out.style = options.style;
-        newOptions.out.overrideAltitudeInToZero = options.overrideAltitudeInToZero;
+        if (options.crsOut.overrideAltitudeInToZero !== undefined) {
+            console.error('Parsing options out.overrideAltitudeInToZero is removed, use Style.xxx.base_altitude instead');
+        }
         newOptions.out.filter = options.filter;
         return newOptions;
-    } else if (options.out && (options.out.withAltitude !== undefined || options.out.withNormal !== undefined)) {
-        console.warn('Parsing options out.withAltitude and out.withNormal are deprecates, use out.structure: 2d or 3d.');
-        if (options.out.withAltitude && options.out.withNormal) {
-            options.structure = '3d';
-        } else {
-            options.structure = '2d';
+    }
+
+    if (options.out) {
+        if (options.out.withAltitude !== undefined || options.out.withNormal !== undefined) {
+            console.warn('Parsing options out.withAltitude and out.withNormal is deprecated, use out.structure: 2d or 3d.');
+            if (options.out.withAltitude && options.out.withNormal) {
+                options.out.structure = '3d';
+            } else {
+                options.out.structure = '2d';
+            }
+        }
+
+        if (options.out.overrideAltitudeInToZero !== undefined) {
+            console.error('Parsing options out.overrideAltitudeInToZero is removed, use Style.xxx.base_altitude instead');
         }
     }
+
     return options;
 };
 
+export const deprecatedFeature2MeshOptions = (options) => {
+    if (options.color) {
+        console.error('Color convert option is removed, use Style.xxx.color');
+    }
+
+    if (options.extrude) {
+        console.error('extrude convert option is removed, use Style.fill.extrusion_height instead');
+    }
+
+    if (options.altitude) {
+        console.error('altitude convert option is removed, use Style.xxx.base_altitude instead');
+    }
+};
+
 export default {};
-
-

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -11,6 +11,10 @@ const inv255 = 1 / 255;
 const canvas = document.createElement('canvas');
 const style_properties = {};
 
+function base_altitudeDefault(properties, coordinates = { z: 0 }) {
+    return coordinates.z;
+}
+
 function mapPropertiesFromContext(mainKey, from, to, context) {
     to[mainKey] = to[mainKey] || {};
     for (const key of style_properties[mainKey]) {
@@ -55,6 +59,8 @@ export function readExpression(property, ctx) {
                 }
             }
             return property.stops[0][1];
+        } else if (property instanceof Function) {
+            return property(ctx.properties());
         } else {
             return property;
         }
@@ -137,42 +143,61 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * @property {number} order - Order of the features that will be associated to
  * the style. It can helps sorting and prioritizing features if needed.
  * @property {Object} fill - Polygons and fillings style.
- * @property {string} fill.color - Defines the main color of the filling. Can be
+ * @property {string|function} fill.color - Defines the main color of the filling. Can be
  * any [valid color
  * string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * Default is no value, indicating that no filling needs to be done.
- * @property {Image|Canvas|string} fill.pattern - Defines a pattern to fill the
+ * If the `Layer` is a `GeometryLayer` you could use `THREE.Color`.
+ * @property {Image|Canvas|string|function} fill.pattern - Defines a pattern to fill the
  * surface with. It can be an `Image` to use directly, or an url to fetch the
  * pattern from. See [this
  * example](http://www.itowns-project.org/itowns/examples/#source_file_geojson_raster)
  * for how to use.
- * @property {number} fill.opacity - The opacity of the color or the
+ * @property {number|function} fill.opacity - The opacity of the color or the
  * pattern. Can be between `0.0` and `1.0`. Default is `1.0`.
- *
+ * For a `GeometryLayer`, this opacity property isn't used.
+ * @property {number|function} fill.base_altitude - `GeometryLayer` Style, defines altitude
+ * for each Coordinates.
+ * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
+ * then the altitude value is set to 0.
+ * @property {number|function} fill.extrusion_height - `GeometryLayer` Style, if defined,
+ * polygons will be extruded by the specified amount
  * @property {Object} stroke - Lines and polygon edges.
- * @property {string} stroke.color The color of the line. Can be any [valid
+ * @property {string|function} stroke.color The color of the line. Can be any [valid
  * color string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * Default is no value, indicating that no stroke needs to be done.
- * @property {number} stroke.opacity - The opacity of the line. Can be between
+ * If the `Layer` is a `GeometryLayer` you could use `THREE.Color`.
+ * @property {number|function} stroke.opacity - The opacity of the line. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
- * @property {number} stroke.width - The width of the line. Default is `1.0`.
+ * For a `GeometryLayer`, this opacity property isn't used.
+ * @property {number|function} stroke.width - The width of the line. Default is `1.0`.
+ * @property {number|function} stroke.base_altitude - `GeometryLayer` Style, defines altitude
+ * for each Coordinates.
+ * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
+ * then the altitude value is set to 0.
  *
  * @property {Object} point - Point style.
- * @property {string} point.color - The color of the point. Can be any [valid
+ * @property {string|function} point.color - The color of the point. Can be any [valid
  * color string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * Default is no value, indicating that no point will be shown.
- * @property {number} point.radius - The radius of the point, in pixel. Default
+ * @property {number|function} point.radius - The radius of the point, in pixel. Default
  * is `2.0`.
- * @property {string} point.line - The color of the border of the point. Can be
+ * @property {string|function} point.line - The color of the border of the point. Can be
  * any [valid color
  * string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
- * @property {number} point.width - The width of the border, in pixel. Default
+ * It's not supported with a `GeometryLayer`.
+ * @property {number|function} point.width - The width of the border, in pixel. Default
  * is `0.0` (no border).
- * @property {number} point.opacity - The opacity of the point. Can be between
+ * @property {number|function} point.opacity - The opacity of the point. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
+ * It's not supported with a `GeometryLayer`.
+ * @property {number|function} point.base_altitude - `GeometryLayer` Style, defines altitude
+ * for each Coordinates.
+ * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
+ * then the altitude value is set to 0.
  *
  * @property {Object} text - All things {@link Label} related.
- * @property {string} text.field - A string to help read the text field from
+ * @property {string|function} text.field - A string to help read the text field from
  * properties of a `FeatureGeometry`, with the key of the property enclosed by
  * brackets. For example, if each geometry contains a `name` property,
  * `text.field` can be set as `{name}`. Default is no value, indicating that no
@@ -185,42 +210,42 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * multiple properties in one field, like if you want the latin name and the
  * local name of a location. Specifying `{name_latin} - {name_local}` can result
  * in `Marrakesh - مراكش` for example.
- * @property {string} text.color - The color of the text. Can be any [valid
+ * @property {string|function} text.color - The color of the text. Can be any [valid
  * color string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * Default is `#000000`.
- * @property {string} text.anchor - The anchor of the text compared to its
+ * @property {string|function} text.anchor - The anchor of the text compared to its
  * position (see {@link Label} for the position). Can be a few value: `top`,
  * `left`, `bottom`, `right`, `center`, `top-left`, `top-right`, `bottom-left`
  * or `bottom-right`. Default is `center`.
- * @property {Array} text.offset - The offset of the text, depending on its
+ * @property {Array|function} text.offset - The offset of the text, depending on its
  * anchor, in pixels. First value is from `left`, second is from `top`. Default
  * is `[0, 0]`.
- * @property {number} text.padding - The padding outside the text, in pixels.
+ * @property {number|function} text.padding - The padding outside the text, in pixels.
  * Default is `2`.
- * @property {number} text.size - The size of the font, in pixels. Default is
+ * @property {number|function} text.size - The size of the font, in pixels. Default is
  * `16`.
- * @property {number} text.wrap - The maximum width, in pixels, before the text
+ * @property {number|function} text.wrap - The maximum width, in pixels, before the text
  * is wrapped, because the string is too long. Default is `10`.
- * @property {number} text.spacing - The spacing between the letters, in `em`.
+ * @property {number|function} text.spacing - The spacing between the letters, in `em`.
  * Default is `0`.
- * @property {string} text.transform - A value corresponding to the [CSS
+ * @property {string|function} text.transform - A value corresponding to the [CSS
  * property
  * `text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform).
  * Default is `none`.
- * @property {string} text.justify - A value corresponding to the [CSS property
+ * @property {string|function} text.justify - A value corresponding to the [CSS property
  * `text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
  * Default is `center`.
- * @property {number} text.opacity - The opacity of the text. Can be between
+ * @property {number|function} text.opacity - The opacity of the text. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
- * @property {Array} text.font - A list (as an array of string) of font family
+ * @property {Array|function} text.font - A list (as an array of string) of font family
  * names, prioritized in the order it is set. Default is `Open Sans Regular,
  * Arial Unicode MS Regular, sans-serif`.
- * @property {string} text.haloColor - The color of the halo. Can be any [valid
+ * @property {string|function} text.haloColor - The color of the halo. Can be any [valid
  * color string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * Default is `#000000`.
- * @property {number} text.haloWidth - The width of the halo, in pixels.
+ * @property {number|function} text.haloWidth - The width of the halo, in pixels.
  * Default is `0`.
- * @property {number} text.haloBlur - The blur value of the halo, in pixels.
+ * @property {number|function} text.haloBlur - The blur value of the halo, in pixels.
  * Default is `0`.
  *
  * @example
@@ -274,6 +299,9 @@ class Style {
         defineStyleProperty(this, 'fill', 'color', params.fill.color);
         defineStyleProperty(this, 'fill', 'opacity', params.fill.opacity, 1.0);
         defineStyleProperty(this, 'fill', 'pattern', params.fill.pattern);
+        defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude, base_altitudeDefault);
+        defineStyleProperty(this, 'fill', 'extrusion_height', params.fill.extrusion_height);
+
         if (typeof this.fill.pattern == 'string') {
             Fetcher.texture(this.fill.pattern).then((pattern) => {
                 this.fill.pattern = pattern.image;
@@ -285,6 +313,7 @@ class Style {
         defineStyleProperty(this, 'stroke', 'opacity', params.stroke.opacity, 1.0);
         defineStyleProperty(this, 'stroke', 'width', params.stroke.width, 1.0);
         defineStyleProperty(this, 'stroke', 'dasharray', params.stroke.dasharray, []);
+        defineStyleProperty(this, 'stroke', 'base_altitude', params.stroke.base_altitude, base_altitudeDefault);
 
         this.point = {};
         defineStyleProperty(this, 'point', 'color', params.point.color);
@@ -292,6 +321,7 @@ class Style {
         defineStyleProperty(this, 'point', 'opacity', params.point.opacity, 1.0);
         defineStyleProperty(this, 'point', 'radius', params.point.radius, 2.0);
         defineStyleProperty(this, 'point', 'width', params.point.width, 0.0);
+        defineStyleProperty(this, 'point', 'base_altitude', params.point.base_altitude, base_altitudeDefault);
 
         this.text = {};
         defineStyleProperty(this, 'text', 'field', params.text.field);
@@ -323,13 +353,13 @@ class Style {
      */
     drawingStylefromContext(context) {
         const style = {};
-        if (this.fill.color || this.fill.pattern) {
+        if (this.fill.color || this.fill.pattern || context.globals.fill) {
             mapPropertiesFromContext('fill', this, style, context);
         }
-        if (this.stroke.color) {
+        if (this.stroke.color || context.globals.stroke) {
             mapPropertiesFromContext('stroke', this, style, context);
         }
-        if (this.point.color) {
+        if (this.point.color || context.globals.point) {
             mapPropertiesFromContext('point', this, style, context);
         }
         if (Object.keys(style).length) {

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -147,7 +147,7 @@ class OrientedImageLayer extends GeometryLayer {
             for (const pano of this.panos) {
                 // set position
                 coord.crs = pano.crs;
-                coord.setFromArray(pano.vertices);
+                coord.setFromArray(pano.vertices).applyMatrix4(orientation.matrix);
                 pano.position = coord.toVector3();
 
                 // set quaternion

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -31,17 +31,13 @@ const firstPtIsOut = (extent, aCoords, crs) => {
     return !extent.isPointInside(coord);
 };
 const toFeature = {
-    populateGeometry(crsIn, coordinates, geometry, collection, feature) {
+    populateGeometry(crsIn, coordinates, geometry, feature) {
         geometry.startSubGeometry(coordinates.length, feature);
-
-        const useAlti = !collection.overrideAltitudeInToZero &&
-                        collection.size == 3 &&
-                        typeof coordinates[0][2] == 'number';
-
+        coord.crs = crsIn;
         // coordinates is a list of pair [[x1, y1], [x2, y2], ..., [xn, yn]]
-        for (const pair of coordinates) {
-            coord.crs = crsIn;
-            coord.setFromValues(pair[0], pair[1], useAlti ? pair[2] : 0);
+        // or list of triplet [[x1, y1, z1], [x2, y2, z2], ..., [xn, yn, zn]]
+        for (const triplet of coordinates) {
+            coord.setFromValues(triplet[0], triplet[1], triplet[2]);
             geometry.pushCoordinates(coord, feature);
         }
         geometry.updateExtent();
@@ -57,7 +53,7 @@ const toFeature = {
         const geometry = feature.bindNewGeometry();
         geometry.properties = properties;
         geometry.properties.style = new Style({}, feature.style).setFromGeojsonProperties(properties, feature.type);
-        this.populateGeometry(crsIn, coordsIn, geometry, collection, feature);
+        this.populateGeometry(crsIn, coordsIn, geometry, feature);
         feature.updateExtent(geometry);
     },
     polygon(feature, crsIn, coordsIn, collection, properties) {
@@ -71,7 +67,7 @@ const toFeature = {
 
         // Then read contour and holes
         for (let i = 0; i < coordsIn.length; i++) {
-            this.populateGeometry(crsIn, coordsIn[i], geometry, collection, feature);
+            this.populateGeometry(crsIn, coordsIn[i], geometry, feature);
         }
         feature.updateExtent(geometry);
     },

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -5,14 +5,6 @@ import handlingError from 'Process/handlerNodeError';
 import Coordinates from 'Core/Geographic/Coordinates';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
-const mat4 = new THREE.Matrix4();
-
-function applyMatrix4(obj, mat4) {
-    if (obj.geometry) {
-        obj.geometry.applyMatrix4(mat4);
-    }
-    obj.children.forEach(c => applyMatrix4(c, mat4));
-}
 
 function assignLayer(object, layer) {
     if (object) {
@@ -89,7 +81,6 @@ export default {
             // if request return empty json, WFSProvider.getFeatures return undefined
             result = result[0];
             if (result) {
-                const isApplied = !result.layer;
                 assignLayer(result, layer);
                 // call onMeshCreated callback if needed
                 if (layer.onMeshCreated) {
@@ -100,22 +91,14 @@ export default {
                     ObjectRemovalHelper.removeChildrenAndCleanupRecursively(layer, result);
                     return;
                 }
-                // We don't use node.matrixWorld here, because feature coordinates are
-                // expressed in crs coordinates (which may be different than world coordinates,
-                // if node's layer is attached to an Object with a non-identity transformation)
-                if (isApplied) {
-                    // NOTE: now data source provider use cache on Mesh
-                    // TODO move transform in feature2Mesh
-                    mat4.copy(node.matrixWorld).invert().elements[14] -= result.minAltitude;
-                    applyMatrix4(result, mat4);
-                }
-
-                if (result.minAltitude) {
-                    result.position.z = result.minAltitude;
-                }
-                result.layer = layer;
-                node.add(result);
-                node.updateMatrixWorld();
+                // remove old group layer
+                node.remove(...node.children.filter(c => c.layer && c.layer.id == layer.id));
+                const group = new THREE.Group();
+                group.layer = layer;
+                group.matrixWorld.copy(node.matrixWorld).invert();
+                group.matrixWorld.decompose(group.position, group.quaternion, group.scale);
+                node.add(group.add(result));
+                group.updateMatrixWorld(true);
             } else {
                 node.layerUpdateState[layer.id].failure(1, true);
             }

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -13,13 +13,6 @@ function assignLayer(object, layer) {
             object.material.transparent = layer.opacity < 1.0;
             object.material.opacity = layer.opacity;
             object.material.wireframe = layer.wireframe;
-
-            if (layer.size) {
-                object.material.size = layer.size;
-            }
-            if (layer.linewidth) {
-                object.material.linewidth = layer.linewidth;
-            }
         }
         object.layers.set(layer.threejsLayer);
         for (const c of object.children) {

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -16,6 +16,7 @@ import ColorLayer from 'Layer/ColorLayer';
 import ElevationLayer from 'Layer/ElevationLayer';
 import GeometryLayer from 'Layer/GeometryLayer';
 import PlanarLayer from 'Core/Prefab/Planar/PlanarLayer';
+import Style from 'Core/Style';
 import Feature2Mesh from 'Converter/Feature2Mesh';
 import LayeredMaterial from 'Renderer/LayeredMaterial';
 import { EMPTY_TEXTURE_ZOOM } from 'Renderer/RasterTile';
@@ -69,19 +70,20 @@ describe('Provide in Sources', function () {
     const nodeLayer = material.getLayer(colorlayer.id);
     const nodeLayerElevation = material.getLayer(elevationlayer.id);
 
-    const featureLayer = new GeometryLayer('geom', new THREE.Group(), { source: false });
-    featureLayer.update = FeatureProcessing.update;
-    featureLayer.crs = 'EPSG:4978';
-    featureLayer.mergeFeatures = false;
-    featureLayer.zoom.min = 10;
-
-    function extrude() {
-        return 5000;
-    }
-
-    function color() {
-        return new THREE.Color(0xffcc00);
-    }
+    const featureLayer = new GeometryLayer('geom', new THREE.Group(), {
+        update: FeatureProcessing.update,
+        convert: Feature2Mesh.convert(),
+        crs: 'EPSG:4978',
+        mergeFeatures: false,
+        zoom: { min: 10 },
+        source: false,
+        style: new Style({
+            fill: {
+                extrusion_height: 5000,
+                color: new THREE.Color(0xffcc00),
+            },
+        }),
+    });
 
     featureLayer.source = new WFSSource({
         url: 'http://',
@@ -96,7 +98,6 @@ describe('Provide in Sources', function () {
         featureCountByCb = fc.features.length;
     };
 
-    featureLayer.convert = Feature2Mesh.convert({ color, extrude });
     planarlayer.attach(featureLayer);
 
     context.elevationLayers = [elevationlayer];

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -12,16 +12,18 @@ describe('Feature', function () {
     const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
     it('Should instance Features', function () {
-        const featurePoint = new Feature(FEATURE_TYPES.POINT, 'EPSG:4326');
-        const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');
-        const featurePolygon = new Feature(FEATURE_TYPES.POLYGON, 'EPSG:4326');
+        const collection = new FeatureCollection(options_A);
+        const featurePoint = new Feature(FEATURE_TYPES.POINT, collection);
+        const featureLine = new Feature(FEATURE_TYPES.LINE, collection);
+        const featurePolygon = new Feature(FEATURE_TYPES.POLYGON, collection);
         assert.equal(featurePoint.type, FEATURE_TYPES.POINT);
         assert.equal(featureLine.type, FEATURE_TYPES.LINE);
         assert.equal(featurePolygon.type, FEATURE_TYPES.POLYGON);
     });
 
     it('Should bind FeatureGeometry', function () {
-        const featureLine = new Feature(FEATURE_TYPES.LINE, 'EPSG:4326');
+        const collection = new FeatureCollection(options_A);
+        const featureLine = new Feature(FEATURE_TYPES.LINE, collection);
         featureLine.bindNewGeometry();
         assert.equal(featureLine.geometryCount, 1);
     });
@@ -56,6 +58,8 @@ describe('Feature', function () {
 
         featureLine.updateExtent(geometry);
 
+        collection_A.updateMatrix();
+        featureLine.extent.applyMatrix4(collection_A.matrix);
         assert.equal(featureLine.extent.south, -1118889.9748579601);
         assert.equal(featureLine.vertices.length, geometry.indices[0].count * featureLine.size);
         assert.equal(featureLine.vertices.length, featureLine.normals.length);

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -15,10 +15,11 @@ describe('FeaturesUtils', function () {
         }));
     it('should correctly compute extent geojson', () =>
         promise.then((collection) => {
-            assert.equal(collection.extent.west, 0.30798339284956455);
-            assert.equal(collection.extent.east, 2.4722900334745646);
-            assert.equal(collection.extent.south, 42.91620643817353);
-            assert.equal(collection.extent.north, 43.72744458647463);
+            const extent = collection.extent.clone().applyMatrix4(collection.matrix);
+            assert.equal(extent.west, 0.30798339284956455);
+            assert.equal(extent.east, 2.4722900334745646);
+            assert.equal(extent.south, 42.91620643817353);
+            assert.equal(extent.north, 43.72744458647463);
         }));
     it('should correctly filter point', () =>
         promise.then((collection) => {

--- a/test/unit/featureprocess.js
+++ b/test/unit/featureprocess.js
@@ -10,6 +10,7 @@ import Extent from 'Core/Geographic/Extent';
 import Coordinates from 'Core/Geographic/Coordinates';
 import OBB from 'Renderer/OBB';
 import TileMesh from 'Core/TileMesh';
+import Style from 'Core/Style';
 import Renderer from './bootstrap';
 
 describe('Layer with Feature process', function () {
@@ -18,14 +19,6 @@ describe('Layer with Feature process', function () {
     const placement = { coord: new Coordinates('EPSG:4326', 1.5, 43), range: 300000 };
     const viewer = new GlobeView(renderer.domElement, placement, { renderer });
 
-    function extrude() {
-        return 5000;
-    }
-
-    function color() {
-        return new THREE.Color(0xffcc00);
-    }
-
     const source = new FileSource({
         url: 'https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson',
         crs: 'EPSG:4326',
@@ -33,12 +26,17 @@ describe('Layer with Feature process', function () {
         networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
     });
 
-    const ariege = new GeometryLayer('ariege', new THREE.Group(), { source, zoom: { min: 7 } });
-
-    ariege.update = FeatureProcessing.update;
-    ariege.convert = Feature2Mesh.convert({
-        color,
-        extrude,
+    const ariege = new GeometryLayer('ariege', new THREE.Group(), {
+        source,
+        style: new Style({
+            fill: {
+                extrusion_height: 5000,
+                color: new THREE.Color(0xffcc00),
+            },
+        }),
+        zoom: { min: 7 },
+        update: FeatureProcessing.update,
+        convert: Feature2Mesh.convert(),
     });
 
     const context = {

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -15,14 +15,14 @@ function parse(geojson) {
 }
 
 describe('GeoJsonParser', function () {
-    it('should set all z coordinates to 1', () =>
+    it('should set all z coordinates to 0', () =>
         parse(holes).then((collection) => {
-            assert.ok(collection.features[0].vertices.every((v, i) => i == 0 || ((i + 1) % 3) != 0 || v == 0));
+            assert.ok(collection.features[0].vertices.every((v, i) => ((i + 1) % 3) != 0 || (v + collection.position.z) == 0));
         }));
 
     it('should respect all z coordinates', () =>
         parse(gpx).then((collection) => {
-            assert.ok(collection.features[0].vertices.every((v, i) => i == 0 || ((i + 1) % 3) != 0 || v != 0));
+            assert.ok(collection.features[0].vertices.every((v, i) => ((i + 1) % 3) != 0 || (v + collection.position.z) != 0));
         }));
 
     it('should return an empty collection', () =>

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -140,9 +140,8 @@ describe('Vector tiles', function () {
                 },
             });
             source.whenReady.then(() => {
-                const styleLand_zoom_3 = source.styles.land.drawingStylefromContext({ globals: { zoom: 3 } });
-                const styleLand_zoom_5 = source.styles.land.drawingStylefromContext({ globals: { zoom: 5 } });
-
+                const styleLand_zoom_3 = source.styles.land.drawingStylefromContext({ globals: { zoom: 3 }, properties: () => {} });
+                const styleLand_zoom_5 = source.styles.land.drawingStylefromContext({ globals: { zoom: 5 }, properties: () => {} });
                 assert.equal(styleLand_zoom_3.fill.color, 'rgb(255,0,0)');
                 assert.equal(styleLand_zoom_3.fill.opacity, 1);
                 assert.equal(styleLand_zoom_5.fill.color, 'rgb(255,0,0)');


### PR DESCRIPTION
## Description
* Use local system to store `FeatureCollection` Coordinates. 
* Use `GeometryLayer` Style instead of `layer.convert` options.
* The altitude coordinates is determined in `FeatureCollection` during parsing phase (instead of Converting phase).
* the altitude maximum and minimum are computed  during parsing phase.

## Motivation
* the local system avoids precision issue (fix  #1596)
* The mesh vertices are directly in good system, and there is not a new transformation.
* the `FeatureCollection` local system axes are **East, North, Up (ENU)**  [Axes conventions](https://en.wikipedia.org/wiki/Axes_conventions).
* Unify altitude coordinates determining  (fix #1330).
* Using `Function` to define properties Style (in `ColorLayer` and `GeometricLayer`)

## WIP
- [x] fix raster picking color.

## BREAKING CHANGES
* `GeometryLayer.convert` options are moved in Style properties. Use  
  * `Style.xxx.color`
  * `Style.xxx.base_altitude`
  * `Style.fill.extrusion_height`
  * `Style.stroke.width`
  * `Style.point.radius`
* `overrideAltitudeInToZero` layer options is removed use `Style.xxx.base_altitude` instead.

#### Local system 
![image](https://user-images.githubusercontent.com/11291849/119515249-fe49ba00-bd75-11eb-8d72-1d3bd3e9108b.png)

#### Use `function` to style `ColorLayer`
![image](https://user-images.githubusercontent.com/11291849/119802784-24d73480-bedf-11eb-823d-6e7513af1e79.png)

