### PR TITLE
fix(parser): GeoJsonParser add legacy identifier to fct readCRS()

### DIFF
--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -8,14 +8,15 @@ function readCRS(json) {
         if (json.crs.type.toLowerCase() == 'epsg') {
             return `EPSG:${json.crs.properties.code}`;
         } else if (json.crs.type.toLowerCase() == 'name') {
-            const epsgIdx = json.crs.properties.name.toLowerCase().indexOf('epsg:');
-            if (epsgIdx >= 0) {
-                // authority:version:code => EPSG:[...]:code
-                const codeStart = json.crs.properties.name.indexOf(':', epsgIdx + 5);
+            if (json.crs.properties.name.toLowerCase().includes('epsg:')) {
+                // OGC CRS URN: urn:ogc:def:crs:authority:version:code => EPSG:[...]:code
+                // legacy identifier: authority:code => EPSG:code
+                const codeStart = json.crs.properties.name.lastIndexOf(':');
                 if (codeStart > 0) {
                     return `EPSG:${json.crs.properties.name.substr(codeStart + 1)}`;
                 }
             }
+            throw new Error(`Unsupported CRS authority '${json.crs.properties.name}'`);
         }
         throw new Error(`Unsupported CRS type '${json.crs}'`);
     }


### PR DESCRIPTION
## Description
The function readCRS() in GeoJsonParser is currently not able to read a crs named under the 'legacy identifier' format (i.e. EPSG:2154), which is used in various application. (as PostGIS)

## Motivation and Context
This fix allows the recognition of the crs used in a geojson if this one is defined under the 'legacy identifier' format.
