### PR TITLE
Type checking, type inference and auto-complete from typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@babel/plugin-transform-runtime": "^7.18.0",
         "@babel/preset-env": "^7.18.0",
         "@babel/register": "^7.17.7",
+        "@types/three": "^0.153.0",
         "babel-inline-import-loader": "^1.0.1",
         "babel-loader": "^8.2.5",
         "babel-plugin-inline-import": "^3.0.0",
@@ -2414,10 +2415,35 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==",
+      "dev": true
+    },
     "node_modules/@types/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-AQ6zewa0ucLJvtUi5HsErbOFKAcQfRLt9zFLlUOvcXBy2G36a+ZDpCHSGdzJVUD8aNURtIjh9aSjCStNMRCcRQ=="
+    },
+    "node_modules/@types/three": {
+      "version": "0.153.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.153.0.tgz",
+      "integrity": "sha512-L9quzIP4lsl6asDCw5zqN5opewCVOKRuB09apw5Acf2AIkoj5gLnUOY5AMB/ntFUt/QfFey0uKZaAd5t+HXSUw==",
+      "dev": true,
+      "dependencies": {
+        "@tweenjs/tween.js": "~18.6.4",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.9",
+        "lil-gui": "~0.17.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.2.tgz",
+      "integrity": "sha512-szL74BnIcok9m7QwYtVmQ+EdIKwbjPANudfuvDrAF8Cljg9MKUlIoc1w5tjj9PMpeSH3U1Xnx//czQybJ0EfSw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -5478,6 +5504,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "dev": true
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7745,6 +7777,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/lil-gui": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
+      "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
+      "dev": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -14199,10 +14237,35 @@
         "@types/node": "*"
       }
     },
+    "@types/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==",
+      "dev": true
+    },
     "@types/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-AQ6zewa0ucLJvtUi5HsErbOFKAcQfRLt9zFLlUOvcXBy2G36a+ZDpCHSGdzJVUD8aNURtIjh9aSjCStNMRCcRQ=="
+    },
+    "@types/three": {
+      "version": "0.153.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.153.0.tgz",
+      "integrity": "sha512-L9quzIP4lsl6asDCw5zqN5opewCVOKRuB09apw5Acf2AIkoj5gLnUOY5AMB/ntFUt/QfFey0uKZaAd5t+HXSUw==",
+      "dev": true,
+      "requires": {
+        "@tweenjs/tween.js": "~18.6.4",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.9",
+        "lil-gui": "~0.17.0"
+      }
+    },
+    "@types/webxr": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.2.tgz",
+      "integrity": "sha512-szL74BnIcok9m7QwYtVmQ+EdIKwbjPANudfuvDrAF8Cljg9MKUlIoc1w5tjj9PMpeSH3U1Xnx//czQybJ0EfSw==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -16579,6 +16642,12 @@
         "pend": "~1.2.0"
       }
     },
+    "fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "dev": true
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -18282,6 +18351,12 @@
           }
         }
       }
+    },
+    "lil-gui": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
+      "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
+      "dev": true
     },
     "lines-and-columns": {
       "version": "1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "q": "^1.5.1",
         "replace-in-file": "^6.3.2",
         "three": "0.153.0",
+        "typescript": "^5.1.6",
         "url-polyfill": "^1.1.12",
         "webpack": "^5.72.1",
         "webpack-cli": "^4.9.2",
@@ -11500,6 +11501,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/typical": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
@@ -21158,6 +21172,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "q": "^1.5.1",
     "replace-in-file": "^6.3.2",
     "three": "0.153.0",
+    "typescript": "^5.1.6",
     "url-polyfill": "^1.1.12",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@babel/plugin-transform-runtime": "^7.18.0",
     "@babel/preset-env": "^7.18.0",
     "@babel/register": "^7.17.7",
+    "@types/three": "^0.153.0",
     "babel-inline-import-loader": "^1.0.1",
     "babel-loader": "^8.2.5",
     "babel-plugin-inline-import": "^3.0.0",

--- a/src/Renderer/c3DEngine.js
+++ b/src/Renderer/c3DEngine.js
@@ -64,6 +64,11 @@ class c3DEngine {
             }
         }.bind(this);
 
+        /**
+         * @type {function}
+         * @param {number} w
+         * @param {number} h
+         */
         this.onWindowResize = function _(w, h) {
             this.width = w;
             this.height = h;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "include": [ "src/Main.js" ],
+    "exclude": [ "node_modules", "lib", "dist" ],
+    "compilerOptions": {
+        /* Type Checking */
+        "strict": true,
+        /* Modules */
+        "baseUrl": ".",
+        "paths": {
+            "*": [ "src/*" ]
+        },
+        "moduleResolution": "nodenext",
+        /* Emit */
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "types",
+        /* JavaScript Support */
+        "allowJs": true,
+        "checkJs": false, // set to true for type checking of js files
+        /* Interop Constraints */
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        /* Language and Environment */
+        "target": "esnext",
+        /* Completeness */
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
## Description

This a work in progress to provide Typescript type checking, inference, auto-complete function to users and developers of the library in a non-invasive way. This PR adds type inference and lsp support (auto-complete, `goToDefinition`-like functions, ...) from typescript for any compatible editor. Type definitions are provided through the [`@types/itowns`](https://www.npmjs.com/package/@types/itowns) package generated from the [Definitely Typed repository](https://github.com/DefinitelyTyped/DefinitelyTyped/) (an aggregate of TypeScript type definitions).

## Motivation and Context

- Quality of life tools for developers of the project (auto-complete, `goToDefinition`-like functions, ...)
- Correct type-checking for typescript users of itowns 

This PR adds the following `devDependencies`:
- `typescript`
- `@types/three`