### PR TITLE
Elevation measure widget

### DIFF
--- a/config/threeExamples.mjs
+++ b/config/threeExamples.mjs
@@ -5,5 +5,6 @@ export default {
         './loaders/DRACOLoader.js',
         './loaders/DDSLoader.js',
         './capabilities/WebGL.js',
+        './renderers/CSS2DRenderer.js',
     ],
 };

--- a/examples/config.json
+++ b/examples/config.json
@@ -85,7 +85,8 @@
         "widgets_navigation": "Navigation",
         "widgets_minimap": "Minimap",
         "widgets_scale": "Scale",
-        "widgets_searchbar": "Searchbar"
+        "widgets_searchbar": "Searchbar",
+        "widgets_elevation": "Elevation Measure"
     },
 
     "Plugins": {

--- a/examples/css/widgets.css
+++ b/examples/css/widgets.css
@@ -83,7 +83,7 @@
 
 /* ---------- BUTTONS GENERIC STYLE : ------------------------------------------------------------------------------- */
 
-#widgets-navigation .widget-button {
+.widget-button {
     background-color: #313336bb;
     border: 1px solid #222222;
     padding: 0;
@@ -95,10 +95,10 @@
     font-weight: 900;
     font-size: 15px;
 }
-#widgets-navigation .widget-button:hover {
+.widget-button:hover {
     cursor: pointer;
 }
-#widgets-navigation .widget-button:active {
+.widget-button:active {
     background-color: #222222;
 }
 
@@ -357,4 +357,33 @@
 
 #widgets-searchbar form > div > p {
     margin: 8px 0;
+}
+
+/* ---------- ELEVATION MEASURE WIDGET : ---------------------------------------------------------------------------- */
+#widgets-elevation {
+    position: absolute;
+    z-index: 10;
+}
+
+#widgets-elevation .widget-button {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background-image: url('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/GUI/widget-elevation-measure.svg'); 
+    background-repeat: no-repeat;
+    background-size: auto 90%;
+    background-position: center;
+}
+
+#widgets-elevation .widget-button-active {
+    background-color: #8B0000;
+    border: 1px solid #800000;
+}
+
+.label-elevation {
+    background-color: #313336bb;
+    color: white;
+    padding: 1;
+    font-weight: 900;
+    font-size: 15px;
 }

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -46,6 +46,9 @@
                 var view;
                 var controls;
 
+                // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+                itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
                 viewerDiv = document.getElementById('viewerDiv');
                 viewerDiv.style.display = 'block';
 

