### PR TITLE
fix(Label): fix occlusion between icons and label text

### DIFF
--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -139,8 +139,8 @@ class Label extends THREE.Object3D {
             // Checking if this.icon is not only zeros is mandatory, to prevent case
             // when a boundary is set to x or y coordinate
             if (
-                this.iconOffset.left !== 0 && this.iconOffset.right !== 0
-                && this.iconOffset.top !== 0 && this.iconOffset.bottom !== 0
+                this.iconOffset.left !== 0 || this.iconOffset.right !== 0
+                || this.iconOffset.top !== 0 || this.iconOffset.bottom !== 0
             ) {
                 this.boundaries.left = Math.min(this.boundaries.left, x + this.iconOffset.left);
                 this.boundaries.right = Math.max(this.boundaries.right, x + this.iconOffset.right);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix an error in occlusion check between icons and label.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Fix an error introduced in #1684.