### PR TITLE
Add a boundingBox attribute to C3DTilesLayer and improve C3DTilesLayer doc

### DIFF
--- a/src/Core/3DTiles/C3DTBoundingVolume.js
+++ b/src/Core/3DTiles/C3DTBoundingVolume.js
@@ -117,6 +117,26 @@ class C3DTBoundingVolume {
         }
         return false;
     }
+
+    /**
+     * Gets the bounding box of the bounding volume.
+     * The bounding volume may be represented by a box, a sphere or an itowns OBB. This method is intended to ease
+     * processes using 3D Tiles bounding volumes.
+     * @returns {THREE.Box3} the bounding box of the bounding volume.
+     */
+    getBoundingBox() {
+        if (this.box) {
+            return this.box;
+        } else if (this.sphere) {
+            const box = new THREE.Box3();
+            this.sphere.getBoundingBox(box);
+            return box;
+        } else if (this.region) {
+            return this.region.box3D;
+        } else {
+            console.error('Unknown bounding volume type. Cannot compute C3DTBoundingVolume bounding box');
+        }
+    }
 }
 
 export default C3DTBoundingVolume;

--- a/test/unit/3dtiles.js
+++ b/test/unit/3dtiles.js
@@ -1,11 +1,12 @@
 import proj4 from 'proj4';
 import assert from 'assert';
-import { Matrix4, Object3D } from 'three';
+import { Matrix4, Object3D, Vector3, Box3 } from 'three';
 import Camera from 'Renderer/Camera';
 import Coordinates from 'Core/Geographic/Coordinates';
 import { computeNodeSSE } from 'Process/3dTilesProcessing';
 import { configureTile } from 'Provider/3dTilesProvider';
 import C3DTileset from '../../src/Core/3DTiles/C3DTileset';
+import C3DTBoundingVolume from '../../src/Core/3DTiles/C3DTBoundingVolume';
 
 function tilesetWithRegion(transformMatrix) {
     const tileset = {
@@ -163,5 +164,30 @@ describe('Distance computation using boundingVolume.sphere', function () {
         computeNodeSSE(camera, tile);
 
         assert.equal(tile.distance, 100 - 1 * 0.01 - 10);
+    });
+});
+
+describe('Compute C3DTilesBoundingVolume bounding box', function () {
+    it('Get bounding box from box', function () {
+        const json = {
+            box: [0, 0, 10,
+                100, 0, 0,
+                0, 100, 0,
+                0, 0, 10,
+            ],
+        };
+        const boundingVolume = new C3DTBoundingVolume(json);
+        const box = boundingVolume.getBoundingBox();
+        const expectedBox = new Box3(new Vector3(-100, -100, 0), new Vector3(100, 100, 20));
+        assert.deepStrictEqual(box, expectedBox);
+    });
+    it('Get bounding box from sphere', function () {
+        const json = {
+            sphere: [0, 0, 10, 140],
+        };
+        const boundingVolume = new C3DTBoundingVolume(json);
+        const box = boundingVolume.getBoundingBox();
+        const expectedBox = new Box3(new Vector3(-140, -140, -130), new Vector3(140, 140, 150));
+        assert.deepStrictEqual(box, expectedBox);
     });
 });


### PR DESCRIPTION
Add a boundingBox attribute to C3DTilesLayer to ease processes based on 3D Tiles layers for itowns users (e.g. to help writting zoomTo methods, to say if a layer is visible or not, etc.).

I think a good improvement would be to add a bounding box attributes to all layers, see #1903 .

Also, I haven't written a test for the region case, see #1905 for an explaination.
