### PR TITLE
fix(FeatureToolTip): fix tooltip legend icon in examples

### DIFF
--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -84,17 +84,23 @@ var FeatureToolTip = (function _() {
             style = (geometry.properties && geometry.properties.style) || feature.style || layer.style;
             var context = { globals: {}, properties: getGeometryProperties(geometry) };
             style = style.drawingStylefromContext(context);
-            fill = style.fill.color;
-            stroke = '1.25px ' + style.stroke.color;
 
             if (feature.type === itowns.FEATURE_TYPES.POLYGON) {
                 symb = '&#9724';
+                if (style) {
+                    fill = style.fill && style.fill.color;
+                    stroke = style.stroke && ('1.25px ' + style.stroke.color);
+                }
             } else if (feature.type === itowns.FEATURE_TYPES.LINE) {
                 symb = '&#9473';
-                fill = style.stroke.color;
+                fill = style && style.stroke && style.stroke.color;
                 stroke = '0px';
             } else if (feature.type === itowns.FEATURE_TYPES.POINT) {
                 symb = '&#9679';
+                if (style && style.point) {  // Style and style.point can be undefined if no style options were passed
+                    fill = style.point.color;
+                    stroke = '1.25px ' + style.point.line;
+                }
             }
 
             content += '<div>';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix `FeatureToolTip` `fillToolTip` method in examples to correct issues with tool tips legend.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
In examples where the tool tip is used (such as [this](http://www.itowns-project.org/itowns/examples/#source_file_shapefile) or [this](http://www.itowns-project.org/itowns/examples/#source_file_kml_raster) examples), the style of the legend within the tooltip could be wrongly computed. It could sometimes cause `undefined` errors, and also have a legend whose style wouldn't match the style of the associated feature.