### PR TITLE
feature(TMSSource): add support for specific TileMatrix identifier

### DIFF
--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -61,7 +61,7 @@ export default {
      * @return {string} the formed url
      */
     xyz: function xyz(coords, source) {
-        return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, coords.zoom)
+        return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, source.tileMatrixCallback(coords.zoom))
             .replace(/(\$\{y\}|%ROW)/, coords.row)
             .replace(/(\$\{x\}|%COL)/, coords.col));
     },

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -30,6 +30,10 @@ const extent = new Extent(CRS.tms_4326, 0, 0, 0);
  * is 0.
  * @property {number} zoom.max - The maximum level of the source. Default value
  * is 20.
+ * @property {function} tileMatrixCallback - a method that create a TileMatrix
+ * identifier from the zoom level. For example, if set to `(zoomLevel) => 'EPSG:4326:' + zoomLevel`,
+ * the TileMatrix that will be fetched at zoom level 5 will be the one with identifier `EPSG:4326:5`.
+ * By default, the method returns the input zoom level.
  *
  * @example <caption><b>Source from OpenStreetMap server :</b></caption>
  * // Create the source
@@ -96,6 +100,7 @@ class TMSSource extends Source {
         this.crs = CRS.formatToTms(source.crs);
         this.tileMatrixSetLimits = source.tileMatrixSetLimits;
         this.extentSetlimits = {};
+        this.tileMatrixCallback = source.tileMatrixCallback || (zoomLevel => zoomLevel);
 
         if (!this.zoom) {
             if (this.tileMatrixSetLimits) {

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -4,7 +4,7 @@ import URLBuilder from 'Provider/URLBuilder';
 import Extent from 'Core/Geographic/Extent';
 
 describe('URL creations', function () {
-    const layer = {};
+    const layer = { tileMatrixCallback: (zoomLevel => zoomLevel) };
 
     it('should correctly replace ${x}, ${y} and ${z} by 359, 512 and 10', function () {
         var coords = new Extent('TMS:4857', 10, 512, 359);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a `tileMatrixCallback` property to `TMSSource`. This property defines a method which can be used to transform the zoom level passed to `TILEMATRIX` paramter when building source `url`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Add support for `TileMatrixSet` whose `TileMatrix` identifier do not only contain the zoom level. This is the case for instance when
`TileMatrixSet = 'EPSG:4326'` : the `TileMatrix` identifier will be like `EPSG:4326:{zoomLevel}`.