### PR TITLE
perf(demutils): texture data read optimization in elevation measurement

### DIFF
--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -222,7 +222,7 @@ class c3DEngine {
 
     bufferToImage(pixelBuffer, width, height) {
         var canvas = document.createElement('canvas');
-        var ctx = canvas.getContext('2d');
+        var ctx = canvas.getContext('2d', { willReadFrequently: true });
 
         // size the canvas to your desired image
         canvas.width = width;

--- a/src/Utils/DEMUtils.js
+++ b/src/Utils/DEMUtils.js
@@ -147,7 +147,7 @@ function _readTextureValueAt(metadata, texture, ...uv) {
         _canvas.width = Math.max(_canvas.width, dw);
         _canvas.height = Math.max(_canvas.height, dh);
 
-        const ctx = _canvas.getContext('2d');
+        const ctx = _canvas.getContext('2d', { willReadFrequently: true });
         ctx.drawImage(texture.image, minx, miny, dw, dh, 0, 0, dw, dh);
         const d = ctx.getImageData(0, 0, dw, dh);
 


### PR DESCRIPTION
Optimize `getImageData` operations with `willReadFrequently` hint in `DemUtils.getElevationValueAt` and `c3DEngine.bufferToImage`  as suggested by the following Chrome warning (thrown in some itowns examples):

> Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently

