### PR TITLE
refacto(feature): use feature crs property for instance center property.

### DIFF
--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -376,7 +376,7 @@ export class FeatureCollection extends THREE.Object3D {
             this.extent = options.buildExtent === false ? undefined : defaultExtent(options.forcedExtentCrs || this.crs);
             this.#setLocalSystem = (center) => {
                 // set local system center
-                center.as('EPSG:4326', this.center);
+                center.as(this.crs, this.center);
 
                 // set position to local system center
                 this.position.copy(center);


### PR DESCRIPTION
## Description
refacto(feature): use feature crs property for instance center property.
