### PR TITLE
fix(Scheduler): replace url subdomains alternatives

### DIFF
--- a/src/Core/Scheduler/Scheduler.js
+++ b/src/Core/Scheduler/Scheduler.js
@@ -9,6 +9,7 @@ import DataSourceProvider from 'Provider/DataSourceProvider';
 import TileProvider from 'Provider/TileProvider';
 import $3dTilesProvider from 'Provider/3dTilesProvider';
 import PointCloudProvider from 'Provider/PointCloudProvider';
+import URLBuilder from 'Provider/URLBuilder';
 import CancelledCommandException from './CancelledCommandException';
 
 function queueOrdering(a, b) {
@@ -153,7 +154,8 @@ Scheduler.prototype.execute = function execute(command) {
 
     // parse host
     const layer = command.layer;
-    const host = layer.source && layer.source.url ? new URL(layer.source.url, document.location).host : undefined;
+    const host = layer.source && layer.source.url ?
+        new URL(URLBuilder.subDomains(layer.source.url), document.location).host : undefined;
 
     command.promise = new Promise((resolve, reject) => {
         command.resolve = resolve;

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -28,6 +28,8 @@ function subDomains(url) {
  * @module URLBuilder
  */
 export default {
+    subDomains,
+
     /**
      * Builds an URL knowing the coordinates and the source to query.
      * <br><br>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When using subdomains alternatives in a `Source` `url` property, the Scheduler tries to generate a new `URL` object passing an incorrect URL. The subdomains alternatives are not replaced, it will be something like `https://${u:xyz.org|yzx.org|zxy.org}/${z}/${x}/${y}.png` instead of `https://yzx.org/${z}/${x}/${y}.png` for instance. 

This PR adds the use of [this method](https://github.com/iTowns/itowns/blob/master/src/Provider/URLBuilder.js#L6) to replace subdomains alternative by the relevant one before generating an `URL` object in `Scheduler`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
fixes #1883 
