### PR TITLE
fix(example): generate correct URL when sharing EPT example

### DIFF
--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -70,8 +70,9 @@
                     loadEPT(url);
 
                     document.getElementById('share').innerHTML = '<a href="' +
-                        location.href.replace(location.search, '?ept=' + url) +
-                        '" target="_blank">Link to share this view</a>';
+                        location.href.replace(location.search, '') +
+                        '?ept=' + url
+                        + '" target="_blank">Link to share this view</a>';
                     document.getElementById('ept_url').value = url;
                 }
             }


### PR DESCRIPTION
There was a problem when getting the URL to share the page. If you load the empty page and then click on "Load the Grand Lyon dataset", the generated URL was wrong.

This PR should fix this problem.

### Before
```
http://localhost:8080/examples/entwine_simple_loader.html?ept=https://download.data.grandlyon.com/files/grandlyon/imagerie/mnt2018/lidar/ept/http://localhost:8080/examples/entwine_simple_loader.html
```

### After
```
http://localhost:8080/examples/entwine_simple_loader.html?ept=https://download.data.grandlyon.com/files/grandlyon/imagerie/mnt2018/lidar/ept/
```

