### PR TITLE
fix(view): fix view resize when width or height is 0

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -1088,6 +1088,11 @@ class View extends THREE.EventDispatcher {
      * the viewer with. By default it is the `clientHeight` of the `viewerDiv`.
      */
     resize(width, height) {
+        if (width < 0 || height < 0) {
+            console.warn(`Trying to resize the View with negative height (${height}) or width (${width}). Skipping resize.`);
+            return;
+        }
+
         if (width == undefined) {
             width = this.domElement.clientWidth;
         }
@@ -1098,8 +1103,10 @@ class View extends THREE.EventDispatcher {
 
         this.#fullSizeDepthBuffer = new Uint8Array(4 * width * height);
         this.mainLoop.gfxEngine.onWindowResize(width, height);
-        this.camera.resize(width, height);
-        this.notifyChange(this.camera.camera3D);
+        if (width !== 0 && height !== 0) {
+            this.camera.resize(width, height);
+            this.notifyChange(this.camera.camera3D);
+        }
     }
 }
 

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -139,12 +139,16 @@ class Camera {
     }
 
     /**
-     * Resize the camera to a given width and height
+     * Resize the camera to a given width and height.
      *
-     * @param   {number}    width               The width to resize the camera to.
-     * @param   {number}    height              The height to resize the camera to.
+     * @param {number} width The width to resize the camera to. Must be strictly positive, won't resize otherwise.
+     * @param {number} height The height to resize the camera to. Must be strictly positive, won't resize otherwise.
      */
     resize(width, height) {
+        if (!width || width <= 0 || !height || height <= 0) {
+            console.warn(`Trying to resize the Camera with invalid height (${height}) or width (${width}). Skipping resize.`);
+            return;
+        }
         const ratio = width / height;
         if (this.camera3D.aspect !== ratio) {
             if (this.camera3D.isOrthographicCamera) {


### PR DESCRIPTION
## Description
Don't resize the camera when the div containing the view has a width or height of 0 and improve parameters verification in `View.resize` and `Camera.resize`.

## Motivation and Context

In a context where itowns was in a div that was hidden (by setting the css property of the div to `display:none`) and then displayed again, the rendering was broken (black screen) if we resized the scene when the div was hidden. This was due to division by 0 in `Camera.resize`. I removed the Camera resize in this case since nothing is rendered when the div holding the view is hidden anyway.