--- a/examples/widgets_elevation.html
+++ b/examples/widgets_elevation.html
@@ -1,0 +1,108 @@
+<html>
+    <head>
+        <title>Itowns - Elevation measurement widget</title>
+
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <!-- Import stylesheet for itowns Widgets plugin. This stylesheet is included in the bundles if you downloaded
+        them, or it can be found in `node_modules/itowns/examples/css` if you installed iTowns with npm. Otherwise, it
+        can be found here : https://raw.githubusercontent.com/iTowns/itowns/master/examples/css/widgets.css -->
+        <link rel="stylesheet" type="text/css" href="css/widgets.css">
+
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <!-- Add a description -->
+        <div id="description">
+            Click on the elevation measurement tool button to activate the tool. Then, click anywhere in the scene to 
+            measure the elevation at a given point.
+        </div>
+
+        <!-- Create a container for itowns viewer -->
+        <div id="viewerDiv"></div>
+
+        <!-- Import iTowns source code -->
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
+        <!-- Import iTowns Widgets plugin -->
+        <script src="../dist/itowns_widgets.js"></script>
+        <!-- Import iTowns LoadingScreen and GuiTools plugins -->
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="js/GUI/GuiTools.js"></script>
+
+
+        <script type="text/javascript">
+
+            // ---------- CREATE A GlobeView FOR SUPPORTING DATA VISUALIZATION : ----------
+
+            // Define camera initial position
+            const placement = {
+                coord: new itowns.Coordinates('EPSG:4326', 4.830119, 45.771966),
+                range: 3000,
+                tilt: 25,
+                heading: 10,
+            }
+
+            // `viewerDiv` contains iTowns' rendering area (`<canvas>`)
+            const viewerDiv = document.getElementById('viewerDiv');
+
+            // Create a GlobeView
+            const view = new itowns.GlobeView(viewerDiv, placement);
+
+            // Setup loading screen and debug menu
+            setupLoadingScreen(viewerDiv, view);
+            const debugMenu = new GuiTools('menuDiv', view);
+
+            // ---------- DISPLAY CONTEXTUAL DATA : ----------
+
+            // Add one imagery layer to the scene. This layer's properties are defined in a json file, but it could be
+            // defined as a plain js object. See `Layer` documentation for more info.
+            itowns.Fetcher.json('layers/JSONLayers/Ortho.json').then((config) => {
+                config.source = new itowns.WMTSSource(config.source);
+                view.addLayer(
+                    new itowns.ColorLayer(config.id, config),
+                ).then(debugMenu.addLayerGUI.bind(debugMenu));
+            });
+
+            // Add two elevation layers, each with a different level of detail. Here again, each layer's properties are
+            // defined in a json file.
+            function addElevationLayerFromConfig(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                view.addLayer(
+                    new itowns.ElevationLayer(config.id, config),
+                ).then(debugMenu.addLayerGUI.bind(debugMenu));
+            }
+            itowns.Fetcher.json('layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+            itowns.Fetcher.json('layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+
+            // 3D Tiles Layer
+            itowns.enableDracoLoader('./libs/draco/');
+            const lyon3DSource = new itowns.C3DTilesSource({
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/3DTiles/lyon_1_4978/tileset.json'
+            });
+            const lyon3DLayer = new itowns.C3DTilesLayer('bordeaux', {
+                name: 'bordeaux',
+                source: lyon3DSource,
+            }, view);
+
+            itowns.View.prototype.addLayer.call(view, lyon3DLayer);
+
+            // ---------- ADD ELEVATION MEASUREMENT WIDGET : ----------
+
+            const elevationMeasure = new itowns_widgets.ElevationMeasure(view);
+
+            // ---------- ADD LIGHTS ----------------------------------
+            var ambLight = new itowns.THREE.AmbientLight(0xffffff);
+            view.scene.add( ambLight );
+
+            // ---------- DEBUG TOOLS : ----------
+
+            debug.createTileDebugUI(debugMenu.gui, view);
+
+        </script>
+    </body>
+</html>

--- a/examples/widgets_minimap.html
+++ b/examples/widgets_minimap.html
@@ -109,7 +109,7 @@
             // When double-clicking the minimap, travel to the cursor location.
             const cursorCoordinates = new itowns.Coordinates(minimap.view.referenceCrs);
             minimap.domElement.addEventListener('dblclick', (event) => {
-                minimap.view.pickCoordinates(event, cursorCoordinates);
+                minimap.view.pickTerrainCoordinates(event, cursorCoordinates);
                 view.controls.lookAtCoordinate({ coord: cursorCoordinates });
             });
 

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -58,7 +58,11 @@ class Coordinates {
     /**
      * @constructor
      *
-     * @param {string} crs - A supported crs (see the `crs` property below).
+     * @param {string} crs - A supported Coordinate Reference System. 'EPSG:4978' and 'EPSG:4326' are
+     * supported by default. To use another CRS, you have to declare it with proj4. For instance:
+     * @example
+     * itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+     * You can find most projections and their proj4 code at [epsg.io]{@link https://epsg.io/}
      * @param {number|Array<number>|Coordinates|THREE.Vector3} [v0=0] -
      * x or longitude value, or a more complex one: it can be an array of three
      * numbers, being x/lon, x/lat, z/alt, or it can be `THREE.Vector3`. It can
@@ -90,6 +94,15 @@ class Coordinates {
         }
 
         this._normalNeedsUpdate = true;
+    }
+
+    /**
+     * Sets the Coordinate Reference System.
+     * @param {String} crs Coordinate Reference System (e.g. 'EPSG:4978')
+     */
+    setCrs(crs) {
+        CRS.isValid(crs);
+        this.crs = crs;
     }
 
     /**

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -215,6 +215,8 @@ export default {
         const clearG = Math.round(255 * clearColor.g);
         const clearB = Math.round(255 * clearColor.b);
 
+        // Raycaster use NDC coordinate
+        const normalized = view.viewToNormalizedCoords(viewCoords);
         const tmp = normalized.clone();
         traversePickingCircle(radius, (x, y) => {
             // x, y are offset from the center of the picking circle,

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import RenderMode from 'Renderer/RenderMode';
 import { unpack1K } from 'Renderer/LayeredMaterial';
+import Coordinates from 'Core/Geographic/Coordinates';
 
 const depthRGBA = new THREE.Vector4();
 // TileMesh picking support function
@@ -84,6 +85,11 @@ function findLayerInParent(obj) {
 const raycaster = new THREE.Raycaster();
 const normalized = new THREE.Vector2();
 
+const pointPos = new THREE.Vector3();
+const pointPosCoord = new Coordinates('EPSG:4978'); // default crs, will be set to view crs when used
+const cameraPos = new THREE.Vector3();
+const cameraPosCoord = new Coordinates('EPSG:4978'); // default crs, will be set to view crs when used
+
 /**
  * @module Picking
  *
@@ -166,9 +172,22 @@ export default {
                 // if baseId matches objId, the clicked point belongs to `o`
                 for (let i = 0; i < candidates.length; i++) {
                     if (candidates[i].objId == o.baseId) {
+                        // Get point position: get the picked point from the buffer geometry and apply local to world
+                        // transform of the picked object
+                        pointPos.fromBufferAttribute(o.geometry.attributes.position, candidates[i].index);
+                        o.localToWorld(pointPos);
+                        // Compute distance to the camera
+                        pointPosCoord.setCrs(view.referenceCrs);
+                        pointPosCoord.setFromVector3(pointPos);
+                        view.camera.camera3D.getWorldPosition(cameraPos);
+                        cameraPosCoord.setCrs(view.referenceCrs);
+                        cameraPosCoord.setFromVector3(cameraPos);
+                        const dist = pointPosCoord.spatialEuclideanDistanceTo(cameraPosCoord);
                         result.push({
                             object: o,
+                            point: pointPos, // the position of the point in the 3D view. Same name and value than what's returned by pickObjectsAt
                             index: candidates[i].index,
+                            distance: dist,
                             layer,
                         });
                     }
@@ -216,7 +235,6 @@ export default {
         const clearB = Math.round(255 * clearColor.b);
 
         // Raycaster use NDC coordinate
-        const normalized = view.viewToNormalizedCoords(viewCoords);
         const tmp = normalized.clone();
         traversePickingCircle(radius, (x, y) => {
             // x, y are offset from the center of the picking circle,

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -956,12 +956,12 @@ class View extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the world position (view's crs: referenceCrs) under view coordinates.
+     * Returns the world position on the terrain (view's crs: referenceCrs) under view coordinates.
      * This position is computed with depth buffer.
      *
      * @param      {THREE.Vector2}  mouse  position in view coordinates (in pixel), if it's null so it's view's center.
      * @param      {THREE.Vector3}  [target=THREE.Vector3()] target. the result will be copied into this Vector3. If not present a new one will be created.
-     * @return     {THREE.Vector3}  the world position in view's crs: referenceCrs.
+     * @return     {THREE.Vector3}  the world position on the terrain in view's crs: referenceCrs.
      */
 
     getPickingPositionFromDepth(mouse, target = new THREE.Vector3()) {
@@ -1028,7 +1028,7 @@ class View extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the world {@link Coordinates} at given view coordinates.
+     * Returns the world {@link Coordinates} of the terrain at given view coordinates.
      *
      * @param   {THREE.Vector2|event}   [mouse]     The view coordinates at which the world coordinates must be
                                                     * returned. This parameter can also be set to a mouse event from
@@ -1037,9 +1037,9 @@ class View extends THREE.EventDispatcher {
      * @param   {Coordinates}           [target]    The result will be copied into this {@link Coordinates}. If not
                                                     * specified, a new {@link Coordinates} instance will be created.
      *
-     * @returns {Coordinates}   The world {@link Coordinates} at the given view coordinates.
+     * @returns {Coordinates}   The world {@link Coordinates} of the terrain at the given view coordinates.
      */
-    pickCoordinates(mouse, target = new Coordinates(this.tileLayer.extent.crs)) {
+    pickTerrainCoordinates(mouse, target = new Coordinates(this.referenceCrs)) {
         if (mouse instanceof Event) {
             this.eventToViewCoords(mouse);
         } else if (mouse && mouse.x !== undefined && mouse.y !== undefined) {
@@ -1057,6 +1057,25 @@ class View extends THREE.EventDispatcher {
         coordinates.as(target.crs, target);
 
         return target;
+    }
+
+    /**
+     * Returns the world {@link Coordinates} of the terrain at given view coordinates.
+     *
+     * @param   {THREE.Vector2|event}   [mouse]     The view coordinates at which the world coordinates must be
+                                                    * returned. This parameter can also be set to a mouse event from
+                                                    * which the view coordinates will be deducted. If not specified, it
+                                                    * will be defaulted to the view's center coordinates.
+     * @param   {Coordinates}           [target]    The result will be copied into this {@link Coordinates}. If not
+                                                    * specified, a new {@link Coordinates} instance will be created.
+     *
+     * @returns {Coordinates}   The world {@link Coordinates} of the terrain at the given view coordinates.
+     *
+     * @deprecated Use View#pickTerrainCoordinates instead.
+     */
+    pickCoordinates(mouse, target = new Coordinates(this.referenceCrs)) {
+        console.warn('Deprecated, use View#pickTerrainCoordinates instead.');
+        return this.pickTerrainCoordinates(mouse, target);
     }
 
     /**

--- a/src/Utils/gui/ElevationMeasure.js
+++ b/src/Utils/gui/ElevationMeasure.js
@@ -1,0 +1,472 @@
+import * as THREE from 'three';
+import { CSS2DRenderer, CSS2DObject } from 'ThreeExtended/renderers/CSS2DRenderer';
+import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
+import Coordinates from 'Core/Geographic/Coordinates';
+import DEMUtils from 'Utils/DEMUtils';
+import { CONTROL_EVENTS } from 'Controls/GlobeControls';
+import Widget from './Widget';
+
+const DEFAULT_OPTIONS = {
+    position: 'top',
+    width: 50,
+    height: 50,
+    placeholder: 'Measure elevation',
+};
+
+const loader = new THREE.TextureLoader();
+const POINT_TEXTURE = loader.load('https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/GUI/circle.png');
+
+const MOVE_POINT_MATERIAL = new THREE.PointsMaterial({
+    color: 0xff0000,
+    size: 10.0,
+    map: POINT_TEXTURE,
+    alphaTest: 0.5,
+    sizeAttenuation: false,
+    depthTest: false, // allows to render the point above the objects of the scene (used with renderOrder = 1)
+});
+
+const CLICK_POINT_MATERIAL = MOVE_POINT_MATERIAL.clone();
+CLICK_POINT_MATERIAL.color.set(0xffffff);
+
+// Constants for garbage collector optimization
+const pickedCoord = new Coordinates('EPSG:4978'); // default crs but will be set to view crs later
+const pickedCoord4326 = new Coordinates('EPSG:4326');
+const cameraPos = new THREE.Vector3();
+const cameraPosGeo = new Coordinates('EPSG:4978'); // default crs but will be set to view crs later
+
+/**
+ * Widget to measure the elevation in the 3D scene. Click anywhere in the scene to measure and display the elevation.
+ * Works on all layers that can be added to itowns: 3D Tiles, terrain, etc.
+ *
+ * @extends Widget
+ *
+ * @property {HTMLElement} domElement An html div containing the searchbar.
+ * @property {HTMLElement} parentElement The parent HTML container of `this.domElement`.
+ * @property {Number} [decimals=2] The number of decimals of the measured elevation.
+ * @property {String} [noElevationText='-'] The text to display when the elevation value is not found (e.g. if the user
+ * tries to measure the elevation where there is no elevation texture available).
+ */
+class ElevationMeasure extends Widget {
+    // --- Internal fields
+    // boolean indicating whether the tool is active or not
+    #active;
+    // the view where to pick
+    #view;
+    // a point following the mouse pointer
+    #movePoint;
+    // a point displayed where the user clicks to mesure elevation
+    #clickPoint;
+    // the threejs CSS2DRenderer used to display the label containing the elevation
+    #labelRenderer;
+    // the threejs label object
+    #labelObj;
+    // boolean used to check if the user is dragging (don't mesure elevation or just clicking (mesure elevation)
+    #drag = false;
+    // store previous mouse move event (and hence last mouse position) to move the movePoint when zooming in or out
+    #previousMouseMoveEvent = null;
+
+    // --- Config options
+    decimals = 2;
+    noElevationText = '-';
+    movePointMaterial = MOVE_POINT_MATERIAL;
+    clickPointMaterial = CLICK_POINT_MATERIAL;
+
+    /**
+     *
+     * @param {View} view the iTowns view in which the tool will measure elevation
+     * @param {Object} options The elevation measure widget optional configuration
+     * @param {HTMLElement} [options.parentElement=view.domElement] The parent HTML container of the div which
+     *                                                              contains searchbar widgets.
+     * @param {String} [options.position='top'] Defines which position within the
+     *                                          `parentElement` the searchbar should be
+                                                                        * displayed to. Possible values are `top`,
+                                                                        * `bottom`, `left`, `right`, `top-left`,
+                                                                        * `top-right`, `bottom-left` and `bottom-right`.
+                                                                        * If the input value does not match one of
+                                                                        * these, it will be defaulted to `top`.
+    * @param {number} [options.width=50] The width in pixels of the scale.
+    * @param {number} [options.height=50] The height in pixels of the scale.
+    * @param {Number} [options.decimals=2] The number of decimals of the measured elevation
+    * @param {String} [options.noElevationText='-'] The text to display when the elevation value is not found (e.g. if
+    * the user tries to measure the elevation where there is no elevation texture available).
+    * @param {Material|Object} [options.movePointMaterial='THREE.PointsMaterial'] Either the material of the point
+    * moving under the cursor (e.g. THREE.PointsMaterial) or options of THREE.PointsMaterial that should be applied to
+    * the default material (e.g. {color: 0x0000FF} for a blue point). If not set, defaults to a THREE.PointsMaterial
+    * with a circle sprite, red color and 10px size.
+    * @param {Material|Object} [options.clickPointMaterial='THREE.PointsMaterial'] Either the material of the point
+    * where the elevation is measured (e.g. THREE.PointsMaterial) or options of THREE.PointsMaterial that should be
+    * applied to the default material (e.g. {size: 20} for a point of size 20px). If not set, defaults to a
+    * THREE.PointsMaterial with a circle sprite, white color and 10px size.
+    */
+    constructor(view, options = {}) {
+        super(view, options, DEFAULT_OPTIONS);
+
+        if (options.decimals !== null && options.decimals !== undefined && !isNaN(options.decimals) &&
+            options.decimals >= 0) {
+            this.decimals = options.decimals;
+        }
+        if (options.noElevationText &&
+            (typeof options.noElevationText === 'string' || options.noElevationText instanceof String)) {
+            this.noElevationText = options.noElevationText;
+        }
+        if (options.movePointMaterial) {
+            if (options.movePointMaterial.isMaterial) {
+                this.movePointMaterial = options.movePointMaterial;
+                // render the point above the objects of the scene (used with renderOrder = 1)
+                this.movePointMaterial.depthTest = false;
+            } else if (typeof options.movePointMaterial === 'object') {
+                this.movePointMaterial.setValues(options.movePointMaterial);
+            } else {
+                console.warn('[Elevation measure widget] Material options should either be a THREE.Material or an object.');
+            }
+        }
+        if (options.clickPointMaterial) {
+            if (options.clickPointMaterial.isMaterial) {
+                this.clickPointMaterial = options.clickPointMaterial;
+                // render the point above the objects of the scene (used with renderOrder = 1)
+                this.clickPointMaterial.depthTest = false;
+            } else if (typeof options.clickPointMaterial === 'object') {
+                this.clickPointMaterial.setValues(options.clickPointMaterial);
+            } else {
+                console.warn('[Elevation measure widget] Material options should either be a THREE.Material or an object.');
+            }
+        }
+
+        this.#view = view;
+        // set constants coordinates crs
+        pickedCoord.setCrs(this.#view.referenceCrs);
+        cameraPosGeo.setCrs(this.#view.referenceCrs);
+
+        this.#active = false;
+        this.domElement.id = 'widgets-elevation';
+
+        const activationButton = document.createElement('button');
+        activationButton.id = 'widgets-elevation-activation-button';
+        activationButton.classList.add('widget-button');
+        activationButton.addEventListener('mousedown', this.onButtonClick.bind(this));
+        this.domElement.appendChild(activationButton);
+    }
+
+    /**
+     * Activate or deactivate tool
+     */
+    onButtonClick() {
+        this.#active = !this.#active;
+        if (this.#active) {
+            document.getElementById('widgets-elevation-activation-button').classList.add('widget-button-active');
+            this.activateTool();
+        } else {
+            document.getElementById('widgets-elevation-activation-button').classList.remove('widget-button-active');
+            this.deactivateTool();
+        }
+    }
+
+    /**
+     * Bind events of the tool and init labels stuff to display the elevation value
+     */
+    activateTool() {
+        // Save function signatures with binding to be able to remove the eventListener in deactivateTool
+        this.onMouseDown = this.onMouseDown.bind(this);
+        this.onMouseMove = this.onMouseMove.bind(this);
+        this.onMouseUp = this.onMouseUp.bind(this);
+        this.onZoom = this.onZoom.bind(this);
+        window.addEventListener('mousedown', this.onMouseDown);
+        window.addEventListener('mousemove', this.onMouseMove);
+        window.addEventListener('mouseup', this.onMouseUp);
+        this.#view.controls.addEventListener(CONTROL_EVENTS.RANGE_CHANGED, this.onZoom);
+
+        this.#movePoint = this.initPoint(this.movePointMaterial);
+        this.#clickPoint = this.initPoint(this.clickPointMaterial);
+        this.initLabel();
+    }
+
+    /**
+     * Go back to a state before the tool has been activated: remove event listeners, points and labels
+     */
+    deactivateTool() {
+        window.removeEventListener('mousedown', this.onMouseDown);
+        window.removeEventListener('mousemove', this.onMouseMove);
+        window.removeEventListener('mouseup', this.onMouseUp);
+        this.#view.controls.removeEventListener(CONTROL_EVENTS.RANGE_CHANGED, this.onZoom);
+
+        this.removePoints();
+        this.removeLabel();
+    }
+
+    /**
+     * Initializes a threejs point with specific attributes
+     * @param {Material} material the threejs Material to apply to the point
+     * @return {Points} the threejs point initialized
+     */
+    initPoint(material) {
+        const typedArr = new Float32Array(3);
+        const bufferAttrib = new THREE.BufferAttribute(typedArr, 3);
+
+        const bufferGeom = new THREE.BufferGeometry();
+        bufferGeom.setAttribute('position', bufferAttrib);
+
+        const point = new THREE.Points(bufferGeom, material);
+
+        point.frustumCulled = false; // Avoid the point to be frustum culled when zooming in.
+        point.renderOrder = 1; // allows to render the point above the other 3D objects of the scene
+        point.visible = false;
+
+        this.#view.scene.add(point);
+
+        return point;
+    }
+
+    /**
+     * Updates a threejs point position
+     * @param {Points} point the threejs point to update
+     * @param {Coordinates} coordinates The coordinates where to display the point
+     */
+    updatePointPosition(point, coordinates) {
+        const pos = point.geometry.attributes.position;
+        pos.array[0] = coordinates.x;
+        pos.array[1] = coordinates.y;
+        pos.array[2] = coordinates.z;
+        pos.needsUpdate = true;
+    }
+
+    /**
+     * Create or update a point in the 3D scene that follows the mouse cursor
+     * @param {Event} event mouse event
+     */
+    onMouseMove(event) {
+        this.#drag = true;
+        this.#previousMouseMoveEvent = event;
+
+        if (this.#movePoint.visible === false) {
+            this.#movePoint.visible = true;
+        }
+
+        const terrainWorldCoordinates = this.#view.pickTerrainCoordinates(event);
+        this.updatePointPosition(this.#movePoint, terrainWorldCoordinates);
+
+        this.#view.notifyChange();
+    }
+
+    onMouseDown() {
+        this.#drag = false;
+    }
+
+    /**
+     * Create or update a point where the user chose to display the elevation.
+     * @param {Event} event mouse event
+     */
+    onMouseUp(event) {
+        // Verify it's a left click and it's not a drag movement
+        if (event.button !== 0 || this.#drag === true) {
+            return;
+        }
+
+        if (this.#clickPoint.visible === false) {
+            this.#clickPoint.visible = true;
+        }
+
+        const terrainWorldCoordinates = this.#view.pickTerrainCoordinates(event);
+        this.updatePointPosition(this.#clickPoint, terrainWorldCoordinates);
+
+        const elevationText = this.getElevationText(event, terrainWorldCoordinates);
+
+        const pointVec3 = terrainWorldCoordinates.toVector3();
+        this.updateLabel(elevationText, pointVec3);
+
+        this.#view.notifyChange(true);
+    }
+
+    /**
+     * Updates move point position on zoom
+     */
+    onZoom() {
+        if (this.#movePoint.visible === false) {
+            this.#movePoint.visible = true;
+        }
+
+        const terrainWorldCoordinates = this.#view.pickTerrainCoordinates(this.#previousMouseMoveEvent);
+        this.updatePointPosition(this.#movePoint, terrainWorldCoordinates);
+
+        this.#view.notifyChange();
+    }
+
+    /**
+     * Compute elevation from mouse position
+     * @param {Event} event the mouse event that generated the elevation measure
+     * @param {Coordinates} terrainWorldCoordinates terrain coordinates in the 3D world correxponding to the mouse
+     * position
+     * @return {String} the elevation text to display in the label
+     */
+    getElevationText(event, terrainWorldCoordinates) {
+        let elevationText = this.noElevationText;
+
+        const pickedObjs = this.#view.pickObjectsAt(event);
+        if (!pickedObjs) {
+            return elevationText;
+        }
+
+        // Picked objects can either be 3D objects (which have an attribute distance indicating its distance to the
+        // camera) or a tileMesh (which don't have a distance attribute). Compute the distance attribute of the tileMesh
+        // to enable sorting objects based on that distance afterwards.
+        for (const obj of pickedObjs) {
+            if (!obj.distance) {
+                if (obj.object.isTileMesh) {
+                    obj.distance = this.computeDistanceToCamera(terrainWorldCoordinates);
+                } else {
+                    console.warn('[Elevation measure widget]: Picked object that are not of type TileMesh should have' +
+                    ' a distance attribute.');
+                }
+            }
+        }
+
+        // Sort objects from the closest to the farest
+        pickedObjs.sort((o1, o2) => o1.distance - o2.distance);
+        const closestObj = pickedObjs[0];
+
+        if (closestObj.object.isTileMesh) {
+            elevationText = this.computeTerrainElevationText(terrainWorldCoordinates, closestObj.object);
+        } else if (closestObj.object.isMesh || closestObj.object.isPoints) {
+            pickedCoord.setFromVector3(closestObj.point);
+            elevationText = this.compute3DObjectElevationText(pickedCoord);
+        } else {
+            console.error('[Elevation measure widget]: Unknown picked object type.');
+        }
+
+        return elevationText;
+    }
+
+    /**
+     * Computes the distance between a point and the camera
+     * @param {Coordinates} point the point in the 3D scene
+     * @return {Number} the spatial euclidean distance between the point and the camera
+     */
+    computeDistanceToCamera(point) {
+        this.#view.camera.camera3D.getWorldPosition(cameraPos);
+        cameraPosGeo.setFromVector3(cameraPos);
+        return point.spatialEuclideanDistanceTo(cameraPosGeo);
+    }
+
+    /**
+     * Computes the elevation and the elevation text to display from a point on the terrain in the 3D scene
+     * (in world coordinates)
+     * @param {Coordinates} terrainCoord The 3D coordinates of the terrain point
+     * @param {TileMesh} tile The picked terrain tile (used to look up elevation)
+     * @return {String} The elevation text to display in the label
+     */
+    computeTerrainElevationText(terrainCoord, tile) {
+        const elevation = DEMUtils.getElevationValueAt(this.#view.tileLayer, terrainCoord, DEMUtils.PRECISE_READ_Z, [tile]);
+        if (elevation !== null && elevation !== undefined && !isNaN(elevation)) {
+            return `${elevation.toFixed(this.decimals)} m`;
+        } else {
+            return this.noElevationText;
+        }
+    }
+
+    /**
+     * COmputes the elevation and elevation text to display from a point in the 3D scene (likely a point on a picked 3D
+     * object in world coordinates)
+     * @param {Coordinates} point the point to compute elevation text from
+     * @return {String} the elevation text to display in the label
+     */
+    compute3DObjectElevationText(point) {
+        // convert the point to 4326 to get elevation
+        point.as('EPSG:4326', pickedCoord4326);
+        return `${pickedCoord4326.z.toFixed(this.decimals)} m`;
+    }
+
+    /**
+     * Initialize all elements to display the measured elevation as a label with threejs: a threejs css 2D renderer,
+     * a callback to render the label at each frame, the div holding the label and a threejs label object.
+     */
+    initLabel() {
+        this.#labelRenderer = new CSS2DRenderer();
+        this.#labelRenderer.setSize(window.innerWidth, window.innerHeight);
+        this.#labelRenderer.domElement.style.position = 'absolute';
+        this.#labelRenderer.domElement.style.top = '0px';
+        document.body.appendChild(this.#labelRenderer.domElement);
+
+        this.renderLabel = this.renderLabel.bind(this);
+        this.#view.addFrameRequester(MAIN_LOOP_EVENTS.AFTER_RENDER, this.renderLabel);
+
+        const labelDiv = document.createElement('div');
+        // hack to position the label above the click point: add a child div containing a translation (if we put it in
+        // labelDiv directly, it gets overwritten by threejs CSS2DRenderer)
+        const posLabel = document.createElement('div');
+        posLabel.classList.add('label-elevation');
+        const pointSize = this.clickPointMaterial.size;
+        // Translation obtained empirically
+        posLabel.style.transform = `translateY(${-((pointSize / 2) + 12)}px)`;
+        labelDiv.appendChild(posLabel);
+        this.#labelObj = new CSS2DObject(labelDiv);
+        this.#view.scene.add(this.#labelObj);
+
+        this.onWindowResize = this.onWindowResize.bind(this);
+        window.addEventListener('resize', this.onWindowResize);
+    }
+
+
+    /**
+     * Callback to render label (called at each frame)
+     */
+    renderLabel() {
+        this.#labelRenderer.render(this.#view.scene, this.#view.camera.camera3D);
+    }
+
+    /**
+     * Update label content and position
+     * @param {String} textContent the new text of the label
+     * @param {Vector3} position the new position of the label
+     */
+    updateLabel(textContent, position) {
+        // Update the posLabel div textContent
+        this.#labelObj.element.childNodes[0].textContent = textContent;
+        this.#labelObj.position.copy(position);
+        this.#labelObj.updateMatrixWorld();
+    }
+
+    /**
+     * Remove label stuff: Div holding the labels, the render label function callback and the threejs label object.
+     * Also initialize label related class properties to null.
+     */
+    removeLabel() {
+        document.body.removeChild(this.#labelRenderer.domElement);
+        this.#labelRenderer = null;
+        this.#view.removeFrameRequester(MAIN_LOOP_EVENTS.AFTER_RENDER, this.renderLabel);
+        this.#view.scene.remove(this.#labelObj);
+        this.#labelObj = null;
+
+        this.#view.notifyChange();
+    }
+
+    /**
+     * Resize label renderer size
+     */
+    onWindowResize() {
+        this.#labelRenderer.setSize(window.innerWidth, window.innerHeight);
+    }
+
+    /**
+     * Remove points objects, geometries, materials and textures and reinitialize points.
+     */
+    removePoints() {
+        if (this.#movePoint) {
+            const movePointGeom = this.#movePoint.geometry;
+            this.#view.scene.remove(this.#movePoint);
+            this.#movePoint = null;
+            movePointGeom.dispose();
+            this.movePointMaterial.dispose();
+        }
+
+        if (this.#clickPoint) {
+            const clickPointGeom = this.#clickPoint.geometry;
+            this.#view.scene.remove(this.#clickPoint);
+            this.#clickPoint = null;
+            clickPointGeom.dispose();
+            this.clickPointMaterial.dispose();
+        }
+
+        POINT_TEXTURE.dispose();
+    }
+}
+
+export default ElevationMeasure;

--- a/src/Utils/gui/Main.js
+++ b/src/Utils/gui/Main.js
@@ -3,3 +3,4 @@ export { default as Navigation } from './Navigation';
 export { default as Minimap } from './Minimap';
 export { default as Scale } from './Scale';
 export { default as Searchbar } from './Searchbar';
+export { default as ElevationMeasure } from './ElevationMeasure';

--- a/test/functional/widgets_elevation.js
+++ b/test/functional/widgets_elevation.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+describe('widgets_elevation', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(
+            'examples/widgets_elevation.html',
+            this.fullTitle(),
+        );
+    });
+
+    it('should run', async () => {
+        assert.ok(result);
+    });
+});


### PR DESCRIPTION
## Description
Add a widget to measure elevation anywhere in the 3D scene. Also contains a few modifications of the API (`Picking` and `View`).

I will write tests and squash commits once we agree on the implementation :) (i.e. after a first review)

Note that I opened a [PR on itowns2-sample-data](https://github.com/iTowns/iTowns2-sample-data/pull/8) for the assets related to this widget (sprite, logo and dataset for the example). 

## Motivation and Context
Implementation of the first tool described in #1868

## Screenshots (if appropriate)

Mesure elevation on the terrain:

![image](https://user-images.githubusercontent.com/16967916/183654952-918a9b0c-2cef-4a22-9700-5a36a8172521.png)

Mesure elevation on any 3D object:
![image](https://user-images.githubusercontent.com/16967916/183655203-47b88ad7-dee5-4e44-810b-905018dd6ebd.png)
