### PR TITLE
feat(3dtiles): add support for binary batch table

### DIFF
--- a/src/Core/3DTiles/utils/BinaryPropertyAccessor.js
+++ b/src/Core/3DTiles/utils/BinaryPropertyAccessor.js
@@ -1,0 +1,104 @@
+import { Vector2, Vector3, Vector4 } from 'three';
+
+/**
+ * @enum {Object} componentTypeBytesSize - Size in byte of a component type.
+ */
+const componentTypeBytesSize = {
+    BYTE: 1,
+    UNSIGNED_BYTE: 1,
+    SHORT: 2,
+    UNSIGNED_SHORT: 2,
+    INT: 4,
+    UNSIGNED_INT: 4,
+    FLOAT: 4,
+    DOUBLE: 8,
+};
+
+/**
+ * @enum {Object} componentTypeConstructor - TypedArray constructor for each 3D Tiles binary componentType
+ */
+const componentTypeConstructor = {
+    BYTE: Int8Array,
+    UNSIGNED_BYTE: Uint8Array,
+    SHORT: Int16Array,
+    UNSIGNED_SHORT: Uint16Array,
+    INT: Int32Array,
+    UNSIGNED_INT: Uint32Array,
+    FLOAT: Float32Array,
+    DOUBLE: Float64Array,
+};
+
+
+/**
+ * @enum {Object} typeComponentsNumber - Number of components for a given type.
+ */
+const typeComponentsNumber = {
+    SCALAR: 1,
+    VEC2: 2,
+    VEC3: 3,
+    VEC4: 4,
+};
+
+/**
+ * @enum {Object} typeConstructor - constructor for types (only for vectors since scalar will be converted to a single
+ * value)
+ */
+const typeConstructor = {
+    // SCALAR: no constructor, just create a value (int, float, etc. depending on componentType)
+    VEC2: Vector2,
+    VEC3: Vector3,
+    VEC4: Vector4,
+};
+
+/**
+ * Parses a 3D Tiles binary property. Used for batch table and feature table parsing. See the 3D Tiles spec for more
+ * information on how these values are encoded:
+ * [3D Tiles spec](https://github.com/CesiumGS/3d-tiles/blob/main/specification/TileFormats/BatchTable/README.md#binary-body))
+ * @param {ArrayBuffer} buffer The buffer to parse values from.
+ * @param {Number} batchLength number of objects in the batch (= number of elements to parse).
+ * @param {Number} byteOffset the offset in bytes into the buffer.
+ * @param {String} componentType the type of component to parse (one of componentTypeBytesSize keys)
+ * @param {String} type the type of element to parse (one of typeComponentsNumber keys)
+ * @returns {Array} an array of values parsed from the buffer. An array of componentType if type is SCALAR. An array
+ * of Threejs Vector2, Vector3 or Vector4 if type is VEC2, VEC3 or VEC4 respectively.
+ */
+function binaryPropertyAccessor(buffer, batchLength, byteOffset, componentType, type) {
+    if (!buffer) {
+        throw new Error('Buffer is mandatory to parse binary property.');
+    }
+    if (typeof batchLength === 'undefined' || batchLength === null) {
+        throw new Error('batchLength is mandatory to parse binary property.');
+    }
+    if (typeof byteOffset === 'undefined' || byteOffset === null) {
+        throw new Error('byteOffset is mandatory to parse binary property.');
+    }
+    if (!componentTypeBytesSize[componentType]) {
+        throw new Error(`Uknown component type: ${componentType}. Cannot access binary property.`);
+    }
+    if (!typeComponentsNumber[type]) {
+        throw new Error(`Uknown type: ${type}. Cannot access binary property.`);
+    }
+
+    const typeNb = typeComponentsNumber[type];
+    const elementsNb = batchLength * typeNb; // Number of elements to parse in the buffer
+
+    const typedArray = new componentTypeConstructor[componentType](buffer, byteOffset, elementsNb);
+
+    if (type === 'SCALAR') {
+        return Array.from(typedArray);
+    } else {
+        // return an array of threejs vectors, depending on type (see typeConstructor)
+        const array = [];
+        // iteration step of 2, 3 or 4, depending on the type (VEC2, VEC3 or VEC4)
+        for (let i = 0; i <= typedArray.length - typeNb; i += typeNb) {
+            const vector = new typeConstructor[type]();
+            // Create a vector from an array, starting at the offset i and takes the right number of elements depending
+            // on its type (Vector2, Vector3, Vector 4)
+            vector.fromArray(typedArray, i);
+            array.push(vector);
+        }
+        return array;
+    }
+}
+
+export default binaryPropertyAccessor;

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -141,8 +141,9 @@ export default {
                 // sizeBegin is an index to the beginning of the batch table
                 const sizeBegin = headerByteLength + b3dmHeader.FTJSONLength +
                     b3dmHeader.FTBinaryLength;
-                const BTBuffer = buffer.slice(sizeBegin, b3dmHeader.BTJSONLength + sizeBegin);
-                promises.push(new C3DTBatchTable(BTBuffer,
+                const BTBuffer = buffer.slice(sizeBegin, sizeBegin + b3dmHeader.BTJSONLength +
+                    b3dmHeader.BTBinaryLength);
+                promises.push(new C3DTBatchTable(BTBuffer, b3dmHeader.BTJSONLength,
                     b3dmHeader.BTBinaryLength, FTJSON.BATCH_LENGTH, options.registeredExtensions));
             } else {
                 promises.push(Promise.resolve({}));

--- a/test/unit/3dtiles.js
+++ b/test/unit/3dtiles.js
@@ -6,6 +6,7 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import { computeNodeSSE } from 'Process/3dTilesProcessing';
 import { configureTile } from 'Provider/3dTilesProvider';
 import C3DTileset from '../../src/Core/3DTiles/C3DTileset';
+import { compareWithEpsilon } from './utils';
 
 function tilesetWithRegion(transformMatrix) {
     const tileset = {
@@ -54,10 +55,6 @@ function tilesetWithSphere(transformMatrix) {
         tileset.root.transform = transformMatrix.elements;
     }
     return tileset;
-}
-
-function compareWithEpsilon(a, b, epsilon) {
-    return a - epsilon < b && a + epsilon > b;
 }
 
 describe('Distance computation using boundingVolume.region', function () {

--- a/test/unit/3dtilesbatchtable.js
+++ b/test/unit/3dtilesbatchtable.js
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
+
+describe('3D Tiles batch table', function () {
+    // encode a javascript object into an arraybuffer (based on the 3D Tiles batch table encoding)
+    function obj2ArrayBuff(obj) {
+        const objJSON = JSON.stringify(obj);
+        const encoder = new TextEncoder();
+        const objUtf8 = encoder.encode(objJSON);
+        const objUint8 = new Uint8Array(objUtf8);
+        return objUint8.buffer;
+    }
+
+    it('Should parse JSON batch table from buffer', function () {
+        const batchTable = {
+            a1: ['bah', 'tah', 'ratata', 'lo'],
+            a2: [0, 1, 2, 3],
+        };
+
+        const batchTableBuffer = obj2ArrayBuff(batchTable);
+
+        const batchTableObj = new C3DTBatchTable(batchTableBuffer, batchTableBuffer.byteLength, 0, 4, {});
+
+        assert.deepStrictEqual(batchTable, batchTableObj.content);
+    });
+
+    it('Should parse JSON and binary batch table from buffer', function () {
+        const a1Val = ['bah', 'tah', 'ratata'];
+        const binVal = [0, 1, 0];
+        const expectedBatchTable = {
+            a1: a1Val,
+            bin: binVal,
+        };
+
+        const batchTableJsonPart = {
+            a1: a1Val,
+            bin: {
+                byteOffset: 0,
+                componentType: 'UNSIGNED_BYTE',
+                type: 'SCALAR',
+            },
+        };
+
+        const jsonPartBuffer = obj2ArrayBuff(batchTableJsonPart);
+
+        const binPartUint8 = new Uint8Array(binVal);
+        const binPartBuffer = binPartUint8.buffer;
+
+        var batchTableBuffer = new Uint8Array(jsonPartBuffer.byteLength + binPartBuffer.byteLength);
+        batchTableBuffer.set(new Uint8Array(jsonPartBuffer), 0);
+        batchTableBuffer.set(new Uint8Array(binPartBuffer), jsonPartBuffer.byteLength);
+
+        const batchTableObj = new C3DTBatchTable(batchTableBuffer, jsonPartBuffer.byteLength, binPartBuffer.byteLength, 3, {});
+
+        assert.deepStrictEqual(expectedBatchTable, batchTableObj.content);
+    });
+});

--- a/test/unit/3dtilesbinarypropertyaccessor.js
+++ b/test/unit/3dtilesbinarypropertyaccessor.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { Vector2 } from 'three';
+import binaryPropertyAccessor from 'Core/3DTiles/utils/BinaryPropertyAccessor';
+import { compareArrayWithEpsilon } from './utils';
+
+describe('3D Tiles Binary Property Accessor', function () {
+    it('Should parse float scalar binary array', function () {
+        const refArray = [3.5, 2.1, -1.5];
+        const typedArray = new Float32Array(refArray);
+        const buffer = typedArray.buffer;
+        const batchLength = 3;
+        const byteOffset = 0;
+        const componentType = 'FLOAT';
+        const type = 'SCALAR';
+
+        var parsedArray = binaryPropertyAccessor(buffer, batchLength, byteOffset, componentType, type);
+
+        assert.ok(compareArrayWithEpsilon(parsedArray, refArray, 0.001));
+    });
+
+    it('Should parse unsigned short int vector2 binary array', function () {
+        const refArray = [14, 12, 3, 5, 108, 500];
+        const typedArray = new Uint16Array(refArray);
+        const buffer = typedArray.buffer;
+        const batchLength = 3;
+        const byteOffset = 0;
+        const componentType = 'UNSIGNED_SHORT';
+        const type = 'VEC2';
+
+        const parsedArray = binaryPropertyAccessor(buffer, batchLength, byteOffset, componentType, type);
+
+        // Create expected array (array of THREE.Vector2s)
+        const expectedArray = [];
+        for (let i = 0; i <= refArray.length - 2; i += 2) {
+            const vec2 = new Vector2();
+            expectedArray.push(vec2.fromArray(refArray, i));
+        }
+
+        // Convert each vector2 to Array and compare them.
+        for (let i = 0; i < parsedArray.length; i++) {
+            assert.ok(compareArrayWithEpsilon(parsedArray[i].toArray(), expectedArray[i].toArray(), 0.001));
+        }
+    });
+});

--- a/test/unit/camera.js
+++ b/test/unit/camera.js
@@ -1,10 +1,7 @@
 import assert from 'assert';
 import Camera, { CAMERA_TYPE } from 'Renderer/Camera';
 import Coordinates from 'Core/Geographic/Coordinates';
-
-function compareWithEpsilon(a, b, epsilon) {
-    return a - epsilon < b && a + epsilon > b;
-}
+import { compareWithEpsilon } from './utils';
 
 describe('camera', function () {
     it('should set good aspect in camera3D', function () {

--- a/test/unit/globeview.js
+++ b/test/unit/globeview.js
@@ -7,10 +7,7 @@ import Extent from 'Core/Geographic/Extent';
 import Renderer from './bootstrap';
 import CameraUtils from '../../src/Utils/CameraUtils';
 import OBB from '../../src/Renderer/OBB';
-
-function compareWithEpsilon(a, b, epsilon) {
-    return a - epsilon < b && a + epsilon > b;
-}
+import { compareWithEpsilon } from './utils';
 
 describe('GlobeView', function () {
     const renderer = new Renderer();

--- a/test/unit/lasparser.js
+++ b/test/unit/lasparser.js
@@ -2,14 +2,11 @@ import assert from 'assert';
 import HttpsProxyAgent from 'https-proxy-agent';
 import LASParser from 'Parser/LASParser';
 import Fetcher from 'Provider/Fetcher';
+import { compareWithEpsilon } from './utils';
 
 describe('LASParser', function () {
     let lasData;
     let lazData;
-
-    function compareWithEpsilon(a, b, epsilon) {
-        return a - epsilon < b && a + epsilon > b;
-    }
 
     before(async () => {
         const networkOptions = process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {};

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,15 @@
+export function compareWithEpsilon(a, b, epsilon) {
+    return a - epsilon < b && a + epsilon > b;
+}
+
+export function compareArrayWithEpsilon(arr1, arr2, epsilon) {
+    if (arr1.length !== arr2.length) {
+        return false;
+    }
+    for (let i = 0; i < arr1.length; i++) {
+        if (!compareWithEpsilon(arr1[i], arr2[i], epsilon)) {
+            return false;
+        }
+    }
+    return true;
+}


### PR DESCRIPTION
## Description

* Add support for [binary batch table attributes](https://github.com/CesiumGS/3d-tiles/blob/main/specification/TileFormats/BatchTable/README.md#binary-body)
* Add tests for 3d tiles binary property parsing

## Motivation and Context

* Improve 3D Tiles support
* Fixes #1826 , #1830 and #919 

*Note: `BinaryPropertyAccessor.js` may also be used for parsing the binary content of the 3D Tiles feature table (not supported by itowns yet).*
