### PR TITLE
refacto(StateControl): simplify `setFromOptions` method

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -163,7 +163,7 @@ let previous;
  * @property   {number} zoomSpeed Speed zoom with mouse
  * @property   {number} rotateSpeed Speed camera rotation in orbit and panoramic mode
  * @property   {number} minDistanceCollision Minimum distance collision between ground and camera
- * @property   {bool} enableDamping enable camera damping, if it's disabled the camera immediately when the mouse button is released.
+ * @property   {boolean} enableDamping enable camera damping, if it's disabled the camera immediately when the mouse button is released.
  * If it's enabled, the camera movement is decelerate.
  */
 class GlobeControls extends THREE.EventDispatcher {

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -98,7 +98,7 @@ class StateControl extends THREE.EventDispatcher {
      * @param      {Number}  mouseButton  The mouse button
      * @param      {Number}  keyboard     The keyboard
      * @param      {Boolean} [double]     Value of the searched state `double` property
-     * @return     {state}  the state corresponding
+     * @return     {State}  the state corresponding
      */
     inputToState(mouseButton, keyboard, double) {
         for (const key of Object.keys(this)) {

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -45,13 +45,13 @@ describe('StateControl', function () {
 
     it('setFromOptions should set states according to given options', function () {
         const options = {
-            PAN: { enable: false },
-            MOVE_GLOBE: { enable: true, mouseButton: MOUSE.LEFT },
-            ORBIT: { enable: true, mouseButton: MOUSE.MIDDLE },
-            DOLLY: { enable: true, mouseButton: MOUSE.RIGHT },
-            PANORAMIC: { enable: true, mouseButton: MOUSE.LEFT, keyboard: 17 },
-            TRAVEL_IN: { enable: true, mouseButton: MOUSE.LEFT, double: true },
-            TRAVEL_OUT: { enable: true, mouseButton: MOUSE.RIGHT, double: true },
+            PAN: { enable: false, double: false },
+            MOVE_GLOBE: { enable: true, double: false, mouseButton: MOUSE.LEFT },
+            ORBIT: { enable: true, double: false, mouseButton: MOUSE.MIDDLE },
+            DOLLY: { enable: true, double: false, mouseButton: MOUSE.RIGHT },
+            PANORAMIC: { enable: true, double: false, mouseButton: MOUSE.LEFT, keyboard: 17 },
+            TRAVEL_IN: { enable: true, double: true, mouseButton: MOUSE.LEFT },
+            TRAVEL_OUT: { enable: true, double: true, mouseButton: MOUSE.RIGHT },
         };
         states.setFromOptions(options);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Simplify the `setFromOptions` method of `StateControl`.
Now, the `enable` property of each `State` does not need to be redefined when using the method. For example, one could now use :
```js
view.controls.states.setFromOptions({
    PAN: { mouseButton: itowns.THREE.MOUSE.LEFT },
    MOVE_GLOBE: { mouseButton: itowns.THREE.MOUSE.RIGHT },
});
```
to switch pan and drag movement controls, where it was previously needed to call :
```js
view.controls.states.setFromOptions({
    PAN: {
        enable: true, 
        mouseButton: itowns.THREE.MOUSE.LEFT,
    },
    MOVE_GLOBE: {
        enable: true, 
        mouseButton: itowns.THREE.MOUSE.RIGHT,
    },
});
```
---
Fix minor glitches on documentation.