### PR TITLE
fix(LayeredMaterialNodeProcessing): checks for source cache with the layer crs for command cancellation

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -27,7 +27,7 @@ function refinementCommandCancellationFn(cmd) {
 
     // Cancel the command if the layer was removed between command scheduling and command execution
     if (!cmd.requester.layerUpdateState[cmd.layer.id]
-        || !cmd.layer.source._featuresCaches[cmd.layer.source.crs]) {
+        || !cmd.layer.source._featuresCaches[cmd.layer.crs]) {
         return true;
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In `RasterLayer` update, when canceling a command, checks if the source cache for the layer CRS was deleted. The cache for the source CRS was checked before, which could give wrong results if the layer CRS and the source CRS were different.

## Motivation and context
Fixes an issue that appeared with PR #1660.
