### PR TITLE
refactor(OBB): remove OBB from node's children.

### DIFF
--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -71,8 +71,6 @@ export default {
             tile.visible = false;
             tile.updateMatrix();
 
-            tile.add(tile.obb);
-
             setTileFromTiledLayer(tile, layer);
 
             if (parent) {

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -272,7 +272,7 @@ class TiledGeometryLayer extends GeometryLayer {
 
     // eslint-disable-next-line
     culling(node, camera) {
-        return !camera.isBox3Visible(node.obb.box3D, node.obb.matrixWorld);
+        return !camera.isBox3Visible(node.obb.box3D, node.matrixWorld);
     }
 
     /**

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -12,6 +12,7 @@ const center = new THREE.Vector3();
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 let obb;
 
+// it could be considered to remove THREE.Object3D extend.
 class OBB extends THREE.Object3D {
     /**
      * Oriented bounding box
@@ -50,14 +51,6 @@ class OBB extends THREE.Object3D {
         this.z.max = cOBB.z.max;
         this.z.scale = cOBB.z.scale;
         return this;
-    }
-
-    /**
-     * Update the top point world
-     *
-     */
-    update() {
-        this.updateMatrixWorld(true);
     }
 
     /**

--- a/test/unit/obb.js
+++ b/test/unit/obb.js
@@ -17,7 +17,7 @@ describe('OBB', function () {
     obb.translateX(translate.x);
     obb.translateY(translate.y);
     obb.translateZ(translate.z);
-    obb.update();
+    obb.updateMatrixWorld(true);
 
     it('should correctly instance obb', () => {
         assert.equal(obb.natBox.min.x, min.x);


### PR DESCRIPTION
## Description
Remove tile's `OBB` (oriented bounding box)

## Motivation and Context
Simplify the data structure and in future simplify the clean processing

see #1991
