### PR TITLE
feat(WMTS): Support vendor specific parameters

### DIFF
--- a/src/Source/WMTSSource.js
+++ b/src/Source/WMTSSource.js
@@ -37,6 +37,10 @@ import TMSSource from 'Source/TMSSource';
  * is 2.
  * @property {number} zoom.max - The maximum level of the source. Default value
  * is 20.
+ * @property {Object} vendorSpecific - An object containing vendor specific
+ * parameters. This object is read simply with the `key` being the name of the
+ * parameter and `value` being the value of the parameter. If used, this
+ * property should be set in the constructor parameters.
  *
  * @example
  * // Create the source
@@ -84,6 +88,13 @@ class WMTSSource extends TMSSource {
             `&STYLE=${source.style || 'normal'}` +
             `&TILEMATRIXSET=${source.tileMatrixSet}` +
             '&TILEMATRIX=%TILEMATRIX&TILEROW=%ROW&TILECOL=%COL';
+
+        this.vendorSpecific = source.vendorSpecific;
+        for (const name in this.vendorSpecific) {
+            if (Object.prototype.hasOwnProperty.call(this.vendorSpecific, name)) {
+                this.url = `${this.url}&${name}=${this.vendorSpecific[name]}`;
+            }
+        }
     }
 }
 

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -126,6 +126,15 @@ describe('Sources', function () {
             assert.ok(source.urlFromExtent(extent));
             assert.ok(source.extentInsideLimit(extent, 5));
         });
+
+        it('should use vendor specific parameters for the creation of the WMTS url', function () {
+            paramsWMTS.vendorSpecific = vendorSpecific;
+            const source = new WMTSSource(paramsWMTS);
+            const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
+            const url = source.urlFromExtent(extent);
+            const end = '&buffer=4096&format_options=dpi:300;quantizer:octree&tiled=true';
+            assert.ok(url.endsWith(end));
+        });
     });
 
     describe('WMSSource', function () {


### PR DESCRIPTION
Authorize vendorSpecific attributes as in WMSSources

Closes  #2027 

## Motivation and Context
Same possibilities as WMSSources to enable vendor specific attributes

