### PR TITLE
fix(Label): rounds the projected coordinates of labels

### DIFF
--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -134,7 +134,11 @@ class Label extends THREE.Object3D {
     }
 
     updateCSSPosition() {
-        this.content.style[STYLE_TRANSFORM] = `translate(${this.boundaries.left + this.padding}px, ${this.boundaries.top + this.padding}px)`;
+        this.content.style[STYLE_TRANSFORM] = `translate(${
+            this.projectedPosition.x + this.offset.left
+        }px, ${
+            this.projectedPosition.y + this.offset.top
+        }px)`;
     }
 
     /**

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -148,7 +148,7 @@ describe('Label', function () {
 
         label.updateProjectedPosition(10.4, 10.6);
         label.updateCSSPosition();
-        assert.equal(label.content.style.transform, 'translate(15.4px, 15.6px)');
+        assert.equal(label.content.style.transform, 'translate(15px, 16px)');
     });
 
     it('updates the horizon culling point', function () {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the coordinates used to position a Label on screen. Floating coordinate numbers where previously passed. Now, it is the rounded value of these floating numbers that is passed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Label projected coordinates are updated only when their integer part is changed. Therefore, it is not strictly necessary to position the labels with floating coordinates (since their floating part won't change if their integer part doesn't).
