### PR TITLE
example(GeoJSON raster): center the camera initial position on the displayed features

### DIFF
--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -137,7 +137,13 @@
                 });
 
                 return view.addLayer(pyoLayer);
-            }).then(FeatureToolTip.addLayer);
+            }).then(FeatureToolTip.addLayer).then(() => {
+                // Center the camera on the data extents
+                const layersExtent = ariegeSource.extent.clone();
+                layersExtent.union(view.getLayerById('pyrenees-orientales').source.extent);
+                view.controls.lookAtCoordinate(layersExtent, false);
+            });
+
 
             debug.createTileDebugUI(menuGlobe.gui, view);
         </script>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Modify the camera initial position in [GeoJSON to raster example](http://www.itowns-project.org/itowns/examples/#source_file_geojson_raster). Now the camera is initialy centered on the displayed GeoJSON data.