### PR TITLE
fix(PlanarControls): fix rounding issues with max and min resolution

### DIFF
--- a/examples/misc_orthographic_camera.html
+++ b/examples/misc_orthographic_camera.html
@@ -46,6 +46,8 @@
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             const viewerDiv = document.getElementById('viewerDiv');
 
+            const startResolution = 3.5429583702391496;
+
             // instantiate PlanarView with an orthographic camera.
             // The extent passed in `placement` is the area that will be displayed by camera.
             const view = new itowns.PlanarView(viewerDiv, extent, {
@@ -53,8 +55,10 @@
                 placement: new itowns.Extent('EPSG:3946', 1838000, 1842000, 5172000, 5174000),
                 controls: {
                     // limit the zoom to a resolution interval
-                    maxResolution: 0.01,  // a pixel shall not represent a metric size smaller than 1 cm
-                    minResolution: 100, // a pixel shall not represent a metric size larger than 100m
+                    // maxResolution: 0.01,  // a pixel shall not represent a metric size smaller than 1 cm
+                    // minResolution: 100, // a pixel shall not represent a metric size larger than 100m
+                    maxResolution: startResolution / 2,
+                    minResolution: startResolution * 2,
                 }
             });
             setupLoadingScreen(viewerDiv, view);
@@ -73,6 +77,25 @@
                 source: wmsImagerySource,
             });
             view.addLayer(wmsImageryLayer);
+
+            var wmsElevationSource = new itowns.WMSSource({
+                extent: extent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                crs: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
 
             // Add a scale :
             const scale = new itowns_widgets.Scale(view, {

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -52,8 +52,17 @@
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             viewerDiv = document.getElementById('viewerDiv');
 
+            let startResolution = 3.3874672875230325;
+            let maxResolution = startResolution / 2;
+            let minResolution = startResolution * 2;
+
             // Instanciate PlanarView*
-            view = new itowns.PlanarView(viewerDiv, extent, { placement: { heading: 49.6, range: 6200, tilt: 17 } });
+            view = new itowns.PlanarView(viewerDiv, extent, { placement: { heading: 49.6, range: 6200, tilt: 17 },
+                controls: {
+                    maxResolution,
+                    minResolution,
+                },
+            });
             setupLoadingScreen(viewerDiv, view);
 
             // Add a WMS imagery source

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -44,10 +44,20 @@
             var d;
 
             // Define geographic extent: CRS, min/max X, min/max Y
+            // extent = new itowns.Extent(
+            //     'EPSG:3946',
+            //     1837816.94334, 1847692.32501,
+            //     5170036.4587, 5178412.82698);
+
+            itowns.proj4.defs(
+                'EPSG:2154',
+                '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'
+            );
             extent = new itowns.Extent(
-                'EPSG:3946',
-                1837816.94334, 1847692.32501,
-                5170036.4587, 5178412.82698);
+                'EPSG:2154',
+                981252.84, 990091.52,
+                6461087.06, 6465714.41,
+            )
 
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             viewerDiv = document.getElementById('viewerDiv');
@@ -66,43 +76,59 @@
             setupLoadingScreen(viewerDiv, view);
 
             // Add a WMS imagery source
+            // var wmsImagerySource = new itowns.WMSSource({
+            //     extent: extent,
+            //     name: 'Ortho2009_vue_ensemble_16cm_CC46',
+            //     url: 'https://download.data.grandlyon.com/wms/grandlyon',
+            //     version: '1.3.0',
+            //     crs: 'EPSG:3946',
+            //     format: 'image/jpeg',
+            // });
             var wmsImagerySource = new itowns.WMSSource({
+                url: 'https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/r/wms',
+                name: 'HR.ORTHOIMAGERY.ORTHOPHOTOS',
+                format: 'image/png',
+                crs: 'EPSG:2154',
                 extent: extent,
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                version: '1.3.0',
-                crs: 'EPSG:3946',
-                format: 'image/jpeg',
-            });
+            })
 
             // Add a WMS imagery layer
-            var wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
-                updateStrategy: {
-                    type: itowns.STRATEGY_DICHOTOMY,
-                    options: {},
-                },
-                source: wmsImagerySource,
-            });
+            // var wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+            //     updateStrategy: {
+            //         type: itowns.STRATEGY_DICHOTOMY,
+            //         options: {},
+            //     },
+            //     source: wmsImagerySource,
+            // });
+            var wmsImageryLayer = new itowns.ColorLayer('wms_imagery', { source: wmsImagerySource });
 
             view.addLayer(wmsImageryLayer);
 
             // Add a WMS elevation source
