### PR TITLE
refactor(Feature): simplify normals data.

### DIFF
--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -64,12 +64,21 @@ function coordinatesToVertices(ptsIn, normals, target, zTranslation, offsetOut =
     offsetOut *= 3;
     const endIn = startIn + countIn;
 
-    for (let i = startIn, j = offsetOut; i < endIn; i += 3, j += 3) {
-        // move the vertex following the normal, to put the point on the good altitude
-        // fill the vertices array at the offset position
-        target[j] = ptsIn[i] + normals[i] * zTranslation;
-        target[j + 1] = ptsIn[i + 1] + normals[i + 1] * zTranslation;
-        target[j + 2] = ptsIn[i + 2] + normals[i + 2] * zTranslation;
+    if (normals) {
+        for (let i = startIn, j = offsetOut; i < endIn; i += 3, j += 3) {
+            // move the vertex following the normal, to put the point on the good altitude
+            // fill the vertices array at the offset position
+            target[j] = ptsIn[i] + normals[i] * zTranslation;
+            target[j + 1] = ptsIn[i + 1] + normals[i + 1] * zTranslation;
+            target[j + 2] = ptsIn[i + 2] + normals[i + 2] * zTranslation;
+        }
+    } else {
+        for (let i = startIn, j = offsetOut; i < endIn; i += 3, j += 3) {
+            // move the vertex following the z axe
+            target[j] = ptsIn[i];
+            target[j + 1] = ptsIn[i + 1];
+            target[j + 2] = ptsIn[i + 2] + zTranslation;
+        }
     }
 }
 

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -29,7 +29,6 @@ function _setGeometryValues(geom, feature, long, lat, alt, normal) {
 }
 
 const coordOut = new Coordinates('EPSG:4326', 0, 0, 0);
-const defaultNormal = new THREE.Vector3(0, 0, 1);
 
 export const FEATURE_TYPES = {
     POINT: 0,
@@ -161,9 +160,9 @@ export class FeatureGeometry {
      * @param {Feature} feature - the feature containing the geometry
      * @param {number} long The longitude coordinate.
      * @param {number} lat The latitude coordinate.
-     * @param {THREE.Vector3} [normal=THREE.Vector3(0,0,1)] the normal on coordinates.
+     * @param {THREE.Vector3} [normal] the normal on coordinates (only for `EPSG:4978` projection).
      */
-    pushCoordinatesValues(feature, long, lat, normal = defaultNormal) {
+    pushCoordinatesValues(feature, long, lat, normal) {
         const altitude = this.baseAltitude(feature);
 
         _setGeometryValues(this, feature, long, lat, altitude, normal);
@@ -245,7 +244,8 @@ class Feature {
         this.vertices = [];
         this.crs = collection.crs;
         this.size = collection.size;
-        this.normals = collection.size == 3 ? [] : undefined;
+        this.normals = collection.crs == 'EPSG:4978' ? [] : undefined;
+
         this.transformToLocalSystem = collection.transformToLocalSystem.bind(collection);
         if (collection.extent) {
             // this.crs is final crs projection, is out projection.

--- a/test/unit/feature.js
+++ b/test/unit/feature.js
@@ -31,17 +31,21 @@ describe('Feature', function () {
     it('Should instance Features with options', function () {
         const collection_A = new FeatureCollection(options_A);
         const collection_B = new FeatureCollection({ crs: 'EPSG:4326', buildExtent: false });
+        const collection_C = new FeatureCollection({ crs: 'EPSG:4978', buildExtent: false });
 
         const featureLine_A = collection_A.requestFeatureByType(FEATURE_TYPES.LINE);
         const featureLine_B = collection_B.requestFeatureByType(FEATURE_TYPES.LINE);
+        const featureLine_C = collection_C.requestFeatureByType(FEATURE_TYPES.LINE);
 
         assert.equal(featureLine_A.size, 3);
-        assert.ok(featureLine_A.normals);
+        assert.ok(!featureLine_A.normals);
         assert.ok(featureLine_A.extent);
 
         assert.equal(featureLine_B.size, 2);
         assert.ok(!featureLine_B.normals);
         assert.ok(!featureLine_B.extent);
+
+        assert.ok(featureLine_C.normals);
     });
 
     it('Should push Coordinates in Feature Geometry', function () {
@@ -62,6 +66,5 @@ describe('Feature', function () {
         featureLine.extent.applyMatrix4(collection_A.matrix);
         assert.equal(featureLine.extent.south, -1118889.9748579601);
         assert.equal(featureLine.vertices.length, geometry.indices[0].count * featureLine.size);
-        assert.equal(featureLine.vertices.length, featureLine.normals.length);
     });
 });


### PR DESCRIPTION
## Description
Simplify using `Feature.normals` data. Finally, they used only with the geocentric projection.
