### PR TITLE
fix(VectorTileSource): set style parent with style Layer

### DIFF
--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -126,6 +126,13 @@ class VectorTilesSource extends TMSSource {
             }
         });
     }
+
+    onLayerAdded(options) {
+        super.onLayerAdded(options);
+        const keys = Object.keys(this.styles);
+
+        keys.forEach((k) => { this.styles[k].parent = options.out.style; });
+    }
 }
 
 export default VectorTilesSource;


### PR DESCRIPTION
## Description
fix(VectorTileSource): set style parent with style Layer.

Possibility to define a non existing style for the layer `VectorTileLayer`.

