### PR TITLE
fix(c3DEngine): fix error when input renderer.domElement is a canvas

### DIFF
--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -29,8 +29,19 @@ class c3DEngine {
             options.isWebGL2 = true;
         }
 
-        const renderer = rendererOrDiv.domElement ? rendererOrDiv : undefined;
-        const viewerDiv = renderer ? renderer.domElement : rendererOrDiv;
+        // If rendererOrDiv parameter is a domElement, we use it as support to display data.
+        // If it is a renderer, we check the renderer.domElement parameter which can be :
+        //    - a domElement, in this case we use this domElement as a support
+        //    - a canvas, in this case we use the canvas parent (which should be a domElement) as a support
+        let renderer;
+        let viewerDiv;
+        if (rendererOrDiv.domElement) {
+            renderer = rendererOrDiv;
+            viewerDiv = renderer.domElement instanceof HTMLDivElement ?
+                renderer.domElement : renderer.domElement.parentElement;
+        } else {
+            viewerDiv = rendererOrDiv;
+        }
 
         this.width = viewerDiv.clientWidth;
         this.height = viewerDiv.clientHeight;

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -62,6 +62,9 @@ class DOMElement {
     }
 }
 
+// Mock HTMLDivElement for Mocha
+global.HTMLDivElement = DOMElement;
+
 // Mock document object for Mocha.
 global.document = {
     createElement: (type) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix an error when building a c3DEngine from an existing `renderer`. If the `renderer.domElement` property is a canvas, itowns could try to add `div` to this canvas (when displaying labels for instance). This can not work properly, as HTML canvas can not be parent of other `domElements`.

To fix this, when the `renderer.domElement` property is a canvas, itowns will add needed `div` to the parent of the canvas.