### PR TITLE
Fix label renderer

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -95,6 +95,7 @@ function _preprocessLayer(view, layer, parentLayer) {
             zoom: layer.zoom,
             crs: source.crs,
             visible: layer.visible,
+            margin: 15,
         });
 
         layer.addEventListener('visible-property-changed', () => {


### PR DESCRIPTION
## Description
Some labels can appear in sky.
Effectively, labels are displayed even though they aren't in frustum camera.

## Motivation and Context
* remove labels glitch 
* improve performance because it reduce the labels count to be processed.

## Screenshot
![chrome-capture](https://user-images.githubusercontent.com/11291849/139037596-0f76dba0-a35c-480a-8406-fcd884890b30.gif)

