### PR TITLE
refactor(GeometryLayer): reference to material properties to Layer properties.

### DIFF
--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -7,20 +7,17 @@ import * as THREE from 'three';
 import TileMesh from 'Core/TileMesh';
 import LayeredMaterial from 'Renderer/LayeredMaterial';
 import newTileGeometry from 'Core/Prefab/TileBuilder';
+import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
 
 const dimensions = new THREE.Vector2();
 
 function setTileFromTiledLayer(tile, tileLayer) {
-    tile.material.transparent = tileLayer.opacity < 1.0;
-    tile.material.opacity = tileLayer.opacity;
-
     if (tileLayer.diffuse) {
         tile.material.diffuse = tileLayer.diffuse;
     }
 
     if (__DEBUG__) {
         tile.material.showOutline = tileLayer.showOutline || false;
-        tile.material.wireframe = tileLayer.wireframe || false;
     }
 
     if (tileLayer.isGlobeLayer) {
@@ -56,6 +53,8 @@ export default {
             result.geometry._count++;
             const crsCount = layer.tileMatrixSets.length;
             const material = new LayeredMaterial(layer.materialOptions, crsCount);
+            ReferLayerProperties(material, layer);
+
             const tile = new TileMesh(result.geometry, material, layer, extent, level);
 
             // Commented because layer.threejsLayer is undefined;

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -100,31 +100,8 @@ class GeometryLayer extends Layer {
             configurable: true,
         });
 
-        this.defineLayerProperty('opacity', 1.0, () => {
-            const root = this.parent ? this.parent.object3d : this.object3d;
-            root.traverse((object) => {
-                if (object.layer == this) {
-                    this.changeOpacity(object);
-                } else if (object.content && object.content.layer == this) {
-                    object.content.traverse(this.changeOpacity);
-                }
-            });
-        });
-
-        this.defineLayerProperty('wireframe', false, () => {
-            const root = this.parent ? this.parent.object3d : this.object3d;
-            root.traverse((object) => {
-                if (object.layer == this && object.material) {
-                    object.material.wireframe = this.wireframe;
-                } else if (object.content && object.content.layer == this) {
-                    object.content.traverse((o) => {
-                        if (o.material && o.layer == this) {
-                            o.material.wireframe = this.wireframe;
-                        }
-                    });
-                }
-            });
-        });
+        this.opacity = 1.0;
+        this.wireframe = false;
 
         this.attachedLayers = [];
         this.visible = config.visible == undefined ? true : config.visible;
@@ -232,27 +209,6 @@ class GeometryLayer extends Layer {
     pickObjectsAt(view, coordinates, radius = this.options.defaultPickingRadius, target = []) {
         const object3d = this.parent ? this.parent.object3d : this.object3d;
         return Picking.pickObjectsAt(view, coordinates, radius, object3d, target, this.threejsLayer);
-    }
-
-    /**
-     * Change the opacity of an object, according to the value of the `opacity`
-     * property of this layer.
-     *
-     * @param {Object} object - The object to change the opacity from. It is
-     * usually a `THREE.Object3d` or an implementation of it.
-     */
-    changeOpacity(object) {
-        if (object.material) {
-            // != undefined: we want the test to pass if opacity is 0
-            if (object.material.opacity != undefined) {
-                object.material.transparent = this.opacity < 1.0;
-                object.material.opacity = this.opacity;
-            }
-            if (object.material.uniforms && object.material.uniforms.opacity != undefined) {
-                object.material.transparent = this.opacity < 1.0;
-                object.material.uniforms.opacity.value = this.opacity;
-            }
-        }
     }
 }
 

--- a/src/Layer/ReferencingLayerProperties.js
+++ b/src/Layer/ReferencingLayerProperties.js
@@ -1,0 +1,37 @@
+
+// next step is move these properties to Style class
+// and hide transparent mechanism
+
+function ReferLayerProperties(material, layer) {
+    if (layer && layer.isGeometryLayer) {
+        let transparent = material.transparent;
+        material.layer = layer;
+
+        if (material.uniforms && material.uniforms.opacity != undefined) {
+            Object.defineProperty(material.uniforms.opacity, 'value', {
+                get: () => material.layer.opacity,
+            });
+        } else if (material.opacity != undefined) {
+            Object.defineProperty(material, 'opacity', {
+                get: () => material.layer.opacity,
+            });
+        }
+
+        Object.defineProperty(material, 'wireframe', {
+            get: () => material.layer.wireframe,
+        });
+        Object.defineProperty(material, 'transparent', {
+            get: () => {
+                if (transparent != material.layer.opacity < 1.0) {
+                    material.needsUpdate = true;
+                    transparent = material.layer.opacity < 1.0;
+                }
+                return transparent;
+            },
+        });
+    }
+
+    return material;
+}
+
+export default ReferLayerProperties;

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -6,6 +6,7 @@ import LegacyGLTFLoader from 'Parser/deprecated/LegacyGLTFLoader';
 import shaderUtils from 'Renderer/Shader/ShaderUtils';
 import utf8Decoder from 'Utils/Utf8Decoder';
 import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
+import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
 
 const matrixChangeUpVectorZtoY = (new THREE.Matrix4()).makeRotationX(Math.PI / 2);
 // For gltf rotation
@@ -201,8 +202,7 @@ export default {
                                 shaderUtils.patchMaterialForLogDepthSupport(mesh.material);
                                 console.warn('b3dm shader has been patched to add log depth buffer support');
                             }
-                            mesh.material.transparent = options.opacity < 1.0;
-                            mesh.material.opacity = options.opacity;
+                            ReferLayerProperties(mesh.material, options.layer);
                         }
                     };
                     gltf.scene.traverse(init_mesh);

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -6,22 +6,6 @@ import Coordinates from 'Core/Geographic/Coordinates';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
-function assignLayer(object, layer) {
-    if (object) {
-        object.layer = layer;
-        if (object.material) {
-            object.material.transparent = layer.opacity < 1.0;
-            object.material.opacity = layer.opacity;
-            object.material.wireframe = layer.wireframe;
-        }
-        object.layers.set(layer.threejsLayer);
-        for (const c of object.children) {
-            assignLayer(c, layer);
-        }
-        return object;
-    }
-}
-
 export default {
     update(context, layer, node) {
         if (!node.parent && node.children.length) {
@@ -74,7 +58,6 @@ export default {
             // if request return empty json, WFSProvider.getFeatures return undefined
             result = result[0];
             if (result) {
-                assignLayer(result, layer);
                 // call onMeshCreated callback if needed
                 if (layer.onMeshCreated) {
                     layer.onMeshCreated(result);

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -13,6 +13,7 @@ function b3dmToMesh(data, layer, url) {
         doNotPatchMaterial: layer.doNotPatchMaterial,
         opacity: layer.opacity,
         registeredExtensions: layer.registeredExtensions,
+        layer,
     };
     return B3dmParser.parse(data, options).then((result) => {
         const batchTable = result.batchTable;
@@ -75,11 +76,6 @@ function executeCommand(command) {
         obj.layers.set(layer.threejsLayer);
         obj.userData.metadata = metadata;
         obj.layer = layer;
-        if (obj.material) {
-            obj.material.transparent = layer.opacity < 1.0;
-            obj.material.opacity = layer.opacity;
-            obj.material.wireframe = layer.wireframe;
-        }
     };
     if (path) {
         // Check if we have relative or absolute url (with tileset's lopocs for example)

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -80,7 +80,14 @@ import CRS from 'Core/Geographic/Crs';
  *     .then(function _(geojson) {
  *         return itowns.GeoJsonParser.parse(geojson, {
  *             in: { crs: 'EPSG:4326' },
- *             out: { crs: view.tileLayer.extent.crs },
+ *             out: { crs: view.tileLayer.extent.crs,
+ *                      style: new itowns.Style({
+ *                          fill: {
+ *                              color: new itowns.THREE.Color(0xffcc00),
+ *                              extrusion_height: () => 5000,
+ *                      }),
+ *                  },
+ *             },
  *         });
  *     }).then(function _(features) {
  *         ariege.source = new itowns.FileSource({

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -80,10 +80,16 @@ import CRS from 'Core/Geographic/Crs';
  * });
  *
  * // Create the layer
- * const geometryLayer = new itowns.GeometryLayer('mesh_build', {
- *     update: itowns.FeatureProcessing.update,
- *     convert: itowns.Feature2Mesh.convert({ extrude: () => 50 }),
+ * const geometryLayer = new itowns.FeatureGeometryLayer('mesh_build', {
+ *     style: new itowns.Style({
+ *         fill: {
+ *             color: new itowns.THREE.Color(0xffcc00),
+ *             base_altitude: (p) => p.altitude,
+ *             extrusion_height: (p) => p.height,
+ *         }
+ *     },
  *     source: wfsSource,
+ *     zoom: { min: 14 },
  * });
  *
  * // Add the layer


### PR DESCRIPTION
## Description
Add referencing to material properties to Layer properties.
Material properties (opacity, wire-frame) point directly to Layer properties.

## Motivation and Context
It avoids, when a layer property is modified, to browse each 3D object to modify their property.
