### PR TITLE
feature(Style): points can now be displayed as icons

### DIFF
--- a/examples/images/arrow.svg
+++ b/examples/images/arrow.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="6.1685719mm"
+   height="2.0668328mm"
+   viewBox="0 0 6.168572 2.0668328"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="arrow.svg"
+   inkscape:version="1.2 (56b05e47e7, 2022-06-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="12.471942"
+     inkscape:cx="7.216198"
+     inkscape:cy="20.566164"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="1920"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-96.874148,-86.999061)">
+    <path
+       style="fill:none;stroke:#008000;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-start:"
+       d="m 97.120049,87.241852 1.615733,1.624042 h 4.306938"
+       id="path804"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/examples/source_file_shapefile.html
+++ b/examples/source_file_shapefile.html
@@ -86,15 +86,29 @@
                     source: velibSource,
                     style: new itowns.Style({
                         zoom: { min: 10, max: 20 },
-                        point: { color: 'white', line: 'green' },
+                        point: {
+                            color: 'white',
+                            line: 'green',
+                            radius: 5,
+                            width: 2,
+                        },
+                        icon: {
+                            source: 'images/arrow.svg',
+                            anchor: 'top-left',
+                            size: 2,
+                        },
                         text: {
                             field: '{name}\n(id: {station_id})',
                             size: 14,
                             haloColor: 'white',
                             haloWidth: 1,
                             font: ['monospace'],
-                        }
+                            anchor: 'top-left',
+                            justify: 'left',
+                            offset: [20, 18],
+                        },
                     }),
