### PR TITLE
fix: resolve deprecated usage of function Three.Quaternion.slerp()

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -519,7 +519,7 @@ class GlobeControls extends THREE.EventDispatcher {
         } else {
             sphericalDelta.theta *= (1 - dampingFactorDefault);
             sphericalDelta.phi *= (1 - dampingFactorDefault);
-            moveAroundGlobe.slerp(dampingMove, this.dampingMoveFactor * 0.2);
+            moveAroundGlobe.slerpQuaternions(moveAroundGlobe, dampingMove, this.dampingMoveFactor * 0.2);
         }
 
         orbitScale = 1;


### PR DESCRIPTION
## Description
Use of Three.Quaternion.slerpQuaternions() in src/Controls/GlobeControls.js instead of deprecated function slerp()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

A function was deprecated in src/Controls/GlobeControls.js and had to be replaced.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

Browser : Mozilla Firefox 93.0

## Screenshots (if appropriate)
