### PR TITLE
version 2.39.1-next.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "itowns",
-  "version": "2.39.0",
+  "version": "2.39.1-next.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "itowns",
-      "version": "2.38.2",
+      "version": "2.39.1-next.0",
       "license": "(CECILL-B OR MIT)",
       "dependencies": {
         "@loaders.gl/las": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itowns",
-  "version": "2.39.0",
+  "version": "2.39.1-next.0",
   "description": "A JS/WebGL framework for 3D geospatial data visualization",
   "main": "lib/Main.js",
   "exports": {


### PR DESCRIPTION
Manualy bump the next version (on `next` branch) to remedy the fact that a a 2.39.1-next.0 version has already been pushed when #1909 was merged. Therefore, the `next` branch must begin from this same 2.39.1-next.0 version to work as intended.

After that, any merge on master should have a working publication for the next version.