### PR TITLE
Modif on Style to add icon properties

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -48,6 +48,7 @@
 
     "FileSource": {
         "source_file_geojson_raster": "GeoJSON to raster",
+        "source_file_geojson_raster_2": "USGS GeoJSON flux to raster (planar view)",
         "source_file_geojson_3d": "GeoJSON to 3D objects",
         "source_file_kml_raster": "KML to raster",
         "source_file_kml_raster_usgs": "USGS KML flux to raster",

--- a/examples/config.json
+++ b/examples/config.json
@@ -50,6 +50,7 @@
         "source_file_geojson_raster": "GeoJSON to raster",
         "source_file_geojson_3d": "GeoJSON to 3D objects",
         "source_file_kml_raster": "KML to raster",
+        "source_file_kml_raster_usgs": "USGS KML flux to raster",
         "source_file_gpx_raster": "GPX to raster",
         "source_file_gpx_3d": "GPX to 3D objects"
     },

--- a/examples/js/plugins/FeatureToolTip.js
+++ b/examples/js/plugins/FeatureToolTip.js
@@ -109,7 +109,7 @@ var FeatureToolTip = (function _() {
             content += '</span>';
 
             if (geometry.properties) {
-                content += (geometry.properties.name || geometry.properties.nom || geometry.properties.description || layer.name || '');
+                content += (geometry.properties.description || geometry.properties.name || geometry.properties.nom || layer.name || '');
             }
 
             if (feature.type === itowns.FEATURE_TYPES.POINT) {

--- a/examples/source_file_geojson_raster_2.html
+++ b/examples/source_file_geojson_raster_2.html
@@ -1,0 +1,119 @@
+<html>
+    <head>
+        <title>Itowns - Planar + color layers from vector data</title>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv" class="viewer"></div>
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="js/plugins/FeatureToolTip.js"></script>
+        <script type="text/javascript">
+            // # Orthographic viewer with one geojson layer and a TMS background layer
+
+            // Define geographic extent: CRS, min/max X, min/max Y
+            var extent = new itowns.Extent(
+                'EPSG:3857',
+                -20037508.34, 20037508.34,
+                -20048966.1, 20048966.1);
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            var viewerDiv = document.getElementById('viewerDiv');
+
+            // Instanciate PlanarView (with ortho camera)
+            // By default itowns' tiles geometry have a "skirt" (ie they have a height),
+            // but in case of orthographic we don't need this feature, so disable it
+            var view = new itowns.PlanarView(viewerDiv, extent, {
+                disableSkirt: true,
+                maxSubdivisionLevel: 10,
+                camera: { type: itowns.CAMERA_TYPE.ORTHOGRAPHIC },
+                placement: new itowns.Extent('EPSG:3857', -20000000, 20000000, -20000000, 20000000),
+                controls: {
+                    // Faster zoom in/out speed
+                    zoomFactor: 3,
+                    // prevent from zooming in too much
+                    maxResolution: 0.005  // a pixel shall not represent a metric size smaller than 5 mm
+                },
+            });
+
+            var menuGlobe = new GuiTools('menuDiv', view, 300);
+
+            setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
+
+            // Add a TMS layer to have a background (OpenStreetMap)
+            // -> TMS imagery source
+            var opensmSource = new itowns.TMSSource({
+                isInverted: true,
+                url: 'https://tile.openstreetmap.org/${z}/${x}/${y}.png',
+                networkOptions: { crossOrigin: 'anonymous' },
+                extent,
+                crs: 'EPSG:3857',
+                attribution: {
+                    name: 'OpenStreetMap',
+                    url: 'http://www.openstreetmap.org/',
+                },
+            });
+            // -> TMS imagery layer
+            var opensmLayer = new itowns.ColorLayer('OPENSM', {
+                updateStrategy: {
+                    type: itowns.STRATEGY_DICHOTOMY,
+                },
+                source: opensmSource,
+            });
+            view.addLayer(opensmLayer);
+
+            // Display the content of the GeoJSON file with ColorLayer and FileSource.
+            // The GeoJSON are loaded from url, set in FileSource
+
+            // Declare the source for the earthquakes data
+            const earthquakeSource = new itowns.FileSource({
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/' +
+                        'geojson/Earthquakes_3857.geojson',
+                crs: 'EPSG:3857',
+                format: 'application/json',
+            });
+
+            function offset(properties) {
+                const radius = properties.mag;
+                return [ 0, -radius ];
+            }
+
+            // Create a ColorLayer with the earthquake information
+            const earthquakeLayer = new itowns.ColorLayer('earthquakes', {
+                source: earthquakeSource,
+                style: new itowns.Style({
+                    point: {
+                        color: function (p) { return p.alert; },
+                        radius: function (p) { return p.mag; },
+                        line: 'black',
+                        width: 0.5,
+                    },
+                    text: {
+                        field: '{title}',
+                        haloColor: 'black',
+                        haloWidth: 1,
+                        anchor: 'bottom',
+                        offset: offset,
+                    },
+                }),
+                addLabelLayer: true,
+            });
+
+            // Add the earthquakes ColorLayer to the view and grant it a tooltip
+            view.addLayer(earthquakeLayer).then(FeatureToolTip.addLayer);
+
+            // Request redraw
+            view.notifyChange(true);
+
+            debug.createTileDebugUI(menuGlobe.gui, view);
+        </script>
+    </body>
+</html>

--- a/examples/source_file_kml_raster_usgs.html
+++ b/examples/source_file_kml_raster_usgs.html
@@ -1,0 +1,94 @@
+<html>
+    <head>
+        <title>Itowns - Globe + color layers from vector data</title>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv" class="viewer"></div>
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="js/plugins/FeatureToolTip.js"></script>
+        <script type="text/javascript">
+            // # Simple Globe viewer
+            /* global itowns, setupLoadingScreen, GuiTools, ToolTip */
+
+            // Define initial camera position
+            var placement = {
+                coord: new itowns.Coordinates('EPSG:4326', 6.8, 45.9),
+            }
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            var viewerDiv = document.getElementById('viewerDiv');
+
+            // Instanciate iTowns GlobeView*
+            var view = new itowns.GlobeView(viewerDiv, placement);
+            var menuGlobe = new GuiTools('menuDiv', view);
+
+            setupLoadingScreen(viewerDiv, view);
+            FeatureToolTip.init(viewerDiv, view);
+
+            // Add one imagery layer to the scene
+            // This layer is defined in a json file but it could be defined as a plain js
+            // object. See Layer* for more info.
+            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ColorLayer('Ortho', config);
+                view.addLayer(layer).then(function _() {
+                    menuGlobe.addLayerGUI.bind(menuGlobe);
+                    itowns.ColorLayersOrdering.moveLayerToIndex(view, 'Ortho', 0);
+                });
+            });
+            // Add two elevation layers.
+            // These will deform iTowns globe geometry to represent terrain elevation.
+            function addElevationLayerFromConfig(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ElevationLayer(config.id, config);
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+            }
+            itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+            itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+
+            // Fetch, Parse and Convert by iTowns
+            var kmlSource = new itowns.FileSource({
+                url: 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_month_depth.kml',
+                crs: 'EPSG:4326',
+                format: 'application/kml',
+            });
+
+            function offset(properties) {
+                const sizeIcon = 64;
+                const scaleIcon = properties['icon-scale'];
+                return [ 0, -0.5 * scaleIcon * sizeIcon ];
+            }
+
+            var kmlStyle = new itowns.Style({
+                zoom: { min: 10, max: 20 },
+                text: {
+                    field: '{name}',
+                    haloColor: 'black',
+                    haloWidth: 1,
+                    color: 'white',
+                    offset: offset,
+                    anchor: 'bottom',
+                },
+            });
+
+            var kmlLayer = new itowns.ColorLayer('Kml', {
+                source: kmlSource,
+                style: kmlStyle,
+                addLabelLayer: true,
+            });
+
+            debug.createTileDebugUI(menuGlobe.gui, view);
+
+            view.addLayer(kmlLayer).then(FeatureToolTip.addLayer);
+        </script>
+    </body>
+</html>

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -2,6 +2,8 @@ import { FEATURE_TYPES } from 'Core/Feature';
 import Cache from 'Core/Scheduler/Cache';
 import Fetcher from 'Provider/Fetcher';
 import * as mapbox from '@mapbox/mapbox-gl-style-spec';
+import { Color } from 'three';
+import { deltaE } from 'Renderer/Color';
 
 import itowns_stroke_single_before from './StyleChunk/itowns_stroke_single_before.css';
 
@@ -77,13 +79,37 @@ function readVectorProperty(property, options) {
     }
 }
 
