### PR TITLE
bugfix(Feature2Texture): prevent drawing points if they lack style

### DIFF
--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -113,7 +113,10 @@ function drawFeature(ctx, feature, extent, style, invCtxScale) {
             const contextStyle = (geometry.properties.style || style).drawingStylefromContext(context);
 
             if (contextStyle) {
-                if (feature.type === FEATURE_TYPES.POINT) {
+                if (
+                    feature.type === FEATURE_TYPES.POINT
+                    && contextStyle.point
+                ) {
                     // cross multiplication to know in the extent system the real size of
                     // the point
                     const px = (Math.round(contextStyle.point.radius * invCtxScale) || 3 * invCtxScale) * scaleRadius;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When viewing vector data including points as a `ColorLayer` that has no `style.point.color` defined, the conversion process fail. Therefore, one cannot decide to only view polygons or lines from a data set that also contains points.

This PR fixes this behavior, allowing to skip points conversion if no style was set for them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Fixes #1847.
