### PR TITLE
fix(View): fix pickCoordinates undefined parameter

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -1055,7 +1055,7 @@ class View extends THREE.EventDispatcher {
     pickCoordinates(mouse, target = new Coordinates(this.tileLayer.extent.crs)) {
         if (mouse instanceof Event) {
             this.eventToViewCoords(mouse);
-        } else if (mouse.x !== undefined && mouse.y !== undefined) {
+        } else if (mouse && mouse.x !== undefined && mouse.y !== undefined) {
             _eventCoords.copy(mouse);
         } else {
             _eventCoords.set(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes a bug that could occur when calling `view.pickCoordinates` method without specifying a `mouse` parameter. The error is the following : `Cannot read properties of undefined (reading 'x')` on line 1058.