-            var wmsElevationSource = new itowns.WMSSource({
+            // var wmsElevationSource = new itowns.WMSSource({
+            //     extent: extent,
+            //     url: 'https://download.data.grandlyon.com/wms/grandlyon',
+            //     name: 'MNT2012_Altitude_10m_CC46',
+            //     crs: 'EPSG:3946',
+            //     width: 256,
+            //     format: 'image/jpeg',
+            // });
+            const wmsElevationSource = new itowns.WMSSource({
+                url: "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/r/wms",
+                name: "ELEVATION.ELEVATIONGRIDCOVERAGE.HIGHRES",
+                format: "image/x-bil;bits=32",
+                crs: 'EPSG:2154',
                 extent: extent,
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                name: 'MNT2012_Altitude_10m_CC46',
-                crs: 'EPSG:3946',
-                width: 256,
-                format: 'image/jpeg',
             });
 
             // Add a WMS elevation layer
-            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
-                useColorTextureElevation: true,
-                colorTextureElevationMinZ: 144,
-                colorTextureElevationMaxZ: 622,
-                source: wmsElevationSource,
-            });
+            // var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+            //     useColorTextureElevation: true,
+            //     colorTextureElevationMinZ: 144,
+            //     colorTextureElevationMaxZ: 622,
+            //     source: wmsElevationSource,
+            // });
+            const wmsElevationLayer = new itowns.ElevationLayer('DEM', { source: wmsElevationSource });
 
             view.addLayer(wmsElevationLayer);
 

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -52,16 +52,16 @@
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             viewerDiv = document.getElementById('viewerDiv');
 
