### PR TITLE
Picking bugfix and API improvements

### DIFF
--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -46,6 +46,9 @@
                 var view;
                 var controls;
 
+                // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+                itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
                 viewerDiv = document.getElementById('viewerDiv');
                 viewerDiv.style.display = 'block';
 

--- a/examples/widgets_minimap.html
+++ b/examples/widgets_minimap.html
@@ -109,7 +109,7 @@
             // When double-clicking the minimap, travel to the cursor location.
             const cursorCoordinates = new itowns.Coordinates(minimap.view.referenceCrs);
             minimap.domElement.addEventListener('dblclick', (event) => {
-                minimap.view.pickCoordinates(event, cursorCoordinates);
+                minimap.view.pickTerrainCoordinates(event, cursorCoordinates);
                 view.controls.lookAtCoordinate({ coord: cursorCoordinates });
             });
 

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -58,7 +58,11 @@ class Coordinates {
     /**
      * @constructor
      *
-     * @param {string} crs - A supported crs (see the `crs` property below).
+     * @param {string} crs - A supported Coordinate Reference System. 'EPSG:4978' and 'EPSG:4326' are
+     * supported by default. To use another CRS, you have to declare it with proj4. For instance:
+     * @example
+     * itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+     * You can find most projections and their proj4 code at [epsg.io]{@link https://epsg.io/}
      * @param {number|Array<number>|Coordinates|THREE.Vector3} [v0=0] -
      * x or longitude value, or a more complex one: it can be an array of three
      * numbers, being x/lon, x/lat, z/alt, or it can be `THREE.Vector3`. It can
@@ -90,6 +94,15 @@ class Coordinates {
         }
 
         this._normalNeedsUpdate = true;
+    }
+
+    /**
+     * Sets the Coordinate Reference System.
+     * @param {String} crs Coordinate Reference System (e.g. 'EPSG:4978')
+     */
+    setCrs(crs) {
+        CRS.isValid(crs);
+        this.crs = crs;
     }
 
     /**

--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import RenderMode from 'Renderer/RenderMode';
 import { unpack1K } from 'Renderer/LayeredMaterial';
+import Coordinates from 'Core/Geographic/Coordinates';
 
 const depthRGBA = new THREE.Vector4();
 // TileMesh picking support function
@@ -84,6 +85,11 @@ function findLayerInParent(obj) {
 const raycaster = new THREE.Raycaster();
 const normalized = new THREE.Vector2();
 
+const pointPos = new THREE.Vector3();
+const pointPosCoord = new Coordinates('EPSG:4978'); // default crs, will be set to view crs when used
+const cameraPos = new THREE.Vector3();
+const cameraPosCoord = new Coordinates('EPSG:4978'); // default crs, will be set to view crs when used
+
 /**
  * @module Picking
  *
@@ -166,9 +172,22 @@ export default {
                 // if baseId matches objId, the clicked point belongs to `o`
                 for (let i = 0; i < candidates.length; i++) {
                     if (candidates[i].objId == o.baseId) {
+                        // Get point position: get the picked point from the buffer geometry and apply local to world
+                        // transform of the picked object
+                        pointPos.fromBufferAttribute(o.geometry.attributes.position, candidates[i].index);
+                        o.localToWorld(pointPos);
+                        // Compute distance to the camera
+                        pointPosCoord.setCrs(view.referenceCrs);
+                        pointPosCoord.setFromVector3(pointPos);
+                        view.camera.camera3D.getWorldPosition(cameraPos);
+                        cameraPosCoord.setCrs(view.referenceCrs);
+                        cameraPosCoord.setFromVector3(cameraPos);
+                        const dist = pointPosCoord.spatialEuclideanDistanceTo(cameraPosCoord);
                         result.push({
                             object: o,
+                            point: pointPos, // the position of the point in the 3D view. Same name and value than what's returned by pickObjectsAt
                             index: candidates[i].index,
+                            distance: dist,
                             layer,
                         });
                     }
@@ -215,6 +234,7 @@ export default {
         const clearG = Math.round(255 * clearColor.g);
         const clearB = Math.round(255 * clearColor.b);
 
+        // Raycaster use NDC coordinate
         const tmp = normalized.clone();
         traversePickingCircle(radius, (x, y) => {
             // x, y are offset from the center of the picking circle,

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -960,12 +960,12 @@ class View extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the world position (view's crs: referenceCrs) under view coordinates.
+     * Returns the world position on the terrain (view's crs: referenceCrs) under view coordinates.
      * This position is computed with depth buffer.
      *
      * @param      {THREE.Vector2}  mouse  position in view coordinates (in pixel), if it's null so it's view's center.
      * @param      {THREE.Vector3}  [target=THREE.Vector3()] target. the result will be copied into this Vector3. If not present a new one will be created.
-     * @return     {THREE.Vector3}  the world position in view's crs: referenceCrs.
+     * @return     {THREE.Vector3}  the world position on the terrain in view's crs: referenceCrs.
      */
 
     getPickingPositionFromDepth(mouse, target = new THREE.Vector3()) {
@@ -1032,18 +1032,19 @@ class View extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the world {@link Coordinates} at given view coordinates.
+     * Returns the world {@link Coordinates} of the terrain at given view coordinates.
      *
-     * @param   {THREE.Vector2|event}   [mouse]     The view coordinates at which the world coordinates must be
-                                                    * returned. This parameter can also be set to a mouse event from
-                                                    * which the view coordinates will be deducted. If not specified, it
-                                                    * will be defaulted to the view's center coordinates.
-     * @param   {Coordinates}           [target]    The result will be copied into this {@link Coordinates}. If not
-                                                    * specified, a new {@link Coordinates} instance will be created.
+     * @param {THREE.Vector2|event} [mouse] The view coordinates at which the world coordinates must be returned. This
+     * parameter can also be set to a mouse event from which the view coordinates will be deducted. If not specified,
+     * it will be defaulted to the view's center coordinates.
+     * @param {Coordinates} [target] The result will be copied into this {@link Coordinates} in the coordinate reference
+     * system of the given coordinate. If not specified, a new {@link Coordinates} instance will be created (in the
+     * view referenceCrs).
      *
-     * @returns {Coordinates}   The world {@link Coordinates} at the given view coordinates.
+     * @returns {Coordinates}   The world {@link Coordinates} of the terrain at the given view coordinates in the
+     * coordinate reference system of the target or in the view referenceCrs if no target is specified.
      */
-    pickCoordinates(mouse, target = new Coordinates(this.tileLayer.extent.crs)) {
+    pickTerrainCoordinates(mouse, target = new Coordinates(this.referenceCrs)) {
         if (mouse instanceof Event) {
             this.eventToViewCoords(mouse);
         } else if (mouse && mouse.x !== undefined && mouse.y !== undefined) {
@@ -1061,6 +1062,25 @@ class View extends THREE.EventDispatcher {
         coordinates.as(target.crs, target);
 
         return target;
+    }
+
+    /**
+     * Returns the world {@link Coordinates} of the terrain at given view coordinates.
+     *
+     * @param   {THREE.Vector2|event}   [mouse]     The view coordinates at which the world coordinates must be
+                                                    * returned. This parameter can also be set to a mouse event from
+                                                    * which the view coordinates will be deducted. If not specified, it
+                                                    * will be defaulted to the view's center coordinates.
+     * @param   {Coordinates}           [target]    The result will be copied into this {@link Coordinates}. If not
+                                                    * specified, a new {@link Coordinates} instance will be created.
+     *
+     * @returns {Coordinates}   The world {@link Coordinates} of the terrain at the given view coordinates.
+     *
+     * @deprecated Use View#pickTerrainCoordinates instead.
+     */
+    pickCoordinates(mouse, target = new Coordinates(this.referenceCrs)) {
+        console.warn('Deprecated, use View#pickTerrainCoordinates instead.');
+        return this.pickTerrainCoordinates(mouse, target);
     }
 
     /**


### PR DESCRIPTION
Some bugfixes and API modifications I had to make for Elevation measure widget #1881 (this PR contains the first commits of PR #1881 that do not relate to elevation measure widget.

fix(picking): fix picking on multiple layers
refacto(view): rename pickCoordinates to pickTerrainCoordinates
example(potree_25d_map): declare map projection code
feat(picking): Add distance and point position to returned object by points picking
feat(Coordinates): Add a setCrs method

These commits have already reviewed in #1881 , so if we can merge it quickly I would appreciate :)