-function getImage(source, key) {
+function getImage(source, value) {
     const target = document.createElement('img');
 
     if (typeof source == 'string') {
-        target.src = source;
-    } else if (source && source[key]) {
-        const sprite = source[key];
+        if (value) {
+            const color = new Color(value);
+            Fetcher.texture(source, { crossOrigin: 'anonymous' })
+                .then((texture) => {
+                    const img = texture.image;
+                    canvas.width = img.naturalWidth;
+                    canvas.height = img.naturalHeight;
+                    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+                    ctx.drawImage(img, 0, 0);
+                    const imgd = ctx.getImageData(0, 0, img.naturalWidth, img.naturalHeight);
+                    const pix = imgd.data;
+
+                    const colorToChange = new Color('white');
+                    for (var i = 0, n = pix.length; i < n; i += 4) {
+                        const d = deltaE(pix.slice(i, i + 3), colorToChange) / 100;
+                        pix[i] = (pix[i] * d +  color.r * 255 * (1 - d));
+                        pix[i + 1] = (pix[i + 1] * d +  color.g * 255 * (1 - d));
+                        pix[i + 2] = (pix[i + 2] * d +  color.b * 255 * (1 - d));
+                    }
+                    ctx.putImageData(imgd, 0, 0);
+                    target.src = canvas.toDataURL('image/png');
+                });
+        } else {
+            target.src = source;
+        }
+    } else if (source && source[value]) {
+        const sprite = source[value];
         canvas.width = sprite.width;
         canvas.height = sprite.height;
         canvas.getContext('2d').drawImage(source.img, sprite.x, sprite.y, sprite.width, sprite.height, 0, 0, sprite.width, sprite.height);
@@ -261,13 +287,18 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * Default is `0`.
  *
  * @property {Object} icon - Defines the appearance of icons attached to label.
- * @property {String} icon.source - The url of the icons' image file.
- * @property {String} icon.key - The key of the icons' image in a vector tile data set.
+ * @property {string} icon.source - The url of the icons' image file.
+ * @property {string} icon.key - The key of the icons' image in a vector tile data set.
  * @property {string} [icon.anchor='center'] - The anchor of the icon compared to the label position.
  * Can be `left`, `bottom`, `right`, `center`, `top-left`, `top-right`, `bottom-left`
  * or `bottom-right`.
  * @property {number} icon.size - If the icon's image is passed with `icon.source` or
  * `icon.key`, it size when displayed on screen is multiplied by `icon.size`. Default is `1`.
+ * @property {string|function} icon.color - The color of the icon. Can be any [valid
+ * color string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+ * It will change the color of the white pixels of the icon source image.
+ * @property {number|function} icon.opacity - The opacity of the icon. Can be between
+ * `0.0` and `1.0`. Default is `1.0`.
  *
  * @example
  * const style = new itowns.Style({
@@ -371,6 +402,8 @@ class Style {
         defineStyleProperty(this, 'icon', 'key', params.icon.key);
         defineStyleProperty(this, 'icon', 'anchor', params.icon.anchor, 'center');
         defineStyleProperty(this, 'icon', 'size', params.icon.size, 1);
+        defineStyleProperty(this, 'icon', 'color', params.icon.color);
+        defineStyleProperty(this, 'icon', 'opacity', params.icon.opacity, 1.0);
     }
 
     /**
@@ -456,8 +489,14 @@ class Style {
             this.text.opacity = properties['label-opacity'];
             this.text.size = properties['label-size'];
 
-            if (properties.icon) {
-                this.icon.source = properties.icon;
+            const icon = {
+                ...(properties.icon !== undefined && { source: properties.icon }),
+                ...(properties['icon-scale'] !== undefined && { size: properties['icon-scale'] }),
+                ...(properties['icon-opacity'] !== undefined && { opacity: properties['icon-opacity'] }),
+                ...(properties['icon-color'] !== undefined && { color: properties['icon-color'] }),
+            };
+            if (Object.keys(icon).length) {
+                this.icon = icon;
             }
         } else {
             this.stroke.color = properties.stroke;
@@ -558,6 +597,9 @@ class Style {
             if (key) {
                 this.icon.key = key;
                 this.icon.size = readVectorProperty(layer.layout['icon-size']) || 1;
+                const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['icon-color'], { type: 'color' }));
+                this.icon.color = color;
+                this.icon.opacity = readVectorProperty(layer.paint['icon-opacity']) || (opacity !== undefined && opacity);
             }
         }
         return this;
@@ -599,16 +641,17 @@ class Style {
         const image = this.icon.source;
         const size = this.icon.size;
         const key = this.icon.key;
+        const color = this.icon.color;
 
-        let icon = cacheStyle.get(image || key, size);
+        let icon = cacheStyle.get(image || key, size, color);
 
         if (!icon) {
             if (key && sprites) {
                 icon = getImage(sprites, key);
             } else {
-                icon = getImage(image);
+                icon = getImage(image, color);
             }
-            cacheStyle.set(icon, image || key, size);
+            cacheStyle.set(icon, image || key, size, color);
         }
 
         const addIcon = () => {
@@ -618,6 +661,8 @@ class Style {
 
             cIcon.width = icon.width * this.icon.size;
             cIcon.height = icon.height * this.icon.size;
+            cIcon.style.color = this.icon.color;
+            cIcon.style.opacity = this.icon.opacity;
             cIcon.style.position = 'absolute';
             cIcon.style.top = '0';
             cIcon.style.left = '0';

--- a/src/Renderer/Color.js
+++ b/src/Renderer/Color.js
@@ -1,0 +1,69 @@
+export function lab2rgb(lab) {
+    var y = (lab[0] + 16) / 116;
+    var x = lab[1] / 500 + y;
+    var z = y - lab[2] / 200;
+    var r; var g; var
+        b;
+
+    x = 0.95047 * ((x * x * x > 0.008856) ? x * x * x : (x - 16 / 116) / 7.787);
+    y = 1.00000 * ((y * y * y > 0.008856) ? y * y * y : (y - 16 / 116) / 7.787);
+    z = 1.08883 * ((z * z * z > 0.008856) ? z * z * z : (z - 16 / 116) / 7.787);
+
+    r = x *  3.2406 + y * -1.5372 + z * -0.4986;
+    g = x * -0.9689 + y *  1.8758 + z *  0.0415;
+    b = x *  0.0557 + y * -0.2040 + z *  1.0570;
+
+    r = (r > 0.0031308) ? (1.055 * r ** (1 / 2.4) - 0.055) : 12.92 * r;
+    g = (g > 0.0031308) ? (1.055 * g ** (1 / 2.4) - 0.055) : 12.92 * g;
+    b = (b > 0.0031308) ? (1.055 * b ** (1 / 2.4) - 0.055) : 12.92 * b;
+
+    return [Math.max(0, Math.min(1, r)) * 255,
+        Math.max(0, Math.min(1, g)) * 255,
+        Math.max(0, Math.min(1, b)) * 255];
+}
+
+
+export function rgb2lab(rgb) {
+    var r = rgb.r || rgb[0] / 255;
+    var g = rgb.g || rgb[1] / 255;
+    var b = rgb.b || rgb[2] / 255;
+    var x; var y; var
+        z;
+
+    r = (r > 0.04045) ? ((r + 0.055) / 1.055) ** 2.4 : r / 12.92;
+    g = (g > 0.04045) ? ((g + 0.055) / 1.055) ** 2.4 : g / 12.92;
+    b = (b > 0.04045) ? ((b + 0.055) / 1.055) ** 2.4 : b / 12.92;
+
+    x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
+    y = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 1.00000;
+    z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
+
+    x = (x > 0.008856) ? x ** (1 / 3) : (7.787 * x) + 16 / 116;
+    y = (y > 0.008856) ? y ** (1 / 3) : (7.787 * y) + 16 / 116;
+    z = (z > 0.008856) ? z ** (1 / 3) : (7.787 * z) + 16 / 116;
+
+    return [(116 * y) - 16, 500 * (x - y), 200 * (y - z)];
+}
+
+// calculate the perceptual distance between colors in CIELAB
+// https://github.com/THEjoezack/ColorMine/blob/master/ColorMine/ColorSpaces/Comparisons/Cie94Comparison.cs
+export function deltaE(rgbA, rgbB) {
+    const labA = rgb2lab(rgbA);
+    const labB = rgb2lab(rgbB);
+    var deltaL = labA[0] - labB[0];
+    var deltaA = labA[1] - labB[1];
+    var deltaB = labA[2] - labB[2];
+    var c1 = Math.sqrt(labA[1] * labA[1] + labA[2] * labA[2]);
+    var c2 = Math.sqrt(labB[1] * labB[1] + labB[2] * labB[2]);
+    var deltaC = c1 - c2;
+    var deltaH = deltaA * deltaA + deltaB * deltaB - deltaC * deltaC;
+    deltaH = deltaH < 0 ? 0 : Math.sqrt(deltaH);
+    var sc = 1.0 + 0.045 * c1;
+    var sh = 1.0 + 0.015 * c1;
+    var deltaLKlsl = deltaL / (1.0);
+    var deltaCkcsc = deltaC / (sc);
+    var deltaHkhsh = deltaH / (sh);
+    var i = deltaLKlsl * deltaLKlsl + deltaCkcsc * deltaCkcsc + deltaHkhsh * deltaHkhsh;
+    return i < 0 ? 0 : Math.sqrt(i);
+}
+

--- a/test/functional/source_file_kml_raster.js
+++ b/test/functional/source_file_kml_raster.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
 
-describe('source_file_geojson_raster', function _() {
+describe('source_file_kml_raster', function _() {
     let result;
     before(async () => {
-        result = await loadExample('examples/source_file_geojson_raster.html', this.fullTitle());
+        result = await loadExample('examples/source_file_kml_raster.html', this.fullTitle());
     });
 
     it('should run', async () => {
@@ -20,14 +20,15 @@ describe('source_file_geojson_raster', function _() {
 
             return Promise.all(promises);
         });
-        assert.equal(2, features.length);
+        assert.equal(features.length, 2); // the layer and the LabelLayer
+        assert.equal(features[0].uuid, features[1].uuid);
     });
 
     it('should pick feature from Layer with SourceFile', async () => {
         const pickedFeatures = await page.evaluate(() => {
             /* global itowns */
             const precision = view.getPixelsToDegrees(5);
-            const geoCoord = new itowns.Coordinates('EPSG:4326', 1.41955, 42.88613, 0);
+            const geoCoord = new itowns.Coordinates('EPSG:4326', 6.80665, 45.91308, 0);
             const promises = [];
             const layers = view.getLayers(l => l.source && l.source.isFileSource);
             for (let i = 0; i < layers.length; i++) {
@@ -39,9 +40,10 @@ describe('source_file_geojson_raster', function _() {
             return Promise.all(promises);
         });
 
-        assert.equal(pickedFeatures.length, 2);// 2 layers added
-        assert.equal(pickedFeatures[0].length, 1, 'feature(s) picked on first layer');
-        assert.equal(pickedFeatures[1].length, 0, 'feature(s) picked on second layer');
-        assert.equal(pickedFeatures[0][0].geometry.properties.nom, 'Ariège');
+        assert.equal(pickedFeatures.length, 2);// layer and the LabelLayer
+        assert.equal(pickedFeatures[0].length, 1);// only 1 feature picked on layer
+        assert.equal(pickedFeatures[1].length, 1);// and 1 on lableLayer
+        assert.equal(pickedFeatures[0][0].geometry.properties.description, pickedFeatures[1][0].geometry.properties.description, 'same feature');
+        assert.equal(pickedFeatures[0][0].geometry.properties.description, 'Zone Aiguillette des Houches');
     });
 });

--- a/test/functional/source_file_kml_raster_usgs.js
+++ b/test/functional/source_file_kml_raster_usgs.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+describe('source_file_kml_raster_usgs', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample('examples/source_file_kml_raster_usgs.html', this.fullTitle());
+    });
+
+    it('should run', async () => {
+        assert.ok(result);
+    });
+
+    it('load features data', async () => {
+        const features = await page.evaluate(() => {
+            const promises = [];
+            const layers = view.getLayers(l => l.source && l.source.isFileSource);
+            for (let i = 0; i < layers.length; i++) {
+                promises.push(layers[i].source.loadData({}, { crs: 'EPSG:4326' }));
+            }
+
+            return Promise.all(promises);
+        });
+        assert.equal(features.length, 2); // the layer and the LabelLayer
+        assert.equal(features[0].uuid, features[1].uuid);
+        assert.equal(features[0].features.length, 1);
+        assert.equal(features[0].features[0].type, 0);
+    });
+});

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -92,6 +92,22 @@ global.document = {
                     image.height = dh;
                     return image;
                 },
