### PR TITLE
fix(FirstPersonControls): prevent context menu from poping

### DIFF
--- a/src/Controls/FirstPersonControls.js
+++ b/src/Controls/FirstPersonControls.js
@@ -99,6 +99,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
             this._onMouseWheel = this.onMouseWheel.bind(this);
             this._onKeyUp = this.onKeyUp.bind(this);
             this._onKeyDown = this.onKeyDown.bind(this);
+            this._onContextMenu = this.onContextMenu.bind(this);
             view.domElement.addEventListener('mousedown', this._onMouseDown, false);
             view.domElement.addEventListener('touchstart', this._onMouseDown, false);
             view.domElement.addEventListener('mousemove', this._onMouseMove, false);
@@ -106,6 +107,8 @@ class FirstPersonControls extends THREE.EventDispatcher {
             view.domElement.addEventListener('mouseup', this._onMouseUp, false);
             view.domElement.addEventListener('touchend', this._onMouseUp, false);
             view.domElement.addEventListener('wheel', this._onMouseWheel, false);
+            // Disable context menu when right clicking.
+            view.domElement.addEventListener('contextmenu', this._onContextMenu, false);
 
             // TODO: Why windows
             document.addEventListener('keydown', this._onKeyDown, false);
@@ -280,6 +283,10 @@ class FirstPersonControls extends THREE.EventDispatcher {
         }
     }
 
+    onContextMenu(event) {
+        event.preventDefault();
+    }
+
     dispose() {
         if (!this.eventListeners) {
             this.view.domElement.removeEventListener('mousedown', this._onMouseDown, false);
@@ -289,6 +296,7 @@ class FirstPersonControls extends THREE.EventDispatcher {
             this.view.domElement.removeEventListener('mouseup', this._onMouseUp, false);
             this.view.domElement.removeEventListener('touchend', this._onMouseUp, false);
             this.view.domElement.removeEventListener('wheel', this._onMouseWheel, false);
+            this.view.domElement.removeEventListener('contextmenu', this._onContextMenu, false);
 
             document.removeEventListener('keydown', this._onKeyDown, false);
             document.removeEventListener('keyup', this._onKeyUp, false);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Prevent displaying context menu on a right click when using `FirstPersonControls`.