### PR TITLE
fix(ColorLayer): fix shader when transparent is true

### DIFF
--- a/src/Renderer/LayeredMaterial.js
+++ b/src/Renderer/LayeredMaterial.js
@@ -49,6 +49,7 @@ const defaultStructLayer = {
     crs: 0,
     effect_parameter: 0,
     effect_type: colorLayerEffects.noEffect,
+    transparent: false,
 };
 
 function updateLayersUniforms(uniforms, olayers, max) {

--- a/src/Renderer/RasterTile.js
+++ b/src/Renderer/RasterTile.js
@@ -111,6 +111,9 @@ export class RasterColorTile extends RasterTile {
     get effect_parameter() {
         return this.layer.effect_parameter;
     }
+    get transparent() {
+        return this.layer.transparent;
+    }
 }
 
 export class RasterElevationTile extends RasterTile {

--- a/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
@@ -4,6 +4,7 @@ struct Layer {
     int effect_type;
     float effect_parameter;
     float opacity;
+    bool transparent;
 };
 
 #include <itowns/custom_header_colorLayer>
@@ -61,14 +62,18 @@ vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer lay
     float borderDistance = getBorderDistance(uv.xy);
     if (textureOffset != layer.textureOffset + int(uv.z) || borderDistance < minBorderDistance ) return vec4(0);
     vec4 color = texture2D(tex, pitUV(uv.xy, offsetScale));
-    if (layer.effect_type == 1) {
-        color.rgb /= color.a;
-        color = applyLightColorToInvisibleEffect(color, layer.effect_parameter);
-    } else if (layer.effect_type == 2) {
-        color.rgb /= color.a;
-        color = applyWhiteToInvisibleEffect(color, layer.effect_parameter);
-    } else if (layer.effect_type == 3) {
+    if (layer.effect_type == 3) {
         #include <itowns/custom_body_colorLayer>
+    } else {
+        if (layer.transparent && color.a != 0.0) {
+            color.rgb /= color.a;
+        }
+
+        if (layer.effect_type == 1) {
+            color = applyLightColorToInvisibleEffect(color, layer.effect_parameter);
+        } else if (layer.effect_type == 2) {
+            color = applyWhiteToInvisibleEffect(color, layer.effect_parameter);
+        }
     }
     color.a *= layer.opacity;
     return color;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fix `ColorLayer` shader to prevent a color change when `ColorLayer.transparent` is set to `true`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

When `ColorLayer.transparent` parameter is set to `true`, the color channels of the layer textures are pre-multiplied by the alpha channel. This prevents fringes to appear when transitioning from an opaque pixel to a transparent one.
In the shader, the color channels must be divided back by the alpha channel, to prevent pre-multiplication from changing pixels color.