### PR TITLE
fix(3dtiles): fix layer opacity changes for 3d tiles pnts

### DIFF
--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import B3dmParser from 'Parser/B3dmParser';
 import PntsParser from 'Parser/PntsParser';
 import Fetcher from 'Provider/Fetcher';
+import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
 import utf8Decoder from 'Utils/Utf8Decoder';
 
 function b3dmToMesh(data, layer, url) {
@@ -28,6 +29,10 @@ function pntsParse(data, layer) {
         const material = layer.material ?
             layer.material.clone() :
             new THREE.PointsMaterial({ size: 0.05, vertexColors: true });
+
+        // refer material properties in the layer so when layers opacity and visibility is updated, the material is
+        // automatically updated
+        ReferLayerProperties(material, layer);
 
         // creation points with geometry and material
         const points = new THREE.Points(result.point.geometry, material);


### PR DESCRIPTION
Opacity and visibility change of a `c3DTilesLayer` were not working for point cloud (pnts) tiles because the property referencing mechanism between the layer and the 3D tiles was not executed.