### PR TITLE
Fix label display

### DIFF
--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -206,7 +206,7 @@ class Label extends THREE.Object3D {
     }
 
     updateElevationFromLayer(layer) {
-        const elevation = DEMUtils.getElevationValueAt(layer, this.coordinates, DEMUtils.FAST_READ_Z);
+        const elevation = Math.max(0, DEMUtils.getElevationValueAt(layer, this.coordinates, DEMUtils.FAST_READ_Z));
         if (elevation && elevation != this.coordinates.z) {
             this.coordinates.z = elevation;
             this.updateHorizonCullingPoint();

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -101,6 +101,7 @@ class Label2DRenderer {
         this.domElement = document.createElement('div');
         this.domElement.style.overflow = 'hidden';
         this.domElement.style.position = 'absolute';
+        this.domElement.style.top = '0';
         this.domElement.style.height = '100%';
         this.domElement.style.width = '100%';
         this.domElement.style.zIndex = 1;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix issues for Label visualization : 
- when using an HTML structure different from itowns default structure, the `div` containing labels could be placed under the canvas. To prevent this, the label `div` `top` css property is enforced to `0`.
- when getting labels altitude from a DEM with artifacts on it (like points to -2000m of altitude supposed to be above see level), we clamp this altitude over see level to allow a correct computing of label's projected coordinates. This fix is a quick fix, and the issue shall be further investigated.