### PR TITLE
Remove Three.js layers using

### DIFF
--- a/examples/misc_collada.html
+++ b/examples/misc_collada.html
@@ -70,7 +70,6 @@
 
                 // building coordinate
                 var coord = new itowns.Coordinates('EPSG:4326', 4.2165, 44.844, 1417);
-                var colladaID = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
 
                 model.position.copy(coord.as(view.referenceCrs));
                 // align up vector with geodesic normal
@@ -78,10 +77,6 @@
                 // user rotate building to align with ortho image
                 model.rotateZ(-Math.PI * 0.2);
                 model.scale.set(1.2, 1.2, 1.2);
-
-                // set camera's layer to do not disturb the picking
-                model.traverse(function _(obj) { obj.layers.set(colladaID); });
-                view.camera.camera3D.layers.enable(colladaID);
 
                 // update coordinate of the mesh
                 model.updateMatrixWorld();

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -305,10 +305,6 @@ class GlobeControls extends THREE.EventDispatcher {
         if (enableTargetHelper) {
             cameraTarget.add(helpers.target);
             view.scene.add(helpers.picking);
-            const layerTHREEjs = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
-            helpers.target.layers.set(layerTHREEjs);
-            helpers.picking.layers.set(layerTHREEjs);
-            this.camera.layers.enable(layerTHREEjs);
         }
 
         if (placement.isExtent) {

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -520,7 +520,6 @@ function featureToMesh(feature, options) {
 
     if (options.layer) {
         mesh.layer = options.layer;
-        mesh.layers.set(options.layer.threejsLayer);
     }
 
     return mesh;

--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -58,10 +58,6 @@ export default {
 
             const tile = new TileMesh(result.geometry, material, layer, extent, level);
 
-            // Commented because layer.threejsLayer is undefined;
-            // Fix me: conflict with object3d added in view.scene;
-            // tile.layers.set(layer.threejsLayer);
-
             if (parent && parent.isTileMesh) {
                 // get parent extent transformation
                 const pTrans = builder.computeSharableExtent(parent.extent);

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -229,9 +229,6 @@ class Atmosphere extends GeometryLayer {
         const skyDome = new Sky();
         skyDome.frustumCulled = false;
 
-        ground.layers.mask = this.object3d.layers.mask;
-        sky.layers.mask = this.object3d.layers.mask;
-        skyDome.layers.mask = this.object3d.layers.mask;
         this.realisticAtmosphere.add(ground);
         this.realisticAtmosphere.add(sky);
         this.realisticAtmosphere.add(skyDome);

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -40,21 +40,6 @@ export const VIEW_EVENTS = {
  * @property {string} type  dblclick-right
  */
 
-
-const _syncGeometryLayerVisibility = function _syncGeometryLayerVisibility(layer, view) {
-    if (layer.object3d) {
-        layer.object3d.visible = layer.visible;
-    }
-
-    if (layer.threejsLayer) {
-        if (layer.visible) {
-            view.camera.camera3D.layers.enable(layer.threejsLayer);
-        } else {
-            view.camera.camera3D.layers.disable(layer.threejsLayer);
-        }
-    }
-};
-
 function _preprocessLayer(view, layer, parentLayer) {
     const source = layer.source;
     if (parentLayer && !layer.extent) {
@@ -65,13 +50,6 @@ function _preprocessLayer(view, layer, parentLayer) {
     }
 
     if (layer.isGeometryLayer) {
-        if (parentLayer) {
-            // layer.threejsLayer *must* be assigned before preprocessing,
-            // because TileProvider.preprocessDataLayer function uses it.
-            layer.threejsLayer = view.mainLoop.gfxEngine.getUniqueThreejsLayer();
-        }
-        layer.defineLayerProperty('visible', true, () => _syncGeometryLayerVisibility(layer, view));
-        _syncGeometryLayerVisibility(layer, view);
         // Find crs projection layer, this is projection destination
         layer.crs = view.referenceCrs;
     } else if (!layer.crs) {
@@ -1001,10 +979,6 @@ class View extends THREE.EventDispatcher {
         mouse.x = Math.floor(mouse.x);
         mouse.y = Math.floor(mouse.y);
 
-        // Prepare state
-        const prev = camera.layers.mask;
-        camera.layers.mask = 1 << this.tileLayer.threejsLayer;
-
         // Render/Read to buffer
         let buffer;
         if (viewPaused) {
@@ -1047,8 +1021,6 @@ class View extends THREE.EventDispatcher {
             target.set(screen.x, screen.y, gl_FragCoord_Z);
             target.unproject(camera);
         }
-
-        camera.layers.mask = prev;
 
         if (target.length() > 10000000) { return undefined; }
 

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -194,7 +194,6 @@ class LabelLayer extends Layer {
             layer: this,
             extentsSource: extentsDestination,
             view: context.view,
-            threejsLayer: this.threejsLayer,
             requester: node,
         };
 

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -36,7 +36,6 @@ function updatePano(context, camera, layer) {
             // put informations about image URL as extent to be used by generic DataSourceProvider, OrientedImageSource will use that.
             extentsSource: imagesInfo,
             view: context.view,
-            threejsLayer: layer.threejsLayer,
             requester: newPano,
             earlyDropFunction: commandCancellation,
         };

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -21,7 +21,6 @@ function initBoundingBox(elt, layer) {
     elt.obj.boxHelper.frustumCulled = false;
     elt.obj.boxHelper.position.copy(elt.tightbbox.min).add(box3.max);
     elt.obj.boxHelper.autoUpdateMatrix = false;
-    elt.obj.boxHelper.layers.mask = layer.bboxes.layers.mask;
     layer.bboxes.add(elt.obj.boxHelper);
     elt.obj.boxHelper.updateMatrix();
     elt.obj.boxHelper.updateMatrixWorld();

--- a/src/Process/FeatureProcessing.js
+++ b/src/Process/FeatureProcessing.js
@@ -52,7 +52,6 @@ export default {
             layer,
             extentsSource: extentsDestination,
             view: context.view,
-            threejsLayer: layer.threejsLayer,
             requester: node,
         };
 

--- a/src/Process/ObjectRemovalHelper.js
+++ b/src/Process/ObjectRemovalHelper.js
@@ -82,9 +82,13 @@ export default {
     removeChildrenAndCleanupRecursively(layer, obj) {
         // Objects are filtered by id because the obj hierarchy may also contain labels that have been added as childs
         // of the objects which have their own removal logic
-        let toRemove = obj.children.filter(c => (c.layer && c.layer.id) === layer.id);
+        let toRemove = obj.children.filter(c => c.layer && c.layer.id === layer.id);
         if (obj.link) {
-            toRemove = toRemove.concat(obj.link);
+            const linkedObjects = obj.link.filter(c => c.layer && c.layer.id === layer.id);
+            if (linkedObjects.length) {
+                toRemove = toRemove.concat(linkedObjects);
+                obj.link = obj.link.filter(c => c.layer && c.layer.id !== layer.id);
+            }
         }
         for (const c of toRemove) {
             this.removeChildrenAndCleanupRecursively(layer, c);

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -78,7 +78,6 @@ function executeCommand(command) {
     const path = metadata.content && (metadata.content.url || metadata.content.uri);
 
     const setLayer = (obj) => {
-        obj.layers.set(layer.threejsLayer);
         obj.userData.metadata = metadata;
         obj.layer = layer;
     };

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -42,7 +42,6 @@ export default {
             }
             points.updateMatrix();
             points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
-            points.layers.set(layer.threejsLayer);
             points.layer = layer;
             points.extent = Extent.fromBox3(command.view.referenceCrs, node.bbox);
             points.userData.node = node;

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -242,21 +242,6 @@ class c3DEngine {
         return image;
     }
 
-    getUniqueThreejsLayer() {
-        // We use three.js Object3D.layers feature to manage visibility of
-        // geometry layers; so we need an internal counter to assign a new
-        // one to each new geometry layer.
-        // Warning: only 32 ([0, 31]) different layers can exist.
-        if (this._nextThreejsLayer > 31) {
-            console.warn('Too much three.js layers. Starting from now all of them will use layerMask = 31');
-            this._nextThreejsLayer = 31;
-        }
-
-        const result = this._nextThreejsLayer++;
-
-        return result;
-    }
-
     depthBufferRGBAValueToOrthoZ(depthBufferRGBA, camera) {
         depthRGBA.fromArray(depthBufferRGBA).divideScalar(255.0);
 

--- a/utils/debug/OBBHelper.js
+++ b/utils/debug/OBBHelper.js
@@ -16,11 +16,6 @@ class OBBHelper extends THREE.Box3Helper {
         this.updateMatrixWorld(true);
     }
 
-    removeChildren() {
-        this.material.dispose();
-        this.geometry.dispose();
-    }
-
     updateMatrixWorld(force = false) {
         if (this.obb.box3D.isEmpty()) {
             return;


### PR DESCRIPTION
## Description
- Remove every usage of [`Three.js layers`](https://threejs.org/docs/?q=layer#api/en/core/Layers).
- Replace the control `GeometryLayer` visibility, handled by `Three.js layers`, by `GeometryLayer.object3D` visibility.
- Use [GeometryLayer](http://www.itowns-project.org/itowns/docs/#api/Layer/GeometryLayer) to display tile debug options ;

## Motivation and Context
- Code simplification, in particular `picking`.
- ThreeJS Layers usage can be problematic in some case as explained in [this issue](https://github.com/iTowns/itowns/issues/1863) #1863
- Remove conflict with `Three.WebXRManager`.

Closes #1863 #1869