### PR TITLE
example(vectorTile): replace expired source in vector tile examples

### DIFF
--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -46,18 +46,11 @@
 
             setupLoadingScreen(viewerDiv, view);
 
+            // Defines a VectorTilesSource to load Vector Tiles data from the geoportail
             var mvtSource = new itowns.VectorTilesSource({
-                style: 'https://raw.githubusercontent.com/Oslandia/postile-openmaptiles/master/style.json',
-                // eslint-disable-next-line no-template-curly-in-string
-                url: 'https://osm.oslandia.io/data/v3/${z}/${x}/${y}.pbf',
-                attribution: {
-                    name: 'OpenStreetMap',
-                    url: 'http://www.openstreetmap.org/',
-                },
-                zoom: {
-                    min: 2,
-                    max: 14,
-                },
+                style: 'https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/standard.json',
+                // We don't display mountains related data to ease visualisation
+                filter: (layer) => !layer['source-layer'].includes('oro_'),
             });
 
             var mvtLayer = new itowns.ColorLayer('MVT', {

--- a/examples/vector_tile_raster_3d.html
+++ b/examples/vector_tile_raster_3d.html
@@ -52,18 +52,11 @@
                 return z - (z % 5);
             }
 
+            // Define a VectorTilesSource to load Vector Tiles data from the geoportail
             var mvtSource = new itowns.VectorTilesSource({
-                style: 'https://raw.githubusercontent.com/Oslandia/postile-openmaptiles/master/style.json',
-                // eslint-disable-next-line no-template-curly-in-string
-                url: 'https://osm.oslandia.io/data/v3/${z}/${x}/${y}.pbf',
-                attribution: {
-                    name: 'OpenStreetMap',
-                    url: 'http://www.openstreetmap.org/',
-                },
-                zoom: {
-                    min: 2,
-                    max: 14,
-                },
+                style: 'https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/standard.json',
+                // We don't display mountains related data to ease visualisation
+                filter: (layer) => !layer['source-layer'].includes('oro_'),
             });
 
             var mvtLayer = new itowns.ColorLayer('MVT', {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace the source of the data displayed in vector tile [2d](http://www.itowns-project.org/itowns/examples/index.html#vector_tile_raster_2d) and [3d](http://www.itowns-project.org/itowns/examples/index.html#vector_tile_raster_3d) examples.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
The source that was used is no longer available.