### PR TITLE
refactoring `LabelLayer` to architecture node

### DIFF
--- a/examples/source_file_kml_raster.html
+++ b/examples/source_file_kml_raster.html
@@ -79,7 +79,7 @@
             var kmlLayer = new itowns.ColorLayer('Kml', {
                 source: kmlSource,
                 style: kmlStyle,
-                addLabelLayer: true,
+                addLabelLayer: { forceClampToTerrain: true },
             });
 
             debug.createTileDebugUI(menuGlobe.gui, view);

--- a/examples/vector_tile_3d_mesh.html
+++ b/examples/vector_tile_3d_mesh.html
@@ -84,7 +84,7 @@
                 source: mapSource,
                 effect_type: itowns.colorLayerEffects.removeLightColor,
                 effect_parameter: 2.5,
-                addLabelLayer: true,
+                addLabelLayer: { performance: true },
                 style: new itowns.Style({
                     text: {
                         color: '#000000',

--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -55,7 +55,7 @@
 
             var mvtLayer = new itowns.ColorLayer('MVT', {
                 source: mvtSource,
-                addLabelLayer: true,
+                addLabelLayer: { performance: true },
             });
 
             view.addLayer(mvtLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));

--- a/examples/vector_tile_raster_3d.html
+++ b/examples/vector_tile_raster_3d.html
@@ -58,7 +58,7 @@
                 source: mvtSource,
                 effect_type: itowns.colorLayerEffects.removeLightColor,
                 effect_parameter: 2.5,
-                addLabelLayer: true,
+                addLabelLayer: { performance: true },
             });
 
             view.addLayer(mvtLayer);

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -90,7 +90,7 @@
                         filter: (layer) => !layer['source-layer'].includes('oro_')
                             && !layer['source-layer'].includes('parcellaire'),
                     }),
-                    addLabelLayer: true,
+                    addLabelLayer: { performance: true },
                 }),
                 { cursor: '+' },
             );

--- a/examples/view_3d_mns_map.html
+++ b/examples/view_3d_mns_map.html
@@ -89,7 +89,7 @@
                         filter: (layer) => !layer['source-layer'].includes('oro_')
                             && !layer['source-layer'].includes('parcellaire'),
                     }),
-                    addLabelLayer: true,
+                    addLabelLayer: { performance: true },
                 }),
                 { cursor: '+' },
             );

--- a/examples/widgets_minimap.html
+++ b/examples/widgets_minimap.html
@@ -93,7 +93,7 @@
                     filter: (layer) => !layer['source-layer'].includes('oro_')
                         && !layer['source-layer'].includes('parcellaire'),
                 }),
-                addLabelLayer: true,
+                addLabelLayer: { performance: true },
             });
 
             // Create a minimap.

