### PR TITLE
Use the same wheel event across all browsers

### DIFF
--- a/src/Controls/FirstPersonControls.js
+++ b/src/Controls/FirstPersonControls.js
@@ -105,8 +105,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
             view.domElement.addEventListener('touchmove', this._onMouseMove, false);
             view.domElement.addEventListener('mouseup', this._onMouseUp, false);
             view.domElement.addEventListener('touchend', this._onMouseUp, false);
-            view.domElement.addEventListener('mousewheel', this._onMouseWheel, false);
-            view.domElement.addEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
+            view.domElement.addEventListener('wheel', this._onMouseWheel, false);
 
             // TODO: Why windows
             document.addEventListener('keydown', this._onKeyDown, false);
@@ -241,14 +240,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
     // Mouse wheel
     onMouseWheel(event) {
         if (this.enabled == false) { return; }
-
-        let delta = 0;
-        if (event.wheelDelta !== undefined) {
-            delta = -event.wheelDelta;
-        // Firefox
-        } else if (event.detail !== undefined) {
-            delta = event.detail;
-        }
+        const delta = event.deltaY;
 
         this.camera.fov =
             THREE.MathUtils.clamp(this.camera.fov + Math.sign(delta),
@@ -296,8 +288,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
             this.view.domElement.removeEventListener('touchmove', this._onMouseMove, false);
             this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
             this.view.domElement.removeEventListener('touchend', this._onMouseUp, false);
-            this.view.domElement.removeEventListener('mousewheel', this._onMouseWheel, false);
-            this.view.domElement.removeEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
+            this.view.domElement.removeEventListener('wheel', this._onMouseWheel, false);
 
             document.removeEventListener('keydown', this._onKeyDown, false);
             document.removeEventListener('keyup', this._onKeyUp, false);

--- a/src/Controls/FlyControls.js
+++ b/src/Controls/FlyControls.js
@@ -68,13 +68,8 @@ function onKeyDown(e) {
 }
 
 function onDocumentMouseWheel(event) {
-    let delta = 0;
-    if (event.wheelDelta !== undefined) {
-        delta = event.wheelDelta;
-    // Firefox
-    } else if (event.detail !== undefined) {
-        delta = -event.detail;
-    }
+    const delta = -event.deltaY;
+
     if (delta < 0) {
         this.moves.add(MOVEMENTS.wheelup);
     } else {
@@ -121,8 +116,7 @@ class FlyControls extends THREE.EventDispatcher {
         view.domElement.addEventListener('touchmove', bindedPM, false);
         view.domElement.addEventListener('mouseup', onDocumentMouseUp.bind(this), false);
         view.domElement.addEventListener('touchend', onDocumentMouseUp.bind(this), false);
-        view.domElement.addEventListener('mousewheel', onDocumentMouseWheel.bind(this), false);
-        view.domElement.addEventListener('DOMMouseScroll', onDocumentMouseWheel.bind(this), false); // firefox
+        view.domElement.addEventListener('wheel', onDocumentMouseWheel.bind(this), false);
         view.domElement.addEventListener('keyup', onKeyUp.bind(this), true);
         view.domElement.addEventListener('keydown', onKeyDown.bind(this), true);
 

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -252,8 +252,7 @@ class GlobeControls extends THREE.EventDispatcher {
 
         this.view.domElement.addEventListener('contextmenu', this._onContextMenuListener, false);
         this.view.domElement.addEventListener('mousedown', this._onMouseDown, false);
-        this.view.domElement.addEventListener('mousewheel', this._onMouseWheel, false);
-        this.view.domElement.addEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
+        this.view.domElement.addEventListener('wheel', this._onMouseWheel, false);
         this.view.domElement.addEventListener('touchstart', this._onTouchStart, false);
         this.view.domElement.addEventListener('touchend', this._onMouseUp, false);
         this.view.domElement.addEventListener('touchmove', this._onTouchMove, false);
@@ -729,16 +728,7 @@ class GlobeControls extends THREE.EventDispatcher {
         event.preventDefault();
 
         this.updateTarget();
-        let delta = 0;
-
-        // WebKit / Opera / Explorer 9
-        if (event.wheelDelta !== undefined) {
-            delta = event.wheelDelta;
-        // Firefox
-        } else if (event.detail !== undefined) {
-            delta = -event.detail;
-        }
-
+        const delta = -event.deltaY;
         this.dolly(delta);
 
         const previousRange = this.getRange(pickedPosition);
@@ -908,8 +898,7 @@ class GlobeControls extends THREE.EventDispatcher {
 
         this.view.domElement.removeEventListener('mousedown', this._onMouseDown, false);
         this.view.domElement.removeEventListener('mousemove', this._onMouseMove, false);
-        this.view.domElement.removeEventListener('mousewheel', this._onMouseWheel, false);
-        this.view.domElement.removeEventListener('DOMMouseScroll', this._onMouseWheel, false); // firefox
+        this.view.domElement.removeEventListener('wheel', this._onMouseWheel, false);
         this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
         this.view.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
 

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -510,14 +510,7 @@ class PlanarControls extends THREE.EventDispatcher {
      * @ignore
      */
     initiateZoom(event) {
-        let delta;
-
-        // mousewheel delta
-        if (undefined !== event.wheelDelta) {
-            delta = event.wheelDelta;
-        } else if (undefined !== event.detail) {
-            delta = -event.detail;
-        }
+        const delta = -event.deltaY;
 
         pointUnderCursor.copy(this.getWorldPointAtScreenXY(mousePosition));
         const newPos = new THREE.Vector3();
@@ -900,7 +893,7 @@ class PlanarControls extends THREE.EventDispatcher {
         this.view.domElement.addEventListener('mouseup', this._handlerOnMouseUp, false);
         this.view.domElement.addEventListener('mouseleave', this._handlerOnMouseUp, false);
         this.view.domElement.addEventListener('mousemove', this._handlerOnMouseMove, false);
-        this.view.domElement.addEventListener('mousewheel', this._handlerOnMouseWheel, false);
+        this.view.domElement.addEventListener('wheel', this._handlerOnMouseWheel, false);
         // focus policy
         if (this.focusOnMouseOver) {
             this.view.domElement.addEventListener('mouseover', this._handlerFocusOnMouseOver, false);
@@ -911,8 +904,6 @@ class PlanarControls extends THREE.EventDispatcher {
         // prevent the default context menu from appearing when right-clicking
         // this allows to use right-click for input without the menu appearing
         this.view.domElement.addEventListener('contextmenu', this._handlerContextMenu, false);
-        // for firefox
-        this.view.domElement.addEventListener('MozMousePixelScroll', this._handlerOnMouseWheel, false);
     }
 
     /**
@@ -926,12 +917,10 @@ class PlanarControls extends THREE.EventDispatcher {
         this.view.domElement.removeEventListener('mouseup', this._handlerOnMouseUp, false);
         this.view.domElement.removeEventListener('mouseleave', this._handlerOnMouseUp, false);
         this.view.domElement.removeEventListener('mousemove', this._handlerOnMouseMove, false);
-        this.view.domElement.removeEventListener('mousewheel', this._handlerOnMouseWheel, false);
+        this.view.domElement.removeEventListener('wheel', this._handlerOnMouseWheel, false);
         this.view.domElement.removeEventListener('mouseover', this._handlerFocusOnMouseOver, false);
         this.view.domElement.removeEventListener('click', this._handlerFocusOnMouseClick, false);
         this.view.domElement.removeEventListener('contextmenu', this._handlerContextMenu, false);
-        // for firefox
-        this.view.domElement.removeEventListener('MozMousePixelScroll', this._handlerOnMouseWheel, false);
     }
 
     /**

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -181,7 +181,7 @@ describe('GlobeControls with globe example', function _() {
                     resolve(view.controls.getRange());
                 }
             });
-            const wheelEvent = new WheelEvent('mousewheel', {
+            const wheelEvent = new WheelEvent('wheel', {
                 deltaY: -50000,
             });
             view.domElement.dispatchEvent(wheelEvent, document);

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -180,13 +180,13 @@ describe('GlobeControls', function () {
 
     it('mouse wheel', function () {
         const startRange = controls.getRange();
-        event.wheelDelta = -10;
-        controls.onMouseWheel(event);
-        assert.ok(controls.getRange() > startRange);
-        event.wheelDelta = 10;
-        controls.onMouseWheel(event);
+        event.deltaY = -10;
         controls.onMouseWheel(event);
         assert.ok(controls.getRange() < startRange);
+        event.deltaY = 10;
+        controls.onMouseWheel(event);
+        controls.onMouseWheel(event);
+        assert.ok(controls.getRange() > startRange);
     });
 
     it('travel in', function (done) {

--- a/test/unit/planarControls.js
+++ b/test/unit/planarControls.js
@@ -53,7 +53,7 @@ describe('Planar Controls', function () {
             cameraInitialZoom = camera.zoom;
         }
 
-        event.wheelDelta = wheelDelta;
+        event.deltaY = wheelDelta;
         controls.onMouseWheel(event);
         controls.update(20, false);
     }


### PR DESCRIPTION
## Description
iTowns uses 'mouseWheel' event which is deprecated and not supported by FireFox and uses 'MozMousePixelScroll' event for Firefox. I replaced this event with the 'wheel' event which is supported in all browsers. On the event we check the value of deltaY property to determine zooming also changed the unit tests to work with this attribute.

old event: https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event
new one: https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event

## Motivation and Context
I encountered this problem while trying to add listeners for iTowns on a canvas element which didn't register 'mouseWheel' event. By changing this we use the same code across all browsers. 
