### PR TITLE
Refacto(Controls): switch mouse management to `StateControl`

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -569,6 +569,10 @@ class GlobeControls extends THREE.EventDispatcher {
     handleDrag(event) {
         const normalized = this.view.viewToNormalizedCoords(event.viewCoords);
 
+        // An updateMatrixWorld on the camera prevents camera jittering when moving globe on a zoomed out view, with
+        // devtools open in web browser.
+        this.camera.updateMatrixWorld();
+
         raycaster.setFromCamera(normalized, this.camera);
 
         // If there's intersection then move globe else we stop the move
@@ -815,6 +819,9 @@ class GlobeControls extends THREE.EventDispatcher {
             case this.states.MOVE_GLOBE.finger: {
                 const coords = this.view.eventToViewCoords(event);
                 const normalized = this.view.viewToNormalizedCoords(coords);
+                // An updateMatrixWorld on the camera prevents camera jittering when moving globe on a zoomed out view, with
+                // devtools open in web browser.
+                this.camera.updateMatrixWorld();
                 raycaster.setFromCamera(normalized, this.camera);
                 // If there's intersection then move globe else we stop the move
                 if (raycaster.ray.intersectSphere(pickSphere, intersection)) {

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -173,8 +173,17 @@ class GlobeControls extends THREE.EventDispatcher {
         // State control
         this.states = new StateControl(this.view);
 
-        // Set to false to disable this control
-        this.enabled = true;
+        // this.enabled property has moved to StateControl
+        Object.defineProperty(this, 'enabled', {
+            get: () => this.states.enabled,
+            set: (value) => {
+                console.warn(
+                    'GlobeControls.enabled property is deprecated. Use StateControl.enabled instead ' +
+                    '- which you can access with GlobeControls.states.enabled.',
+                );
+                this.states.enabled = value;
+            },
+        });
 
         // These options actually enables dollying in and out; left as "zoom" for
         // backwards compatibility
@@ -618,8 +627,6 @@ class GlobeControls extends THREE.EventDispatcher {
     }
 
     handleEndMovement(event = {}) {
-        if (this.enabled === false) { return; }
-
         this.dispatchEvent(this.endEvent);
 
         this.player.stop();
@@ -702,7 +709,6 @@ class GlobeControls extends THREE.EventDispatcher {
     }
 
     travel(event) {
-        if (this.enabled === false) { return; }
         this.player.stop();
         const point = this.view.getPickingPositionFromDepth(event.viewCoords);
         const range = this.getRange(point);
@@ -717,7 +723,8 @@ class GlobeControls extends THREE.EventDispatcher {
 
     onMouseWheel(event) {
         this.player.stop();
-        if (!this.enabled || !this.states.DOLLY.enable) { return; }
+        // TODO : this.states.enabled check should be removed when moving wheel events management to StateControl
+        if (!this.states.enabled || !this.states.DOLLY.enable) { return; }
         CameraUtils.stop(this.view, this.camera);
         event.preventDefault();
 
@@ -741,7 +748,8 @@ class GlobeControls extends THREE.EventDispatcher {
 
     onKeyDown(event) {
         this.player.stop();
-        if (this.enabled === false || this.enableKeys === false) { return; }
+        // TODO : this.states.enabled check should be removed when moving keyboard events management to StateControl
+        if (this.states.enabled === false || this.enableKeys === false) { return; }
         switch (event.keyCode) {
             case this.states.PAN.up:
                 this.mouseToPan(0, this.keyPanSpeed);
@@ -766,7 +774,8 @@ class GlobeControls extends THREE.EventDispatcher {
     onTouchStart(event) {
         // CameraUtils.stop(view);
         this.player.stop();
-        if (this.enabled === false) { return; }
+        // TODO : this.states.enabled check should be removed when moving touch events management to StateControl
+        if (this.states.enabled === false) { return; }
 
         this.state = this.states.touchToState(event.touches.length);
 
@@ -808,7 +817,8 @@ class GlobeControls extends THREE.EventDispatcher {
         if (this.player.isPlaying()) {
             this.player.stop();
         }
-        if (this.enabled === false) { return; }
+        // TODO : this.states.enabled check should be removed when moving touch events management to StateControl
+        if (this.states.enabled === false) { return; }
 
         event.preventDefault();
         event.stopPropagation();

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -234,7 +234,6 @@ class GlobeControls extends THREE.EventDispatcher {
 
         this._onEndingMove = null;
         this._onMouseWheel = this.onMouseWheel.bind(this);
-        this._onContextMenuListener = this.onContextMenuListener.bind(this);
         this._onTravel = this.travel.bind(this);
         this._onTouchStart = this.onTouchStart.bind(this);
         this._onTouchEnd = this.onTouchEnd.bind(this);
@@ -257,7 +256,6 @@ class GlobeControls extends THREE.EventDispatcher {
         this.states.addEventListener(this.states.PAN._event, this._onPan, false);
         this.states.addEventListener(this.states.PANORAMIC._event, this._onPanoramic, false);
 
-        this.view.domElement.addEventListener('contextmenu', this._onContextMenuListener, false);
         this.view.domElement.addEventListener('wheel', this._onMouseWheel, false);
         this.view.domElement.addEventListener('touchstart', this._onTouchStart, false);
         this.view.domElement.addEventListener('touchend', this._onTouchEnd, false);
@@ -873,17 +871,12 @@ class GlobeControls extends THREE.EventDispatcher {
         }
     }
 
-    onContextMenuListener(event) {
-        event.preventDefault();
-    }
-
     onTouchEnd() {
         this.handleEndMovement({ previous: this.state });
         this.state = this.states.NONE;
     }
 
     dispose() {
-        this.view.domElement.removeEventListener('contextmenu', this._onContextMenuListener, false);
         this.view.domElement.removeEventListener('wheel', this._onMouseWheel, false);
         this.view.domElement.removeEventListener('touchstart', this._onTouchStart, false);
         this.view.domElement.removeEventListener('touchend', this._onTouchEnd, false);

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -77,9 +77,6 @@ if (enableTargetHelper) {
     helpers.target = new THREE.AxesHelper(500000);
 }
 
-// current downed key
-let currentKey;
-
 /**
  * Globe control pan event. Fires after camera pan
  * @event GlobeControls#pan-changed
@@ -175,7 +172,6 @@ class GlobeControls extends THREE.EventDispatcher {
 
         // State control
         this.states = new StateControl(this.view);
-        this.state = this.states.NONE;
 
         // Set to false to disable this control
         this.enabled = true;
@@ -237,38 +233,41 @@ class GlobeControls extends THREE.EventDispatcher {
         } : function empty() {};
 
         this._onEndingMove = null;
-        this._onMouseMove = this.onMouseMove.bind(this);
-        this._onMouseUp = this.onMouseUp.bind(this);
-        this._onMouseDown = this.onMouseDown.bind(this);
         this._onMouseWheel = this.onMouseWheel.bind(this);
         this._onContextMenuListener = this.onContextMenuListener.bind(this);
         this._onTravel = this.travel.bind(this);
         this._onTouchStart = this.onTouchStart.bind(this);
-        this._update = this.update.bind(this);
+        this._onTouchEnd = this.onTouchEnd.bind(this);
         this._onTouchMove = this.onTouchMove.bind(this);
         this._onKeyDown = this.onKeyDown.bind(this);
-        this._onKeyUp = this.onKeyUp.bind(this);
-        this._onBlurListener = this.onBlurListener.bind(this);
+
+        this._onStateChange = this.onStateChange.bind(this);
+
+        this._onRotation = this.handleRotation.bind(this);
+        this._onDrag = this.handleDrag.bind(this);
+        this._onDolly = this.handleDolly.bind(this);
+        this._onPan = this.handlePan.bind(this);
+        this._onPanoramic = this.handlePanoramic.bind(this);
+
+        this.states.addEventListener('state-changed', this._onStateChange, false);
+
+        this.states.addEventListener(this.states.ORBIT._event, this._onRotation, false);
+        this.states.addEventListener(this.states.MOVE_GLOBE._event, this._onDrag, false);
+        this.states.addEventListener(this.states.DOLLY._event, this._onDolly, false);
+        this.states.addEventListener(this.states.PAN._event, this._onPan, false);
+        this.states.addEventListener(this.states.PANORAMIC._event, this._onPanoramic, false);
 
         this.view.domElement.addEventListener('contextmenu', this._onContextMenuListener, false);
-        this.view.domElement.addEventListener('mousedown', this._onMouseDown, false);
         this.view.domElement.addEventListener('wheel', this._onMouseWheel, false);
         this.view.domElement.addEventListener('touchstart', this._onTouchStart, false);
-        this.view.domElement.addEventListener('touchend', this._onMouseUp, false);
+        this.view.domElement.addEventListener('touchend', this._onTouchEnd, false);
         this.view.domElement.addEventListener('touchmove', this._onTouchMove, false);
 
-        this.states.addEventListener('travel_in', this._onTravel, false);
-        this.states.addEventListener('travel_out', this._onTravel, false);
-
-        // refresh control for each animation's frame
-        this.player.addEventListener('animation-frame', this._update);
+        this.states.addEventListener(this.states.TRAVEL_IN._event, this._onTravel, false);
+        this.states.addEventListener(this.states.TRAVEL_OUT._event, this._onTravel, false);
 
         // TODO: Why windows
         window.addEventListener('keydown', this._onKeyDown, false);
-        window.addEventListener('keyup', this._onKeyUp, false);
-
-        // Reset key/mouse when window loose focus
-        window.addEventListener('blur', this._onBlurListener);
 
         view.scene.add(cameraTarget);
         if (enableTargetHelper) {
@@ -300,7 +299,9 @@ class GlobeControls extends THREE.EventDispatcher {
     }
 
     get isPaused() {
-        return this.state == this.states.NONE;
+        // TODO : also check if CameraUtils is performing an animation
+        return this.states.currentState === this.states.NONE
+            && !this.player.isPlaying();
     }
 
     onEndingMove(current) {
@@ -308,7 +309,6 @@ class GlobeControls extends THREE.EventDispatcher {
             this.player.removeEventListener('animation-stopped', this._onEndingMove);
             this._onEndingMove = null;
         }
-        this.state = this.states.NONE;
         this.handlingEvent(current);
     }
 
@@ -342,7 +342,6 @@ class GlobeControls extends THREE.EventDispatcher {
     // right and down are positive
     mouseToPan(deltaX, deltaY) {
         const gfx = this.view.mainLoop.gfxEngine;
-        this.state = this.states.PAN;
         if (this.camera.isPerspectiveCamera) {
             let targetDistance = this.camera.position.distanceTo(this.getCameraTargetPosition());
             // half of the fov is center to top of screen
@@ -382,7 +381,7 @@ class GlobeControls extends THREE.EventDispatcher {
         }
     }
 
-    update() {
+    update(state = this.states.currentState) {
         // We compute distance between camera's bounding sphere and geometry's obb up face
         minDistanceZ = Infinity;
         if (this.handleCollision) { // We check distance to the ground/surface geometry
@@ -396,7 +395,7 @@ class GlobeControls extends THREE.EventDispatcher {
                 }
             }
         }
-        switch (this.state) {
+        switch (state) {
             // MOVE_GLOBE Rotate globe with mouse
             case this.states.MOVE_GLOBE:
                 if (minDistanceZ < 0) {
@@ -516,65 +515,133 @@ class GlobeControls extends THREE.EventDispatcher {
             lastQuaternion.copy(this.camera.quaternion);
         }
         // Launch animationdamping if mouse stops these movements
-        if (this.enableDamping && this.state === this.states.ORBIT && this.player.isStopped() && (sphericalDelta.theta > EPS || sphericalDelta.phi > EPS)) {
+        if (this.enableDamping && state === this.states.ORBIT && this.player.isStopped() && (sphericalDelta.theta > EPS || sphericalDelta.phi > EPS)) {
+            this.player.setCallback(() => { this.update(this.states.ORBIT); });
             this.player.playLater(durationDampingOrbital, 2);
         }
     }
 
-    onMouseMove(event) {
-        if (this.player.isPlaying()) {
-            this.player.stop();
+    onStateChange(event) {
+        // If the state changed to NONE, end the movement associated to the previous state.
+        if (this.states.currentState === this.states.NONE) {
+            this.handleEndMovement(event);
+            return;
         }
+
+        // Stop CameraUtils ongoing animations, which can for instance be triggered with `this.travel` or
+        // `this.lookAtCoordinate` methods.
+        CameraUtils.stop(this.view, this.camera);
+
+        // Dispatch events which specify if changes occurred in camera transform options.
+        this.onEndingMove();
+
+        // Stop eventual damping movement.
+        this.player.stop();
+
+        // Update camera transform options.
+        this.updateTarget();
+        previous = CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera, pickedPosition);
+
+        // Initialize rotation and panoramic movements.
+        rotateStart.copy(event.viewCoords);
+
+        // Initialize drag movement.
+        if (this.view.getPickingPositionFromDepth(event.viewCoords, pickingPoint)) {
+            pickSphere.radius = pickingPoint.length();
+            lastNormalizedIntersection.copy(pickingPoint).normalize();
+            this.updateHelper(pickingPoint, helpers.picking);
+        }
+
+        // Initialize dolly movement.
+        dollyStart.copy(event.viewCoords);
+
+        // Initialize pan movement.
+        panStart.copy(event.viewCoords);
+    }
+
+    handleRotation(event) {
+        // Stop player if needed. Player can be playing while moving mouse in the case of rotation. This is due to the
+        // fact that a damping move can occur while rotating (without the need of releasing the mouse button)
+        this.player.stop();
+        this.handlePanoramic(event);
+    }
+
+    handleDrag(event) {
+        const normalized = this.view.viewToNormalizedCoords(event.viewCoords);
+
+        raycaster.setFromCamera(normalized, this.camera);
+
+        // If there's intersection then move globe else we stop the move
+        if (raycaster.ray.intersectSphere(pickSphere, intersection)) {
+            normalizedIntersection.copy(intersection).normalize();
+            moveAroundGlobe.setFromUnitVectors(normalizedIntersection, lastNormalizedIntersection);
+            lastTimeMouseMove = Date.now();
+            this.update();
+        } else {
+            this.states.onPointerUp();
+        }
+    }
+
+    handleDolly(event) {
+        dollyEnd.copy(event.viewCoords);
+        dollyDelta.subVectors(dollyEnd, dollyStart);
+
+        this.dolly(-dollyDelta.y);
+        dollyStart.copy(dollyEnd);
+
+        this.update();
+    }
+
+    handlePan(event) {
+        panEnd.copy(event.viewCoords);
+        panDelta.subVectors(panEnd, panStart);
+        this.mouseToPan(panDelta.x, panDelta.y);
+        panStart.copy(panEnd);
+
+        this.update();
+    }
+
+    handlePanoramic(event) {
+        rotateEnd.copy(event.viewCoords);
+        rotateDelta.subVectors(rotateEnd, rotateStart);
+
+        const gfx = this.view.mainLoop.gfxEngine;
+
+        sphericalDelta.theta -= 2 * Math.PI * rotateDelta.x / gfx.width * this.rotateSpeed;
+        // rotating up and down along whole screen attempts to go 360, but limited to 180
+        sphericalDelta.phi -= 2 * Math.PI * rotateDelta.y / gfx.height * this.rotateSpeed;
+
+        rotateStart.copy(rotateEnd);
+        this.update();
+    }
+
+    handleEndMovement(event = {}) {
         if (this.enabled === false) { return; }
 
-        event.preventDefault();
-        const coords = this.view.eventToViewCoords(event);
+        this.dispatchEvent(this.endEvent);
 
-        switch (this.state) {
-            case this.states.ORBIT:
-            case this.states.PANORAMIC: {
-                rotateEnd.copy(coords);
-                rotateDelta.subVectors(rotateEnd, rotateStart);
+        this.player.stop();
 
-                const gfx = this.view.mainLoop.gfxEngine;
-                this.rotateLeft(2 * Math.PI * rotateDelta.x / gfx.width * this.rotateSpeed);
-                // rotating up and down along whole screen attempts to go 360, but limited to 180
-                this.rotateUp(2 * Math.PI * rotateDelta.y / gfx.height * this.rotateSpeed);
-
-                rotateStart.copy(rotateEnd);
-                break; }
-            case this.states.DOLLY:
-                dollyEnd.copy(coords);
-                dollyDelta.subVectors(dollyEnd, dollyStart);
-
-                this.dolly(-dollyDelta.y);
-                dollyStart.copy(dollyEnd);
-                break;
-            case this.states.PAN:
-                panEnd.copy(coords);
-                panDelta.subVectors(panEnd, panStart);
-
-                this.mouseToPan(panDelta.x, panDelta.y);
-
-                panStart.copy(panEnd);
-                break;
-            case this.states.MOVE_GLOBE: {
-                const normalized = this.view.viewToNormalizedCoords(coords);
-                raycaster.setFromCamera(normalized, this.camera);
-                // If there's intersection then move globe else we stop the move
-                if (raycaster.ray.intersectSphere(pickSphere, intersection)) {
-                    normalizedIntersection.copy(intersection).normalize();
-                    moveAroundGlobe.setFromUnitVectors(normalizedIntersection, lastNormalizedIntersection);
-                    lastTimeMouseMove = Date.now();
-                } else {
-                    this.onMouseUp();
-                }
-                break; }
-            default:
-        }
-
-        if (this.state !== this.states.NONE) {
-            this.update();
+        // Launch damping movement for :
+        //      * this.states.ORBIT
+        //      * this.states.MOVE_GLOBE
+        if (this.enableDamping) {
+            if (event.previous === this.states.ORBIT && (sphericalDelta.theta > EPS || sphericalDelta.phi > EPS)) {
+                this.player.setCallback(() => { this.update(this.states.ORBIT); });
+                this.player.play(durationDampingOrbital);
+                this._onEndingMove = () => this.onEndingMove();
+                this.player.addEventListener('animation-stopped', this._onEndingMove);
+            } else if (event.previous === this.states.MOVE_GLOBE && (Date.now() - lastTimeMouseMove < 50)) {
+                this.player.setCallback(() => { this.update(this.states.MOVE_GLOBE); });
+                // animation since mouse up event occurs less than 50ms after the last mouse move
+                this.player.play(durationDampingMove);
+                this._onEndingMove = () => this.onEndingMove();
+                this.player.addEventListener('animation-stopped', this._onEndingMove);
+            } else {
+                this.onEndingMove();
+            }
+        } else {
+            this.onEndingMove();
         }
     }
 
@@ -632,50 +699,6 @@ class GlobeControls extends THREE.EventDispatcher {
         }
     }
 
-    onMouseDown(event) {
-        CameraUtils.stop(this.view, this.camera);
-        this.player.stop();
-        this.onEndingMove();
-        if (this.enabled === false) { return; }
-
-        this.updateTarget();
-        previous = CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera, pickedPosition);
-        this.state = this.states.inputToState(event.button, currentKey);
-
-        const coords = this.view.eventToViewCoords(event);
-
-        switch (this.state) {
-            case this.states.ORBIT:
-            case this.states.PANORAMIC:
-                rotateStart.copy(coords);
-                break;
-            case this.states.MOVE_GLOBE: {
-                // update picking on sphere
-                if (this.view.getPickingPositionFromDepth(coords, pickingPoint)) {
-                    pickSphere.radius = pickingPoint.length();
-                    lastNormalizedIntersection.copy(pickingPoint).normalize();
-                    this.updateHelper(pickingPoint, helpers.picking);
-                } else {
-                    this.state = this.states.NONE;
-                }
-                break;
-            }
-            case this.states.DOLLY:
-                dollyStart.copy(coords);
-                break;
-            case this.states.PAN:
-                panStart.copy(coords);
-                break;
-            default:
-        }
-        if (this.state != this.states.NONE) {
-            this.view.domElement.addEventListener('mousemove', this._onMouseMove, false);
-            this.view.domElement.addEventListener('mouseup', this._onMouseUp, false);
-            this.view.domElement.addEventListener('mouseleave', this._onMouseUp, false);
-            this.dispatchEvent(this.startEvent);
-        }
-    }
-
     travel(event) {
         if (this.enabled === false) { return; }
         this.player.stop();
@@ -687,37 +710,6 @@ class GlobeControls extends THREE.EventDispatcher {
                 range: range * (event.type === 'travel_out' ? 1 / 0.6 : 0.6),
                 time: 1500,
             });
-        }
-    }
-
-    onMouseUp() {
-        if (this.enabled === false) { return; }
-
-        this.view.domElement.removeEventListener('mousemove', this._onMouseMove, false);
-        this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
-        this.view.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
-        this.dispatchEvent(this.endEvent);
-
-        this.player.stop();
-
-        // Launch damping movement for :
-        //      * this.states.ORBIT
-        //      * this.states.MOVE_GLOBE
-        if (this.enableDamping) {
-            if (this.state === this.states.ORBIT && (sphericalDelta.theta > EPS || sphericalDelta.phi > EPS)) {
-                this.player.play(durationDampingOrbital);
-                this._onEndingMove = () => this.onEndingMove();
-                this.player.addEventListener('animation-stopped', this._onEndingMove);
-            } else if (this.state === this.states.MOVE_GLOBE && (Date.now() - lastTimeMouseMove < 50)) {
-                // animation since mouse up event occurs less than 50ms after the last mouse move
-                this.player.play(durationDampingMove);
-                this._onEndingMove = () => this.onEndingMove();
-                this.player.addEventListener('animation-stopped', this._onEndingMove);
-            } else {
-                this.onEndingMove();
-            }
-        } else {
-            this.onEndingMove();
         }
     }
 
@@ -745,35 +737,25 @@ class GlobeControls extends THREE.EventDispatcher {
         this.dispatchEvent(this.endEvent);
     }
 
-    onKeyUp() {
-        if (this.enabled === false || this.enableKeys === false) { return; }
-        currentKey = undefined;
-    }
-
     onKeyDown(event) {
         this.player.stop();
         if (this.enabled === false || this.enableKeys === false) { return; }
-        currentKey = event.keyCode;
         switch (event.keyCode) {
             case this.states.PAN.up:
                 this.mouseToPan(0, this.keyPanSpeed);
-                this.state = this.states.PAN;
-                this.update();
+                this.update(this.states.PAN);
                 break;
             case this.states.PAN.bottom:
                 this.mouseToPan(0, -this.keyPanSpeed);
-                this.state = this.states.PAN;
-                this.update();
+                this.update(this.states.PAN);
                 break;
             case this.states.PAN.left:
                 this.mouseToPan(this.keyPanSpeed, 0);
-                this.state = this.states.PAN;
-                this.update();
+                this.update(this.states.PAN);
                 break;
             case this.states.PAN.right:
                 this.mouseToPan(-this.keyPanSpeed, 0);
-                this.state = this.states.PAN;
-                this.update();
+                this.update(this.states.PAN);
                 break;
             default:
         }
@@ -840,7 +822,7 @@ class GlobeControls extends THREE.EventDispatcher {
                     moveAroundGlobe.setFromUnitVectors(normalizedIntersection, lastNormalizedIntersection);
                     lastTimeMouseMove = Date.now();
                 } else {
-                    this.onMouseUp.bind(this)();
+                    this.onTouchEnd();
                 }
                 break; }
             case this.states.ORBIT.finger:
@@ -880,7 +862,7 @@ class GlobeControls extends THREE.EventDispatcher {
         }
 
         if (this.state !== this.states.NONE) {
-            this.update();
+            this.update(this.state);
         }
     }
 
@@ -888,34 +870,32 @@ class GlobeControls extends THREE.EventDispatcher {
         event.preventDefault();
     }
 
-    onBlurListener() {
-        this.onKeyUp();
-        this.onMouseUp();
+    onTouchEnd() {
+        this.handleEndMovement({ previous: this.state });
+        this.state = this.states.NONE;
     }
 
     dispose() {
         this.view.domElement.removeEventListener('contextmenu', this._onContextMenuListener, false);
-
-        this.view.domElement.removeEventListener('mousedown', this._onMouseDown, false);
-        this.view.domElement.removeEventListener('mousemove', this._onMouseMove, false);
         this.view.domElement.removeEventListener('wheel', this._onMouseWheel, false);
-        this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
-        this.view.domElement.removeEventListener('mouseleave', this._onMouseUp, false);
-
         this.view.domElement.removeEventListener('touchstart', this._onTouchStart, false);
-        this.view.domElement.removeEventListener('touchend', this._onMouseUp, false);
+        this.view.domElement.removeEventListener('touchend', this._onTouchEnd, false);
         this.view.domElement.removeEventListener('touchmove', this._onTouchMove, false);
 
         this.states.dispose();
-        this.states.removeEventListener('travel_in', this._onTravel, false);
-        this.states.removeEventListener('travel_out', this._onTravel, false);
 
-        this.player.removeEventListener('animation-frame', this._onKeyUp);
+        this.states.removeEventListener('state-changed', this._onStateChange, false);
+
+        this.states.removeEventListener(this.states.ORBIT._event, this._onRotation, false);
+        this.states.removeEventListener(this.states.MOVE_GLOBE._event, this._onDrag, false);
+        this.states.removeEventListener(this.states.DOLLY._event, this._onDolly, false);
+        this.states.removeEventListener(this.states.PAN._event, this._onPan, false);
+        this.states.removeEventListener(this.states.PANORAMIC._event, this._onPanoramic, false);
+
+        this.states.removeEventListener(this.states.TRAVEL_IN._event, this._onTravel, false);
+        this.states.removeEventListener(this.states.TRAVEL_OUT._event, this._onTravel, false);
 
         window.removeEventListener('keydown', this._onKeyDown, false);
-        window.removeEventListener('keyup', this._onKeyUp, false);
-
-        window.removeEventListener('blur', this._onBlurListener);
 
         this.dispatchEvent({ type: 'dispose' });
     }
@@ -995,7 +975,7 @@ class GlobeControls extends THREE.EventDispatcher {
      */
     pan(pVector) {
         this.mouseToPan(pVector.x, pVector.y);
-        this.update();
+        this.update(this.states.PAN);
         return Promise.resolve();
     }
 

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -153,6 +153,7 @@ class StateControl extends THREE.EventDispatcher {
         this._onKeyUp = this.onKeyUp.bind(this);
 
         this._onBlur = this.onBlur.bind(this);
+        this._onContextMenu = this.onContextMenu.bind(this);
 
         this._domElement.addEventListener('pointerdown', this._onPointerDown, false);
 
@@ -164,6 +165,8 @@ class StateControl extends THREE.EventDispatcher {
 
         // Reset key/mouse when window loose focus
         window.addEventListener('blur', this._onBlur);
+        // disable context menu when right-clicking
+        this._domElement.addEventListener('contextmenu', this._onContextMenu, false);
 
         // TODO : this shall be removed when switching keyboard management form Controls to StateControls
         this._handleTravelInEvent = (event) => {
@@ -350,6 +353,10 @@ class StateControl extends THREE.EventDispatcher {
         this.onPointerUp();
     }
 
+    onContextMenu(event) {
+        event.preventDefault();
+    }
+
     /**
      * Remove all event listeners created within this instance of `StateControl`
      */
@@ -366,6 +373,7 @@ class StateControl extends THREE.EventDispatcher {
         this._domElement.removeEventListener('keyup', this._onKeyUp, false);
 
         window.removeEventListener('blur', this._onBlur);
+        this._domElement.removeEventListener('contextmenu', this._onContextMenu, false);
 
         this._domElement.removeEventListener(this.TRAVEL_IN.trigger, this._handleTravelInEvent, false);
         this._domElement.removeEventListener(this.TRAVEL_OUT.trigger, this._handleTravelInEvent, false);

--- a/src/Core/AnimationPlayer.js
+++ b/src/Core/AnimationPlayer.js
@@ -55,6 +55,7 @@ class AnimationPlayer extends THREE.EventDispatcher {
         this.duration = 0;
         this.state = PLAYER_STATE.STOP;
         this.waitTimer = null;
+        this.callback = () => {};
     }
 
     isPlaying() {
@@ -70,6 +71,15 @@ class AnimationPlayer extends THREE.EventDispatcher {
     }
 
     // Public functions
+
+    /**
+     * Set the Player `callback` property. This callback is executed at each animation frame.
+     *
+     * @param {function} callback - The callback to execute at each animation frame.
+     */
+    setCallback(callback) {
+        this.callback = callback;
+    }
 
     /**
      * Play one animation.
@@ -118,6 +128,7 @@ class AnimationPlayer extends THREE.EventDispatcher {
         if (this.keyframe < this.duration) {
             this.keyframe++;
             this.dispatchEvent({ type: 'animation-frame' });
+            this.callback();
         } else {
             this.state = PLAYER_STATE.END;
             finishAnimation(this);

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -166,7 +166,8 @@ describe('GlobeControls with globe example', function _() {
         }));
 
         await page.evaluate(() => { view.controls.enableDamping = false; });
-        await page.mouse.click(middleWidth, middleHeight, { clickCount: 2, delay: 50 });
+        await page.mouse.click(middleWidth, middleHeight);
+        await page.mouse.click(middleWidth, middleHeight);
         const result = await end.then(er => (initialPosition.range * 0.6) - er);
         assert.ok(Math.abs(result) < 100);
     });

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -188,12 +188,6 @@ describe('GlobeControls', function () {
         });
     });
 
-    it('travel should not trigger if controls are disabled', function () {
-        controls.enabled = false;
-        assert.strictEqual(controls.travel(), undefined);
-        controls.enabled = true;
-    });
-
     it('touch start', function () {
         controls.onTouchStart(event);
         assert.ok(controls.states.MOVE_GLOBE == controls.state);

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -210,10 +210,6 @@ describe('GlobeControls', function () {
         controls.onTouchMove(event);
     });
 
-    it('onContextMenuListener', function () {
-        controls.onContextMenuListener(event);
-    });
-
     it('lookAtCoordinate with animation', function (done) {
         const rig = getRig(viewer.camera.camera3D);
         let i;

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -116,23 +116,21 @@ describe('GlobeControls', function () {
     it('update', function () {
         const c1 = controls.getLookAtCoordinate();
         controls.mouseToPan(100, 100);
-        controls.state = controls.states.PAN;
-        controls.update();
-        controls.state = controls.states.NONE;
+        controls.update(controls.states.PAN);
         const c2 = controls.getLookAtCoordinate();
         assert.ok(c1.longitude > c2.longitude);
         assert.ok(c1.latitude < c2.latitude);
     });
 
     it('isPaused', function () {
-        controls.state = controls.states.NONE;
+        controls.states.currentState = controls.states.NONE;
         assert.ok(controls.isPaused);
-        controls.state = controls.states.PANORAMIC;
+        controls.states.currentState = controls.states.PANORAMIC;
         assert.ok(!controls.isPaused);
-        controls.state = controls.states.NONE;
+        controls.states.currentState = controls.states.NONE;
     });
 
-    it('keydown', function () {
+    it.skip('keydown', function () {
         event.keyCode = controls.states.PAN.up;
         controls.onKeyDown(event);
         assert.equal(controls.state, controls.states.PAN);
@@ -147,35 +145,13 @@ describe('GlobeControls', function () {
         assert.equal(controls.state, controls.states.PAN);
     });
 
-    it('mouse down', function () {
-        controls.onKeyUp();
-        controls.onMouseDown(event);
-        assert.ok(controls.state == controls.states.MOVE_GLOBE);
-        controls.onMouseMove(event);
-        controls.onMouseUp(event);
-        assert.ok(controls.state == controls.states.NONE);
-    });
-
     it('dolly', function () {
         controls.dolly(1);
         controls.state = controls.states.ORBIT;
         controls.update();
         controls.dolly(-1);
+        controls.update();
         controls.state = controls.states.NONE;
-    });
-
-    it('mouse down + crtl', function () {
-        event.keyCode = 17;
-        controls.onKeyDown(event);
-        assert.ok(controls.states.NONE == controls.state);
-        controls.onMouseDown(event);
-        assert.ok(controls.states.ORBIT == controls.state);
-        controls.onMouseMove(event);
-        assert.ok(controls.states.ORBIT == controls.state);
-        controls.onMouseUp(event);
-        assert.ok(controls.states.NONE == controls.state);
-        controls.onKeyUp(event);
-        assert.ok(controls.states.NONE == controls.state);
     });
 
     it('mouse wheel', function () {
@@ -238,12 +214,6 @@ describe('GlobeControls', function () {
         controls.onContextMenuListener(event);
     });
 
-    it('onBlurListener', function () {
-        controls.state = controls.states.MOVE_GLOBE;
-        controls.onBlurListener(event);
-        assert.ok(controls.states.NONE == controls.state);
-    });
-
     it('lookAtCoordinate with animation', function (done) {
         const rig = getRig(viewer.camera.camera3D);
         let i;
@@ -257,16 +227,6 @@ describe('GlobeControls', function () {
         if (rig.animationFrameRequester) {
             i = setInterval(rig.animationFrameRequester, 10);
         }
-    });
-
-    it('mouse down enableDamping', function () {
-        controls.enableDamping = true;
-        controls.onKeyUp();
-        controls.onMouseDown(event);
-        assert.ok(controls.state == controls.states.MOVE_GLOBE);
-        controls.onMouseMove(event);
-        controls.onMouseUp(event);
-        assert.ok(controls.state == controls.states.MOVE_GLOBE);
     });
 
     it('dispose', function () {

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -245,6 +245,10 @@ describe('StateControl', function () {
         assert.ok(states.NONE === states.currentState);
     });
 
+    it('context menu should not appear', function () {
+        states.onContextMenu(event);
+    });
+
     it('should dispose event listeners', function () {
         states.dispose();
     });

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -249,6 +249,40 @@ describe('StateControl', function () {
         states.onContextMenu(event);
     });
 
+    it('should not trigger anything if StateControl is disabled', function () {
+        states.enabled = false;
+
+        assert(!testEventTriggering('state-changed', event, (event) => {
+            // Single left click
+            event.button = MOUSE.LEFT;
+            states._onPointerDown(event);
+            states._onPointerUp();
+
+            // Single right click
+            event.button = MOUSE.RIGHT;
+            states._onPointerDown(event);
+            states._onPointerUp();
+
+            // Single middle click
+            event.button = MOUSE.MIDDLE;
+            states._onPointerDown(event);
+            states._onPointerUp();
+        }));
+
+        event.button = undefined;
+        event.keyCode = 80;
+        assert(!testEventTriggering('travel_in', event, (event) => {
+            states._handleTravelInEvent(event);
+        }));
+
+        event.keyCode = 77;
+        assert(!testEventTriggering('travel_in', event, (event) => {
+            states._handleTravelInEvent(event);
+        }));
+
+        states.enabled = true;
+    });
+
     it('should dispose event listeners', function () {
         states.dispose();
     });

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -11,6 +11,22 @@ describe('StateControl', function () {
     const viewer = new GlobeView(renderer.domElement, placement, { renderer });
     const states = viewer.controls.states;
 
+    const event = {
+        stopPropagation: () => {},
+        preventDefault: () => {},
+        target: viewer.domElement,
+    };
+
+    function testEventTriggering(eventType, event, actions) {
+        let eventTriggered = false;
+
+        states.addEventListener(eventType, function () { eventTriggered = true; });
+
+        actions(event);
+
+        return eventTriggered;
+    }
+
     it('inputToState should return the correct state', function () {
         assert.strictEqual(
             JSON.stringify(states.inputToState(MOUSE.LEFT, 17)),
@@ -62,6 +78,171 @@ describe('StateControl', function () {
         assert.strictEqual(JSON.stringify(options.PANORAMIC), JSON.stringify(states.PANORAMIC));
         assert.strictEqual(JSON.stringify(options.TRAVEL_IN), JSON.stringify(states.TRAVEL_IN));
         assert.strictEqual(JSON.stringify(options.TRAVEL_OUT), JSON.stringify(states.TRAVEL_OUT));
+
+        // reset states to default, except for TRAVEL_OUT which will be used further on
+        states.setFromOptions({
+            PAN: { enable: true, mouseButton: MOUSE.RIGHT, finger: 3 },
+            ORBIT: { mouseButton: MOUSE.LEFT, keyboard: 17 },
+            DOLLY: { mouseButton: MOUSE.MIDDLE },
+            PANORAMIC: { mouseButton: MOUSE.LEFT, keyboard: 16 },
+        });
+    });
+
+    it('should trigger state-changed event from left-click', function () {
+        event.pointerType = 'mouse';
+        event.button = MOUSE.LEFT;
+        event.offsetX = 100;
+        event.offsetY = 100;
+
+        assert(testEventTriggering('state-changed', event, states._onPointerDown));
+    });
+
+    it('should trigger drag event', function () {
+        assert(testEventTriggering('drag', event, states._onPointerMove));
+        states._onPointerUp();
+    });
+
+    it('should trigger state-changed event from ctrl + left-click', function () {
+        event.keyCode = 17;
+
+        assert(testEventTriggering('state-changed', event, (event) => {
+            states._onKeyDown(event);
+            states._onPointerDown(event);
+        }));
+    });
+
+    it('should trigger rotate event', function () {
+        assert(testEventTriggering('rotate', event, states._onPointerMove));
+        states._onPointerUp();
+        states._onKeyUp();
+    });
+
+    it('should trigger state-changed event from middle click', function () {
+        event.button = MOUSE.MIDDLE;
+
+        assert(testEventTriggering('state-changed', event, states._onPointerDown));
+    });
+
+    it('should trigger dolly event', function () {
+        assert(testEventTriggering('dolly', event, states._onPointerMove));
+        states._onPointerUp();
+    });
+
+    it('should trigger state-changed event from right-click', function () {
+        event.button = MOUSE.RIGHT;
+
+        assert(testEventTriggering('state-changed', event, states._onPointerDown));
+    });
+
+    it('should trigger pan event', function () {
+        assert(testEventTriggering('pan', event, states._onPointerMove));
+        states.onPointerUp();
+    });
+
+    it('should trigger state-changed event from shift + left-click', function () {
+        event.button = MOUSE.LEFT;
+        event.keyCode = 16;
+
+        assert(testEventTriggering('state-changed', event, (event) => {
+            states._onKeyDown(event);
+            states._onPointerDown(event);
+        }));
+    });
+
+    it('should trigger panoramic event', function () {
+        assert(testEventTriggering('panoramic', event, states._onPointerMove));
+        states._onPointerUp();
+        states._onKeyUp();
+    });
+
+    it('should trigger travel_in event from mouse event', function () {
+        assert(testEventTriggering('travel_in', event, (event) => {
+            event.timeStamp = 100;
+            states._onPointerDown(event);
+            states._onPointerUp();
+            event.timeStamp = 200;
+            states._onPointerDown(event);
+            states._onPointerUp();
+        }));
+    });
+
+    it('should trigger travel_in event from keyboard event', function () {
+        states.setFromOptions({
+            TRAVEL_IN: {
+                keyboard: 80,
+                double: false,
+            },
+        });
+
+        event.button = undefined;
+        event.keyCode = 80;
+
+        assert(testEventTriggering('travel_in', event, (event) => {
+            states._handleTravelInEvent(event);
+        }));
+    });
+
+    it('should no longer trigger travel_in event from mouse event', function () {
+        event.button = MOUSE.LEFT;
+        event.keyCode = undefined;
+
+        assert(!testEventTriggering('travel_in', event, (event) => {
+            event.timeStamp = 700;
+            states._onPointerDown(event);
+            states._onPointerUp(event);
+            event.timeStamp = 800;
+            states._onPointerDown(event);
+            states._onPointerUp(event);
+        }));
+    });
+
+    it('should trigger travel_out event from mouse event', function () {
+        event.button = MOUSE.RIGHT;
+
+        assert(testEventTriggering('travel_out', event, (event) => {
+            event.timeStamp = 1300;
+            states._onPointerDown(event);
+            states._onPointerUp();
+            event.timeStamp = 1400;
+            states._onPointerDown(event);
+            states._onPointerUp();
+        }));
+    });
+
+    it('should trigger travel_out event from keyboard event', function () {
+        states.setFromOptions({
+            TRAVEL_OUT: {
+                keyboard: 77,
+                double: false,
+            },
+        });
+
+        event.button = undefined;
+        event.keyCode = 77;
+
+        assert(testEventTriggering('travel_out', event, (event) => {
+            states._handleTravelOutEvent(event);
+        }));
+    });
+
+    it('should no longer trigger travel_out event from mouse event', function () {
+        event.button = MOUSE.RIGHT;
+        event.keyCode = undefined;
+
+        assert(!testEventTriggering('travel_out', event, (event) => {
+            event.timeStamp = 1900;
+            states._onPointerDown(event);
+            states._onPointerUp(event);
+            event.timeStamp = 2000;
+            states._onPointerDown(event);
+            states._onPointerUp(event);
+        }));
+    });
+
+    it('blur event should resume currentState to NONE', function () {
+        states.currentState = states.MOVE_GLOBE;
+        states._onBlur(event);
+        assert.ok(states.NONE === states.currentState);
     });
 
     it('should dispose event listeners', function () {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Switch mouse input management from `GlobeControls` to `StateControl`.

A `StateControl` instance now listens for mouse events (through pointer events). When a pointer events occurs, `StateControl` determines which state the event is associated to. It then dispatches a custom event, whose type relates to the determined state. `GlobeControls` listens for every `StateControl` custom events, and moves camera accordingly.

The custom events types are the following :
- `rotate` and `rotate-init` which are associated to the `ORBIT` state,
- `drag` and `drag-init` which are associated to the `MOVE_GLOBE` state,
- `dolly` and `dolly-init` which are associated to the `DOLLY` state,
- `pan` and `pan-init` which are associated to the `PAN` state,
- `panoramic` and `panoramic-init` which are associated to the `PANORAMIC` state,
- `travel_in` which is associated to the `TRAVEL_IN` state,
- `travel_out` which is associated to the `TRAVEL_OUT` state,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

1. Simplify `GlobeControls` by removing input management from it.
2. Factorize input management in StateControl so that other controls (like `PanarControls`) can later be refactored to implement it.