### PR TITLE
refacto(label): render only object with labels.

### DIFF
--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -59,7 +59,9 @@ class c3DEngine {
         this.renderView = function _(view) {
             this.renderer.clear();
             this.renderer.render(view.scene, view.camera.camera3D);
-            this.label2dRenderer.render(view.scene, view.camera.camera3D);
+            if (view.tileLayer) {
+                this.label2dRenderer.render(view.tileLayer.object3d, view.camera.camera3D);
+            }
         }.bind(this);
 
         this.onWindowResize = function _(w, h) {


### PR DESCRIPTION
## Description
Render only the `tileLayer`, this is the only object with labels.

## Motivation and Context
Optimize labels rendering.