### PR TITLE
Avoid geocentric projection for geographic `Extent`

### DIFF
--- a/src/Core/Geographic/Crs.js
+++ b/src/Core/Geographic/Crs.js
@@ -27,6 +27,11 @@ function is4326(crs) {
     return crs === 'EPSG:4326';
 }
 
+function isGeocentric(crs) {
+    const projection = proj4.defs(crs);
+    return !projection ? false : projection.projName == 'geocent';
+}
+
 function _unitFromProj4Unit(projunit) {
     if (projunit === 'degrees') {
         return UNIT.DEGREE;
@@ -120,6 +125,14 @@ export default {
      * @return {boolean}
      */
     is4326,
+    /**
+     * Is the CRS geocentric ?
+     * if crs isn't defined the method returns false.
+     *
+     * @param {string} crs - The CRS to test.
+     * @return {boolean}
+     */
+    isGeocentric,
 
     /**
      * Give a reasonnable epsilon to use with this CRS.

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -69,6 +69,8 @@ class Extent {
      * Extent is geographical bounding rectangle defined by 4 limits: west, east, south and north.
      * If crs is tiled projection (WMTS or TMS), the extent is defined by zoom, row and column.
      *
+     * Warning, using geocentric projection isn't consistent with geographical extent.
+     *
      * @param {String} crs projection of limit values.
      * @param {number|Array.<number>|Coordinates|Object} v0 west value, zoom
      * value, Array of values [west, east, south and north], Coordinates of
@@ -79,6 +81,10 @@ class Extent {
      * @param {number} [v3] north value
      */
     constructor(crs, v0, v1, v2, v3) {
+        if (CRS.isGeocentric(crs)) {
+            throw new Error(`${crs} is geocentric projection, it's not make sense with geographical extent`);
+        }
+
         this.isExtent = true;
         this.crs = crs;
         // Scale/zoom

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -47,12 +47,8 @@ function boundingVolumeToExtent(crs, volume, transform) {
         return Extent.fromBox3(crs, box);
     } else {
         const sphere = tmpSphere.copy(volume.sphere).applyMatrix4(transform);
-        return new Extent(crs, {
-            west: sphere.center.x - sphere.radius,
-            east: sphere.center.x + sphere.radius,
-            south: sphere.center.y - sphere.radius,
-            north: sphere.center.y + sphere.radius,
-        });
+        const box = sphere.getBoundingBox(tmpBox3);
+        return Extent.fromBox3(crs, box);
     }
 }
 
@@ -81,6 +77,7 @@ function _subdivideNodeAdditive(context, layer, node, cullingTest) {
             node.add(tile);
             tile.updateMatrixWorld();
 
+            // The extent is calculated but it's never used in 3D tiles process
             const extent = boundingVolumeToExtent(layer.extent.crs, tile.boundingVolume, tile.matrixWorld);
             tile.traverse((obj) => {
                 obj.extent = extent;
@@ -289,6 +286,7 @@ export function init3dTilesLayer(view, scheduler, layer, rootTile) {
             tile.updateMatrixWorld();
             layer.tileset.tiles[tile.tileId].loaded = true;
             layer.root = tile;
+            // The extent is calculated but it's never used in 3D tiles process
             layer.extent = boundingVolumeToExtent(layer.crs || view.referenceCrs,
                 tile.boundingVolume, tile.matrixWorld);
             layer.onTileContentLoaded(tile);

--- a/test/unit/CameraUtils.js
+++ b/test/unit/CameraUtils.js
@@ -6,6 +6,9 @@ import CameraUtils from 'Utils/CameraUtils';
 import DEMUtils from 'Utils/DEMUtils';
 import Camera, { CAMERA_TYPE } from 'Renderer/Camera';
 import Extent from 'Core/Geographic/Extent';
+import proj4 from 'proj4';
+
+proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 function equalToFixed(value1, value2, toFixed) {
     return value1.toFixed(toFixed) === value2.toFixed(toFixed);
@@ -113,6 +116,7 @@ describe('Camera utils unit test', function () {
     it('should transform camera from given extent', function () {
         view.isPlanarView = true;
         view.isGlobeView = false;
+        view.referenceCrs = 'EPSG:2154';
         const orthographicCamera = new Camera(view.referenceCrs, 60, 40, { type: CAMERA_TYPE.ORTHOGRAPHIC });
         let camera3D = orthographicCamera.camera3D;
 

--- a/test/unit/extent.js
+++ b/test/unit/extent.js
@@ -60,7 +60,7 @@ describe('Extent', function () {
         const box = new Box3(
             new Vector3(Math.random(), Math.random()),
             new Vector3(Math.random(), Math.random()));
-        const fromBox = Extent.fromBox3('EPSG:4978', box);
+        const fromBox = Extent.fromBox3('EPSG:4326', box);
 
         assert.equal(fromBox.west, box.min.x);
         assert.equal(fromBox.east, box.max.x);
@@ -314,5 +314,9 @@ describe('Extent', function () {
         assert.equal(0, center.x);
         assert.equal(90, center.y);
         assert.equal(0, center.z);
+    });
+
+    it('should throw error when instance with geocentric projection', () => {
+        assert.throws(() => new Extent('EPSG:4978'));
     });
 });

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -31,7 +31,7 @@ describe('LabelLayer', function () {
         geometry.closeSubGeometry(3, feature);
         geometry.properties = { content: 'foo' };
 
-        extent = new Extent('EPSG:4978', -10, 10, -10, 10);
+        extent = new Extent('EPSG:4326', -10, 10, -10, 10);
     });
 
     it('should create Labels from a FeatureCollection like object', function () {
@@ -43,7 +43,7 @@ describe('LabelLayer', function () {
 describe('Label', function () {
     let label;
     let style;
-    const c = new Coordinates('EPSG:4978');
+    const c = new Coordinates('EPSG:4326');
     const sprites = {
         img: '',
         icon: { x: 0, y: 0, width: 10, height: 10 },

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -20,14 +20,6 @@ describe('URL creations', function () {
         assert.equal(result, 'http://server.geo/wmts/SERVICE=WMTS&TILEMATRIX=12&TILEROW=1410&TILECOL=2072');
     });
 
-    it('should correctly replace %bbox by 12,35,14,46', function () {
-        const extent = new Extent('EPSG:4978', 12, 14, 35, 46);
-        layer.crs = 'EPSG:4978';
-        layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
-        const result = URLBuilder.bbox(extent, layer);
-        assert.equal(result, 'http://server.geo/wms/BBOX=12.00,35.00,14.00,46.00&FORMAT=jpg&SERVICE=WMS');
-    });
-
     it('should correctly replace %bbox by 12,14,35,46', function () {
         const extent = new Extent('EPSG:4326', 12, 14, 35, 46);
         layer.crs = 'EPSG:4326';


### PR DESCRIPTION
## Description
Geocentric projection (like `EPSG:4978`) for geographic `Extent` doesn't make sense.
Now, it isn't possible to instance a `Extent` with Geocentric projection.

Source/layer with geocentric projection, the extent will calculate in `EPSG:4326`.

## Motivation and Context
Avoid wrong geographic extent.