### PR TITLE
Fix scale elevation updating

### DIFF
--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -57,8 +57,9 @@ class TileMesh extends THREE.Mesh {
         if (min == null && max == null) {
             return;
         }
-        // FIXME: Why the floors ? This is not conservative : the obb may be too short by almost 1m !
-        if (Math.floor(min) !== Math.floor(this.obb.z.min) || Math.floor(max) !== Math.floor(this.obb.z.max)) {
+        // update bbox if min or max have changed by at least one decimal
+        // or if scale changed
+        if (min.toFixed(1) !== this.obb.z.min.toFixed(1) || max.toFixed(1) !== this.obb.z.max.toFixed(1) || scale != this.obb.z.scale) {
             this.obb.updateZ(min, max, scale);
             if (this.horizonCullingPointElevationScaled) {
                 this.horizonCullingPointElevationScaled.setLength(this.obb.z.delta + this.horizonCullingPoint.length());

--- a/src/Layer/ElevationLayer.js
+++ b/src/Layer/ElevationLayer.js
@@ -55,21 +55,7 @@ class ElevationLayer extends RasterLayer {
     constructor(id, config = {}) {
         super(id, config);
         this.isElevationLayer = true;
-
-        // This is used to add a factor needed to color texture
-        let baseScale = 1.0;
-        if (this.useColorTextureElevation) {
-            baseScale = this.colorTextureElevationMaxZ - this.colorTextureElevationMinZ;
-        }
-
-        this.defineLayerProperty('scale', this.scale || 1.0, (self) => {
-            self.parent.object3d.traverse((obj) => {
-                if (obj.layer == self.parent && obj.material) {
-                    obj.material.setElevationScale(self.scale * baseScale);
-                    obj.obb.updateScaleZ(self.scale);
-                }
-            });
-        });
+        this.defineLayerProperty('scale', this.scale || 1.0);
     }
 
     /**
@@ -90,6 +76,13 @@ class ElevationLayer extends RasterLayer {
 
         // listen elevation updating
         rasterElevationNode.addEventListener('updatedElevation', updateBBox);
+
+        // listen scaling elevation updating
+        this.addEventListener('scale-property-changed', updateBBox);
+        // remove scaling elevation updating if node is removed
+        node.addEventListener('dispose', () => {
+            this.removeEventListener('scale-property-changed', updateBBox);
+        });
 
         return rasterElevationNode;
     }

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -25,8 +25,8 @@ export default {
                 } else {
                     obj.material.dispose();
                 }
-                // obj.material = null;
             }
+            obj.dispatchEvent({ type: 'dispose' });
         }
     },
 

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -63,7 +63,7 @@ describe('Provide in Sources', function () {
     planarlayer.attach(colorlayer);
     planarlayer.attach(elevationlayer);
 
-    const fakeNode = { material,  setBBoxZ: () => {} };
+    const fakeNode = { material,  setBBoxZ: () => {},  addEventListener: () => {} };
     colorlayer.setupRasterNode(fakeNode);
     elevationlayer.setupRasterNode(fakeNode);
 

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -133,7 +133,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
                 const l3js = l.threejsLayer;
 
                 if (layer.id == obb_layer_id) {
-                    helper = new OBBHelper(node.obb, `id:${node.id}`);
+                    helper = new OBBHelper(node.obb);
                     if (helper.children[0]) {
                         helper.children[0].layers.set(l3js);
                     }


### PR DESCRIPTION
## Description
The scale elevation updating isn't really correctly impacted on the terrain tiles.

This update has re-factorized to use events instead of `Object3D.traverse`.
