### PR TITLE
fix(Label): fix size of labels div

### DIFF
--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -99,10 +99,8 @@ const vector = new THREE.Vector3();
 class Label2DRenderer {
     constructor() {
         this.domElement = document.createElement('div');
-        this.domElement.style.overflow = 'hidden';
         this.domElement.style.position = 'absolute';
         this.domElement.style.top = '0';
-        this.domElement.style.height = '100%';
         this.domElement.style.width = '100%';
         this.domElement.style.zIndex = 1;
 
@@ -121,7 +119,6 @@ class Label2DRenderer {
 
     setSize(width, height) {
         this.domElement.style.width = `${width}`;
-        this.domElement.style.height = `${height}`;
 
         this.halfWidth = width / 2;
         this.halfHeight = height / 2;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Reduce labels div height to 0, and let Labels overflow this container. This fixes an issue where user could not have `mouseover` nor `mouseclick` events triggered on the canvas. This issue mainly occurred using Potree tools when integrating Potree in iTowns.