### PR TITLE
WebXR support

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -38,6 +38,13 @@
         "source_stream_wfs_raster": "WFS to raster"
     },
 
+
+    "WebXR (experimental)": {
+        "webxr_3dtiles_25d": "3DTiles on 2.5D map (WebXR)",
+        "webxr_potree_25d_map": "Potree on 2.5D map (WebXR)",
+        "webxr_source_stream_wfs_25d": "WFS to 2.5D objects (WebXR)"
+    },
+    
     "Specific source options": {
         "source_file_from_format": "format",
         "source_file_from_methods": "fetcher and parser"

--- a/examples/js/VRButton.js
+++ b/examples/js/VRButton.js
@@ -1,0 +1,203 @@
+class VRButton {
+
+	static createButton( renderer, options ) {
+
+		if ( options ) {
+
+			console.error( 'THREE.VRButton: The "options" parameter has been removed. Please set the reference space type via renderer.xr.setReferenceSpaceType() instead.' );
+
+		}
+
+		const button = document.createElement( 'button' );
+
+		function showEnterVR( /*device*/ ) {
+
+			let currentSession = null;
+
+			async function onSessionStarted( session ) {
+
+				session.addEventListener( 'end', onSessionEnded );
+
+				await renderer.xr.setSession( session );
+				button.textContent = 'EXIT VR';
+
+				currentSession = session;
+
+			}
+
+			function onSessionEnded( /*event*/ ) {
+
+				currentSession.removeEventListener( 'end', onSessionEnded );
+
+				button.textContent = 'ENTER VR';
+
+				currentSession = null;
+
+			}
+
+			//
+
+			button.style.display = '';
+
+			button.style.cursor = 'pointer';
+			button.style.left = 'calc(50% - 50px)';
+			button.style.width = '100px';
+
+			button.textContent = 'ENTER VR';
+
+			button.onmouseenter = function () {
+
+				button.style.opacity = '1.0';
+
+			};
+
+			button.onmouseleave = function () {
+
+				button.style.opacity = '0.5';
+
+			};
+
+			button.onclick = function () {
+
+				if ( currentSession === null ) {
+
+					// WebXR's requestReferenceSpace only works if the corresponding feature
+					// was requested at session creation time. For simplicity, just ask for
+					// the interesting ones as optional features, but be aware that the
+					// requestReferenceSpace call will fail if it turns out to be unavailable.
+					// ('local' is always available for immersive sessions and doesn't need to
+					// be requested separately.)
+
+					const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
+					navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
+
+				} else {
+
+					currentSession.end();
+
+				}
+
+			};
+
+		}
+
+		function disableButton() {
+
+			button.style.display = '';
+
+			button.style.cursor = 'auto';
+			button.style.left = 'calc(50% - 75px)';
+			button.style.width = '150px';
+
+			button.onmouseenter = null;
+			button.onmouseleave = null;
+
+			button.onclick = null;
+
+		}
+
+		function showWebXRNotFound() {
+
+			disableButton();
+
+			button.textContent = 'VR NOT SUPPORTED';
+
+		}
+
+		function showVRNotAllowed( exception ) {
+
+			disableButton();
+
+			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+
+			button.textContent = 'VR NOT ALLOWED';
+
+		}
+
+		function stylizeElement( element ) {
+
+			element.style.position = 'absolute';
+			element.style.bottom = '20px';
+			element.style.padding = '12px 6px';
+			element.style.border = '1px solid #fff';
+			element.style.borderRadius = '4px';
+			element.style.background = 'rgba(0,0,0,0.1)';
+			element.style.color = '#fff';
+			element.style.font = 'normal 13px sans-serif';
+			element.style.textAlign = 'center';
+			element.style.opacity = '0.5';
+			element.style.outline = 'none';
+			element.style.zIndex = '999';
+
+		}
+
+		if ( 'xr' in navigator ) {
+
+			button.id = 'VRButton';
+			button.style.display = 'none';
+
+			stylizeElement( button );
+
+			navigator.xr.isSessionSupported( 'immersive-vr' ).then( function ( supported ) {
+
+				supported ? showEnterVR() : showWebXRNotFound();
+
+				if ( supported && VRButton.xrSessionIsGranted ) {
+
+					button.click();
+
+				}
+
+			} ).catch( showVRNotAllowed );
+
+			return button;
+
+		} else {
+
+			const message = document.createElement( 'a' );
+
+			if ( window.isSecureContext === false ) {
+
+				message.href = document.location.href.replace( /^http:/, 'https:' );
+				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
+
+			} else {
+
+				message.href = 'https://immersiveweb.dev/';
+				message.innerHTML = 'WEBXR NOT AVAILABLE';
+
+			}
+
+			message.style.left = 'calc(50% - 90px)';
+			message.style.width = '180px';
+			message.style.textDecoration = 'none';
+
+			stylizeElement( message );
+
+			return message;
+
+		}
+
+	}
+
+	static xrSessionIsGranted = false;
+
+	static registerSessionGrantedListener() {
+
+		if ( 'xr' in navigator ) {
+
+			navigator.xr.addEventListener( 'sessiongranted', () => {
+
+				VRButton.xrSessionIsGranted = true;
+
+			} );
+
+		}
+
+	}
+
+}
+
+VRButton.registerSessionGrantedListener();
+
+export { VRButton };

--- a/examples/webxr_3dtiles_25d.html
+++ b/examples/webxr_3dtiles_25d.html
@@ -1,0 +1,143 @@
+<html>
+    <head>
+        <title>Itowns - 3D Tiles on 2.5D map example</title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv" class="viewer"></div>
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="js/3dTilesHelper.js"></script>
+        <script type="module">
+            import { VRButton } from './js/VRButton.js';
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
+            // Define geographic extent: CRS, min/max X, min/max Y
+            var extent = new itowns.Extent( 'EPSG:3946',
+                1837816.94334, 1847692.32501,
+                5170036.4587, 5178412.82698);
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            var viewerDiv = document.getElementById('viewerDiv');
+
+            // Instanciate PlanarView*
+            var cameraCoord = new itowns.Coordinates('EPSG:3946', 1841980,
+                5175682, 3000)
+            var view = new itowns.PlanarView(viewerDiv, extent, { placement: {
+                coord: cameraCoord, heading: 30, range: 4000, tilt: 30 } });
+
+            setupLoadingScreen(viewerDiv, view);
+
+            // Enable WebXR
+            const renderer = view.mainLoop.gfxEngine.renderer;
+            renderer.setClearColor(0x0);
+            document.body.appendChild( VRButton.createButton( renderer ) );
+            renderer.xr.enabled = true;
+            renderer.setAnimationLoop( () => view.mainLoop.gfxEngine.renderView( view ) );
+            view.render = function() {}
+
+            const scale = 0.001;
+            const quat = new itowns.THREE.Quaternion(-1,0,0,1).normalize();
+            const trans = new itowns.Coordinates('EPSG:3946', 1841980,
+                  5175682, 0).toVector3().multiplyScalar(-scale).applyQuaternion(quat);
+            view.scene.position.copy(trans);
+            view.scene.quaternion.copy(quat);
+            view.scene.scale.set(scale, scale, scale);
+            view.scene.updateMatrixWorld();
+            view.camera.camera3D.position.multiplyScalar(scale);
+            view.camera.camera3D.position.applyQuaternion(quat);
+            view.camera.camera3D.position.add(trans);
+            view.camera.camera3D.quaternion.copy(quat);
+            view.camera.camera3D.updateMatrixWorld();
+
+            // Add a WMS imagery source
+            var wmsImagerySource = new itowns.WMSSource({
+                extent: extent,
+                name: 'Ortho2009_vue_ensemble_16cm_CC46',
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                version: '1.3.0',
+                crs: 'EPSG:3946',
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS imagery layer
+            var wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+                updateStrategy: {
+                    type: itowns.STRATEGY_DICHOTOMY,
+                    options: {},
+                },
+                source: wmsImagerySource,
+            });
+
+            view.addLayer(wmsImageryLayer);
+
+            // Add a WMS elevation source
+            var wmsElevationSource = new itowns.WMSSource({
+                extent: extent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                crs: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
+
+            // Add 3D Tiles layer
+            // This 3D Tiles tileset uses the draco compression that is an
+            // extension of gltf. We need to enable it.
+            itowns.enableDracoLoader('./libs/draco/');
+
+            var $3dTilesLayer = new itowns.C3DTilesLayer(
+                '3d-tiles-layer-building', {
+                    name: 'Lyon-2015-building',
+                    source: new itowns.C3DTilesSource({
+                        url:
+                            'http://rict.liris.cnrs.fr/DataStore/Lyon1er-2015/tileset.json',
+                    }),
+                }, view);
+
+            // Lights
+            var dirLight = new itowns.THREE.DirectionalLight(0xffffff, 1);
+            dirLight.position.set(-0.9, 0.3, 1);
+            dirLight.updateMatrixWorld();
+            view.scene.add( dirLight );
+
+            var ambLight = new itowns.THREE.AmbientLight(0xffffff, 0.2);
+            view.scene.add( ambLight );
+
+            // Pick 3D Tiles features when hovering them with the mouse and
+            // display their semantic information in an html div
+            var pickingArgs = {};
+            pickingArgs.htmlDiv = document.getElementById('featureInfo');
+            pickingArgs.view = view;
+            pickingArgs.layer = $3dTilesLayer;
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayer);
+
+            // Request redraw
+            view.notifyChange();
+
+            // Add a debug UI
+            var menu = new GuiTools('menuDiv', view);
+            var d = new debug.Debug(view, menu.gui);
+            debug.createTileDebugUI(menu.gui, view, view.tileLayer, d);
+            debug.create3dTilesDebugUI(menu.gui, view, $3dTilesLayer, d);
+        </script>
+    </body>
+</html>

--- a/examples/webxr_potree_25d_map.html
+++ b/examples/webxr_potree_25d_map.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Point Cloud Viewer</title>
+
+        <style type="text/css">
+            #info {
+                color: #7ad7ff;
+                font-family: 'Open Sans', sans-serif;
+                position: absolute;
+                top: 0;
+                left: 0;
+                padding: 0.3rem;
+                background-color: #404040;
+                z-index: 1;
+            }
+            @media (max-width: 600px) {
+                #info,
+                .dg {
+                    display: none;
+                }
+            }
+        </style>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <div id="viewerDiv">
+            <div id="info"></div>
+        </div>
+
+        <div>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+            <script src="../dist/itowns.js"></script>
+            <script src="js/GUI/LoadingScreen.js"></script>
+            <script src="../dist/debug.js"></script>
+            <script type="module">
+                import { VRButton } from './js/VRButton.js';
+                var potreeLayer;
+                var oldPostUpdate;
+                var viewerDiv;
+                var debugGui;
+                var view;
+                var controls;
+
+                viewerDiv = document.getElementById('viewerDiv');
+                viewerDiv.style.display = 'block';
+
+                debugGui = new dat.GUI();
+
+                // TODO: do we really need to disable logarithmicDepthBuffer ?
+                view = new itowns.View('EPSG:3946', viewerDiv);
+                setupLoadingScreen(viewerDiv, view);
+
+                // Enable WebXR
+                const renderer = view.mainLoop.gfxEngine.renderer;
+                renderer.setClearColor(0x0);
+                document.body.appendChild( VRButton.createButton( renderer ) );
+                renderer.xr.enabled = true;
+                renderer.setAnimationLoop( function () {
+                    view.mainLoop.gfxEngine.renderView( view );
+                } );
+                view.render = function() {}
+
+                // Configure Point Cloud layer
+                potreeLayer = new itowns.PotreeLayer('eglise_saint_blaise_arles', {
+                    source: new itowns.PotreeSource({
+                        file: 'eglise_saint_blaise_arles.js',
+                        url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/eglise_saint_blaise_arles',
+                        crs: view.referenceCrs,
+                    }),
+                });
+
+                // point selection on double-click
+                function dblClickHandler(event) {
+                    var pick = view.pickObjectsAt(event, 5, potreeLayer);
+
+                    for (const p of pick) {
+                        console.info('Selected point #' + p.index + ' in position (' +
+                            p.object.position.x + ', ' +
+                            p.object.position.y + ', ' +
+                            p.object.position.z +
+                         ') in Points ' + p.object.layer.id);
+                    }
+                }
+                view.domElement.addEventListener('dblclick', dblClickHandler);
+
+                function placeCamera(position, lookAt) {
+                    view.camera.camera3D.position.copy(position);
+                    view.camera.camera3D.lookAt(lookAt);
+                    // translate the scene and the camera so that "lookAt" is placed at the origin (=the anchor position of webXR)
+                    view.scene.children[0].position.copy(lookAt);
+                    view.scene.children[0].position.negate();
+                    view.scene.children[0].updateMatrixWorld();
+                    view.camera.camera3D.position.sub(lookAt);
+                    view.camera.camera3D.updateMatrixWorld();
+
+                    // create controls
+                    controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
+                    debugGui.add(controls.options, 'moveSpeed', 1, 100).name('Movement speed');
+
+                    view.notifyChange(view.camera.camera3D);
+                }
+
+                // add potreeLayer to scene
+                function onLayerReady() {
+                    var ratio;
+                    var position;
+                    var lookAt = new itowns.THREE.Vector3();
+                    var size = new itowns.THREE.Vector3();
+
+                    potreeLayer.root.bbox.getSize(size);
+                    potreeLayer.root.bbox.getCenter(lookAt);
+
+                    debug.PotreeDebug.initTools(view, potreeLayer, debugGui);
+
+                    view.camera.camera3D.far = 2.0 * size.length();
+
+                    ratio = size.x / size.z;
+                    position = potreeLayer.root.bbox.min.clone().add(
+                        size.multiply({ x: 0, y: 0, z: ratio * 0.5 }));
+                    lookAt.z = potreeLayer.root.bbox.min.z;
+                    placeCamera(position, lookAt);
+                    controls.moveSpeed = size.length() / 3;
+
+                    // update stats window
+                    var info = document.getElementById('info');
+                    view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, () => {
+                        info.textContent = potreeLayer.displayedCount.toLocaleString() + ' points';
+                    });
+                }
+                window.view = view;
+                view.addLayer(potreeLayer).then(onLayerReady);
+            </script>
+    </body>
+</html>

