### PR TITLE
Fix color layer opacity

### DIFF
--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -88,7 +88,7 @@ GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {
         layer.visible = value;
         this.view.notifyChange(layer);
     }).bind(this));
-    folder.add({ opacity: layer.opacity }, 'opacity').min(0.0).max(1.0).onChange((function updateOpacity(value) {
+    folder.add({ opacity: layer.opacity }, 'opacity', 0.0, 1.0, 0.01).onChange((function updateOpacity(value) {
         layer.opacity = value;
         this.view.notifyChange(layer);
     }).bind(this));

--- a/src/Renderer/RasterTile.js
+++ b/src/Renderer/RasterTile.js
@@ -35,6 +35,7 @@ class RasterTile extends THREE.EventDispatcher {
 
         this._handlerCBEvent = () => { this.material.layersNeedUpdate = true; };
         layer.addEventListener('visible-property-changed', this._handlerCBEvent);
+        layer.addEventListener('opacity-property-changed', this._handlerCBEvent);
     }
 
     get id() {
@@ -72,6 +73,7 @@ class RasterTile extends THREE.EventDispatcher {
     dispose(removeEvent) {
         if (removeEvent) {
             this.layer.removeEventListener('visible-property-changed', this._handlerCBEvent);
+            this.layer.removeEventListener('opacity-property-changed', this._handlerCBEvent);
             // dispose all events
             this._listeners = {};
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Update `ColorLayer` uniforms when changing the `opacity` property. If a `ColorLayer` is initialized with an `opacity` of 0, some of its uniforms are not created (probably to prevent having useless uniforms, since the layer would be invisible anyway). When the layer opacity is then changed, the uniforms are not updated. Therefore, the layer still has some un-created uniforms which make it stay invisible.
To fix this behavior, I update the uniforms when the layer opacity is changed.

## Motivation and Context

Fix an bug described in [this PackO issue](https://github.com/ign-packo/PackO/issues/164) : when initializing a `ColorLayer` opacity to `0`, it could not be dynamically changed afterward without disabling then re-enabling layer `visibility`.
Also, the slider on dat GUI would be initialized with a step of 1, making it "binary" (only 0 and 1 values could be reached).