### PR TITLE
fix(ShapefileParser): prevent ignoring input crs wen given

### DIFF
--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -77,7 +77,7 @@ export default {
         }
 
         options.in = options.in || {};
-        options.in.crs = data.prj ? proj4(data.prj).oProj.datumName : undefined;
+        options.in.crs = data.prj ? proj4(data.prj).oProj.datumName : options.in.crs;
 
         return Promise.resolve(result).then(res => GeoJsonParser.parse(res, options));
     },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When parsing shapefile data, the [documentation](http://www.itowns-project.org/itowns/docs/#api/Parser/ShapefileParser) indicates that the `.prj` file is not mandatory. However, if no `.prj` file is given, the input data CRS will default to `EPSG:4326`, even though another input CRS was defined in shapefile parser options.

With this PR, the input CRS defaults to `EPSG:4326` only if no `.prj` file or input CRS were given.