### PR TITLE
Rework style

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -253,7 +253,7 @@ h3 {
 
 .tooltip {
     display: none;
-    background-image: linear-gradient(rgba(80, 80, 80,0.95), rgba(60, 60, 60,0.95));
+    background-image: linear-gradient(rgba(167, 164, 164, 0.95), rgba(60, 60, 60,0.95));
     box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
     margin-top: 20px;
     margin-left: 20px;

--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -64,42 +64,38 @@ const FeatureToolTip = (function _() {
         }
     }
 
-    function getGeometryProperties(geometry) {
-        return function properties() { return geometry.properties; };
-    }
-
     function fillToolTip(features, layer, options) {
         let content = '';
         let feature;
         let geometry;
-        let style;
+        const style = layer.style;
         let fill;
         let stroke;
         let symb = '';
         let prop;
 
+        const context = style.context;
+
         for (let p = 0; p < features.length; p++) {
             feature = features[p];
             geometry = feature.geometry;
-            style = (geometry.properties && geometry.properties.style) || feature.style || layer.style;
-            const context = { globals: {}, properties: getGeometryProperties(geometry) };
-            style = style.applyContext(context);
+
+            context.setFeature(feature);
+            context.setGeometry(geometry);
 
             if (feature.type === itowns.FEATURE_TYPES.POLYGON) {
                 symb = '&#9724';
-                if (style) {
-                    fill = style.fill && style.fill.color;
-                    stroke = style.stroke && ('1.25px ' + style.stroke.color);
-                }
+                fill = style.fill && style.fill.color;
+                stroke = style.stroke && ('1.25px ' + style.stroke.color);
             } else if (feature.type === itowns.FEATURE_TYPES.LINE) {
                 symb = '&#9473';
-                fill = style && style.stroke && style.stroke.color;
+                fill = style.stroke && style.stroke.color;
                 stroke = '0px';
             } else if (feature.type === itowns.FEATURE_TYPES.POINT) {
                 symb = '&#9679';
-                if (style && style.point) {  // Style and style.point can be undefined if no style options were passed
-                    fill = style.point.color;
-                    stroke = '1.25px ' + style.point.line;
+                if (style.point || style.icon) {  // Style and style.point can be undefined if no style options were passed
+                    fill = (style.point && style.point.color) || (style.icon && style.icon.color);
+                    stroke = '1.25px ' + ((style.point && style.point.line) || 'black');
                 }
             }
 
@@ -109,10 +105,10 @@ const FeatureToolTip = (function _() {
             content += '</span>';
 
             if (geometry.properties) {
-                content += (geometry.properties.description || geometry.properties.name || geometry.properties.nom || layer.name || '');
+                content += (geometry.properties.description || geometry.properties.name || geometry.properties.nom || geometry.properties.title || layer.name || '');
             }
 
-            if (feature.type === itowns.FEATURE_TYPES.POINT) {
+            if (feature.type === itowns.FEATURE_TYPES.POINT && options.writeLatLong) {
                 content += '<br/><span class="coord">long ' + feature.coordinates[0].toFixed(4) + '</span>';
                 content += '<br/><span class="coord">lat ' + feature.coordinates[1].toFixed(4) + '</span>';
             }
@@ -231,8 +227,8 @@ const FeatureToolTip = (function _() {
             }
 
             const opts = options || { filterAllProperties: true };
-            opts.filterProperties = opts.filterProperties == undefined ? [] : opts.filterProperties;
-            opts.filterProperties.concat(['name', 'nom', 'style', 'description']);
+            opts.filterProperties = opts.filterProperties === undefined ? [] : opts.filterProperties;
+            opts.writeLatLong = opts.writeLatLong || false;
 
             layers.push({ layer: layer, options: opts });
             layersId.push(layer.id);

--- a/examples/source_file_gpx_3d.html
+++ b/examples/source_file_gpx_3d.html
@@ -61,6 +61,15 @@
 
             var waypointGeometry = new itowns.THREE.BoxGeometry(1, 1, 80);
             var waypointMaterial = new itowns.THREE.MeshBasicMaterial({ color: 0xffffff });
+            const style = {
+                stroke: {
+                    color: 'red',
+                    width: 2,
+                },
+                point: {
+                    color: 'white',
+                }
+            };
             // Listen for globe full initialisation event
             view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, function () {
                 console.info('Globe initialized');
@@ -72,18 +81,9 @@
                         out: {
                             crs: view.referenceCrs,
                             structure: '3d',
-                            style: new itowns.Style({
-                                stroke: {
-                                    color: 'red',
-                                    width: 2,
-                                },
-                                point: {
-                                    color: 'white',
-                                }
-                            }),
                         }
                     }))
-                    .then(itowns.Feature2Mesh.convert())
+                    .then(itowns.Feature2Mesh.convert({style}))
                     .then(function (mesh) {
                         if (mesh) {
                             mesh.updateMatrixWorld();

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -7,7 +7,7 @@ import Extent from 'Core/Geographic/Extent';
 import Crs from 'Core/Geographic/Crs';
 import OrientationUtils from 'Utils/OrientationUtils';
 import Coordinates from 'Core/Geographic/Coordinates';
-import { StyleContext } from 'Core/Style';
+import Style, { StyleContext } from 'Core/Style';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 const context = new StyleContext();
@@ -194,6 +194,7 @@ function featureToPoint(feature, options) {
 
     const pointMaterialSize = [];
     context.globals = { point: true };
+    context.setFeature(feature);
 
     for (const geometry of feature.geometries) {
         const start = geometry.indices[0].offset;
@@ -208,7 +209,7 @@ function featureToPoint(feature, options) {
             }
 
             coord.copy(context.setLocalCoordinatesFromArray(feature.vertices, v));
-            const style = feature.style.applyContext(context);
+            const style = Style.applyContext(context);
             const { base_altitude, color, radius } = style.point;
             coord.z = 0;
 
@@ -253,6 +254,7 @@ function featureToLine(feature, options) {
 
     const lineMaterialWidth = [];
     context.globals = { stroke: true };
+    context.setFeature(feature);
 
     const countIndices = (count - feature.geometries.length) * 2;
     const indices = getIntArrayFromSize(countIndices, count);
@@ -288,7 +290,7 @@ function featureToLine(feature, options) {
             }
 
             coord.copy(context.setLocalCoordinatesFromArray(feature.vertices, v));
-            const style = feature.style.applyContext(context);
+            const style = Style.applyContext(context);
             const { base_altitude, color, width } = style.stroke;
             coord.z = 0;
 
@@ -322,6 +324,7 @@ function featureToPolygon(feature, options) {
     const batchIds = new Uint32Array(vertices.length / 3);
     const batchId = options.batchId || ((p, id) => id);
     context.globals = { fill: true };
+    context.setFeature(feature);
 
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
     normal.set(0, 0, 1).multiply(inverseScale);
@@ -349,7 +352,7 @@ function featureToPolygon(feature, options) {
             }
 
             coord.copy(context.setLocalCoordinatesFromArray(feature.vertices, i));
-            const style = feature.style.applyContext(context);
+            const style = Style.applyContext(context);
             const { base_altitude, color } = style.fill;
             coord.z = 0;
 
@@ -410,6 +413,7 @@ function featureToExtrudedPolygon(feature, options) {
     let featureId = 0;
 
     context.globals = { fill: true };
+    context.setFeature(feature);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
     normal.set(0, 0, 1).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
@@ -435,7 +439,7 @@ function featureToExtrudedPolygon(feature, options) {
 
             coord.copy(context.setLocalCoordinatesFromArray(ptsIn, i));
 
-            const style = feature.style.applyContext(context);
+            const style = Style.applyContext(context);
             const { base_altitude, extrusion_height, color } = style.fill;
             coord.z = 0;
 
@@ -653,6 +657,7 @@ export default {
                 // as in examples/source_file_gpx_3d.html.
                 options.layer = this || { style: options.style };
             }
+            context.layerStyle = options.layer.style;
 
             context.setCollection(collection);
 

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -424,7 +424,7 @@ export class FeatureCollection extends THREE.Object3D {
     /**
      * Updates the global transform of the object and its descendants.
      *
-     * @param {booolean}  force   The force
+     * @param {boolean}  force   The force
      */
     updateMatrixWorld(force) {
         super.updateMatrixWorld(force);
@@ -497,13 +497,5 @@ export class FeatureCollection extends THREE.Object3D {
         ref._pos = feature._pos;
         this.features.push(ref);
         return ref;
-    }
-
-    setParentStyle(style) {
-        if (style) {
-            this.features.forEach((f) => {
-                f.style.parent = style;
-            });
-        }
     }
 }

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -251,7 +251,7 @@ class Feature {
         }
         this._pos = 0;
         this._pushValues = (this.size === 3 ? push3DValues : push2DValues).bind(this);
-        this.style = new Style({}, collection.style);
+        this.style = Style.setFromProperties;
     }
     /**
      * Instance a new {@link FeatureGeometry}  and push in {@link Feature}.

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -83,7 +83,7 @@ class Label extends THREE.Object3D {
 
         if (typeof content === 'string') {
             this.content = document.createElement('div');
-            this.content.textContent = content;
+            this.content.textContent = style.text.field;
         } else {
             this.content = content.cloneNode(true);
         }

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -755,19 +755,27 @@ class Style {
      *
      * @returns {StyleOptions} containing all properties for itowns.Style
      */
-    setFromVectorTileLayer(layer, sprites, order = 0, symbolToCircle = false) {
+    static setFromVectorTileLayer(layer, sprites, order = 0, symbolToCircle = false) {
+        const style = {
+            fill: {},
+            stroke: {},
+            point: {},
+            text: {},
+            icon: {},
+        };
+
         layer.layout = layer.layout || {};
         layer.paint = layer.paint || {};
 
-        this.order = order;
+        style.order = order;
 
-        if (layer.type === 'fill' && !this.fill.color) {
+        if (layer.type === 'fill') {
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['fill-color'] || layer.paint['fill-pattern'], { type: 'color' }));
-            this.fill.color = color;
-            this.fill.opacity = readVectorProperty(layer.paint['fill-opacity']) || opacity;
+            style.fill.color = color;
+            style.fill.opacity = readVectorProperty(layer.paint['fill-opacity']) || opacity;
             if (layer.paint['fill-pattern']) {
                 try {
-                    this.fill.pattern = {
+                    style.fill.pattern = {
                         id: layer.paint['fill-pattern'],
                         source: sprites.source,
                         cropValues: sprites[layer.paint['fill-pattern']],
@@ -780,82 +788,82 @@ class Style {
 
             if (layer.paint['fill-outline-color']) {
                 const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['fill-outline-color'], { type: 'color' }));
-                this.stroke.color = color;
-                this.stroke.opacity = opacity;
-                this.stroke.width = 1.0;
-                this.stroke.dasharray = [];
+                style.stroke.color = color;
+                style.stroke.opacity = opacity;
+                style.stroke.width = 1.0;
+                style.stroke.dasharray = [];
             }
-        } else if (layer.type === 'line' && !this.stroke.color) {
+        } else if (layer.type === 'line') {
             const prepare = readVectorProperty(layer.paint['line-color'], { type: 'color' });
             const { color, opacity } = rgba2rgb(prepare);
-            this.stroke.dasharray = readVectorProperty(layer.paint['line-dasharray']);
-            this.stroke.color = color;
-            this.stroke.lineCap = layer.layout['line-cap'];
-            this.stroke.width = readVectorProperty(layer.paint['line-width']);
-            this.stroke.opacity = readVectorProperty(layer.paint['line-opacity']) || opacity;
+            style.stroke.dasharray = readVectorProperty(layer.paint['line-dasharray']);
+            style.stroke.color = color;
+            style.stroke.lineCap = layer.layout['line-cap'];
+            style.stroke.width = readVectorProperty(layer.paint['line-width']);
+            style.stroke.opacity = readVectorProperty(layer.paint['line-opacity']) || opacity;
         } else if (layer.type === 'circle' || symbolToCircle) {
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['circle-color'], { type: 'color' }));
-            this.point.color = color;
-            this.point.opacity = opacity;
-            this.point.radius = readVectorProperty(layer.paint['circle-radius']);
+            style.point.color = color;
+            style.point.opacity = opacity;
+            style.point.radius = readVectorProperty(layer.paint['circle-radius']);
         } else if (layer.type === 'symbol') {
             // overlapping order
-            this.text.zOrder = readVectorProperty(layer.layout['symbol-z-order']);
-            if (this.text.zOrder == 'auto') {
-                this.text.zOrder = readVectorProperty(layer.layout['symbol-sort-key']) || 'Y';
-            } else if (this.text.zOrder == 'viewport-y') {
-                this.text.zOrder = 'Y';
-            } else if (this.text.zOrder == 'source') {
-                this.text.zOrder = 0;
+            style.text.zOrder = readVectorProperty(layer.layout['symbol-z-order']);
+            if (style.text.zOrder == 'auto') {
+                style.text.zOrder = readVectorProperty(layer.layout['symbol-sort-key']) || 'Y';
+            } else if (style.text.zOrder == 'viewport-y') {
+                style.text.zOrder = 'Y';
+            } else if (style.text.zOrder == 'source') {
+                style.text.zOrder = 0;
             }
 
             // position
-            this.text.anchor = readVectorProperty(layer.layout['text-anchor']);
-            this.text.offset = readVectorProperty(layer.layout['text-offset']);
-            this.text.padding = readVectorProperty(layer.layout['text-padding']);
-            this.text.size = readVectorProperty(layer.layout['text-size']);
-            this.text.placement = readVectorProperty(layer.layout['symbol-placement']);
-            this.text.rotation = readVectorProperty(layer.layout['text-rotation-alignment']);
+            style.text.anchor = readVectorProperty(layer.layout['text-anchor']);
+            style.text.offset = readVectorProperty(layer.layout['text-offset']);
+            style.text.padding = readVectorProperty(layer.layout['text-padding']);
+            style.text.size = readVectorProperty(layer.layout['text-size']);
+            style.text.placement = readVectorProperty(layer.layout['symbol-placement']);
+            style.text.rotation = readVectorProperty(layer.layout['text-rotation-alignment']);
 
             // content
-            this.text.field = readVectorProperty(layer.layout['text-field']);
-            this.text.wrap = readVectorProperty(layer.layout['text-max-width']);
-            this.text.spacing = readVectorProperty(layer.layout['text-letter-spacing']);
-            this.text.transform = readVectorProperty(layer.layout['text-transform']);
-            this.text.justify = readVectorProperty(layer.layout['text-justify']);
+            style.text.field = readVectorProperty(layer.layout['text-field']);
+            style.text.wrap = readVectorProperty(layer.layout['text-max-width']);
+            style.text.spacing = readVectorProperty(layer.layout['text-letter-spacing']);
+            style.text.transform = readVectorProperty(layer.layout['text-transform']);
+            style.text.justify = readVectorProperty(layer.layout['text-justify']);
 
             // appearance
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['text-color'], { type: 'color' }));
-            this.text.color = color;
-            this.text.opacity = readVectorProperty(layer.paint['text-opacity']) || (opacity !== undefined && opacity);
+            style.text.color = color;
+            style.text.opacity = readVectorProperty(layer.paint['text-opacity']) || (opacity !== undefined && opacity);
 
-            this.text.font = readVectorProperty(layer.layout['text-font']);
+            style.text.font = readVectorProperty(layer.layout['text-font']);
             const haloColor = readVectorProperty(layer.paint['text-halo-color'], { type: 'color' });
             if (haloColor) {
-                this.text.haloColor = haloColor.color || haloColor;
-                this.text.haloWidth = readVectorProperty(layer.paint['text-halo-width']);
-                this.text.haloBlur = readVectorProperty(layer.paint['text-halo-blur']);
+                style.text.haloColor = haloColor.color || haloColor;
+                style.text.haloWidth = readVectorProperty(layer.paint['text-halo-width']);
+                style.text.haloBlur = readVectorProperty(layer.paint['text-halo-blur']);
             }
 
             // additional icon
             const iconImg = readVectorProperty(layer.layout['icon-image']);
             if (iconImg) {
                 try {
-                    this.icon.id = iconImg;
-                    this.icon.source = sprites.source;
-                    this.icon.cropValues = sprites[iconImg];
+                    style.icon.id = iconImg;
+                    style.icon.source = sprites.source;
+                    style.icon.cropValues = sprites[iconImg];
 
-                    this.icon.size = readVectorProperty(layer.layout['icon-size']) || 1;
+                    style.icon.size = readVectorProperty(layer.layout['icon-size']) || 1;
                     const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['icon-color'], { type: 'color' }));
-                    this.icon.color = color;
-                    this.icon.opacity = readVectorProperty(layer.paint['icon-opacity']) || (opacity !== undefined && opacity);
+                    style.icon.color = color;
+                    style.icon.opacity = readVectorProperty(layer.paint['icon-opacity']) || (opacity !== undefined && opacity);
                 } catch (err) {
                     err.message = `VTlayer '${layer.id}': argument sprites must not be null when using layer.layout['icon-image']`;
                     throw err;
                 }
             }
         }
-        return this;
+        return style;
     }
 
     /**

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -146,13 +146,7 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
         name,
         {
             enumerable: true,
-            get: () => {
-                if (property === undefined) {
-                    return style.parent[category][name] || defaultValue;
-                } else {
-                    return property;
-                }
-            },
+            get: () => property ?? defaultValue,
             set: (v) => {
                 property = v;
             },
@@ -548,23 +542,12 @@ class Style {
      * @param {StyleOptions} [params={}] An object that contain any properties
      * (order, zoom, fill, stroke, point, text or/and icon)
      * and sub properties of a Style (@see {@link StyleOptions}).
-     * @param {Style} [parent] The parent style, that is looked onto if a value
-     * is missing.
      * @constructor
      */
-    constructor(params = {}, parent) {
+    constructor(params = {}) {
         this.isStyle = true;
 
         this.order = params.order || 0;
-
-        this.parent = parent || {
-            zoom: {},
-            fill: {},
-            stroke: {},
-            point: {},
-            text: {},
-            icon: {},
-        };
 
         params.zoom = params.zoom || {};
         params.fill = params.fill || {};

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -163,7 +163,9 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  *
  * @property {Object}           globals Style type (fill, stroke, point, text and or icon) to consider, it also
  *                                  contains the current zoom.
- * @property {Object}           collection The FeatureCollection to which the FeatureGeometry is attached
+ * @property {Object}           collection The FeatureCollection to which the FeatureGeometry is attached.
+ * @property {Object}           properties Properties of the FeatureGeometry.
+ * @property {string}           type Geometry type of the feature. Can be `point`, `line`, or `polygon`.
  * @property {Coordinates}      coordinates The coordinates (in world space) of the last vertex (x, y, z) set with
  *                                  setLocalCoordinatesFromArray().
  * private properties:
@@ -171,18 +173,24 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * @property {Coordinates}      localCoordinates @private Coordinates object to store coordinates in local space.
  * @property {boolean}          worldCoordsComputed @private Have the world coordinates already been computed
  *                                  from the local coordinates?
+ * @property {Feature}          feature  @private The itowns feature of interest.
  * @property {FeatureGeometry}  geometry  @private The FeatureGeometry to compute the style.
  */
 export class StyleContext {
     #worldCoord = new Coordinates('EPSG:4326', 0, 0, 0);
     #localCoordinates = new Coordinates('EPSG:4326', 0, 0, 0);
     #worldCoordsComputed = true;
+    #feature = {};
     #geometry = {};
     /**
      * @constructor
      */
     constructor() {
         this.globals = {};
+    }
+
+    setFeature(f) {
+        this.#feature = f;
     }
 
     setGeometry(g) {
@@ -201,6 +209,10 @@ export class StyleContext {
 
     get properties() {
         return this.#geometry.properties;
+    }
+
+    get type() {
+        return this.#feature.type;
     }
 
     get coordinates() {
@@ -646,7 +658,7 @@ class Style {
      * Map style object properties (fill, stroke, point, text and icon) from context to Style.
      * Only the necessary properties are mapped to object.
      * if a property is expression, the mapped value will be the expression result depending on context.
-     * @param  {Object}  context  The context of the FeatureGeometry that we want to get the Style.
+     * @param  {StyleContext}  context  The context of the FeatureGeometry that we want to get the Style.
      *
      * @return {Style}  mapped style depending on context.
      */

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -674,11 +674,12 @@ class Style {
     /**
      * set Style from (geojson-like) properties.
      * @param {Object} properties (geojson-like) properties.
-     * @param {Number} type
+     * @param {FeatureContext} featCtx the context of the feature
      *
      * @returns {StyleOptions} containing all properties for itowns.Style
      */
-    static setFromProperties(properties, type) {
+    static setFromProperties(properties, featCtx) {
+        const type = featCtx.type;
         const style = {};
         if (type === FEATURE_TYPES.POINT) {
             const point = {

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -695,17 +695,26 @@ class Style {
      *
      * @returns {StyleOptions} containing all properties for itowns.Style
      */
-    setFromGeojsonProperties(properties, type) {
+    static setFromProperties(properties, type) {
+        const style = {};
         if (type === FEATURE_TYPES.POINT) {
-            this.point.color = properties.fill;
-            this.point.opacity = properties['fill-opacity'];
-            this.point.line = properties.stroke;
-            this.point.radius = properties.radius;
-
-            this.text.color = properties['label-color'];
-            this.text.opacity = properties['label-opacity'];
-            this.text.size = properties['label-size'];
-
+            const point = {
+                ...(properties.fill !== undefined && { color: properties.fill }),
+                ...(properties['fill-opacity'] !== undefined && { opacity: properties['fill-opacity'] }),
+                ...(properties.stroke !== undefined && { line: properties.stroke }),
+                ...(properties.radius !== undefined && { radius: properties.radius }),
+            };
+            if (Object.keys(point).length) {
+                style.point = point;
+            }
+            const text = {
+                ...(properties['label-color'] !== undefined && { color: properties['label-color'] }),
+                ...(properties['label-opacity'] !== undefined && { opacity: properties['label-opacity'] }),
+                ...(properties['label-size'] !== undefined && { size: properties['label-size'] }),
+            };
+            if (Object.keys(point).length) {
+                style.text = text;
+            }
             const icon = {
                 ...(properties.icon !== undefined && { source: properties.icon }),
                 ...(properties['icon-scale'] !== undefined && { size: properties['icon-scale'] }),
@@ -713,19 +722,28 @@ class Style {
                 ...(properties['icon-color'] !== undefined && { color: properties['icon-color'] }),
             };
             if (Object.keys(icon).length) {
-                this.icon = icon;
+                style.icon = icon;
             }
         } else {
-            this.stroke.color = properties.stroke;
-            this.stroke.width = properties['stroke-width'];
-            this.stroke.opacity = properties['stroke-opacity'];
-
+            const stroke = {
+                ...(properties.stroke !== undefined && { color: properties.stroke }),
+                ...(properties['stroke-width'] !== undefined && { width: properties['stroke-width'] }),
+                ...(properties['stroke-opacity'] !== undefined && { opacity: properties['stroke-opacity'] }),
+            };
+            if (Object.keys(stroke).length) {
+                style.stroke = stroke;
+            }
             if (type !== FEATURE_TYPES.LINE) {
-                this.fill.color = properties.fill;
-                this.fill.opacity = properties['fill-opacity'];
+                const fill = {
+                    ...(properties.fill !== undefined && { color: properties.fill }),
+                    ...(properties['fill-opacity'] !== undefined && { opacity: properties['fill-opacity'] }),
+                };
+                if (Object.keys(fill).length) {
+                    style.fill = fill;
+                }
             }
         }
-        return this;
+        return style;
     }
 
     /**

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -17,7 +17,7 @@ const inv255 = 1 / 255;
 const canvas = (typeof document !== 'undefined') ? document.createElement('canvas') : {};
 const style_properties = {};
 
-function base_altitudeDefault(properties, ctx) {
+function baseAltitudeDefault(properties, ctx) {
     return ctx?.coordinates?.z || ctx?.collection?.center?.z || 0;
 }
 
@@ -581,7 +581,7 @@ class Style {
         defineStyleProperty(this, 'fill', 'color', params.fill.color);
         defineStyleProperty(this, 'fill', 'opacity', params.fill.opacity, 1.0);
         defineStyleProperty(this, 'fill', 'pattern', params.fill.pattern);
-        defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude, base_altitudeDefault);
+        defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude, baseAltitudeDefault);
         defineStyleProperty(this, 'fill', 'extrusion_height', params.fill.extrusion_height);
 
         this.stroke = {};
@@ -589,7 +589,7 @@ class Style {
         defineStyleProperty(this, 'stroke', 'opacity', params.stroke.opacity, 1.0);
         defineStyleProperty(this, 'stroke', 'width', params.stroke.width, 1.0);
         defineStyleProperty(this, 'stroke', 'dasharray', params.stroke.dasharray, []);
-        defineStyleProperty(this, 'stroke', 'base_altitude', params.stroke.base_altitude, base_altitudeDefault);
+        defineStyleProperty(this, 'stroke', 'base_altitude', params.stroke.base_altitude, baseAltitudeDefault);
 
         this.point = {};
         defineStyleProperty(this, 'point', 'color', params.point.color);
@@ -597,7 +597,7 @@ class Style {
         defineStyleProperty(this, 'point', 'opacity', params.point.opacity, 1.0);
         defineStyleProperty(this, 'point', 'radius', params.point.radius, 2.0);
         defineStyleProperty(this, 'point', 'width', params.point.width, 0.0);
-        defineStyleProperty(this, 'point', 'base_altitude', params.point.base_altitude, base_altitudeDefault);
+        defineStyleProperty(this, 'point', 'base_altitude', params.point.base_altitude, baseAltitudeDefault);
         defineStyleProperty(this, 'point', 'model', params.point.model);
 
         this.text = {};

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -49,6 +49,8 @@ export function readExpression(property, ctx) {
             // In this proposal, metadata will be accessed in the callee by the
             // `context.properties` property.
             return property(ctx.properties, ctx);
+        } else if (typeof property === 'string' || property instanceof String) {
+            return property.replace(/\{(.+?)\}/g, (a, b) => (ctx.properties[b] || '')).trim();
         } else {
             return property;
         }
@@ -716,24 +718,6 @@ class Style {
         }
         style.order = styleConc.order;
         return new Style(style);
-    }
-
-    /**
-     * Returns a string, associating `style.text.field` and properties to use to
-     * replace the keys in `style.text.field`.
-     *
-     * @param {FeatureContext} context The context linked to the feature
-     *
-     * @return {string|undefined} The formatted string if `style.text.field` is defined, nothing otherwise.
-     */
-    getTextFromProperties(context) {
-        if (!this.text.field) { return; }
-
-        if (this.text.field.expression) {
-            return readExpression(this.text.field, context);
-        } else {
-            return this.text.field.replace(/\{(.+?)\}/g, (a, b) => (context.properties()[b] || '')).trim();
-        }
     }
 
     /**

--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -373,6 +373,9 @@ class C3DTilesLayer extends GeometryLayer {
         if (!this._style) {
             return false;
         }
+        if (!this.object3d) {
+            return false;
+        }
 
         const currentMaterials = [];// list materials used for this update
 

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -84,7 +84,6 @@ class ColorLayer extends RasterLayer {
         deprecatedColorLayerOptions(config);
         super(id, config);
         this.isColorLayer = true;
-        this.style = config.style;
         this.defineLayerProperty('visible', true);
         this.defineLayerProperty('opacity', 1.0);
         this.defineLayerProperty('sequence', 0);

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -243,6 +243,7 @@ class LabelLayer extends GeometryLayer {
         // Converting the extent now is faster for further operation
         extent.as(data.crs, _extent);
         coord.crs = data.crs;
+
         context.globals = {
             icon: true,
             text: true,
@@ -259,7 +260,7 @@ class LabelLayer extends GeometryLayer {
 
             // determine if altitude style is specified by the user
             const altitudeStyle = f.style.point.base_altitude;
-            const isDefaultElevationStyle = altitudeStyle instanceof Function && altitudeStyle.name == 'base_altitudeDefault';
+            const isDefaultElevationStyle = altitudeStyle instanceof Function && altitudeStyle.name == 'baseAltitudeDefault';
 
             // determine if the altitude needs update with ElevationLayer
             labels.needsAltitude = labels.needsAltitude || this.forceClampToTerrain === true || (isDefaultElevationStyle && !f.hasRawElevationData);

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -6,7 +6,7 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 import Label from 'Core/Label';
 import { FEATURE_TYPES } from 'Core/Feature';
-import Style, { readExpression, StyleContext } from 'Core/Style';
+import { readExpression, StyleContext } from 'Core/Style';
 import { ScreenGrid } from 'Renderer/Label2DRenderer';
 
 const context = new StyleContext();
@@ -238,18 +238,11 @@ class LabelLayer extends GeometryLayer {
     convert(data, extent) {
         const labels = [];
 
-        const layerField = this.style && this.style.text && this.style.text.field;
-
         // Converting the extent now is faster for further operation
         extent.as(data.crs, _extent);
         coord.crs = data.crs;
 
-        context.globals = {
-            icon: true,
-            text: true,
-            zoom: extent.zoom,
-        };
-        context.layerStyle = this.style;
+        context.setZoom(extent.zoom);
 
         data.features.forEach((f) => {
             // TODO: add support for LINE and POLYGON
@@ -279,20 +272,20 @@ class LabelLayer extends GeometryLayer {
 
                 context.setGeometry(g);
                 let content;
+                this.style.setContext(context);
+                const layerField = this.style.text && this.style.text.field;
                 if (this.labelDomelement) {
                     content = readExpression(this.labelDomelement, context);
                 } else if (!geometryField && !featureField && !layerField) {
                     // Check if there is an icon, with no text
                     if (!(g.properties.style && (g.properties.style.icon.source || g.properties.style.icon.key))
                         && !(f.style && f.style.icon && (f.style.icon.source || f.style.icon.key))
-                        && !(this.style && this.style.icon && (this.style.icon.source || this.style.icon.key))) {
+                        && !(this.style.icon && (this.style.icon.source || this.style.icon.key))) {
                         return;
                     }
                 }
 
-                const style = Style.applyContext(context);
-
-                const label = new Label(content, coord.clone(), style);
+                const label = new Label(content, coord.clone(), this.style);
 
                 label.layerId = this.id;
                 label.padding = this.margin || label.padding;

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -288,12 +288,6 @@ class LabelLayer extends GeometryLayer {
                         && !(this.style && this.style.icon && (this.style.icon.source || this.style.icon.key))) {
                         return;
                     }
-                } else if (geometryField) {
-                    content = new Style(g.properties.style).getTextFromProperties(context);
-                } else if (featureField) {
-                    content = new Style(f.style).getTextFromProperties(context);
-                } else if (layerField) {
-                    content = new Style(this.style).getTextFromProperties(context);
                 }
 
                 const style = Style.applyContext(context);

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -98,6 +98,8 @@ class Layer extends THREE.EventDispatcher {
             throw new Error(`Layer ${id} needs Source`);
         }
         super();
+        this.isLayer = true;
+
         if (config.style && !(config.style instanceof Style)) {
             if (typeof config.style.fill?.pattern === 'string') {
                 console.warn('Using style.fill.pattern = { source: Img|url } is adviced');
@@ -105,8 +107,7 @@ class Layer extends THREE.EventDispatcher {
             }
             config.style = new Style(config.style);
         }
-        this.isLayer = true;
-
+        this.style = config.style || new Style();
         Object.assign(this, config);
 
         Object.defineProperty(this, 'id', {

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -73,8 +73,9 @@ const toFeature = {
         }
 
         const geometry = feature.bindNewGeometry();
+        properties.style = Style.setFromProperties(properties, feature.type);
         geometry.properties = properties;
-        geometry.properties.style = new Style({}, feature.style).setFromGeojsonProperties(properties, feature.type);
+
         this.populateGeometry(crsIn, coordsIn, geometry, feature);
         feature.updateExtent(geometry);
     },
@@ -84,8 +85,8 @@ const toFeature = {
             return;
         }
         const geometry = feature.bindNewGeometry();
+        properties.style = Style.setFromProperties(properties, feature.type);
         geometry.properties = properties;
-        geometry.properties.style = new Style({}, feature.style).setFromGeojsonProperties(properties, feature.type);
 
         // Then read contour and holes
         for (let i = 0; i < coordsIn.length; i++) {

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -1,6 +1,5 @@
 import Coordinates from 'Core/Geographic/Coordinates';
 import { FeatureCollection, FEATURE_TYPES } from 'Core/Feature';
-import Style from 'Core/Style';
 import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
 
 function readCRS(json) {
@@ -73,7 +72,6 @@ const toFeature = {
         }
 
         const geometry = feature.bindNewGeometry();
-        properties.style = Style.setFromProperties(properties, feature.type);
         geometry.properties = properties;
 
         this.populateGeometry(crsIn, coordsIn, geometry, feature);
@@ -85,7 +83,6 @@ const toFeature = {
             return;
         }
         const geometry = feature.bindNewGeometry();
-        properties.style = Style.setFromProperties(properties, feature.type);
         geometry.properties = properties;
 
         // Then read contour and holes

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -175,10 +175,6 @@ class FileSource extends Source {
                     this.extent.applyMatrix4(data.matrixWorld);
                 }
             }
-
-            if (data.isFeatureCollection) {
-                data.setParentStyle(options.out.style);
-            }
         });
     }
 

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -94,9 +94,11 @@ class VectorTilesSource extends TMSSource {
                 if (layer.type === 'background') {
                     this.backgroundLayer = layer;
                 } else if (ffilter(layer)) {
-                    const style = new Style().setFromVectorTileLayer(layer, this.sprites, order, this.symbolToCircle);
-                    style.zoom.min = layer.minzoom || 0;
-                    style.zoom.max = layer.maxzoom || 24;
+                    const style = Style.setFromVectorTileLayer(layer, this.sprites, order, this.symbolToCircle);
+                    style.zoom = {
+                        min: layer.minzoom || 0,
+                        max: layer.maxzoom || 24,
+                    };
                     this.styles[layer.id] = style;
 
                     if (!this.layers[layer['source-layer']]) {

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -138,9 +138,6 @@ class VectorTilesSource extends TMSSource {
                 console.warn('With VectorTilesSource and FeatureGeometryLayer, the accurate option is always false');
                 options.out.accurate = false;
             }
-            const keys = Object.keys(this.styles);
-
-            keys.forEach((k) => { this.styles[k].parent = options.out.style; });
         }
     }
 }

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -95,10 +95,6 @@ class VectorTilesSource extends TMSSource {
                     this.backgroundLayer = layer;
                 } else if (ffilter(layer)) {
                     const style = Style.setFromVectorTileLayer(layer, this.sprites, order, this.symbolToCircle);
-                    style.zoom = {
-                        min: layer.minzoom || 0,
-                        max: layer.maxzoom || 24,
-                    };
                     this.styles[layer.id] = style;
 
                     if (!this.layers[layer['source-layer']]) {

--- a/test/unit/3dtileslayerstyle.js
+++ b/test/unit/3dtileslayerstyle.js
@@ -4,7 +4,6 @@ import * as THREE from 'three';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import Extent from 'Core/Geographic/Extent';
 import PlanarView from 'Core/Prefab/PlanarView';
-import Style from 'Core/Style';
 import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
 import C3DTilesSource from 'Source/C3DTilesSource';
 import C3DTilesLayer from 'Layer/C3DTilesLayer';
@@ -35,6 +34,27 @@ describe('3DTilesLayer Style', () => {
         view,
     );
 
+    $3dTilesLayer.style = {
+        fill: {
+            color: (c3DTileFeature) => {
+                if (c3DTileFeature.batchId > 1) {
+                    return 'red';
+                } else {
+                    return 'blue';
+                }
+            },
+            opacity: (c3DTileFeature) => {
+                if (c3DTileFeature.getInfo().something) {
+                    return 0.1;
+                } else if (c3DTileFeature.userData.something === 'random') {
+                    return 1;
+                } else {
+                    return 0.5;
+                }
+            },
+        },
+    };
+
     // Create a 'fake' tile content for this test purpose
     const createTileContent = (tileId) => {
         const geometry = new THREE.SphereGeometry(15, 32, 16);
@@ -60,28 +80,6 @@ describe('3DTilesLayer Style', () => {
 
         return result;
     };
-
-    $3dTilesLayer.style = new Style({
-        fill: {
-            color: (c3DTileFeature) => {
-                if (c3DTileFeature.batchId > 1) {
-                    return 'red';
-                } else {
-                    return 'blue';
-                }
-            },
-            opacity: (c3DTileFeature) => {
-                if (c3DTileFeature.getInfo().something) {
-                    return 0.1;
-                } else if (c3DTileFeature.userData.something === 'random') {
-                    return 1;
-                } else {
-                    return 0.5;
-                }
-            },
-        },
-    });
-
 
     it('Load tile content', function () {
         for (let index = 0; index < 10; index++) {

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -56,15 +56,15 @@ describe('Label', function () {
     };
 
     before('init style', function () {
-        style = new Style();
-        style.setFromVectorTileLayer({
+        const layerVT = {
             type: 'symbol',
             paint: {},
             layout: {
                 'icon-image': 'icon',
                 'icon-size': 1,
             },
-        }, sprites);
+        };
+        style = new Style(Style.setFromVectorTileLayer(layerVT, sprites));
     });
 
     it('should throw errors for bad Label construction', function () {

--- a/test/unit/label.js
+++ b/test/unit/label.js
@@ -50,20 +50,21 @@ describe('Label', function () {
     let label;
     let style;
     const c = new Coordinates('EPSG:4326');
+    const layerVT = {
+        type: 'symbol',
+        paint: {},
+        layout: {
+            'icon-image': 'icon',
+            'icon-size': 1,
+            'text-field': 'label',
+        },
+    };
     const sprites = {
         img: '',
         icon: { x: 0, y: 0, width: 10, height: 10 },
     };
 
     before('init style', function () {
-        const layerVT = {
-            type: 'symbol',
-            paint: {},
-            layout: {
-                'icon-image': 'icon',
-                'icon-size': 1,
-            },
-        };
         style = new Style(Style.setFromVectorTileLayer(layerVT, sprites));
     });
 
@@ -72,9 +73,14 @@ describe('Label', function () {
         assert.throws(() => { label = new Label('content'); });
     });
 
-    it('should correctly create Labels', function () {
-        assert.doesNotThrow(() => { label = new Label('', c); });
-        assert.doesNotThrow(() => { label = new Label(document.createElement('div'), c); });
+    describe('should correctly create Labels', function () {
+        it('with label from style', function () {
+            assert.doesNotThrow(() => { label = new Label('', c, style); });
+            assert.equal(label.content.textContent, layerVT.layout['text-field']);
+        });
+        it('from a DomElement', function () {
+            assert.doesNotThrow(() => { label = new Label(document.createElement('div'), c); });
+        });
     });
 
     it('should hide the DOM', function () {

--- a/test/unit/style.js
+++ b/test/unit/style.js
@@ -308,12 +308,16 @@ describe('Style', function () {
             const imgId = 'filler';
             const vectorTileLayer = {
                 type: 'fill',
-                paint: {
-                    'fill-pattern': imgId,
-                    'fill-outline-color': '#eba55f',
-                },
+                paint: { 'fill-outline-color': '#eba55f' },
             };
+            it('without fill-pattern (or sprites)', () => {
+                const style = Style.setFromVectorTileLayer(vectorTileLayer);
+                // fill-outline-color
+                assert.equal(style.stroke.color, '#eba55f');
+            });
+
             it('with fill-pattern (and sprites)', () => {
+                vectorTileLayer.paint['fill-pattern'] = imgId;
                 const sprites = {
                     filler: { x: 0, y: 0, width: 0, height: 0, pixelRatio: 1 },
                     source: 'ImgUrl',
@@ -322,11 +326,6 @@ describe('Style', function () {
                 // fill-pattern
                 assert.equal(style.fill.pattern.id, imgId);
                 assert.equal(style.fill.pattern.cropValues, sprites[imgId]);
-            });
-            it('without fill-pattern (or sprites)', () => {
-                const style = Style.setFromVectorTileLayer(vectorTileLayer);
-                // fill-outline-color
-                assert.equal(style.stroke.color, '#eba55f');
             });
         });
         it("layer.type==='line'", () => {

--- a/test/unit/style.js
+++ b/test/unit/style.js
@@ -1,4 +1,5 @@
 import Style from 'Core/Style';
+import { FEATURE_TYPES } from 'Core/Feature';
 import assert from 'assert';
 import Fetcher from 'Provider/Fetcher';
 import { TextureLoader } from 'three';
@@ -276,6 +277,87 @@ describe('Style', function () {
                         done();
                     }).catch(done);
             });
+        });
+    });
+
+    describe('setFromProperties', () => {
+        it('FEATURE_TYPES.POINT', () => {
+            const properties = {
+                radius: 2,
+                'label-color': '#eba55f',
+                'icon-color': '#eba55f',
+            };
+            const style = Style.setFromProperties(properties, FEATURE_TYPES.POINT);
+            assert.equal(style.point.radius, 2);
+            assert.equal(style.text.color, '#eba55f');
+            assert.equal(style.icon.color, '#eba55f');
+        });
+        it('FEATURE_TYPES.POLYGON', () => {
+            const properties = {
+                fill: '#eba55f',
+                stroke: '#eba55f',
+            };
+            const style = Style.setFromProperties(properties, FEATURE_TYPES.POLYGON);
+            assert.equal(style.stroke.color, '#eba55f');
+            assert.equal(style.fill.color, '#eba55f');
+        });
+    });
+
+    describe('setFromVectorTileLayer', () => {
+        describe("layer.type==='fill'", () => {
+            const imgId = 'filler';
+            const vectorTileLayer = {
+                type: 'fill',
+                paint: {
+                    'fill-pattern': imgId,
+                    'fill-outline-color': '#eba55f',
+                },
+            };
+            it('with fill-pattern (and sprites)', () => {
+                const sprites = {
+                    filler: { x: 0, y: 0, width: 0, height: 0, pixelRatio: 1 },
+                    source: 'ImgUrl',
+                };
+                const style = Style.setFromVectorTileLayer(vectorTileLayer, sprites);
+                // fill-pattern
+                assert.equal(style.fill.pattern.id, imgId);
+                assert.equal(style.fill.pattern.cropValues, sprites[imgId]);
+            });
+            it('without fill-pattern (or sprites)', () => {
+                const style = Style.setFromVectorTileLayer(vectorTileLayer);
+                // fill-outline-color
+                assert.equal(style.stroke.color, '#eba55f');
+            });
+        });
+        it("layer.type==='line'", () => {
+            const vectorTileLayer = {
+                type: 'line',
+                paint: {
+                    'line-color': '#eba55f',
+                },
+            };
+            const style = Style.setFromVectorTileLayer(vectorTileLayer);
+            assert.equal(style.stroke.color, '#eba55f');
+        });
+        it("layer.type==='circle'", () => {
+            const vectorTileLayer = {
+                type: 'circle',
+                paint: {
+                    'circle-color': '#eba55f',
+                },
+            };
+            const style = Style.setFromVectorTileLayer(vectorTileLayer);
+            assert.equal(style.point.color, '#eba55f');
+        });
+        it("layer.type==='symbol'", () => {
+            const vectorTileLayer = {
+                type: 'symbol',
+                layout: {
+                    'symbol-z-order': 'auto',
+                },
+            };
+            const style = Style.setFromVectorTileLayer(vectorTileLayer);
+            assert.equal(style.text.zOrder, 'Y');
         });
     });
 });

--- a/test/unit/style.js
+++ b/test/unit/style.js
@@ -287,7 +287,7 @@ describe('Style', function () {
                 'label-color': '#eba55f',
                 'icon-color': '#eba55f',
             };
-            const style = Style.setFromProperties(properties, FEATURE_TYPES.POINT);
+            const style = Style.setFromProperties(properties, { type: FEATURE_TYPES.POINT });
             assert.equal(style.point.radius, 2);
             assert.equal(style.text.color, '#eba55f');
             assert.equal(style.icon.color, '#eba55f');
@@ -297,7 +297,7 @@ describe('Style', function () {
                 fill: '#eba55f',
                 stroke: '#eba55f',
             };
-            const style = Style.setFromProperties(properties, FEATURE_TYPES.POLYGON);
+            const style = Style.setFromProperties(properties, { type: FEATURE_TYPES.POLYGON });
             assert.equal(style.stroke.color, '#eba55f');
             assert.equal(style.fill.color, '#eba55f');
         });

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -5,6 +5,7 @@ import VectorTileParser from 'Parser/VectorTileParser';
 import VectorTilesSource from 'Source/VectorTilesSource';
 import Extent from 'Core/Geographic/Extent';
 import urlParser from 'Parser/MapBoxUrlParser';
+import Style from 'Core/Style';
 
 describe('Vector tiles', function () {
     // this PBF file comes from https://github.com/mapbox/vector-tile-js
@@ -140,8 +141,8 @@ describe('Vector tiles', function () {
                 },
             });
             source.whenReady.then(() => {
-                const styleLand_zoom_3 = source.styles.land.applyContext({ globals: { zoom: 3 }, properties: () => {} });
-                const styleLand_zoom_5 = source.styles.land.applyContext({ globals: { zoom: 5 }, properties: () => {} });
+                const styleLand_zoom_3 = new Style(source.styles.land).applyContext({ globals: { zoom: 3 }, properties: () => {} });
+                const styleLand_zoom_5 = new Style(source.styles.land).applyContext({ globals: { zoom: 5 }, properties: () => {} });
                 assert.equal(styleLand_zoom_3.fill.color, 'rgb(255,0,0)');
                 assert.equal(styleLand_zoom_3.fill.opacity, 1);
                 assert.equal(styleLand_zoom_5.fill.color, 'rgb(255,0,0)');

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -51,21 +51,21 @@ describe('Vector tiles', function () {
             assert.equal(square2[1], square2[4 * size + 1]);
 
             done();
-        });
+        }).catch(done);
     });
 
     it('returns nothing', (done) => {
         parse(null).then((collection) => {
             assert.equal(collection, undefined);
             done();
-        });
+        }).catch(done);
     });
 
     it('filters all features out', (done) => {
         parse(multipolygon, {}).then((collection) => {
             assert.equal(collection.features.length, 0);
             done();
-        });
+        }).catch(done);
     });
 
     describe('VectorTilesSource', function () {
@@ -87,7 +87,7 @@ describe('Vector tiles', function () {
                 // eslint-disable-next-line no-template-curly-in-string
                 assert.equal(source.url, 'http://server.geo/${z}/${x}/${y}.pbf');
                 done();
-            });
+            }).catch(done);
         });
 
         it('reads the background layer', (done) => {
@@ -101,7 +101,7 @@ describe('Vector tiles', function () {
             source.whenReady.then(() => {
                 assert.ok(source.backgroundLayer);
                 done();
-            });
+            }).catch(done);
         });
 
         it('creates styles and assigns filters', (done) => {
@@ -122,7 +122,7 @@ describe('Vector tiles', function () {
                 assert.ok(source.styles.land);
                 assert.equal(source.styles.land.fill.color, 'rgb(255,0,0)');
                 done();
-            });
+            }).catch(done);
         });
 
         it('get style from context', (done) => {
@@ -140,15 +140,16 @@ describe('Vector tiles', function () {
                     }],
                 },
             });
-            source.whenReady.then(() => {
-                const styleLand_zoom_3 = new Style(source.styles.land).applyContext({ globals: { zoom: 3 }, properties: () => {} });
-                const styleLand_zoom_5 = new Style(source.styles.land).applyContext({ globals: { zoom: 5 }, properties: () => {} });
-                assert.equal(styleLand_zoom_3.fill.color, 'rgb(255,0,0)');
-                assert.equal(styleLand_zoom_3.fill.opacity, 1);
-                assert.equal(styleLand_zoom_5.fill.color, 'rgb(255,0,0)');
-                assert.equal(styleLand_zoom_5.fill.opacity, 0.5);
-                done();
-            });
+            source.whenReady
+                .then(() => {
+                    const styleLand_zoom_3 = Style.applyContext({ globals: { zoom: 3 }, properties: () => {}, style: source.styles.land });
+                    const styleLand_zoom_5 = Style.applyContext({ globals: { zoom: 5 }, properties: () => {}, style: source.styles.land });
+                    assert.equal(styleLand_zoom_3.fill.color, 'rgb(255,0,0)');
+                    assert.equal(styleLand_zoom_3.fill.opacity, 1);
+                    assert.equal(styleLand_zoom_5.fill.color, 'rgb(255,0,0)');
+                    assert.equal(styleLand_zoom_5.fill.opacity, 0.5);
+                    done();
+                }).catch(done);
         });
 
         it('loads the style from a file', (done) => {
@@ -162,7 +163,7 @@ describe('Vector tiles', function () {
                 assert.equal(source.styles.land.zoom.min, 5);
                 assert.equal(source.styles.land.zoom.max, 13);
                 done();
-            });
+            }).catch(done);
         });
 
         it('sets the correct Style#zoom.min', (done) => {
@@ -222,7 +223,7 @@ describe('Vector tiles', function () {
                 assert.equal(source.styles.fourth.zoom.min, 0);
                 assert.equal(source.styles.fifth.zoom.min, 3);
                 done();
-            });
+            }).catch(done);
         });
 
         it('Vector tile source mapbox url', () => {

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -5,7 +5,6 @@ import VectorTileParser from 'Parser/VectorTileParser';
 import VectorTilesSource from 'Source/VectorTilesSource';
 import Extent from 'Core/Geographic/Extent';
 import urlParser from 'Parser/MapBoxUrlParser';
-import Style from 'Core/Style';
 
 describe('Vector tiles', function () {
     // this PBF file comes from https://github.com/mapbox/vector-tile-js
@@ -123,33 +122,6 @@ describe('Vector tiles', function () {
                 assert.equal(source.styles.land.fill.color, 'rgb(255,0,0)');
                 done();
             }).catch(done);
-        });
-
-        it('get style from context', (done) => {
-            const source = new VectorTilesSource({
-                url: 'fakeurl',
-                style: {
-                    sources: { geojson: {} },
-                    layers: [{
-                        id: 'land',
-                        type: 'fill',
-                        paint: {
-                            'fill-color': 'rgb(255, 0, 0)',
-                            'fill-opacity': { stops: [[2, 1], [5, 0.5]] },
-                        },
-                    }],
-                },
-            });
-            source.whenReady
-                .then(() => {
-                    const styleLand_zoom_3 = Style.applyContext({ globals: { zoom: 3 }, properties: () => {}, style: source.styles.land });
-                    const styleLand_zoom_5 = Style.applyContext({ globals: { zoom: 5 }, properties: () => {}, style: source.styles.land });
-                    assert.equal(styleLand_zoom_3.fill.color, 'rgb(255,0,0)');
-                    assert.equal(styleLand_zoom_3.fill.opacity, 1);
-                    assert.equal(styleLand_zoom_5.fill.color, 'rgb(255,0,0)');
-                    assert.equal(styleLand_zoom_5.fill.opacity, 0.5);
-                    done();
-                }).catch(done);
         });
 
         it('loads the style from a file', (done) => {


### PR DESCRIPTION
## Description
Change how itowns.Style() is used in relation with itowns.Feature.
- remove propertie 'style' at some level to keep to the miminum:
   - 2 were kept: layer and feature
   - 2 were removed: collection and geometry.properties
- make prioritarization of style work : layer (user) > feature (data) and this for all sub properties of style.
   - currently, the layer style is not always applied over the data style. (see example 1)
   -  when one properties of point, stroke or fill is given, it all needed to be given or the default value will be used even if the child properties is existing. 

Additional changes :
- The instanciation of itowns.style is now only done on converter and not anymore on Source nor during the Feature generation:
For that we currently create an object style, to store all properties used later on for the instanciation of itowns.Style().

- A slight change in base_altitude has been made, to be able to use a function for feature.style.

- All references to parent Style had been removed.

- Merge Style.symbolStylefromContext() with Style.drawingStylefromContext()


Examples:

1) source_file_kml_raster -> adding text.color: 'red'

in master branch:
![image](https://github.com/iTowns/itowns/assets/47628509/59c4d6bc-73ce-43d3-8a18-d6ce1acef1ee)   
with that PR:
![image](https://github.com/iTowns/itowns/assets/47628509/b58efd98-4e75-47cc-a051-2961adaf855b)
