### PR TITLE
Update 3D Tiles dataset to textured one

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -86,7 +86,7 @@
                     name: 'Lyon-2015-building',
                     source: new itowns.C3DTilesSource({
                         url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/' +
-                            '3DTiles/mesh-lyon-2015/tileset.json',
+                            '3DTiles/lyon_1_3946_textured_draco/tileset.json',
                     }),
                 }, view);
 


### PR DESCRIPTION
Update 3D Tiles dataset of 3dtiles_25d example to use a textured one:

![image](https://user-images.githubusercontent.com/16967916/223731959-b6e5971d-e3b4-4df0-94f1-89cd9e43601e.png)

(Bounding boxes displayed because #2021)