### PR TITLE
feature(Label): add support to pass custom domElements to labels 

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -59,7 +59,8 @@
         "misc_compare_25d_3d": "Compare 2.5D and 3D maps",
         "misc_georeferenced_images": "Georeferenced image",
         "misc_orthographic_camera": "Orthographic camera",
-        "misc_custom_controls": "Define custom controls"
+        "misc_custom_controls": "Define custom controls",
+        "misc_custom_label": "Custom label popup"
     },
 
     "Plugins": {

--- a/examples/misc_custom_label.html
+++ b/examples/misc_custom_label.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Custom popup</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="css/example.css">
+    <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+    <style>
+        .bubble {
+            background-color: #fff;
+            border-radius: 10px;
+            text-align: center;
+            padding: 10px 15px;
+            box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, .3), 0 0.0625rem 0.125rem rgba(0, 0, 0, .2);
+        }
+        .pointer {
+            height: 12px;
+            width: 12px;
+            background-color: #fff;
+            transform: translate(-50%, -50%) rotate(45deg);
+            position: relative;
+            left: 80%;
+        }
+    </style>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+</head>
+<body>
+<div id="description">
+    Clicking a position while holding `p` key down will pop a custom popup.
+</div>
+<div id="viewerDiv" class="viewer"></div>
+
+<script src="js/GUI/GuiTools.js"></script>
+<script src="../dist/itowns.js"></script>
+<script src="../dist/debug.js"></script>
+<script src="js/GUI/LoadingScreen.js"></script>
+<script src="js/plugins/FeatureToolTip.js"></script>
+<script type="text/javascript">
+    /* global itowns */
+
+    // Setup view and layers
+    const placement = {
+        coord: new itowns.Coordinates('EPSG:4326', 3.5, 44),
+        range: 1000000,
+    };
+    const viewerDiv = document.getElementById('viewerDiv');
+    const view = new itowns.GlobeView(viewerDiv, placement);
+    var menuGlobe = new GuiTools('menuDiv', view);
+    itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
+        config.source = new itowns.WMTSSource(config.source);
+        view.addLayer(new itowns.ColorLayer('Ortho', config));
+    });
+    function addElevationLayerFromConfig(config) {
+        config.source = new itowns.WMTSSource(config.source);
+        view.addLayer(new itowns.ElevationLayer(config.id, config));
+    }
+    itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+    itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+    debug.createTileDebugUI(menuGlobe.gui, view);
+
+    // Create a custom div which will be displayed as a label
+    const customDiv = document.createElement('div');
+    const bubble = document.createElement('div');
+    bubble.classList.add('bubble');
+    customDiv.appendChild(bubble);
+    const pointer = document.createElement('div');
+    pointer.classList.add('pointer');
+    customDiv.appendChild(pointer);
+
+    // Define a method to set the content of custom label
+    function setLabelContent(properties) {
+        const coord = properties.position.as('EPSG:4326');
+        bubble.textContent = `
+            lon : ${Math.round(coord.x * 100) / 100}° |
+            lat : ${Math.round(coord.y * 100) / 100}° |
+            alt : ${Math.round(coord.z)}m `;
+        return customDiv;
+    }
+
+    // Add a Label on `p` + click
+    let pickMode = false;
+    viewerDiv.addEventListener('keydown', function () {
+        if (event.key === 'p') { pickMode = true; }
+    }, false);
+    viewerDiv.addEventListener('keyup', function () {
+        if (event.key === 'p') { pickMode = false; }
+    }, false);
+    viewerDiv.addEventListener('mousedown', addFeatureFromMouseEvent, false);
+
+    // this const shall receive the mouse coordinates when user clicks while holding `p` pressed
+    const featureCoord = new itowns.Coordinates(view.referenceCrs);
+
+    function addFeatureFromMouseEvent(event) {
+        if (!pickMode) {
+            return;
+        }
+
+        featureCoord.setFromVector3(view.getPickingPositionFromDepth(view.eventToViewCoords(event)));
+
+        const features = createFeatureAt(featureCoord);
+
+        // the source of the feature layer
+        const source = new itowns.FileSource({ features });
+
+        // create labelLayer
+        const layer = new itowns.LabelLayer('idLabelLayer', {
+            source: source,
+            domElement: setLabelContent,
+            style: new itowns.Style({
+                text: { anchor: [-0.8, -1] },
+            }),
+        });
+
+        view.addLayer(layer);
+
+        // remove mouse event listener to prevent adding other layer sharing `idLabelLayer` id
+        viewerDiv.removeEventListener('mousedown', addFeatureFromMouseEvent, false);
+    }
+
+    function createFeatureAt(coordinate) {
+        // create new featureCollection
+        const collection = new itowns.FeatureCollection({
+            crs: view.tileLayer.extent.crs,
+            buildExtent: true,
+            structure: '2d',
+        });
+
+        // create new feature
+        const feature = collection.requestFeatureByType(itowns.FEATURE_TYPES.POINT);
+
+        // add geometries to feature
+        const geometry = feature.bindNewGeometry();
+        geometry.startSubGeometry(1, feature);
+        geometry.pushCoordinates(coordinate, feature);
+        geometry.properties.position = coordinate;
+
+        geometry.updateExtent();
+        feature.updateExtent(geometry);
+        collection.updateExtent(feature.extent);
+
+        return collection;
+    }
+</script>
+</body>
+</html>

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -79,24 +79,28 @@ class Label extends THREE.Object3D {
         this.projectedPosition = { x: 0, y: 0 };
         this.boundaries = { left: 0, right: 0, top: 0, bottom: 0 };
 
-        this.content = document.createElement('div');
+        if (typeof content === 'string') {
+            this.content = document.createElement('div');
+            this.content.textContent = content;
+        } else {
+            this.content = content.cloneNode(true);
+        }
+
         this.content.classList.add('itowns-label');
         this.content.style.userSelect = 'none';
         this.content.style.position = 'absolute';
-        if (typeof content == 'string') {
-            this.content.textContent = content;
-        } else {
-            this.content.appendChild(content);
-        }
+
         this.baseContent = content;
 
         if (style.isStyle) {
             this.anchor = style.getTextAnchorPosition();
             this.styleOffset = style.text.offset;
-            if (style.text.haloWidth > 0) {
-                this.content.classList.add('itowns-stroke-single');
+            if (typeof content === 'string') {
+                if (style.text.haloWidth > 0) {
+                    this.content.classList.add('itowns-stroke-single');
+                }
+                style.applyToHTML(this.content, sprites);
             }
-            style.applyToHTML(this.content, sprites);
         } else {
             this.anchor = [0, 0];
             this.styleOffset = [0, 0];

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -692,9 +692,11 @@ class Style {
      *
      * @param {Object} ctx - An object containing the feature context.
      *
-     * @return {string} The formatted string.
+     * @return {string|undefined} The formatted string if `style.text.field` is defined, nothing otherwise.
      */
     getTextFromProperties(ctx) {
+        if (!this.text.field) { return; }
+
         if (this.text.field.expression) {
             return readExpression(this.text.field, ctx);
         } else {

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -6,6 +6,7 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 import Label from 'Core/Label';
 import { FEATURE_TYPES } from 'Core/Feature';
+import { readExpression } from 'Core/Style';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
@@ -33,6 +34,15 @@ class LabelLayer extends Layer {
      * contains three elements `name, protocol, extent`, these elements will be
      * available using `layer.name` or something else depending on the property
      * name.
+     * @param {domElement|function} config.domElement - An HTML domElement.
+     * If set, all `Label` displayed within the current instance `LabelLayer`
+     * will be this domElement.
+     *
+     * It can be set to a method. The single parameter of this method gives the
+     * properties of each feature on which a `Label` is created.
+     *
+     * If set, all the parameters set in the `LabelLayer` `Style.text` will be overridden,
+     * except for the `Style.text.anchor` parameter which can help place the label.
      */
     constructor(id, config = {}) {
         super(id, config);
@@ -45,6 +55,8 @@ class LabelLayer extends Layer {
         });
 
         this.buildExtent = true;
+
+        this.labelDomelement = config.domElement;
     }
 
     /**
@@ -95,7 +107,9 @@ class LabelLayer extends Layer {
                 const geometryField = g.properties.style && g.properties.style.text.field;
                 let content;
                 const context = { globals, properties: () => g.properties };
-                if (!geometryField && !featureField && !layerField) {
+                if (this.labelDomelement) {
+                    content = readExpression(this.labelDomelement, context);
+                } else if (!geometryField && !featureField && !layerField) {
                     // Check if there is an icon, with no text
                     if (!(g.properties.style && (g.properties.style.icon.source || g.properties.style.icon.key))
                         && !(f.style && (f.style.icon.source || f.style.icon.key))


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add `domElement` parameter to `Style.text`. It can be set to a `DomElement` (like a `div` for instance) which will be displayed as a `Label`.

Add an example of label creation from mouse clicking. The created label is set with the `Style.text.domElement` parameter.

## Screenshots

The image bellow shows a custom `Label` displayed in the example.

![Capture d’écran du 2021-07-08 17-34-31](https://user-images.githubusercontent.com/73115044/124950537-cab7ac00-e012-11eb-99dd-9715b539903b.png)

## Note

This PR is rebased on #1686, as it needs to pass a custom `anchor` to the custom label.