### PR TITLE
fix(CameraUtils): fix bugs in `CameraUtils`

### DIFF
--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -347,7 +347,7 @@ export default {
      * @property {boolean} [proxy=true] use proxy to handling camera's transformation. if proxy == true, other camera's transformation stops rig's transformation
      * @property {Number} [easing=TWEEN.Easing.Quartic.InOut] in and out easing animation
      * @property {function} [callback] callback call each animation's frame (params are current cameraTransform and worldTargetPosition)
-     * @property {boolean} [stopPlaceOnGroundAtEnd=defaultStopPlaceOnGroundAtEnd] stop place target on the ground at animation ending
+     * @property {boolean} [stopPlaceOnGroundAtEnd=false] stop place target on the ground at animation ending
      */
     /**
      * Default value for option to stop place target
@@ -478,14 +478,14 @@ export default {
             rig.setProxy(view, camera);
         }
         return rig.animateCameraToLookAtTarget(view, camera, params).promise.then((finished) => {
-            const params = rig.getParams();
             const stopPlaceOnGround = params.stopPlaceOnGroundAtEnd === undefined ?
                 this.defaultStopPlaceOnGroundAtEnd : params.stopPlaceOnGroundAtEnd;
+            const newTransformation = rig.getParams();
             if (stopPlaceOnGround) {
                 rig.stop(view);
             }
-            params.finished = finished;
-            return params;
+            newTransformation.finished = finished;
+            return newTransformation;
         });
     },
 

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -82,7 +82,7 @@ class CameraRig extends THREE.Object3D {
         this.add(this.seaLevel);
         this.seaLevel.add(this.target);
         this.target.add(this.camera);
-        // sea level's geograohic coordinate
+        // target's geographic coordinate
         this.coord = new Coordinates('EPSG:4978', 0, 0);
         // sea level's worldPoistion
         this.targetWorldPosition = new THREE.Vector3();
@@ -121,9 +121,13 @@ class CameraRig extends THREE.Object3D {
     }
 
     setTargetFromCoordinate(view, coord) {
-        // clamp altitude to seaLevel
+        // compute precise coordinate (coord) altitude and clamp it above seaLevel
         coord.as(tileLayer(view).extent.crs, this.coord);
-        const altitude = Math.max(0, this.coord.z);
+        const altitude = Math.max(0, DEMUtils.getElevationValueAt(
+            tileLayer(view),
+            this.coord,
+            DEMUtils.PRECISE_READ_Z,
+        ) || this.coord.z);
         this.coord.z = altitude;
         // adjust target's position with clamped altitude
         this.coord.as(view.referenceCrs).toVector3(targetPosition);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix some bugs in `CameraUtils` : 

---

### Inaccuracy on `CameraRig`'s `target` position : 

When running : 
```js
const transformOptions = itowns.CameraUtils.getTransformCameraLookingAtTarget(view, view.camera.camera3D);
```
the `CameraRig`'s `target` (stored under `transformOptions.coord` property) is computed with the `view.getPickingPositionFromDepth` method, hence having an inaccurate altitude.

Then, when running :
```js
itowns.CameraUtils.animateCameraToLookAtTarget(view, view.camera.camera3D, transformOptions);
```
the `target` toward which camera is moved has its altitude overridden with `DEMUtils.getElevationValueAt` method, which is more accurate from the picking method.

This results in a difference between a camera position when getting its `CameraTransformOptions` and when animating to these `CameraTransformOptions`.

To fix this, I compute the accurate altitude (with `DEMUtils` method) when calling `CameraUtils.getTransformCameraLookingAtTarget`.

---

### Overridden `CameraTransformOptions.stopPlaceOnGroundAtEnd` parameter

The `CameraTransformOptions.stopPlaceOnGroundAtEnd` parameter was overridden and thus never considered when animating camera. This has been fixed with this PR. 


