### PR TITLE
Fix picking bug and don't pick atmosphere layer

### DIFF
--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -99,6 +99,7 @@ function findLayerInParent(obj) {
 }
 
 const raycaster = new THREE.Raycaster();
+const normalized = new THREE.Vector2();
 
 /**
  * @module Picking
@@ -208,8 +209,9 @@ export default {
         } else {
             raycaster.layers.enableAll();
         }
+        // Raycaster use NDC coordinate
+        view.viewToNormalizedCoords(viewCoords, normalized);
         if (radius < 0) {
-            const normalized = view.viewToNormalizedCoords(viewCoords);
             raycaster.setFromCamera(normalized, view.camera.camera3D);
 
             const intersects = raycaster.intersectObject(object, true);
@@ -239,8 +241,6 @@ export default {
         const clearG = Math.round(255 * clearColor.g);
         const clearB = Math.round(255 * clearColor.b);
 
-        // Raycaster use NDC coordinate
-        const normalized = view.viewToNormalizedCoords(viewCoords);
         const tmp = normalized.clone();
         traversePickingCircle(radius, (x, y) => {
             // x, y are offset from the center of the picking circle,

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -739,6 +739,9 @@ class View extends THREE.EventDispatcher {
         const mouse = (mouseOrEvt instanceof Event) ? this.eventToViewCoords(mouseOrEvt) : mouseOrEvt;
 
         for (const source of sources) {
+            if (source.isAtmosphere) {
+                continue;
+            }
             if (source.isGeometryLayer) {
                 if (!source.ready) {
                     console.warn('view.pickObjectAt : layer is not ready : ', source);


### PR DESCRIPTION
## Description
Two improvements on picking:
* Fix a bug that occurred when picking on multiple sources:
`View.pickObjectsAt()` calls `View.eventToViewCoords()` without a target result to get mouse view coordinates (`mouse`), so the result is stored in `_eventCoords`. `View.pickObjectsAt()` then calls `Picking.pickObjectsAt` on each sources which sometimes calls `View.viewToNormalizedCoords()` also with no result target, so the result is also stored in `_eventCoords`, which modifies the value of `mouse` which is then used for picking on other sources but with a wrong value.
* Don't pick atmosphere layer (I cannot see any use case)