### PR TITLE
Improve resources disposal

### DIFF
--- a/docs/tutorials/Fundamentals.md
+++ b/docs/tutorials/Fundamentals.md
@@ -76,6 +76,8 @@ Some point clouds formats such as Potree, Las and Entwine already have parsers d
 | :---: | :---: | :---: |
 | A simple `ColorLayer` is displayed | An `ElevationLayer` is added to represent terrain elevation | A `GeometryLayer` is added to model the buildings |
 
+Note that `{@link ColorLayer}` and `{@link ElevationLayer}` don't have their own geometry and are always *attached* to a `{@link GeometryLayer}` (generally the layer representing the geometry of the globe or of the plane). `{@link ColorLayer}` are projected onto this `{@link GeometryLayer}` and `{@link ElevationLayer}` are used to read elevation and to apply it to a `{@link GeometryLayer}`.
+
 ***
 
 ## Style

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -290,7 +290,14 @@ class LabelLayer extends Layer {
         }
     }
 
-    delete() {
+    /**
+     * All layer's objects and domElements are removed.
+     * @param {boolean} [clearCache=false] Whether to clear the layer cache or not
+     */
+    delete(clearCache) {
+        if (clearCache) {
+            this.cache.clear();
+        }
         this.domElement.parentElement.removeChild(this.domElement);
 
         this.parent.level0Nodes.forEach(obj => this.removeLabelsFromNodeRecursive(obj));

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -236,9 +236,10 @@ class Layer extends THREE.EventDispatcher {
 
     /**
      * Remove and dispose all objects from layer.
+     * @param {boolean} [clearCache=false] Whether to clear the layer cache or not
      */
     // eslint-disable-next-line
-    delete() {
+    delete(clearCache) {
         console.warn('Function delete doesn\'t exist for this layer');
     }
 }

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -108,10 +108,14 @@ class OrientedImageLayer extends GeometryLayer {
         }
         super(id, new THREE.Group(), config);
 
-        this.background = config.background || createBackground(config.backgroundDistance);
         this.isOrientedImageLayer = true;
 
+        this.background = config.background || createBackground(config.backgroundDistance);
+
         if (this.background) {
+            // Add layer id to easily identify the objects later on (e.g. to delete the geometries when deleting the layer)
+            this.background.layer = this.background.layer ?? {};
+            this.background.layer.id = this.background.layer.id ?? id;
             this.object3d.add(this.background);
         }
 
@@ -205,9 +209,16 @@ class OrientedImageLayer extends GeometryLayer {
      * Delete background, but doesn't delete OrientedImageLayer.material. For the moment, this material visibility is set to false.
      * You need to replace OrientedImageLayer.material applied on each object, if you want to continue displaying them.
      * This issue (see #1018 {@link https://github.com/iTowns/itowns/issues/1018}) will be fixed when OrientedImageLayer will be a ColorLayer.
-     */
-    delete() {
-        super.delete();
+    * @param {boolean} [clearCache=false] Whether to clear the layer cache or not
+    */
+    delete(clearCache) {
+        if (this.background) {
+            // only delete geometries if it has some
+            super.delete();
+        }
+        if (clearCache) {
+            this.cache.clear();
+        }
         this.material.visible = false;
         console.warn('You need to replace OrientedImageLayer.material applied on each object. This issue will be fixed when OrientedImageLayer will be a ColorLayer. the material visibility is set to false. To follow issue see https://github.com/iTowns/itowns/issues/1018');
     }

--- a/src/Layer/RasterLayer.js
+++ b/src/Layer/RasterLayer.js
@@ -15,8 +15,12 @@ class RasterLayer extends Layer {
 
     /**
     * All layer's textures are removed from scene and disposed from video device.
+    * @param {boolean} [clearCache=false] Whether to clear the layer cache or not
     */
-    delete() {
+    delete(clearCache) {
+        if (clearCache) {
+            this.cache.clear();
+        }
         for (const root of this.parent.level0Nodes) {
             root.traverse(removeLayeredMaterialNodeLayer(this.id));
         }

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -1,3 +1,14 @@
+function disposeSingleMaterialAndTextures(material) {
+    material.dispose();
+    // dispose textures
+    for (const key of Object.keys(material)) {
+        const val = material[key];
+        if (val && val.isTexture) {
+            val.dispose();
+        }
+    }
+}
+
 export default {
     /**
      * Cleanup obj to release three.js allocated resources
@@ -6,7 +17,8 @@ export default {
     cleanup(obj) {
         obj.layer = null;
 
-        if (typeof obj.dispose === 'function') {
+        // THREE.Scene dispose function displays a deprecation message
+        if (!obj.isScene && typeof obj.dispose === 'function') {
             obj.dispose();
         } else {
             if (obj.geometry) {
@@ -20,10 +32,10 @@ export default {
             if (obj.material) {
                 if (Array.isArray(obj.material)) {
                     for (const material of obj.material) {
-                        material.dispose();
+                        disposeSingleMaterialAndTextures(material);
                     }
                 } else {
-                    obj.material.dispose();
+                    disposeSingleMaterialAndTextures(obj.material);
                 }
             }
             obj.dispatchEvent({ type: 'dispose' });
@@ -44,7 +56,7 @@ export default {
     },
 
     /**
-     * Remove obj's children belonging to a layer and cleanup objexts.
+     * Remove an obj and all its children belonging to a layer and only cleanup the obj (and not its children).
      * obj will be disposed but its children **won't**!
      * @param {Layer} layer The layer that objects must belong to. Other object are ignored
      * @param {Object3D} obj The Object3D we want to clean
@@ -61,13 +73,15 @@ export default {
     },
 
     /**
-     * Recursively remove obj's children belonging to a layer.
+     * Recursively remove an obj and all its children belonging to a layer.
      * All removed obj will have their geometry/material disposed.
      * @param {Layer} layer The layer that objects must belong to. Other object are ignored
      * @param {Object3D} obj The Object3D we want to clean
      * @return {Array} an array of removed Object3D from obj (not including the recursive removals)
      */
     removeChildrenAndCleanupRecursively(layer, obj) {
+        // Objects are filtered by id because the obj hierarchy may also contain labels that have been added as childs
+        // of the objects which have their own removal logic
         let toRemove = obj.children.filter(c => (c.layer && c.layer.id) === layer.id);
         if (obj.link) {
             toRemove = toRemove.concat(obj.link);


### PR DESCRIPTION
## Description

Improve resource disposal by:
* using `ObjectRemovalHelper` to remove 3D objects when a `GeometryLayer` is deleted
* disposing textures in `ObjectRemovalHelper`
* allowing to clear the cache or not when disposing the view and layers

## Motivation and Context

Some resources where not disposed after disposing itowns view. To make sure of it, you can add `setTimeout(function() {view.dispose();}, 40000);` at the end of any itowns example. Some tests I made with the chrome Memory tool, on two itowns examples:

### Before the MR

**3dtiles_basic.html:**

*Before disposing the view*
![3dtiles_basic_before](https://user-images.githubusercontent.com/16967916/186124662-f0b8f97a-b7ad-41d6-b20e-678717b37b54.png)

*After disposing the view*
![3dtiles_basic_after](https://user-images.githubusercontent.com/16967916/186124746-9ffd002a-d620-4647-95c1-52e2b1ee4527.png)

Notice that nearly any memory is freed and that there is still `ArrayBuffers` which contains geometries

**vector_tile_3d_mesh.html:**

*Before disposing the view*
![vector_tile_3d_mesh_before](https://user-images.githubusercontent.com/16967916/186125472-b8ff0a21-0db9-4b59-826c-ccff501ade3d.png)

*After disposing the view*
![vector_tile_3d_mesh_after](https://user-images.githubusercontent.com/16967916/186125514-fa8b6d59-fbd5-4aa7-80b2-6346392c5744.png)

Same here, not much is deleted

### After the MR

*Before disposing the view*
![image](https://user-images.githubusercontent.com/16967916/186126216-9183518d-69e1-4306-97c8-07d12d0a7ee5.png)

*After disposing the view*
![image](https://user-images.githubusercontent.com/16967916/186126367-6286d775-d329-4b55-b741-4b672a2de9d1.png)

It's not perfect but more resources are disposed.

**vector_tile_3d_mesh.html:**

I have less success with this one :grin: 

*Before disposing the view*
![image](https://user-images.githubusercontent.com/16967916/186127926-fd5324b3-c476-4aa4-83a2-c9f405f9bb53.png)

*After disposing the view*
![image](https://user-images.githubusercontent.com/16967916/186127972-f56f18ed-522f-4636-a81a-7232a2f54136.png)

There is still many `Feature` and `FeatureGeometry` after the view disposal, but I haven't found out where they are stored and how to delete them. Note that the cache and the threejs object3Ds are deleted the same way than for `c3DTileslayer` since both `c3DTilesLayer` and `FeatureGeometryLayer` inherit from `GeometryLayer`.  Help wanted for this one :slightly_smiling_face: 

## Open discussion

I think we could still improve some other things. Let me know what you think, if you agree I will implement them:
* Harmonize functions names for resource disposal (some are named dispose, other delete, other clear, other remove, etc.): rename them all to `dispose` (the name used in threejs)
* Some caches are declared as constants outside classes and are not exported: `cacheStyle` in `Style.js`, `cacheTile` and `cacheBuffer` in `TileBuilder.js`. Therefore they cannot be cleared properly when disposing the view. I think they should be stored in the view so we can clear them when needed.
* Fetched data are cached twice:
  * Once after being parsed, in `Source._featuresCaches`
  * Once after being converted, in `Layer.cache`
I think this greatly affects itowns memory footprint, especially when loading heavy dataset. In addition, I don't think there is a case where only one cache is deleted: they are both deleted when the layer is deleted (or when the cache lifetime has expired). WDYT about caching them only once ? (in `Layer.cache` to avoid transforming them again)
