### PR TITLE
fix(GlobeControls): fix black screen when zooming outside globe

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -673,18 +673,20 @@ class GlobeControls extends THREE.EventDispatcher {
     }
 
     updateTarget() {
-        // Update camera's target position
-        this.view.getPickingPositionFromDepth(null, pickedPosition);
-        const distance = !isNaN(pickedPosition.x) ? this.camera.position.distanceTo(pickedPosition) : 100;
-        targetPosition.set(0, 0, -distance);
-        this.camera.localToWorld(targetPosition);
+        // Check if the middle of the screen is on the globe (to prevent having a dark-screen bug if outside the globe)
+        if (this.view.getPickingPositionFromDepth(null, pickedPosition)) {
+            // Update camera's target position
+            const distance = !isNaN(pickedPosition.x) ? this.camera.position.distanceTo(pickedPosition) : 100;
+            targetPosition.set(0, 0, -distance);
+            this.camera.localToWorld(targetPosition);
 
-        // set new camera target on globe
-        positionObject(targetPosition, cameraTarget);
-        cameraTarget.matrixWorldInverse.copy(cameraTarget.matrixWorld).invert();
-        targetPosition.copy(this.camera.position);
-        targetPosition.applyMatrix4(cameraTarget.matrixWorldInverse);
-        spherical.setFromVector3(targetPosition);
+            // set new camera target on globe
+            positionObject(targetPosition, cameraTarget);
+            cameraTarget.matrixWorldInverse.copy(cameraTarget.matrixWorld).invert();
+            targetPosition.copy(this.camera.position);
+            targetPosition.applyMatrix4(cameraTarget.matrixWorldInverse);
+            spherical.setFromVector3(targetPosition);
+        }
     }
 
     handlingEvent(current) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When placing camera target in `GlobeControls`, check if the target's position is on the globe. If not, its position stays unchanged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Fix a black screen bug that could occur when zooming while the screen center was not on the globe. This bug is shown in the gif bellow.

![test](https://user-images.githubusercontent.com/73115044/136807801-980ac573-1dff-4bac-9602-86b06f67d373.gif)