+                    displayAsIcon: true,
                     addLabelLayer: true,
                 }));
             }).then((layer => {

--- a/examples/source_file_shapefile.html
+++ b/examples/source_file_shapefile.html
@@ -16,35 +16,48 @@
         <script src="js/plugins/FeatureToolTip.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
-            // Define initial camera position
-            var placement = {
+
+
+
+            // ---------- CREATE A GlobeView FOR SUPPORTING DATA VISUALIZATION : ----------
+
+            // Define camera initial position
+            const placement = {
                 coord: new itowns.Coordinates('EPSG:4326', 2.351323, 48.856712),
                 range: 25000,
-            }
+            };
 
             // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
-            var viewerDiv = document.getElementById('viewerDiv');
+            const viewerDiv = document.getElementById('viewerDiv');
 
-            // Instantiate iTowns GlobeView*
-            var view = new itowns.GlobeView(viewerDiv, placement);
-            var menuGlobe = new GuiTools('menuDiv', view);
+            // Create a GlobeView
+            const view = new itowns.GlobeView(viewerDiv, placement);
 
+            // Setup loading screen and debug menu
             setupLoadingScreen(viewerDiv, view);
+            const debugMenu = new GuiTools('menuDiv', view);
             FeatureToolTip.init(viewerDiv, view);
 
-            // Add one imagery layer to the scene
-            // This layer is defined in a json file but it could be defined as a plain js
-            // object. See Layer* for more info.
+
+
+            // ---------- DISPLAY ORTHO-IMAGES : ----------
+
+            // Add one imagery layer to the scene. This layer's properties are defined in a json file, but it could be
+            // defined as a plain js object. See `Layer` documentation for more info.
             itowns.Fetcher.json('./layers/JSONLayers/OPENSM.json').then(function _(config) {
                 config.source = new itowns.TMSSource(config.source);
-                var layer = new itowns.ColorLayer('OPENSM', config);
-                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+                view.addLayer(
+                    new itowns.ColorLayer('OPENSM', config),
+                ).then(debugMenu.addLayerGUI.bind(debugMenu));
             });
 
 
 
-            // As there is no Shapefile fetcher directly bundled within iTowns, we need to specify a method to fetch data.
-            // We use here `multiple` fetcher, which can fetch multiple files within multiple formats.
+            // ---------- DISPLAY DATA FROM .shp FILE : ----------
+
+            // Handle fetching step.
+            // As there is no Shapefile fetcher directly bundled within iTowns, we need to specify a method to fetch
+            // data. We use here `multiple` fetcher, which can fetch multiple files within multiple formats.
             itowns.Fetcher.multiple(
                 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/shapefile/velib-disponibilite-en-temps-reel',
                 {
@@ -54,17 +67,19 @@
                     text: ['prj'],
                 },
             ).then((fetched) => {
-                // Once our Shapefile data is fetched, we can parse it by running itowns built-in Shapefile parser.
+                // Handle parsing step.
+                // We parse the fetched data into a FeatureCollection by running iTowns built-in Shapefile parser.
+                // See http://www.itowns-project.org/itowns/docs/#api/Base/FeatureCollection.
                 return itowns.ShapefileParser.parse(fetched, {
-                    // Options indicating how the features should be built from data.
+                    // Information on the FeatureCollection that should be created from the fetched data. Here, we pass
+                    // a FeatureBuildingOptions.
+                    // See (http://www.itowns-project.org/itowns/docs/#api/Base/FeatureBuildingOptions).
                     out: {
-                        // Specitfy the crs to convert the input coordinates to.
                         crs: view.tileLayer.extent.crs,
                     },
                 });
             }).then((parsed) => {
-                // We can then instantiate a FileSource, passing the parsed data,
-                // and create a Layer bound to this source.
+                // Define a FileSource from the parsed data and create a Layer bound to this source.
                 const velibSource = new itowns.FileSource({ features: parsed });
 
                 return view.addLayer(new itowns.ColorLayer('velib', {
@@ -86,6 +101,12 @@
                 // Finally, we generate tooltip for when the mouse hovers the data displayed within our created layer.
                 FeatureToolTip.addLayer(layer, { filterAllProperties: false });
             }));
+
+
+
+            // ---------- DEBUG TOOLS : ----------
+
+            debug.createTileDebugUI(debugMenu.gui, view);
 
         </script>
     </body>

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -102,7 +102,7 @@ function drawPoint(ctx, x, y, style = {}, invCtxScale) {
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
-function drawFeature(ctx, feature, extent, style, invCtxScale) {
+function drawFeature(ctx, feature, extent, style, invCtxScale, layer) {
     const extentDim = extent.planarDimensions();
     const scaleRadius = extentDim.x / ctx.canvas.width;
     const globals = { zoom: extent.zoom };
@@ -117,6 +117,9 @@ function drawFeature(ctx, feature, extent, style, invCtxScale) {
                     feature.type === FEATURE_TYPES.POINT
                     && contextStyle.point
                 ) {
+                    // Don't display point as raster if they are already displayed as icons.
+                    if (layer.displayAsIcon) { continue; }
+
                     // cross multiplication to know in the extent system the real size of
                     // the point
                     const px = (Math.round(contextStyle.point.radius * invCtxScale) || 3 * invCtxScale) * scaleRadius;
@@ -151,7 +154,7 @@ const featureExtent = new Extent('EPSG:4326', 0, 0, 0, 0);
 export default {
     // backgroundColor is a THREE.Color to specify a color to fill the texture
     // with, given there is no feature passed in parameter
-    createTextureFromFeature(collection, extent, sizeTexture, style, backgroundColor) {
+    createTextureFromFeature(collection, extent, sizeTexture, layer, backgroundColor) {
         let texture;
 
         if (collection) {
@@ -169,7 +172,7 @@ export default {
                 ctx.fillStyle = backgroundColor.getStyle();
                 ctx.fillRect(0, 0, sizeTexture, sizeTexture);
             }
-            ctx.globalCompositeOperation = style.globalCompositeOperation || 'source-over';
+            ctx.globalCompositeOperation = layer.style.globalCompositeOperation || 'source-over';
             ctx.imageSmoothingEnabled = false;
             ctx.lineJoin = 'round';
 
@@ -200,7 +203,7 @@ export default {
 
             // Draw the canvas
             for (const feature of collection.features) {
-                drawFeature(ctx, feature, featureExtent, feature.style || style, invCtxScale);
+                drawFeature(ctx, feature, featureExtent, feature.style || layer.style, invCtxScale, layer);
             }
 
             texture = new THREE.CanvasTexture(c);

--- a/src/Converter/textureConverter.js
+++ b/src/Converter/textureConverter.js
@@ -28,7 +28,7 @@ export default {
                 undefined;
 
             extentDestination.as(CRS.formatToEPSG(layer.crs), extentTexture);
-            texture = Feature2Texture.createTextureFromFeature(data, extentTexture, 256, layer.style, backgroundColor);
+            texture = Feature2Texture.createTextureFromFeature(data, extentTexture, 256, layer, backgroundColor);
             texture.features = data;
             texture.extent = extentDestination;
         } else if (data.isTexture) {

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -192,6 +192,17 @@ class Coordinates {
     }
 
     /**
+     * Returns `true` if this Coordinates instance and the Coordinates passed in parameters are the same - i.e. : they
+     * register the same position. Otherwise, it returns `false`.
+     *
+     * @param   {Coordinates}   coordinates     The coordinates to compare to this instance of Coordinates.
+     * @returns {boolean}   `true` if both coordinates are the same, `false` otherwise.
+     */
+    equals(coordinates) {
+        return coordinates.as(this.crs).toVector3().equals(this.toVector3());
+    }
+
+    /**
      * Return this Coordinates values into a `THREE.Vector3`.
      *
      * @param {THREE.Vector3} [target] - The target to put the values in. If not

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -88,6 +88,12 @@ class Label extends THREE.Object3D {
             this.content = content.cloneNode(true);
         }
 
+        // Display labels with content (either text or domElement) on top of content-less labels (such as labels with
+        // only an icon for instance).
+        if (content !== '') {
+            this.content.style.zIndex = '1';
+        }
+
         this.content.classList.add('itowns-label');
         this.content.style.userSelect = 'none';
         this.content.style.position = 'absolute';

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -82,6 +82,8 @@ class Label extends THREE.Object3D {
         if (typeof content === 'string') {
             this.content = document.createElement('div');
             this.content.textContent = content;
+        } else if (content instanceof HTMLCanvasElement) {
+            this.content = content;
         } else {
             this.content = content.cloneNode(true);
         }

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -367,6 +367,7 @@ class Style {
         defineStyleProperty(this, 'text', 'haloBlur', params.text.haloBlur, 0);
 
         this.icon = {};
+        defineStyleProperty(this, 'icon', 'pointIcon', params.icon.pointIcon);
         defineStyleProperty(this, 'icon', 'source', params.icon.source);
         defineStyleProperty(this, 'icon', 'key', params.icon.key);
         defineStyleProperty(this, 'icon', 'anchor', params.icon.anchor, 'center');
@@ -406,9 +407,8 @@ class Style {
     symbolStylefromContext(context) {
         const style = new Style();
         mapPropertiesFromContext('text', this, style, context);
-        if (this.icon) {
-            mapPropertiesFromContext('icon', this, style, context);
-        }
+        mapPropertiesFromContext('icon', this, style, context);
+        mapPropertiesFromContext('point', this, style, context);
         style.order = this.order;
         return style;
     }
@@ -592,23 +592,42 @@ class Style {
             domElement.setAttribute('data-before', domElement.textContent);
         }
 
-        if (!this.icon.source && !this.icon.key) {
+        if (!this.icon.pointIcon && !this.icon.source && !this.icon.key) {
             return;
         }
 
-        const image = this.icon.source;
-        const size = this.icon.size;
-        const key = this.icon.key;
+        let icon;
 
-        let icon = cacheStyle.get(image || key, size);
+        if (this.icon.pointIcon) {
+            icon = this.icon.pointIcon;
 
-        if (!icon) {
-            if (key && sprites) {
-                icon = getImage(sprites, key);
-            } else {
-                icon = getImage(image);
+            icon.setAttribute('class', 'itowns-icon');
+
+            icon.width = 2 * (this.point.radius + this.point.width);
+            icon.height = icon.width;
+
+            icon.style.width = 2 * this.point.radius;
+            icon.style.height = icon.style.width;
+            icon.style.backgroundColor = this.point.color;
+            icon.style.border = `${this.point.width}px solid ${this.point.line}`;
+            icon.style.borderRadius = '50%';
+
+            icon.complete = true;
+        } else {
+            const image = this.icon.source;
+            const size = this.icon.size;
+            const key = this.icon.key;
+
+            icon = cacheStyle.get(image || key, size);
+
+            if (!icon) {
+                if (key && sprites) {
+                    icon = getImage(sprites, key);
+                } else {
+                    icon = getImage(image);
+                }
+                cacheStyle.set(icon, image || key, size);
             }
-            cacheStyle.set(icon, image || key, size);
         }
 
         const addIcon = () => {

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -69,12 +69,16 @@ class ScreenGrid {
         const miny = Math.max(0, Math.floor(obj.boundaries.top / this.height * this.y));
         const maxy = Math.min(this.y - 1, Math.floor(obj.boundaries.bottom / this.height * this.y));
 
-        for (let i = minx; i <= maxx; i++) {
-            for (let j = miny; j <= maxy; j++) {
-                if (this.grid[i][j].length > 0) {
-                    if (this.grid[i][j].some(l => isIntersectedOrOverlaped(l.boundaries, obj.boundaries))) {
-                        this.hidden.push(obj);
-                        return false;
+        if (!obj.allowOverlapping) {
+            for (let i = minx; i <= maxx; i++) {
+                for (let j = miny; j <= maxy; j++) {
+                    if (this.grid[i][j].length > 0) {
+                        if (this.grid[i][j].some(
+                            l => !l.allowOverlapping && isIntersectedOrOverlaped(l.boundaries, obj.boundaries))
+                        ) {
+                            this.hidden.push(obj);
+                            return false;
+                        }
                     }
                 }
             }

--- a/test/unit/coordinate.js
+++ b/test/unit/coordinate.js
@@ -125,4 +125,15 @@ describe('Coordinates', function () {
         assert.equal(distance, 199991.80319097277);
         assert.equal(distance, coord1.spatialEuclideanDistanceTo(coord0));
     });
+
+    it('should assert equality for Coordinates', function () {
+        const coord0 = new Coordinates('EPSG:4326', 0, 0);
+        const coord1 = new Coordinates('EPSG:4326', 0, 0);
+        const coord2 = new Coordinates('EPSG:4326', 0, 1);
+        const coord3 = new Coordinates('EPSG:4978', 6378137, 0);
+
+        assert.ok(coord0.equals(coord1));
+        assert.ok(!coord0.equals(coord2));
+        assert.ok(coord0.equals(coord3));
+    });
 });

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -38,6 +38,16 @@ describe('LabelLayer', function () {
         const labels = layer.convert(collection, extent);
         assert.ok(labels[0].isLabel);
     });
+
+    it('should replace style.point by style.icon if displayAsIcon is true', function () {
+        const labelLayer = new LabelLayer('labelLayer', {
+            source: false,
+            style: { point: { color: 'red', line: 'green', displayAsIcon: true } },
+        });
+        labelLayer.source = {};
+        assert.strictEqual(labelLayer.style.point.color, undefined);
+        assert.strictEqual(labelLayer.style.point.line, undefined);
+    });
 });
 
 describe('Label', function () {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add support to display points as label icons in a `ColorLayer` or a `LabelLayer`.

If user defines `Style.point` of a `ColorLayer`, and set the `ColorLayer` `addLabelLayer` parameter to true, points will be displayed as label icons. If `addLabelLayer` is unset or set to false, point will be kept rasterized.
User can also define `Style.point` for a `LabelLayer`, in which case points will obviously be displayed as label icons.