-            let startResolution = 3.3874672875230325;
-            let maxResolution = startResolution / 2;
-            let minResolution = startResolution * 2;
+            // let startResolution = 3.3874672875230325;
+            // let maxResolution = startResolution / 2;
+            // let minResolution = startResolution * 2;
 
             // Instanciate PlanarView*
             view = new itowns.PlanarView(viewerDiv, extent, { placement: { heading: 49.6, range: 6200, tilt: 17 },
-                controls: {
-                    maxResolution,
-                    minResolution,
-                },
+                // controls: {
+                //     maxResolution,
+                //     minResolution,
+                // },
             });
             setupLoadingScreen(viewerDiv, view);
 

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
+import CameraUtils from 'Utils/CameraUtils';
 
 // event keycode
 export const keys = {
@@ -520,16 +521,22 @@ class PlanarControls extends THREE.EventDispatcher {
         const delta = -event.deltaY;
 
         pointUnderCursor.copy(this.getWorldPointAtScreenXY(mousePosition));
+        // pointUnderCursor.copy(this.getWorldPointAtScreenXY());
         const newPos = new THREE.Vector3();
 
         if (delta > 0 || (delta < 0 && this.maxAltitude > this.camera.position.z)) {
             const zoomFactor = delta > 0 ? this.zoomInFactor : this.zoomOutFactor;
+
+            const target = CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera).coord.toVector3();
 
             // do not zoom if the resolution after the zoom is outside resolution limits
             const endResolution = this.view.getPixelsToMeters() / zoomFactor;
             // The endResolution value is rounded to the 1E-6 decimal above when compared to maxResolution,
             // and it is rounded to the 1E-6 decimal below when compared to minResolution.
             // This prevents rounding issues when endResolution has too many decimals.
+            console.log('start resolution : ', this.view.getPixelsToMeters() * 1E6);
+            console.log('end resolution : ', endResolution * 1E6);
+            console.log('');
             if (
                 this.maxResolution > Math.ceil(endResolution * 1E6)
                 || Math.floor(endResolution * 1E6) > this.minResolution

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -78,7 +78,6 @@ const travelStartPos = new THREE.Vector3();
 const travelStartRot = new THREE.Quaternion();
 const travelEndRot = new THREE.Quaternion();
 let travelEndRes;
-let reductionFactor = 1;
 let travelAlpha = 0;
 let travelDuration = 0;
 let travelUseRotation = false;
@@ -582,13 +581,11 @@ class PlanarControls extends THREE.EventDispatcher {
                     (1 - 1 / zoomFactor),
                 );
 
-                console.log(endCoordinates);
-                const copyEndCoordinates = endCoordinates.clone();
-                copyEndCoordinates.project(this.camera);
-                console.log(endCoordinates);
+                // const copyEndCoordinates = endCoordinates.clone();
+                // copyEndCoordinates.project(this.camera);
 
                 const endFloorCoordinates = this.view.getPickingPositionFromDepth(
-                    this.view.normalizedToViewCoords(copyEndCoordinates),
+                    this.view.normalizedToViewCoords(endCoordinates.clone().project(this.camera)),
                 );
                 console.log('end coordinates = ', endCoordinates);
                 console.log('end floor coordinates = ', endFloorCoordinates);
@@ -600,25 +597,6 @@ class PlanarControls extends THREE.EventDispatcher {
                 cameraTransformOptions.time = 1000;
                 cameraTransformOptions.easing = CameraUtils.Easing.Quartic.Out;
                 CameraUtils.animateCameraToLookAtTarget(this.view, this.camera, cameraTransformOptions);
-
-                // this.state = STATE.ZOOM;
-                // this.view.notifyChange(this.camera);
-                //
-                // // camera position at the beginning of zoom movement
-                // travelStartPos.copy(this.camera.position);
-                // // camera position at the end of zoom movement
-                // travelEndPos.copy(newPos.lerpVectors(
-                //     this.camera.position,
-                //     pointUnderCursor,
-                //     (1 - 1 / zoomFactor),
-                // ));
-                // travelEndRes = endResolution;
-                //
-                // reductionFactor = 1;
-                //
-                // travelAlpha = 0;
-                // travelDuration = this.zoomTravelTime;
-                // this.updateMouseCursorType();
 
                 // // target position
                 // newPos.lerpVectors(
@@ -668,43 +646,6 @@ class PlanarControls extends THREE.EventDispatcher {
 
         // completion test
         this.testAnimationEnd();
-    }
-
-    /**
-     * Handle the animated zoom change for a perspective camera, when state is `ZOOM`.
-     *
-     * @param   {number}    dt  the delta time between two updates in milliseconds
-     * @ignore
-     */
-    handleZoom(dt) {
-        travelAlpha += reductionFactor * (dt / 1000) / THREE.MathUtils.lerp(
-            this.autoTravelTimeMin,
-            this.autoTravelTimeMax,
-            Math.min(
-                1,
-                travelEndPos.distanceTo(this.camera.position) / this.autoTravelTimeDist,
-            ),
-        );
-
-        // new position
-        this.camera.position.lerpVectors(
-            travelStartPos,
-            travelEndPos,
-            travelAlpha,
-        );
-
-        // completion test
-        // TODO : This end test
-        if (travelAlpha > 0.9) {
-            const currentResolution = this.view.getPixelsToMeters();
-            if (Math.abs(Math.floor(travelEndRes * 1E6) - Math.floor(currentResolution * 1E6)) > 1E4) {
-                console.log('current : ', currentResolution, 'end : ', travelEndRes);
-                reductionFactor /= 1.5;
-            } else {
-                this.state = STATE.NONE;
-                this.updateMouseCursorType();
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix some rounding issues concerning `minResolution` and `maxResolution` parameters.
due to some incorrect rounding, the user could be unable to zoom out to reach a resolution equals to the `minResolution` parameter (or to zoom in to reach a resolution equals to the `maxResolution` parameter).

To fix this, the following is done : 

- The resolution values are all rounded up to 10 to the minus sixth meters.
- The `maxResolution` (which is the minimal value the resolution must take) is rounded bellow.
- The `minResolution` (which is the maximal value the resolution must take) is rounded above.
- The current view resolution is rounded bellow or above depending if it is compared to `maxResolution` or minResolution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Closes #1659.

## Left to do

- [ ] When zooming in or out in a `PlanarView` with a `PerspectiveCamera`, the distance traveled does not strictly matches the value implied by the `zoomFactor` parameter. This imprecision causes the same issue as mentioned in #1659.