--- a/src/Core/Label.js
+++ b/src/Core/Label.js
@@ -90,8 +90,6 @@ class Label extends THREE.Object3D {
         this.content.style.userSelect = 'none';
         this.content.style.position = 'absolute';
 
-        this.baseContent = content;
-
         if (style.isStyle) {
             this.anchor = style.getTextAnchorPosition();
             this.styleOffset = style.text.offset;
@@ -199,9 +197,7 @@ class Label extends THREE.Object3D {
     }
 
     update3dPosition(crs) {
-        this.coordinates.as(crs, coord);
-        coord.toVector3(this.position);
-        this.parent.worldToLocal(this.position);
+        this.coordinates.as(crs, coord).toVector3(this.position);
         this.updateMatrixWorld();
     }
 
@@ -218,8 +214,6 @@ class Label extends THREE.Object3D {
 
         if (!isNaN(elevation) && elevation != this.coordinates.z) {
             this.coordinates.z = elevation;
-            this.updateHorizonCullingPoint();
-            return true;
         }
     }
 

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -44,8 +44,6 @@ class TileMesh extends THREE.Mesh {
         this.layerUpdateState = {};
         this.isTileMesh = true;
 
-        this.domElements = {};
-
         this.geoidHeight = 0;
 
         this.link = {};
@@ -112,12 +110,6 @@ class TileMesh extends THREE.Mesh {
     onBeforeRender() {
         if (this.material.layersNeedUpdate) {
             this.material.updateLayersUniforms();
-        }
-    }
-
-    findClosestDomElement(id) {
-        if (this.parent.isTileMesh) {
-            return this.parent.domElements[id] || this.parent.findClosestDomElement(id);
         }
     }
 }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -75,6 +75,7 @@ function _preprocessLayer(view, layer, parentLayer) {
             source,
             style: layer.style,
             zoom: layer.zoom,
+            performance: layer.addLabelLayer.performance,
             crs: source.crs,
             visible: layer.visible,
             margin: 15,

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -79,6 +79,7 @@ function _preprocessLayer(view, layer, parentLayer) {
             crs: source.crs,
             visible: layer.visible,
             margin: 15,
+            forceClampToTerrain: layer.addLabelLayer.forceClampToTerrain,
         });
 
         layer.addEventListener('visible-property-changed', () => {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -49,7 +49,7 @@ function _preprocessLayer(view, layer, parentLayer) {
         }
     }
 
-    if (layer.isGeometryLayer) {
+    if (layer.isGeometryLayer && !layer.isLabelLayer) {
         // Find crs projection layer, this is projection destination
         layer.crs = view.referenceCrs;
     } else if (!layer.crs) {
@@ -69,6 +69,8 @@ function _preprocessLayer(view, layer, parentLayer) {
         }
         // Because the features are shared between layer and labelLayer.
         layer.buildExtent = true;
+        // label layer needs 3d data structure.
+        layer.structure = '3d';
         const labelLayer = new LabelLayer(`${layer.id}-label`, {
             source,
             style: layer.style,

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
-import Layer from 'Layer/Layer';
+import GeometryLayer from 'Layer/GeometryLayer';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 import Label from 'Core/Label';
@@ -13,6 +13,122 @@ const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
 
 /**
+ * DomNode is a node in the tree data structure of labels divs.
+ *
+ * @class DomNode
+ */
+class DomNode {
+    #domVisibility = false;
+
+    constructor() {
+        this.dom = document.createElement('div');
+
+        this.dom.style.display = 'none';
+
+        this.visible = true;
+    }
+
+    get visible() { return this.#domVisibility; }
+
+    set visible(v) {
+        if (v !== this.#domVisibility) {
+            this.#domVisibility = v;
+            this.dom.style.display = v ? 'block' : 'none';
+        }
+    }
+
+    hide() { this.visible = false; }
+
+    show() { this.visible = true; }
+
+    add(node) {
+        this.dom.append(node.dom);
+    }
+}
+
+/**
+ * LabelsNode is node of tree data structure for LabelLayer.
+ * the node is made of dom elements and 3D labels.
+ *
+ * @class      LabelsNode
+ */
+class LabelsNode extends THREE.Group {
+    constructor(node) {
+        super();
+        // attached node parent
+        this.nodeParent = node;
+        // When this is set, it calculates the position in that frame and resets this property to false.
+        this.needsUpdate = true;
+    }
+
+    // instanciate dom elements
+    initializeDom() {
+        // create root dom
+        this.domElements = new DomNode();
+        // create labels container dom
+        this.domElements.labels = new DomNode();
+
+        this.domElements.add(this.domElements.labels);
+    }
+
+    // add node label
+    // add label 3d and dom label
+    addLabel(label) {
+        // add 3d object
+        this.add(label);
+
+        // add dom label
+        this.domElements.labels.dom.append(label.content);
+
+        // Batch update the dimensions of labels all at once to avoid
+        // redraw for at least this tile.
+        label.initDimensions();
+
+        // add horizon culling point if it's necessary
+        // the horizon culling is applied to nodes that trace the horizon which
+        // corresponds to the low zoom node, that's why the culling is done for a zoom lower than 4.
+        if (this.nodeParent.layer.isGlobeLayer && this.nodeParent.level < 4) {
+            label.horizonCullingPoint = new THREE.Vector3();
+        }
+    }
+
+    // remove node label
+    // remove label 3d and dom label
+    removeLabel(label) {
+        // remove 3d object
+        this.remove(label);
+
+        // remove dom label
+        this.domElements.labels.dom.removeChild(label.content);
+    }
+
+    // update position if it's necessary
+    updatePosition(label) {
+        if (this.needsUpdate) {
+            // update elevation from elevation layer.
+            if (this.needsAltitude) {
+                label.updateElevationFromLayer(this.nodeParent.layer, [this.nodeParent]);
+            }
+
+            // update elevation label
+            label.update3dPosition(this.nodeParent.layer.crs);
+
+            // update horizon culling
+            label.updateHorizonCullingPoint();
+        }
+    }
+
+    // return labels count
+    count() {
+        return this.children.length;
+    }
+
+    get labels() {
+        return this.children;
+    }
+}
+
+/**
  * A layer to handle a bunch of `Label`. This layer can be created on its own,
  * but it is better to use the option `addLabelLayer` on another `Layer` to let
  * it work with it (see the `vector_tile_raster_2d` example).
@@ -21,7 +137,7 @@ const _extent = new Extent('EPSG:4326', 0, 0, 0, 0);
  * LabelLayer.  Default is true. You should not change this, as it is used
  * internally for optimisation.
  */
-class LabelLayer extends Layer {
+class LabelLayer extends GeometryLayer {
     /**
      * @constructor
      * @extends Layer
@@ -45,24 +161,41 @@ class LabelLayer extends Layer {
      * except for the `Style.text.anchor` parameter which can help place the label.
      */
     constructor(id, config = {}) {
-        super(id, config);
+        const domElement = config.domElement;
+        delete config.domElement;
+        super(id, config.object3d || new THREE.Group(), config);
 
         this.isLabelLayer = true;
-        this.domElement = document.createElement('div');
-        this.domElement.id = `itowns-label-${this.id}`;
-        this.defineLayerProperty('visible', true, () => {
-            this.domElement.style.display = this.visible ? 'block' : 'none';
-        });
-
+        this.domElement = new DomNode();
+        this.domElement.show();
+        this.domElement.dom.id = `itowns-label-${this.id}`;
         this.buildExtent = true;
+        this.crs = config.source.crs;
 
-        this.labelDomelement = config.domElement;
+        this.labelDomelement = domElement;
 
         // The margin property defines a space around each label that cannot be occupied by another label.
         // For example, if some labelLayer has a margin value of 5, there will be at least 10 pixels
         // between each labels of the layer
         // TODO : this property should be moved to Style after refactoring style properties structure
         this.margin = config.margin;
+    }
+
+    get visible() {
+        return super.visible;
+    }
+
+    set visible(value) {
+        super.visible = value;
+        if (value) {
+            this.domElement?.show();
+        } else {
+            this.domElement?.hide();
+        }
+    }
+
+    get submittedLabelNodes() {
+        return this.object3d.children;
     }
 
     /**
@@ -98,7 +231,14 @@ class LabelLayer extends Layer {
                 return;
             }
 
-            const featureField = f.style && f.style.text.field;
+            const featureField = f.style.text.field;
+
+            // determine if altitude style is specified by the user
+            const altitudeStyle = f.style.point.base_altitude;
+            const isDefaultElevationStyle = altitudeStyle instanceof Function && altitudeStyle.name == 'base_altitudeDefault';
+
+            // determine if the altitude needs update with ElevationLayer
+            labels.needsAltitude = labels.needsAltitude || (isDefaultElevationStyle && !f.hasRawElevationData);
 
             f.geometries.forEach((g) => {
                 // NOTE: this only works because only POINT is supported, it
@@ -107,7 +247,6 @@ class LabelLayer extends Layer {
                 // Transform coordinate to data.crs projection
                 coord.applyMatrix4(data.matrixWorld);
 
-                if (f.size == 2) { coord.z = 0; }
                 if (!_extent.isPointInside(coord)) { return; }
 
                 const geometryField = g.properties.style && g.properties.style.text.field;
@@ -136,10 +275,6 @@ class LabelLayer extends Layer {
                 label.layerId = this.id;
                 label.padding = this.margin || label.padding;
 
-                if (f.size == 2) {
-                    label.needsAltitude = true;
-                }
-
                 labels.push(label);
             });
         });
@@ -148,43 +283,75 @@ class LabelLayer extends Layer {
     }
 
     // placeholder
-    preUpdate() {}
+    preUpdate(context, sources) {
+        if (sources.has(this.parent)) {
+            this.object3d.clear();
+        }
+    }
+
+    #submitToRendering(labelsNode) {
+        labelsNode.domElements?.labels.show();
+
+        this.object3d.add(labelsNode);
+    }
+
+    #disallowToRendering(labelsNode) {
+        labelsNode.domElements?.labels.hide();
+
+        this.object3d.remove(labelsNode);
+    }
+
+    #findClosestDomElement(node) {
+        if (node.parent?.isTileMesh) {
+            return node.parent.link[this.id]?.domElements || this.#findClosestDomElement(node.parent);
+        } else {
+            return this.domElement;
+        }
+    }
+
+    #hasLabelChildren(object) {
+        return object.children.every(c => c.layerUpdateState && c.layerUpdateState[this.id]?.hasFinished());
+    }
 
     update(context, layer, node, parent) {
-        if (!parent && node.children.length) {
+        if (!parent && node.link[layer.id]) {
             // if node has been removed dispose three.js resource
             ObjectRemovalHelper.removeChildrenAndCleanupRecursively(this, node);
             return;
         }
 
+        const labelsNode = node.link[layer.id] || new LabelsNode(node);
+        node.link[layer.id] = labelsNode;
+
         if (this.frozen || !node.visible || !this.visible) {
             return;
+        }
+
+        if (!node.material.visible && this.#hasLabelChildren(node)) {
+            return this.#disallowToRendering(labelsNode);
         }
 
         const extentsDestination = node.getExtentsByProjection(this.source.crs) || [node.extent];
         const zoomDest = extentsDestination[0].zoom;
 
         if (zoomDest < layer.zoom.min || zoomDest > layer.zoom.max) {
-            return;
+            return this.#disallowToRendering(labelsNode);
         }
 
         if (node.layerUpdateState[this.id] === undefined) {
             node.layerUpdateState[this.id] = new LayerUpdateState();
         }
 
-        const elevationLayer = node.material.getElevationLayer();
-        if (elevationLayer && node.layerUpdateState[elevationLayer.id].canTryUpdate()) {
-            node.children.forEach((c) => {
-                if (c.isLabel && c.needsAltitude && c.updateElevationFromLayer(this.parent, [node])) {
-                    c.update3dPosition(context.view.referenceCrs);
-                }
-            });
-        }
-
-        if (!node.layerUpdateState[this.id].canTryUpdate()) {
-            return;
-        } else if (!this.source.extentInsideLimit(node.extent, zoomDest)) {
+        if (!this.source.extentInsideLimit(node.extent, zoomDest)) {
             node.layerUpdateState[this.id].noMoreUpdatePossible();
+            return;
+        } else if (this.#hasLabelChildren(node.parent)) {
+            if (!node.material.visible) {
+                labelsNode.needsUpdate = true;
+            }
+            this.#submitToRendering(labelsNode);
+            return;
+        } else if (!node.layerUpdateState[this.id].canTryUpdate()) {
             return;
         }
 
@@ -201,9 +368,13 @@ class LabelLayer extends Layer {
             if (!result) { return; }
 
             const renderer = context.view.mainLoop.gfxEngine.label2dRenderer;
-            const labelsDiv = [];
+
+            labelsNode.initializeDom();
+
+            this.#findClosestDomElement(node).add(labelsNode.domElements);
 
             result.forEach((labels) => {
+                // Clean if there isnt' parent
                 if (!node.parent) {
                     labels.forEach((l) => {
                         ObjectRemovalHelper.removeChildrenAndCleanupRecursively(this, l);
@@ -212,57 +383,29 @@ class LabelLayer extends Layer {
                     return;
                 }
 
+                labelsNode.needsAltitude = labelsNode.needsAltitude || labels.needsAltitude;
+
+                // Add all labels for this tile at once to batch it
                 labels.forEach((label) => {
-                    if (label.needsAltitude) {
-                        label.updateElevationFromLayer(this.parent, [node]);
-                    }
-
-                    const present = node.children.find(l => l.isLabel && l.baseContent == label.baseContent);
-
-                    if (!present) {
-                        node.add(label);
-                        label.update3dPosition(context.view.referenceCrs);
-
-                        if (node.level < 4) {
-                            label.horizonCullingPoint = new THREE.Vector3();
-                            label.updateHorizonCullingPoint();
-                        }
-
-                        labelsDiv.push(label.content);
+                    if (node.extent.isPointInside(label.coordinates)) {
+                        labelsNode.addLabel(label);
                     }
                 });
             });
 
-            if (labelsDiv.length > 0) {
-                // Add all labels for this tile at once to batch it
-                let nodeDomElement = node.domElements[this.id];
-                if (!nodeDomElement) {
-                    nodeDomElement = { dom: document.createElement('div'), visible: true };
-                    node.domElements[this.id] = nodeDomElement;
-                }
+            if (labelsNode.count()) {
+                labelsNode.domElements.labels.hide();
 
-                nodeDomElement.dom.append(...labelsDiv);
-                const closestDomElement = node.findClosestDomElement(this.id);
-                ((closestDomElement && closestDomElement.dom) || this.domElement).appendChild(nodeDomElement.dom);
-                nodeDomElement.visible = true;
+                node.addEventListener('show', () => labelsNode.domElements.labels.show());
 
-                // Batch update the dimensions of labels all at once to avoid
-                // redraw for at least this tile.
-                result.forEach(labels => labels.forEach(label => label.initDimensions()));
-                result.forEach(labels => labels.forEach((label) => { label.visible = false; }));
-
-                // Sort labels so they can be the first in the renderer. That
-                // way, we cull labels on parent tile first, and then on
-                // children tile. This allows a z-order priority, and reduce
-                // flickering.
-                node.children.sort(c => (c.isLabel ? -c.order : 1));
+                node.addEventListener('hidden', () => this.#disallowToRendering(labelsNode));
 
                 // Necessary event listener, to remove any Label attached to
-                // this tile
-                node.addEventListener('removed', () => {
-                    result.forEach(labels => labels.forEach(l => node.remove(l)));
-                    this.removeNodeDomElement(node);
-                });
+                node.addEventListener('removed', () => this.removeNodeDomElement(node));
+
+                if (labelsNode.needsAltitude && node.material.getElevationLayer()) {
+                    node.material.getElevationLayer().addEventListener('rasterElevationLevelChanged', () => { labelsNode.needsUpdate = true; });
+                }
             }
 
             node.layerUpdateState[this.id].noMoreUpdatePossible();
@@ -271,21 +414,20 @@ class LabelLayer extends Layer {
 
     removeLabelsFromNodeRecursive(node) {
         node.children.forEach((c) => {
-            if (c.isLabel && c.layerId === this.id) {
-                node.remove(c);
-            } else if (c.isTileMesh) {
-                this.removeLabelsFromNodeRecursive(c);
+            if (c.link[this.id]) {
+                delete c.link[this.id];
             }
+            this.removeLabelsFromNodeRecursive(c);
         });
 
         this.removeNodeDomElement(node);
     }
 
     removeNodeDomElement(node) {
-        if (node.domElements[this.id]) {
-            const child = node.domElements[this.id].dom;
+        if (node.link[this.id]?.domElements) {
+            const child = node.link[this.id].domElements.dom;
             child.parentElement.removeChild(child);
-            delete node.domElements[this.id];
+            delete node.link[this.id].domElements;
         }
     }
 
@@ -297,7 +439,7 @@ class LabelLayer extends Layer {
         if (clearCache) {
             this.cache.clear();
         }
-        this.domElement.parentElement.removeChild(this.domElement);
+        this.domElement.dom.parentElement.removeChild(this.domElement.dom);
 
         this.parent.level0Nodes.forEach(obj => this.removeLabelsFromNodeRecursive(obj));
     }

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -183,6 +183,7 @@ class LabelLayer extends GeometryLayer {
         this.buildExtent = true;
         this.crs = config.source.crs;
         this.performance = config.performance || true;
+        this.forceClampToTerrain = config.forceClampToTerrain || false;
 
         this.labelDomelement = domElement;
 
@@ -250,7 +251,7 @@ class LabelLayer extends GeometryLayer {
             const isDefaultElevationStyle = altitudeStyle instanceof Function && altitudeStyle.name == 'base_altitudeDefault';
 
             // determine if the altitude needs update with ElevationLayer
-            labels.needsAltitude = labels.needsAltitude || (isDefaultElevationStyle && !f.hasRawElevationData);
+            labels.needsAltitude = labels.needsAltitude || this.forceClampToTerrain === true || (isDefaultElevationStyle && !f.hasRawElevationData);
 
             f.geometries.forEach((g) => {
                 // NOTE: this only works because only POINT is supported, it

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -74,6 +74,8 @@ class LabelsNode extends THREE.Group {
         this.domElements.labels = new DomNode();
 
         this.domElements.add(this.domElements.labels);
+
+        this.domElements.labels.dom.style.opacity = '0';
     }
 
     // add node label
@@ -184,6 +186,8 @@ class LabelLayer extends GeometryLayer {
         this.crs = config.source.crs;
         this.performance = config.performance || true;
         this.forceClampToTerrain = config.forceClampToTerrain || false;
+
+        this.toHide = new THREE.Group();
 
         this.labelDomelement = domElement;
 
@@ -306,15 +310,11 @@ class LabelLayer extends GeometryLayer {
     }
 
     #submitToRendering(labelsNode) {
-        labelsNode.domElements?.labels.show();
-
         this.object3d.add(labelsNode);
     }
 
     #disallowToRendering(labelsNode) {
-        labelsNode.domElements?.labels.hide();
-
-        this.object3d.remove(labelsNode);
+        this.toHide.add(labelsNode);
     }
 
     #findClosestDomElement(node) {
@@ -449,6 +449,7 @@ class LabelLayer extends GeometryLayer {
 
             if (labelsNode.count()) {
                 labelsNode.domElements.labels.hide();
+                labelsNode.domElements.labels.dom.style.opacity = '1.0';
 
                 node.addEventListener('show', () => labelsNode.domElements.labels.show());
 

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -18,9 +18,6 @@ import Cache from 'Core/Scheduler/Cache';
  * @property {Promise} whenReady - this promise is resolved when the layer is added and all initializations are done.
  * This promise is resolved with this layer.
  * This promise is returned by [View#addLayer]{@link View}.
- * @property {boolean} [addLabelLayer=false] - Used to tell if this layer has
- * labels to display from its data. For example, it needs to be set to `true`
- * for a layer with vector tiles. If it's `true` a new `LabelLayer` is added and attached to this `Layer`.
  * @property {object} [zoom] - This property is used only the layer is attached to [TiledGeometryLayer]{@link TiledGeometryLayer}.
  * By example,
  * The layer checks the tile zoom level to determine if the layer is visible in this tile.
@@ -56,6 +53,12 @@ class Layer extends THREE.EventDispatcher {
      * the layer doesn't need Source (like debug Layer or procedural layer).
      * @param {number} [config.cacheLifeTime=Infinity] - set life time value in cache.
      * This value is used for [Cache]{@link Cache} expiration mechanism.
+     * @param {(boolean|Object)} [config.addLabelLayer=false] - Used to tell if this layer has
+     * labels to display from its data. For example, it needs to be set to `true`
+     * for a layer with vector tiles. If it's `true` a new `LabelLayer` is added and attached to this `Layer`.
+     * You can also configure it with [LabelLayer]{@link LabelLayer} options described below such as: `addLabelLayer: { performance: true }`.
+     * @param {boolean} [config.addLabelLayer.performance=false] - In case label layer adding, so remove labels that have no chance of being visible.
+     * Indeed, even in the best case, labels will never be displayed. By example, if there's many labels.
      *
      * @example
      * // Add and create a new Layer

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -59,6 +59,7 @@ class Layer extends THREE.EventDispatcher {
      * You can also configure it with [LabelLayer]{@link LabelLayer} options described below such as: `addLabelLayer: { performance: true }`.
      * @param {boolean} [config.addLabelLayer.performance=false] - In case label layer adding, so remove labels that have no chance of being visible.
      * Indeed, even in the best case, labels will never be displayed. By example, if there's many labels.
+     * @param {boolean} [config.addLabelLayer.forceClampToTerrain=false] - use elevation layer to clamp label on terrain.
      *
      * @example
      * // Add and create a new Layer

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -97,6 +97,8 @@ class TiledGeometryLayer extends GeometryLayer {
             this.object3d.add(...level0s);
             this.object3d.updateMatrixWorld();
         }));
+
+        this.maxScreenSizeNode = this.sseSubdivisionThreshold * (SIZE_DIAGONAL_TEXTURE * 2);
     }
 
     /**

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -148,7 +148,7 @@ class Label2DRenderer {
 
                             this.culling(label, camera);
                         });
-
+                    labelsNode.domElements.labels.show();
                     labelsNode.needsUpdate = false;
                 });
         });
@@ -172,6 +172,11 @@ class Label2DRenderer {
             } else {
                 l.visible = false;
             }
+        });
+
+        labelLayers.forEach((labelLayer) => {
+            labelLayer.toHide.children.forEach(labelsNode => labelsNode.domElements?.labels.hide());
+            labelLayer.toHide.clear();
         });
     }
 

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -1,15 +1,9 @@
 import * as THREE from 'three';
+import GlobeLayer from 'Core/Prefab/Globe/GlobeLayer';
 
 function isIntersectedOrOverlaped(a, b) {
     return !(a.left > b.right || a.right < b.left
         || a.top > b.bottom || a.bottom < b.top);
-}
-
-// find label in children
-function hasLabelChildren(object) {
-    const parent = object.parent;
-    return parent.material && !parent.material.visible &&
-        parent.children.find(c => c.isTileMesh && c.children.find(cc => cc.isLabel));
 }
 
 const frustum = new THREE.Frustum();
@@ -21,7 +15,6 @@ class ScreenGrid {
         this.y = y;
 
         this.grid = [];
-        this.hidden = [];
         this.visible = [];
 
         this.resize();
@@ -40,7 +33,6 @@ class ScreenGrid {
             }
         }
 
-        this.hidden = [];
         this.visible = [];
     }
 
@@ -73,7 +65,7 @@ class ScreenGrid {
             for (let j = miny; j <= maxy; j++) {
                 if (this.grid[i][j].length > 0) {
                     if (this.grid[i][j].some(l => isIntersectedOrOverlaped(l.boundaries, obj.boundaries))) {
-                        this.hidden.push(obj);
+                        obj.visible = false;
                         return false;
                     }
                 }
@@ -136,16 +128,30 @@ class Label2DRenderer {
     }
 
     registerLayer(layer) {
-        this.domElement.appendChild(layer.domElement);
+        this.domElement.appendChild(layer.domElement.dom);
     }
 
     render(scene, camera) {
-        if (!this.infoTileLayer || !this.infoTileLayer.layer.attachedLayers.find(l => l.isLabelLayer && l.visible)) { return; }
+        const labelLayers = this.infoTileLayer && this.infoTileLayer.layer.attachedLayers.filter(l => l.isLabelLayer && l.visible);
+        if (labelLayers.length == 0) { return; }
         this.grid.reset();
 
         // set camera frustum
         frustum.setFromProjectionMatrix(camera.projectionMatrix);
-        this.culling(scene, this.infoTileLayer.displayed.extent, camera);
+
+        labelLayers.forEach((labelLayer) => {
+            labelLayer.submittedLabelNodes.forEach(
+                (labelsNode) => {
+                    labelsNode.labels.forEach(
+                        (label) => {
+                            labelsNode.updatePosition(label);
+
+                            this.culling(label, camera);
+                        });
+
+                    labelsNode.needsUpdate = false;
+                });
+        });
 
         // sort by order, then by visibility inside those subsets
         // https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-hierarchy
@@ -163,86 +169,39 @@ class Label2DRenderer {
             if (this.grid.insert(l)) {
                 l.visible = true;
                 l.updateCSSPosition();
+            } else {
+                l.visible = false;
             }
         });
-
-        this.grid.hidden.forEach((label) => { label.visible = false; });
     }
 
-    culling(object, extent, camera) {
-        if (!object.isLabel) {
-            if (!object.visible) {
-                this.hideNodeDOM(object);
-                return;
-            // Don't go further if the node can't be in the screen space (it
-            // does not need to be rendered to continue the culling)
-            } else if (object.extent && !object.extent.intersectsExtent(extent)) {
-                this.hideNodeDOM(object);
-                return;
-            }
-
-            this.showNodeDOM(object);
-
-            object.children.forEach(c => this.culling(c, extent, camera));
-        // the presence of the label inside the visible extent and if children has label, we can filter more labels.
-        } else if (!extent.isPointInside(object.coordinates) || hasLabelChildren(object)) {
-            this.grid.hidden.push(object);
-        // the presence of the label inside frustum camera.
-        } else if (!frustum.containsPoint(object.getWorldPosition(worldPosition).applyMatrix4(camera.matrixWorldInverse))) {
-            this.grid.hidden.push(object);
-        // Do some horizon culling (if possible) if the tiles level is small
-        // enough. The chosen value of 4 seems to provide a good result.
-        } else if (object.parent.level < 4 && object.parent.layer.horizonCulling && object.parent.layer.horizonCulling(object.horizonCullingPoint)) {
-            this.grid.hidden.push(object);
+    culling(label, camera) {
+        label.getWorldPosition(worldPosition);
+        // Check if the frustum contains tle label
+        if (!frustum.containsPoint(worldPosition.applyMatrix4(camera.matrixWorldInverse)) ||
+        // Check if globe horizon culls the label
+        // Do some horizon culling (if possible) if the tiles level is small enough.
+            label.horizonCullingPoint && GlobeLayer.horizonCulling(label.horizonCullingPoint) ||
+        // Check if content isn't present in visible labels
+            this.grid.visible.some((l) => {
+                // TODO for icon without text filter by position
+                const textContent = label.content.textContent;
+                return textContent !== '' && l.content.textContent.toLowerCase() == textContent.toLowerCase();
+            })) {
+            label.visible = false;
         } else {
-            // projecting world position object
+            // projecting world position label
             worldPosition.applyMatrix4(camera.projectionMatrix);
 
-            object.updateProjectedPosition(worldPosition.x * this.halfWidth + this.halfWidth, -worldPosition.y * this.halfHeight + this.halfHeight);
+            label.updateProjectedPosition(worldPosition.x * this.halfWidth + this.halfWidth, -worldPosition.y * this.halfHeight + this.halfHeight);
 
-            // Are considered duplicates, labels that have the same screen
-            // coordinates and the same base content.
-            if (this.grid.visible.some(l => l.projectedPosition.x == object.projectedPosition.x
-                && l.projectedPosition.y == object.projectedPosition.y
-                && l.baseContent == object.baseContent)) {
-                object.parent.remove(object);
-                this.grid.hidden.push(object);
-            } else {
-                this.grid.visible.push(object);
-            }
+            this.grid.visible.push(label);
         }
     }
 
     removeLabelDOM(label) {
         this.garbage.appendChild(label.content);
         this.garbage.innerHTML = '';
-    }
-
-    hideNodeDOM(node) {
-        if (node.domElements) {
-            const domElements = Object.values(node.domElements);
-            if (domElements.length > 0) {
-                domElements.forEach((domElement) => {
-                    if (domElement.visible == true) {
-                        domElement.dom.style.display = 'none';
-                        domElement.visible = false;
-                    }
-                });
-            } else {
-                node.children.filter(n => n.isTileMesh).forEach(n => this.hideNodeDOM(n));
-            }
-        }
-    }
-
-    showNodeDOM(node) {
-        if (node.domElements) {
-            Object.values(node.domElements).forEach((domElement) => {
-                if (domElement.visible == false) {
-                    domElement.dom.style.display = 'block';
-                    domElement.visible = true;
-                }
-            });
-        }
     }
 }
 

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -9,7 +9,7 @@ function isIntersectedOrOverlaped(a, b) {
 const frustum = new THREE.Frustum();
 
 // A grid to manage labels on the screen.
-class ScreenGrid {
+export class ScreenGrid {
     constructor(x = 12, y = 10, width, height) {
         this.x = x;
         this.y = y;

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -47,7 +47,11 @@ class DOMElement {
         this[att] = val;
     }
     focus() {}
-    appendChild(c) { this.children.push(c); }
+    appendChild(c) {
+        c.parentNode = this;
+        this.children.push(c);
+    }
+    append(c) { this.appendChild(c); }
     cloneNode() { return Object.create(this); }
     getBoundingClientRect() { return { x: 0, y: 0, width: this.width, height: this.height }; }
     addEventListener(event, cb) { this.events.set(event, cb); }


### PR DESCRIPTION
## Description
### Apply architecture node, simplify process and the rendering.

* `LabelLayer` extends `GeometryLayer`;
* introduce `DomNode` and `LabelsNode` to structure data in **architecture node**;
* simplify and optimize the process post-convert and the label culling;

### Performance

It added an **option perfomance** in `LabelLayer`.
This option allows to **reduce the number of labels** to be processed and rendered **without altering the final rendering**.
This reduction is done by filtering the labels that can never be displayed because they are too numerous.
The results are interesting when the data have too many labels for a given extent.
By example, the label process and rendering are **ten times faster** on IGN vector tiles.

### Others

* add **option to force clamping on terrain**, in case the original elevation data are wrong;
* add unit tests with all the context of the itowns processes;
* fix label culling on `GlobeView`;

https://user-images.githubusercontent.com/11291849/234934004-5ac0752f-f4f4-4b75-82da-19180f8aa462.mp4

## Motivation and Context

* remove last children in `TileMesh` other that `TileMesh`: will simplify removal `ObjectRemovalHelper`;