+                getImageData: (sx, sy, sw, sh) => {
+                    const imageData = {
+                        data: new Uint8ClampedArray(sw * sh * 4),
+                        colorSpace: 'srgb',
+                        height: sh,
+                        width: sw,
+                    };
+                    return imageData;
+                },
+                // eslint-disable-next-line no-unused-vars
+                putImageData: (imageData, dx, dy) => {
+                    const image = global.document.createElement('img');
+                    image.width = imageData.sw;
+                    image.height = imageData.sh;
+                    return image;
+                },
                 canvas,
             });
 

--- a/test/unit/style.js
+++ b/test/unit/style.js
@@ -1,38 +1,110 @@
-import Style from 'Core/Style';
+import Style, { cacheStyle } from 'Core/Style';
 import assert from 'assert';
+import Fetcher from 'Provider/Fetcher';
+import { TextureLoader } from 'three';
+
+const textureLoader = new TextureLoader();
+Fetcher.texture = (url, options = {}) => {
+    let res;
+    let rej;
+
+    textureLoader.crossOrigin = options.crossOrigin;
+
+    const promise = new Promise((resolve, reject) => {
+        res = resolve;
+        rej = reject;
+    });
+
+    textureLoader.load(url, (x) => {
+        x.image = document.createElement('img');
+        return res(x);
+    }, () => {}, rej);
+    return promise;
+};
 
 describe('Style', function () {
-    const style1 = new Style();
-    style1.point.color = 'red';
-    style1.fill.color = 'blue';
-    style1.stroke.color = 'black';
-    style1.text.haloWidth = 1;
+    const style = new Style();
+    style.point.color = 'red';
+    style.fill.color = 'blue';
+    style.stroke.color = 'black';
+    style.text.haloWidth = 1;
 
     it('Copy style', () => {
-        const style2 = new Style().copy(style1);
-        assert.equal(style1.point.color, style2.point.color);
-        assert.equal(style1.fill.color, style2.fill.color);
-        assert.equal(style1.stroke.color, style2.stroke.color);
+        const styleCopy = new Style().copy(style);
+        assert.equal(style.point.color, styleCopy.point.color);
+        assert.equal(style.fill.color, styleCopy.fill.color);
+        assert.equal(style.stroke.color, styleCopy.stroke.color);
     });
 
     it('Clone style', () => {
-        const style2 = style1.clone(style1);
-        assert.equal(style1.point.color, style2.point.color);
-        assert.equal(style1.fill.color, style2.fill.color);
-        assert.equal(style1.stroke.color, style2.stroke.color);
+        const styleClone = style.clone(style);
+        assert.equal(style.point.color, styleClone.point.color);
+        assert.equal(style.fill.color, styleClone.fill.color);
+        assert.equal(style.stroke.color, styleClone.stroke.color);
     });
 
-    it('applyToHTML', () => {
-        const dom = document.createElement('canvas');
-        style1.applyToHTML(dom);
-        assert.equal(dom.style.padding, '2px');
-        assert.equal(dom.style.maxWidth, '10em');
-        assert.equal(dom.style.color, '#000000');
-        assert.equal(dom.style.fontSize, '16px');
-        assert.equal(dom.style.fontFamily, 'Open Sans Regular,Arial Unicode MS Regular,sans-serif');
-        assert.equal(dom.style.textTransform, 'none');
-        assert.equal(dom.style.letterSpacing, '0em');
-        assert.equal(dom.style.textAlign, 'center');
-        assert.equal(dom.style['--text_stroke_width'], '1px');
+    const sprites = {
+        img: '',
+        'fill-pattern': { x: 0, y: 0, width: 10, height: 10 },
+    };
+
+    describe('applyToHTML', () => {
+        it('with icon.source and icon.key undefined', () => {
+            const dom = document.createElement('canvas');
+            style.applyToHTML(dom);
+            assert.equal(dom.style.padding, '2px');
+            assert.equal(dom.style.maxWidth, '10em');
+            assert.equal(dom.style.color, '#000000');
+            assert.equal(dom.style.fontSize, '16px');
+            assert.equal(dom.style.fontFamily, 'Open Sans Regular,Arial Unicode MS Regular,sans-serif');
+            assert.equal(dom.style.textTransform, 'none');
+            assert.equal(dom.style.letterSpacing, '0em');
+            assert.equal(dom.style.textAlign, 'center');
+            assert.equal(dom.style['--text_stroke_width'], '1px');
+        });
+
+        const sourceString = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/images/kml_circle.png';
+        describe('with icon.source (test getImage())', () => {
+            it('icon.source is string but icon.key is undefined ', () => {
+                const dom = document.createElement('canvas');
+                const style1 = style.clone(style);
+                style1.icon = {
+                    source: 'icon',
+                };
+                style1.applyToHTML(dom);
+                const img = cacheStyle.get('icon', 1);
+                img.emitEvent('load');
+                assert.equal(dom.children[0].class, 'itowns-icon');
+                assert.equal(dom.children[0].style['z-index'], -1);
+            });
+            it('icon.source is string and icon.color=#0400fd', () => {
+                const dom = document.createElement('canvas');
+                const style1 = style.clone(style);
+                style1.icon = {
+                    source: sourceString,
+                    color: '#0400fd',
+                };
+                style1.applyToHTML(dom);
+                const img = cacheStyle.get(sourceString, 1);
+
+                img.emitEvent('load');
+                assert.equal(dom.children.length, 1);
+                assert.equal(dom.children[0].class, 'itowns-icon');
+                assert.equal(dom.children[0].style['z-index'], -1);
+            });
+            it('with icon.key and sprites', () => {
+                const dom = document.createElement('canvas');
+                const style1 = style.clone(style);
+                style1.icon = {
+                    key: 'fill-pattern',
+                };
+
+                style1.applyToHTML(dom, sprites);
+                const img = cacheStyle.get('fill-pattern', 1);
+                img.emitEvent('load');
+                assert.equal(dom.children[0].class, 'itowns-icon');
+                assert.equal(dom.children[0].style['z-index'], -1);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Motivation and Context
Using official kml and geojson sources (USGS flux), the icon properties were not well handled.
This PR aims at being able to handle 'official' kml flux and being able to interpreter the opacity and color properties of icon.

## Description
In addition to changes in the file Style.js. Two new examples were added:
- one kml file source from a USGS flux (last 3 months worldwide earthquakes)
- one geojson file source from a USGS data (3 month earthquake at at a given date) in a planar view

and the plugins FeatureToolTip has been adapted to the changes.

We use this PR and the new example to improve the geojson and kml source file functional tests.
