### PR TITLE
examples: define z-index for minimap

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -165,6 +165,7 @@ h3 {
     left: 20;
     bottom: 20;
     color: white;
+    z-index: 1000;
 }
 
 #divScaleWidget {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Enforce minimap `z-index` css property to a high value to make sure that the minimap will always appear on top of other objects, however the structure of the html page.