--- a/examples/webxr_source_stream_wfs_25d.html
+++ b/examples/webxr_source_stream_wfs_25d.html
@@ -1,0 +1,332 @@
+<html>
+    <head>
+        <title>Itowns - WFS (geojson) example</title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <div id="description">
+            <p>Key bindings</p>
+            <ul>
+              <li>Left-Click: camera translation (drag)</li>
+              <li>Right-Click: camera translation (pan)</li>
+              <li>Ctrl + Left-Click: camera rotation (orbit)</li>
+              <li>Spacebar / Wheel-Click: smart zoom</li>
+              <li>Mouse Wheel: zoom in/out</li>
+              <li>T: orient camera to a top view</li>
+              <li>Y: move camera to start position</li>
+            </ul>
+            <br />
+            <p><b>Information Batiment</b></p>
+            <ul id="info"></ul>
+        </div>
+        <div id="viewerDiv"></div>
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script type="module">
+            import { VRButton } from './js/VRButton.js';
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+            /* global itowns,document, setupLoadingScreen, window */
+
+            var extent;
+            var viewerDiv;
+            var view;
+            var meshes;
+            var p;
+            var wmsImagerySource;
+            var wmsImageryLayer;
+            var rgb;
+            var lyonTclBusSource;
+            var color = new itowns.THREE.Color();
+
+            // Define geographic extent: CRS, min/max X, min/max Y
+            extent = new itowns.Extent(
+                'EPSG:3946',
+                1837816.94334, 1847692.32501,
+                5170036.4587, 5178412.82698);
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            viewerDiv = document.getElementById('viewerDiv');
+
+            // Instanciate PlanarView*
+            view = new itowns.PlanarView(viewerDiv, extent, {
+                placement: {
+                    coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0),
+                    heading: 45,
+                    range: 1800,
+                    tilt: 30,
+                }
+            });
+            setupLoadingScreen(viewerDiv, view);
+            
+            // Enable WebXR
+            const renderer = view.mainLoop.gfxEngine.renderer;
+            renderer.setClearColor(0x0);
+            document.body.appendChild( VRButton.createButton( renderer ) );
+            renderer.xr.enabled = true;
+            renderer.setAnimationLoop( function () {
+              renderer.clear();
+              renderer.render(view.scene, view.camera.camera3D);
+            } );
+            view.render = function() { }
+
+            const scale = 0.005;
+            const quat = new itowns.THREE.Quaternion(-1,0,0,1).normalize();
+            const trans = new itowns.Coordinates('EPSG:3946', 1841980,
+                  5175682, 0).toVector3().multiplyScalar(-scale).applyQuaternion(quat);
+            view.scene.position.copy(trans);
+            view.scene.quaternion.copy(quat);
+            view.scene.scale.set(scale, scale, scale);
+            view.scene.updateMatrixWorld();
+            view.camera.camera3D.position.multiplyScalar(scale);
+            view.camera.camera3D.position.applyQuaternion(quat);
+            view.camera.camera3D.position.add(trans);
+            view.camera.camera3D.quaternion.copy(quat);
+            view.camera.camera3D.updateMatrixWorld();
+
+            wmsImagerySource = new itowns.WMSSource({
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                networkOptions: { crossOrigin: 'anonymous' },
+                version: '1.3.0',
+                name: 'Ortho2009_vue_ensemble_16cm_CC46',
+                crs: 'EPSG:3946',
+                extent: extent,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS imagery layer
+            wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+                transparent: false,
+                source: wmsImagerySource,
+            });
+
+            view.addLayer(wmsImageryLayer);
+
+            // Add a WMS elevation source
+            var wmsElevationSource = new itowns.WMSSource({
+                extent: extent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                crs: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
+
+            var tile;
+            var linesBus = [];
+
+            function altitudeLine(properties, contour) {
+                var result;
+                var z = 0;
+                if (contour) {
+                    result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0, tile);
+                    if (!result) {
+                        result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0);
+                    }
+                    if (result) {
+                        tile = [result.tile];
+                        z = result.coord.z;
+                    }
+                    return z + 5;
+                }
+            }
+
+            function acceptFeatureBus(properties) {
+                if (properties.sens == 'Aller') {
+                    var line = properties.ligne;
+                    if (linesBus.indexOf(line) === -1) {
+                        linesBus.push(line);
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            lyonTclBusSource = new itowns.WFSSource({
+                url: 'https://download.data.grandlyon.com/wfs/rdata?',
+                protocol: 'wfs',
+                version: '2.0.0',
+                id: 'tcl_bus',
+                typeName: 'tcl_sytral.tcllignebus',
+                crs: 'EPSG:3946',
+                extent: {
+                    west: 1822174.60,
+                    east: 1868247.07,
+                    south: 5138876.75,
+                    north: 5205890.19,
+                },
+                format: 'geojson',
+            });
+
+            var lyonTclBusLayer = new itowns.FeatureGeometryLayer('lyon_tcl_bus', {
+                filter: acceptFeatureBus,
+                source: lyonTclBusSource,
+                zoom: { min: 2 },
+
+                style: new itowns.Style({
+                    stroke: {
+                        base_altitude: altitudeLine,
+                        width: 5,
+                    }
+                })
+            });
+
+            view.addLayer(lyonTclBusLayer);
+
+            function colorBuildings(properties) {
+                if (properties.usage_1 === 'Résidentiel') {
+                    return color.set(0xFDFDFF);
+                } else if (properties.usage_1 === 'Annexe') {
+                    return color.set(0xC6C5B9);
+                } else if (properties.usage_1 === 'Commercial et services') {
+                    return color.set(0x62929E);
+                } else if (properties.usage_1 === 'Religieux') {
+                    return color.set(0x393D3F);
+                } else if (properties.usage_1 === 'Sportif') {
+                    return color.set(0x546A7B);
+                }
+
+                return color.set(0x555555);
+            }
+
+            function extrudeBuildings(properties) {
+                return properties.hauteur;
+            }
+
+            function altitudeBuildings(properties) {
+                return properties.altitude_minimale_sol;
+            }
+
+            meshes = [];
+            function scaler(/* dt */) {
+                var i;
+                var mesh;
+                if (meshes.length) {
+                    view.notifyChange();
+                }
+                for (i = 0; i < meshes.length; i++) {
+                    mesh = meshes[i];
+                    mesh.scale.z = Math.min(
+                        1.0, mesh.scale.z + 0.1);
+                    mesh.updateMatrixWorld(true);
+                }
+                meshes = meshes.filter(function filter(m) { return m.scale.z < 1; });
+            }
+
+            function acceptFeature(properties) {
+                return !!properties.hauteur;
+            }
+
+            view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.BEFORE_RENDER, scaler);
+
+            var wfsBuildingSource = new itowns.WFSSource({
+                url: 'https://wxs.ign.fr/topographie/geoportail/wfs?',
+                version: '2.0.0',
+                typeName: 'BDTOPO_V3:batiment',
+                crs: 'EPSG:4326',
+                ipr: 'IGN',
+                format: 'application/json',
+                extent: {
+                    west: 4.568,
+                    east: 5.18,
+                    south: 45.437,
+                    north: 46.03,
+                },
+            });
+
+            var wfsBuildingLayer = new itowns.FeatureGeometryLayer('wfsBuilding', {
+                onMeshCreated: function scaleZ(mesh) {
+                    mesh.children.forEach(c => {
+                        c.scale.z = 0.01;
+                        meshes.push(c);
+                    })
+                },
+                batchId: function (property, featureId) { return featureId; },
+                filter: acceptFeature,
+                crs: 'EPSG:3946',
+                source: wfsBuildingSource,
+                zoom: { min: 4 },
+
+                style: new itowns.Style({
+                    fill: {
+                        color: colorBuildings,
+                        base_altitude: altitudeBuildings,
+                        extrusion_height: extrudeBuildings,
+                    }
+                })
+            });
+
+            view.addLayer(wfsBuildingLayer);
+
+            var wfsCartoSource = new itowns.WFSSource({
+                url: 'https://wxs.ign.fr/cartovecto/geoportail/wfs?',
+                version: '2.0.0',
+                typeName: 'BDCARTO_BDD_WLD_WGS84G:zone_habitat_mairie',
+                crs: 'EPSG:3946',
+                ipr: 'IGN',
+                format: 'application/json',
+            });
+
+            var wfsCartoStyle = new itowns.Style({
+                zoom: { min: 0, max: 20 },
+                text: {
+                    field: '{toponyme}',
+                    color: 'white',
+                    transform: 'uppercase',
+                    size: 15,
+                    haloColor: 'rgba(20,20,20, 0.8)',
+                    haloWidth: 3,
+                },
+            });
+
+            var wfsCartoLayer = new itowns.LabelLayer('wfsCarto', {
+                source: wfsCartoSource,
+                style: wfsCartoStyle,
+            });
+
+            view.addLayer(wfsCartoLayer);
+
+            function picking(event) {
+                var htmlInfo = document.getElementById('info');
+                var intersects = view.pickObjectsAt(event, 2, 'wfsBuilding');
+                var properties;
+                var info;
+                var batchId;
+                htmlInfo.innerHTML = ' ';
+
+                if (intersects.length) {
+                    batchId = intersects[0].object.geometry.attributes.batchId.array[intersects[0].face.a];
+                    properties = intersects[0].object.feature.geometries[batchId].properties;
+                    Object.keys(properties).map(function (objectKey) {
+                        var value = properties[objectKey];
+                        if (value) {
+                            var key = objectKey.toString();
+                            if (key[0] !== '_' && key !== 'geometry_name') {
+                                info = value.toString();
+                                htmlInfo.innerHTML +='<li><b>' + key + ': </b>' + info + '</li>';
+                            }
+                        }
+                    });
+                    return properties;
+                }
+            }
+
+            window.addEventListener('mousemove', picking, false);
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Description
This proof of concept show some initial support for [WebXR](https://immersiveweb.dev/). This adds 3 examples which feature the Three's VRButton for entering the immersive mode.

## Motivation and Context
Three.js supports WebXR, which is the web standard for virtual/mixed/augmented reality. Having iTowns support WebXR would enable an immersive iTowns experience on any WebXR compatible device (hololens, vive, android...)

## Screenshots
![image](https://user-images.githubusercontent.com/7373521/178012836-3d60657c-9c45-4e5f-bd7e-a8a34813caba.png)
![image](https://user-images.githubusercontent.com/7373521/178017274-f2601e69-90a0-4843-8b8f-9bec26aba654.png)

## Tested Platforms
- [x] Hololens 2 on Edge
- [x] [Web XR API Emulator](https://github.com/MozillaReality/WebXR-emulator-extension) on firefox 102

## Known Issues (to be completed...)
- Enabling WebXR is hacky
- Camera poses between immersive and non immersive mode are not synchronized
- Camera orientation in immersive mode does not align the vertical direction of the virtual world with the one of the real world.
- LOD computation is broken (low res raster tiles and point patches, no 3D features)
