### PR TITLE
refacto(Feature): defaults buildExtent parameter to true for 2d structure

### DIFF
--- a/examples/js/plugins/CSVnVRTParser.js
+++ b/examples/js/plugins/CSVnVRTParser.js
@@ -18,7 +18,6 @@
  * }).then(function _(res) {
  *     res.csv = Papa.parse(res.csv.trim()).data;
  *     return CSVnVRTParser.parse(res, { out: {
- *              buildExtent: true,
  *              crs: 'EPSG:4326'
  *          }
  *     });

--- a/examples/misc_custom_label.html
+++ b/examples/misc_custom_label.html
@@ -124,8 +124,6 @@
         // create new featureCollection
         const collection = new itowns.FeatureCollection({
             crs: view.tileLayer.extent.crs,
-            buildExtent: true,
-            structure: '2d',
         });
 
         // create new feature

--- a/examples/plugins_vrt.html
+++ b/examples/plugins_vrt.html
@@ -50,7 +50,6 @@
             }).then(function _(res) {
                 res.csv = Papa.parse(res.csv.trim()).data;
                 return CSVnVRTParser.parse(res, { out: {
-                    buildExtent: true,
                     crs: view.tileLayer.extent.crs,
                 }});
             }).then(function _(features) {

--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -109,9 +109,6 @@
                     // Here, we pass a FeatureBuildingOptions (http://www.itowns-project.org/itowns/docs/#api/Base/FeatureBuildingOptions)
                     out: {
                         crs: view.tileLayer.extent.crs,
-                        buildExtent: true,
-                        mergeFeatures: true,
-                        structure: '2d',
                     },
                 });
             }).then(function _(features) {

--- a/examples/source_file_shapefile.html
+++ b/examples/source_file_shapefile.html
@@ -50,7 +50,6 @@
                 return itowns.ShapefileParser.parse(res, {
                     out: {
                         crs: view.tileLayer.extent.crs,
-                        buildExtent: true,
                     }
                 });
             }).then(function _(features) {

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -41,17 +41,18 @@ const typeToStyleProperty = ['point', 'stroke', 'fill'];
 
 /**
  * @property {string} crs - The CRS to convert the input coordinates to.
- * @property {Extent|boolean} [filteringExtent=undefined] - Optional filter to reject
- * features outside of extent. Extent filetring is file extent if filteringExtent is true.
- * @property {boolean} [buildExtent=false] - If true the geometry will
- * have an extent property containing the area covered by the geometry.
- * True if the layer does not inherit from {@link GeometryLayer}.
- * @property {string} forcedExtentCrs - force feature extent crs if buildExtent is true.
- * @property {function} [filter] - Filter function to remove features
- * @property {boolean} [mergeFeatures=true] - If true all geometries are merged by type and multi-type
  * @property {string} [structure='2d'] - data structure type : 2d or 3d.
  * If the structure is 3d, the feature have 3 dimensions by vertices positions and
  * a normal for each vertices.
+ * @property {Extent|boolean} [filteringExtent=undefined] - Optional filter to reject
+ * features outside of extent. Extent filtering is file extent if filteringExtent is true.
+ * @property {boolean} [buildExtent] - If true the geometry will
+ * have an extent property containing the area covered by the geometry.
+ * Default value is false if `structure` parameter is set to '3d', and true otherwise.
+ * True if the layer does not inherit from {@link GeometryLayer}.
+ * @property {string} forcedExtentCrs - force feature extent crs if buildExtent is true.
+ * @property {function} [filter] - Filter function to remove features
+ * @property {boolean} [mergeFeatures=true] - If true all geometries are merged by type and multi-type.
  * @property {Style} style - The style to inherit when creating
  * style for all new features.
  *
@@ -361,7 +362,6 @@ export class FeatureCollection extends THREE.Object3D {
         this.crs = CRS.formatToEPSG(options.crs);
         this.features = [];
         this.mergeFeatures = options.mergeFeatures === undefined ? true : options.mergeFeatures;
-        this.extent = options.buildExtent ? defaultExtent(options.forcedExtentCrs || this.crs) : undefined;
         this.size = options.structure == '3d' ? 3 : 2;
         this.filterExtent = options.filterExtent;
         this.style = options.style;
@@ -370,6 +370,7 @@ export class FeatureCollection extends THREE.Object3D {
         this.center = new Coordinates('EPSG:4326', 0, 0);
 
         if (this.size == 2) {
+            this.extent = options.buildExtent === false ? undefined : defaultExtent(options.forcedExtentCrs || this.crs);
             this._setLocalSystem = (center) => {
                 // set local system center
                 center.as('EPSG:4326', this.center);
@@ -381,6 +382,7 @@ export class FeatureCollection extends THREE.Object3D {
             };
             this._transformToLocalSystem = transformToLocalSystem2D;
         } else {
+            this.extent = options.buildExtent ? defaultExtent(options.forcedExtentCrs || this.crs) : undefined;
             this._setLocalSystem = (center) => {
                 // set local system center
                 center.as('EPSG:4326', this.center);

--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -32,7 +32,6 @@ import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
  *         },
  *         out: {
  *             crs: view.tileLayer.extent.crs,
- *             buildExtent: true,
  *         }
  *     });
  * }).then(function _(geojson) {

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -79,13 +79,8 @@ import CRS from 'Core/Geographic/Crs';
  * itowns.Fetcher.json('https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/departements/09-ariege/departement-09-ariege.geojson')
  *     .then(function _(geojson) {
  *         return itowns.GeoJsonParser.parse(geojson, {
- *             in: { in: 'EPSG:4326' },
- *             out: {
-     *             crs: view.tileLayer.extent.crs,
-     *             buildExtent: true,
-     *             mergeFeatures: true,
-     *             structure: '2d',
- *             },
+ *             in: { crs: 'EPSG:4326' },
+ *             out: { crs: view.tileLayer.extent.crs },
  *         });
  *     }).then(function _(features) {
  *         ariege.source = new itowns.FileSource({

--- a/test/functional/source_file_geojson_raster.js
+++ b/test/functional/source_file_geojson_raster.js
@@ -30,7 +30,7 @@ describe('source_file_geojson_raster', function _() {
             const promises = [];
             const layers = view.getLayers(l => l.source && l.source.isFileSource);
             for (let i = 0; i < layers.length; i++) {
-                promises.push(layers[i].source.loadData({}, { crs: 'EPSG:4326' }));
+                promises.push(layers[i].source.loadData({}, { crs: 'EPSG:4326', buildExtent: false }));
             }
 
             return Promise.all(promises).then(fa => fa.filter(f => itowns

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -30,7 +30,7 @@ describe('Feature', function () {
 
     it('Should instance Features with options', function () {
         const collection_A = new FeatureCollection(options_A);
-        const collection_B = new FeatureCollection({ crs: 'EPSG:4326' });
+        const collection_B = new FeatureCollection({ crs: 'EPSG:4326', buildExtent: false });
 
         const featureLine_A = collection_A.requestFeatureByType(FEATURE_TYPES.LINE);
         const featureLine_B = collection_B.requestFeatureByType(FEATURE_TYPES.LINE);

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -32,7 +32,6 @@ describe('GeoJsonParser', function () {
             },
             out: {
                 crs: 'EPSG:3946',
-                buildExtent: true,
                 filteringExtent: new Extent('EPSG:3946', 10, 20, 10, 20),
             },
         }).then((collection) => {

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -23,7 +23,7 @@ describe('LabelLayer', function () {
         };
         layer.style.text.field = 'content';
 
-        collection = new FeatureCollection({ crs: 'EPSG:4326', buildExtent: true });
+        collection = new FeatureCollection({ crs: 'EPSG:4326' });
         const feature = collection.requestFeatureByType(FEATURE_TYPES.POINT);
         const geometry = feature.bindNewGeometry();
         geometry.startSubGeometry(0, feature);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Defaults `buildExtent` parameters for `FeatureCollection` to true if `structure` parameter is set to `2d`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Simplify `FeatureCollection` implementation process by avoiding having to specify parameter that is often true with 2d features.