### PR TITLE
Refacto(Controls): switch keyboard management to `StateControl`

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -154,7 +154,6 @@ let previous;
  * @param      {number}  options.minDistance Minimum distance between ground and camera
  * @param      {number}  options.maxDistance Maximum distance between ground and camera
  * @param      {bool}  options.handleCollision enable collision camera with ground
- * @property   {bool} enabled enable control
  * @property   {number} minDistance Minimum distance between ground and camera
  * @property   {number} maxDistance Maximum distance between ground and camera
  * @property   {number} zoomSpeed Speed zoom with mouse

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -118,6 +118,8 @@ function stateToTrigger(state) {
                                     * a given position. The target position depends on the key/mouse binding of this
                                     * state. If bound to a mouse button, the target position is the mouse position.
                                     * Otherwise, it is the center of the screen. It is disabled by default.
+ * @property {boolean}  enable      Defines whether all input will be communicated to the associated `Controls` or not.
+                                    * Default is true.
  */
 class StateControl extends THREE.EventDispatcher {
     constructor(view, options = {}) {

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -130,21 +130,6 @@ describe('GlobeControls', function () {
         controls.states.currentState = controls.states.NONE;
     });
 
-    it.skip('keydown', function () {
-        event.keyCode = controls.states.PAN.up;
-        controls.onKeyDown(event);
-        assert.equal(controls.state, controls.states.PAN);
-        event.keyCode = controls.states.PAN.bottom;
-        controls.onKeyDown(event);
-        assert.equal(controls.state, controls.states.PAN);
-        event.keyCode = controls.states.PAN.left;
-        controls.onKeyDown(event);
-        assert.equal(controls.state, controls.states.PAN);
-        event.keyCode = controls.states.PAN.right;
-        controls.onKeyDown(event);
-        assert.equal(controls.state, controls.states.PAN);
-    });
-
     it('dolly', function () {
         controls.dolly(1);
         controls.state = controls.states.ORBIT;
@@ -171,6 +156,7 @@ describe('GlobeControls', function () {
         controls.travel({
             viewCoords: viewer.eventToViewCoords(event),
             type: 'travel_in',
+            direction: 'in',
         }).then(() => {
             assert.ok(controls.getRange() < startRange);
             done();
@@ -182,6 +168,7 @@ describe('GlobeControls', function () {
         controls.travel({
             viewCoords: viewer.eventToViewCoords(event),
             type: 'travel_out',
+            direction: 'out',
         }).then(() => {
             assert.ok(controls.getRange() > startRange);
             done();

--- a/test/unit/statecontrol.js
+++ b/test/unit/statecontrol.js
@@ -139,6 +139,36 @@ describe('StateControl', function () {
         states.onPointerUp();
     });
 
+    it('should trigger pan event from up arrow key press', function () {
+        event.button = undefined;
+
+        // UP arrow key
+        event.keyCode = 38;
+        assert(testEventTriggering('pan', event, states._onKeyDown));
+        states._onKeyUp();
+    });
+
+    it('should trigger pan event from bottom arrow key press', function () {
+        // BOTTOM arrow key
+        event.keyCode = 40;
+        assert(testEventTriggering('pan', event, states._onKeyDown));
+        states._onKeyUp();
+    });
+
+    it('should trigger pan event from left arrow key press', function () {
+        // LEFT arrow key
+        event.keyCode = 37;
+        assert(testEventTriggering('pan', event, states._onKeyDown));
+        states._onKeyUp();
+    });
+
+    it('should trigger pan event from right arrow key press', function () {
+        // RIGHT arrow key
+        event.keyCode = 39;
+        assert(testEventTriggering('pan', event, states._onKeyDown));
+        states._onKeyUp();
+    });
+
     it('should trigger state-changed event from shift + left-click', function () {
         event.button = MOUSE.LEFT;
         event.keyCode = 16;
@@ -170,16 +200,14 @@ describe('StateControl', function () {
         states.setFromOptions({
             TRAVEL_IN: {
                 keyboard: 80,
-                double: false,
             },
         });
 
         event.button = undefined;
         event.keyCode = 80;
 
-        assert(testEventTriggering('travel_in', event, (event) => {
-            states._handleTravelInEvent(event);
-        }));
+        assert(testEventTriggering('travel_in', event, states._onKeyDown));
+        states._onKeyUp();
     });
 
     it('should no longer trigger travel_in event from mouse event', function () {
@@ -220,9 +248,8 @@ describe('StateControl', function () {
         event.button = undefined;
         event.keyCode = 77;
 
-        assert(testEventTriggering('travel_out', event, (event) => {
-            states._handleTravelOutEvent(event);
-        }));
+        assert(testEventTriggering('travel_out', event, states._onKeyDown));
+        states._onKeyUp();
     });
 
     it('should no longer trigger travel_out event from mouse event', function () {
@@ -270,14 +297,38 @@ describe('StateControl', function () {
         }));
 
         event.button = undefined;
-        event.keyCode = 80;
         assert(!testEventTriggering('travel_in', event, (event) => {
-            states._handleTravelInEvent(event);
+            event.keyCode = 80;
+            states._onKeyDown(event);
+            states._onKeyUp();
         }));
 
-        event.keyCode = 77;
         assert(!testEventTriggering('travel_in', event, (event) => {
-            states._handleTravelInEvent(event);
+            event.keyCode = 77;
+            states._onKeyDown(event);
+            states._onKeyUp();
+        }));
+
+        assert(!testEventTriggering('pan', event, (event) => {
+            // Left arrow key
+            event.keyCode = 37;
+            states._onKeyDown(event);
+            states._onKeyUp();
+
+            // Up arrow key
+            event.keyCode = 38;
+            states._onKeyDown(event);
+            states._onKeyUp();
+
+            // Right arrow key
+            event.keyCode = 39;
+            states._onKeyDown(event);
+            states._onKeyUp();
+
+            // Bottom arrow key
+            event.keyCode = 40;
+            states._onKeyDown(event);
+            states._onKeyUp();
         }));
 
         states.enabled = true;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Switch keyoard input management from `GlobeControls` to `StateControl`.

A `StateControl` instance now listens for keyboard events. When a keyboard events occurs, `StateControl` determines which state the event is associated to. It then dispatches a custom event, whose type relates to the determined state. `GlobeControls` listens for every `StateControl` custom events, and moves camera accordingly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

1. Simplify GlobeControls by removing input management from it.
2. Factorize input management in StateControl so that other controls (like PanarControls) can later be refactored to implement it.