### PR TITLE
chore: add submodule for examples.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/Main.js",
   "exports": {
       ".": "./lib/Main.js",
-      "./widgets": "./lib/Utils/gui/Main.js"
+      "./widgets": "./lib/Utils/gui/Main.js",
+      "./examples/*": "./examples/js/*.js"
   },
   "scripts": {
     "lint": "eslint \"src/**/*.js\" \"test/**/*.js\" \"examples/**/*.js\" \"docs/*.js\"",


### PR DESCRIPTION
## Description
Add submodule for examples.

## Motivation and Context
After #1817, it seems that "exmaples/js/*.js" cannot be imported.
It would be great if it allowed.