### PR TITLE
Feature(Style): add support for custom icon in labels

### DIFF
--- a/examples/source_file_kml_raster.html
+++ b/examples/source_file_kml_raster.html
@@ -72,6 +72,9 @@
                     haloWidth: 1,
                     transform: 'uppercase',
                 },
+                icon: {
+                    anchor: 'bottom',
+                },
             });
 
             var kmlLayer = new itowns.ColorLayer('Kml', {

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -97,9 +97,9 @@ class LabelLayer extends Layer {
                 const context = { globals, properties: () => g.properties };
                 if (!geometryField && !featureField && !layerField) {
                     // Check if there is an icon, with no text
-                    if (!(g.properties.style && g.properties.style.icon)
-                        && !(f.style && f.style.icon)
-                        && !(this.style && this.style.icon)) {
+                    if (!(g.properties.style && (g.properties.style.icon.source || g.properties.style.icon.key))
+                        && !(f.style && (f.style.icon.source || f.style.icon.key))
+                        && !(this.style && (this.style.icon.source || this.style.icon.key))) {
                         return;
                     }
                 } else if (geometryField) {

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -57,6 +57,9 @@ class DOMElement {
         }
     }
     createSVGMatrix() {}
+    getElementsByClassName(className) {
+        return [this.children.find(element => element.class === className)];
+    }
 }
 
 // Mock document object for Mocha.

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -78,40 +78,44 @@ describe('Label', function () {
         const img = cacheStyle.get('icon', 1);
         img.complete = true;
         img.emitEvent('load');
-        assert.equal(label.content.children[0].style.right, 'calc(50% - 5px)');
-        assert.equal(label.content.children[0].style.top, 'calc(50% - 5px)');
+        assert.equal(label.content.children[0].style.left, `${-0.5 * img.width}px`);
+        assert.equal(label.content.children[0].style.top, `${-0.5 * img.height}px`);
 
 
-        style.text.anchor = 'left';
+        style.icon.anchor = 'left';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.right, 'calc(100% - 5px)');
-        assert.equal(label.content.children[0].style.top, 'calc(50% - 5px)');
+        assert.equal(label.content.children[0].style.left, '0');
+        assert.equal(label.content.children[0].style.top, `${-0.5 * img.height}px`);
 
-        style.text.anchor = 'right';
+        style.icon.anchor = 'right';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.top, 'calc(50% - 5px)');
+        assert.equal(label.content.children[0].style.left, `${-img.width}px`);
+        assert.equal(label.content.children[0].style.top, `${-0.5 * img.height}px`);
 
-        style.text.anchor = 'top';
+        style.icon.anchor = 'top';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.right, 'calc(50% - 5px)');
+        assert.equal(label.content.children[0].style.left, `${-0.5 * img.width}px`);
+        assert.equal(label.content.children[0].style.top, '0');
 
-        style.text.anchor = 'bottom';
+        style.icon.anchor = 'bottom';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.top, 'calc(100% - 5px)');
-        assert.equal(label.content.children[0].style.right, 'calc(50% - 5px)');
+        assert.equal(label.content.children[0].style.left, `${-0.5 * img.width}px`);
+        assert.equal(label.content.children[0].style.top, `${-img.height}px`);
 
-        style.text.anchor = 'bottom-left';
+        style.icon.anchor = 'bottom-left';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.right, 'calc(100% - 5px)');
-        assert.equal(label.content.children[0].style.top, 'calc(100% - 5px)');
+        assert.equal(label.content.children[0].style.left, '0');
+        assert.equal(label.content.children[0].style.top, `${-img.height}px`);
 
-        style.text.anchor = 'bottom-right';
+        style.icon.anchor = 'bottom-right';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.top, 'calc(100% - 5px)');
+        assert.equal(label.content.children[0].style.left, `${-img.width}px`);
+        assert.equal(label.content.children[0].style.top, `${-img.height}px`);
 
-        style.text.anchor = 'top-left';
+        style.icon.anchor = 'top-left';
         label = new Label('', c, style);
-        assert.equal(label.content.children[0].style.right, 'calc(100% - 5px)');
+        assert.equal(label.content.children[0].style.left, '0');
+        assert.equal(label.content.children[0].style.top, '0');
     });
 
     it('should hide the DOM', function () {
@@ -125,6 +129,7 @@ describe('Label', function () {
     });
 
     it('initializes the dimensions', function () {
+        style.text.anchor = 'top-left';
         label = new Label('', c, style);
         assert.equal(label.offset, undefined);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add an `icon` parameter in `Style`, allowing user to define the `source`, the `key`, the `anchor` and the `size` of the icons displayed within labels.

The anchoring of icons within labels is now independent from the label text anchoring. This allows passing different `anchor` parameters for `Style.text` and `Style.icon`.

The boundaries of a label now also includes the icon it may contain. This results in icons no more superposing other label text.

## Screenshot
The picture bellow shows the [shapefile example](https://github.com/iTowns/itowns/blob/master/examples/source_file_shapefile.html) where the `Style` for the _velib_ `ColorLayer` has been modified as such : 

```js
var velibStyle = new itowns.Style({
    zoom: { min: 10, max: 20 },
    text: {
        field: '{name}\n(id: {station_id})',
        size: 14,
        haloColor: 'white',
        haloWidth: 1,
        font: ['monospace'],
        justify: left,
        anchor: 'top-left',
    },
    icon: {
        source: '{link to the position marker image}',
        anchor: 'bottom',
    },
});     
```

![Capture d’écran du 2021-07-07 14-30-17](https://user-images.githubusercontent.com/73115044/124759709-3b39cc80-df30-11eb-9e6f-911be63d4875.png)

## Note
This PR is rebased on #1683, as it changes labels boundaries, and #1683 make label position computing independent from its boundaries.