### PR TITLE
C3DTilesLayer Style

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@ The following people have contributed to iTowns.
   * [Marie Lamure](https://github.com/mlamure)
   * [Vincent Jaillot](https://github.com/jailln)
   * [Valentin Rigolle](https://github.com/Crejak)
+  * [Valentin Machado](https://github.com/valentinMachado)
 
 * [virtualcitySYSTEMS](https://www.virtualcitysystems.de/)
   * [Ben Kuster](https://github.com/bkuster)

--- a/docs/config.json
+++ b/docs/config.json
@@ -118,7 +118,8 @@
                 "C3DTBatchTable",
                 "C3DTBoundingVolume",
                 "C3DTExtensions",
-                "C3DTBatchTableHierarchyExtension"
+                "C3DTBatchTableHierarchyExtension",
+                "C3DTFeature"
             ],
 
             "Plugins": [

--- a/docs/config.json
+++ b/docs/config.json
@@ -133,7 +133,8 @@
                 "Navigation",
                 "Minimap",
                 "Scale",
-                "Searchbar"
+                "Searchbar",
+                "C3DTilesStyle"
             ]
         },
         "tutorialSections": {

--- a/examples/config.json
+++ b/examples/config.json
@@ -85,7 +85,8 @@
         "widgets_navigation": "Navigation",
         "widgets_minimap": "Minimap",
         "widgets_scale": "Scale",
-        "widgets_searchbar": "Searchbar"
+        "widgets_searchbar": "Searchbar",
+        "widgets_3dtiles_style": "3DTiles Style"
     },
 
     "Plugins": {

--- a/examples/css/widgets.css
+++ b/examples/css/widgets.css
@@ -358,3 +358,31 @@
 #widgets-searchbar form > div > p {
     margin: 8px 0;
 }
+
+/* ---------- 3D Tiles Style : --------------------------------------------------------------------- */
+
+#widgets-3dtilesstyle {
+    position: absolute;
+    z-index: 2;
+    background-color: #313336bb; /* maybe create global variables for this file */
+    padding: 5px;
+}
+
+#widgets-3dtilesstyle select,input{
+    width: 100%;
+    background-color: inherit;
+}
+
+#widgets-3dtilesstyle option {
+    color:black;
+}
+
+#widgets-3dtilesstyle * {
+    color:#ffffff;
+    padding: 2px;
+}
+
+#widgets-3dtilesstyle label {
+    text-transform: uppercase;
+    display: block;
+}

--- a/examples/js/3dTilesHelper.js
+++ b/examples/js/3dTilesHelper.js
@@ -23,10 +23,10 @@ function fillHTMLWithPickingInfo(event, pickingArg) {
 
     // Get information from intersected objects (from the batch table and
     // eventually the 3D Tiles extensions
-    var featureDisplayableInfo = pickingArg.layer.getInfoFromIntersectObject(intersects);
+    var closestC3DTileFeature = pickingArg.layer.getC3DTileFeatureFromIntersectsArray(intersects);
 
-    if (featureDisplayableInfo) {
+    if (closestC3DTileFeature) {
         // eslint-disable-next-line
-        pickingArg.htmlDiv.appendChild(createHTMLListFromObject(featureDisplayableInfo));
+        pickingArg.htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature.getInfo()));
     }
 }

--- a/examples/widgets_3dtiles_style.html
+++ b/examples/widgets_3dtiles_style.html
@@ -1,0 +1,130 @@
+<html>
+    <head>
+        <title>Itowns - 3D Tiles Style Widget </title>
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/widgets.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv" class="viewer"></div>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/itowns_widgets.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="js/GUI/GuiTools.js"></script>
+        <script type="text/javascript">
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
+            // Define geographic extent: CRS, min/max X, min/max Y
+            const extent = new itowns.Extent( 'EPSG:3946',
+                1840816.94334, 1843692.32501,
+                5175036.4587, 5177412.82698);
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            const viewerDiv = document.getElementById('viewerDiv');
+
+            // Instanciate PlanarView*
+            const cameraCoord = new itowns.Coordinates('EPSG:3946', 1841980,
+                5175682, 3000)
+            const view = new itowns.PlanarView(viewerDiv, extent, { placement: {
+                coord: cameraCoord, heading: 30, range: 4000, tilt: 30 } });
+
+            setupLoadingScreen(viewerDiv, view);
+
+            // Add a WMS imagery source
+            const wmsImagerySource = new itowns.WMSSource({
+                extent: extent,
+                name: 'Ortho2009_vue_ensemble_16cm_CC46',
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                version: '1.3.0',
+                crs: 'EPSG:3946',
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS imagery layer
+            const wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+                updateStrategy: {
+                    type: itowns.STRATEGY_DICHOTOMY,
+                    options: {},
+                },
+                source: wmsImagerySource,
+            });
+
+            view.addLayer(wmsImageryLayer);
+
+            // Add a WMS elevation source
+            const wmsElevationSource = new itowns.WMSSource({
+                extent: extent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                crs: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            const wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
+
+            const $3dTilesLayer = new itowns.C3DTilesLayer(
+                0, {
+                    name: 'First Lyon Rounding 2018',
+                    source: new itowns.C3DTilesSource({
+                        url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/' +
+                            '3DTiles/lyon1_with_surface_type_2018/tileset.json',
+                    })
+                }, view);
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayer);
+
+            // Lights
+            const dirLight = new itowns.THREE.DirectionalLight(0xffffff, 1);
+            dirLight.position.set(-0.9, 0.3, 1);
+            dirLight.updateMatrixWorld();
+            view.scene.add( dirLight );
+
+            const ambLight = new itowns.THREE.AmbientLight(0xffffff, 0.2);
+            view.scene.add( ambLight );
+
+            // Request redraw
+            view.notifyChange();
+
+            // Add 3D Tiles Style Widget
+            const widget = new itowns_widgets.C3DTilesStyle(view);
+            widget.domElement.setAttribute('id', 'widgets-3dtilesstyle');
+
+            // Add a box3 to C3DTileFeature onclick
+            const geometry = new itowns.THREE.BoxGeometry();
+            const material = new itowns.THREE.MeshBasicMaterial( {color: 0x00ff00, opacity: 0.5, transparent: true} );
+            const cube = new itowns.THREE.Mesh( geometry, material );
+            view.domElement.onclick = (event) => {
+                const intersects = view.pickObjectsAt(event, 0, [$3dTilesLayer]);
+                const c3DTileFeatureClicked = $3dTilesLayer.getC3DTileFeatureFromIntersectsArray(intersects);
+                
+                if (c3DTileFeatureClicked) {
+                    const worldBox3 = $3dTilesLayer.computeWorldBox3(c3DTileFeatureClicked);
+                    cube.scale.copy(worldBox3.max.clone().sub(worldBox3.min));
+                    worldBox3.getCenter(cube.position);
+                    cube.updateMatrixWorld();
+                    view.scene.add(cube);
+                    view.notifyChange();
+                }
+            }
+
+            // Add a debug UI
+            const menu = new GuiTools('menuDiv', view);
+            const d = new debug.Debug(view, menu.gui);
+            debug.createTileDebugUI(menu.gui, view, view.tileLayer, d);
+        </script>
+    </body>
+</html>

--- a/src/Core/3DTiles/C3DTBatchTable.js
+++ b/src/Core/3DTiles/C3DTBatchTable.js
@@ -18,13 +18,13 @@ import C3DTilesTypes from './C3DTilesTypes';
  */
 class C3DTBatchTable {
     /**
-     * @param {ArrayBuffer} buffer - batch table buffer to parse
-     * @param {number} jsonLength - batch table json part length
-    * @param {number} binaryLength - batch table binary part length
-     * @param {number} batchLength - the length of the batch.
-     * @param {Object} registeredExtensions - extensions registered to the layer
+     * @param {ArrayBuffer} [buffer=new ArrayBuffer()] - batch table buffer to parse
+     * @param {number} [jsonLength=0] - batch table json part length
+    * @param {number} [binaryLength=0] - batch table binary part length
+     * @param {number} [batchLength=0] - the length of the batch.
+     * @param {Object} [registeredExtensions] - extensions registered to the layer
      */
-    constructor(buffer, jsonLength, binaryLength, batchLength, registeredExtensions) {
+    constructor(buffer = new ArrayBuffer(), jsonLength = 0, binaryLength = 0, batchLength = 0, registeredExtensions) {
         if (arguments.length === 4 &&
             typeof batchLength === 'object' &&
             !Array.isArray(batchLength) &&
@@ -40,7 +40,8 @@ class C3DTBatchTable {
         this.batchLength = batchLength;
 
         const jsonBuffer = buffer.slice(0, jsonLength);
-        const jsonContent = JSON.parse(utf8Decoder.decode(new Uint8Array(jsonBuffer)));
+        const decodedJsonBuffer = utf8Decoder.decode(new Uint8Array(jsonBuffer));
+        const jsonContent = decodedJsonBuffer === '' ? null : JSON.parse(decodedJsonBuffer);
 
         if (binaryLength > 0) {
             const binaryBuffer = buffer.slice(jsonLength, jsonLength + binaryLength);
@@ -71,7 +72,7 @@ class C3DTBatchTable {
         // returned object to batchTable.extensions
         // Extensions must be registered in the layer (see an example of this in
         // 3dtiles_hierarchy.html)
-        if (jsonContent.extensions) {
+        if (jsonContent && jsonContent.extensions) {
             this.extensions =
                 registeredExtensions.parseExtensions(jsonContent.extensions, this.type);
             delete jsonContent.extensions;

--- a/src/Core/3DTiles/C3DTFeature.js
+++ b/src/Core/3DTiles/C3DTFeature.js
@@ -1,0 +1,44 @@
+/**
+ * C3DTFeature is a feature of a 3DTiles
+ *
+ * @class      C3DTFeature
+ * @param {number} tileId - tile id
+ * @param {number} batchId - batch id
+ * @param {Array<{start:number,count:number}>} groups - groups in geometry.attributes matching batchId
+ * @param {object} info - info in the batchTable
+ * @param {object} [userData={}] - some userData
+ * @property {number} tileId - tile id
+ * @property {number} batchId - batch id
+ * @property {Array<{start:number,count:number}>} groups - groups in geometry.attributes matching batchId
+ * @property {object} info - info in the batchTable
+ * @property {object} [userData={}] - some userData
+ */
+class C3DTFeature {
+    #info;
+    constructor(tileId, batchId, groups, info, userData = {}) {
+        /** @type {number} */
+        this.tileId = tileId;
+
+        /** @type {number} */
+        this.batchId = batchId;
+
+        /** @type {Array<{start:number,count:number}>} */
+        this.groups = groups;
+
+        /** @type {object} */
+        this.userData = userData;
+
+        /** @type {object} */
+        this.#info = info;
+    }
+
+    /**
+     *
+     * @returns {object} - batchTable info
+     */
+    getInfo() {
+        return this.#info;
+    }
+}
+
+export default C3DTFeature;

--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -3,10 +3,24 @@ import GeometryLayer from 'Layer/GeometryLayer';
 import { init3dTilesLayer, pre3dTilesUpdate, process3dTilesNode } from 'Process/3dTilesProcessing';
 import C3DTileset from 'Core/3DTiles/C3DTileset';
 import C3DTExtensions from 'Core/3DTiles/C3DTExtensions';
+// eslint-disable-next-line no-unused-vars
+import Style from 'Core/Style';
+import C3DTFeature from 'Core/3DTiles/C3DTFeature';
+import { optimizeGeometryGroups } from 'Utils/ThreeUtils';
+
+export const C3DTILES_LAYER_EVENTS = {
+    /**
+     * Fires when a tile content has been loaded
+     * @event C3DTilesLayer#on-tile-content-loaded
+     * @property type {string} on-tile-content-loaded
+     */
+    ON_TILE_CONTENT_LOADED: 'on-tile-content-loaded',
+};
 
 const update = process3dTilesNode();
 
 class C3DTilesLayer extends GeometryLayer {
+    #fillColorMaterialsBuffer;
     /**
      * Constructs a new instance of 3d tiles layer.
      * @constructor
@@ -45,12 +59,8 @@ class C3DTilesLayer extends GeometryLayer {
      * threshold at which child nodes of the current node will be loaded and added to the scene.
      * @param {Number} [config.cleanupDelay=1000] The time (in ms) after which a tile content (and its children) are
      * removed from the scene.
-     * @param {Function} [config.onTileContentLoaded] Callback executed when the content of a tile is loaded.
-     * @param {Boolean|Material} [config.overrideMaterials='false'] option to override the materials of all the layer's
-     * objects. If true, a threejs [MeshBasicMaterial](https://threejs.org/docs/index.html?q=meshbasic#api/en/materials/MeshBasicMaterial)
-     * is set up. config.overrideMaterials can also be a threejs [Material](https://threejs.org/docs/index.html?q=material#api/en/materials/Material)
-     * in which case it will be used as the material for all objects of the layer.
      * @param {C3DTExtensions} [config.registeredExtensions] 3D Tiles extensions managers registered for this tileset.
+     * @param {Style} [config.style=null] - style used for this layer
      * @param  {View}  view  The view
      */
     constructor(id, config, view) {
@@ -58,11 +68,33 @@ class C3DTilesLayer extends GeometryLayer {
         this.isC3DTilesLayer = true;
         this.sseThreshold = config.sseThreshold || 16;
         this.cleanupDelay = config.cleanupDelay || 1000;
-        this.onTileContentLoaded = config.onTileContentLoaded || (() => {});
         this.protocol = '3d-tiles';
-        this.overrideMaterials = config.overrideMaterials ?? false;
         this.name = config.name;
         this.registeredExtensions = config.registeredExtensions || new C3DTExtensions();
+
+        /** @type {Style} */
+        this._style = config.style || null;
+
+        /** @type {Map<string, THREE.MeshStandardMaterial>} */
+        this.#fillColorMaterialsBuffer = new Map();
+
+        /**
+         * Map all C3DTFeature of the layer according their tileId and their batchId
+         * Map< tileId, Map< batchId, C3DTFeature>>
+         *
+         * @type {Map<number, Map<number,C3DTFeature>>}
+         */
+        this.tilesC3DTileFeatures = new Map();
+
+        if (config.onTileContentLoaded) {
+            console.warn('DEPRECATED onTileContentLoaded should not be passed at the contruction, use C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED event instead');
+            this.addEventListener(C3DTilesLayer.EVENT_TILE_CONTENT_LOADED, config.onTileContentLoaded);
+        }
+
+        if (config.overrideMaterials) {
+            console.warn('overrideMaterials is deprecated, use style API instead');
+            this.overrideMaterials = config.overrideMaterials;
+        }
 
         this._cleanableTiles = [];
 
@@ -142,48 +174,291 @@ class C3DTilesLayer extends GeometryLayer {
     }
 
     /**
-     * Gets semantic information from batch table and batch table extensions
-     * of an intersected feature.
+     * Get the closest c3DTileFeature of an intersects array.
      * @param {Array} intersects - @return An array containing all
      * targets picked under specified coordinates. Intersects can be
      * computed with view.pickObjectsAt(..). See fillHTMLWithPickingInfo()
      * in 3dTilesHelper.js for an example.
-     * @returns {Object} - an object containing the batch id, the
-     * information from the batch table and from the extension of the batch
-     * table for an intersected feature.
+     * @returns {C3DTileFeature} - the closest C3DTileFeature of the intersects array
      */
-    getInfoFromIntersectObject(intersects) {
-        const resultInfo = {};
-
-        let batchID = -1;
-        let batchTable = {};
-        // First, we get the ID and the batch table of the intersected object.
-        // (the semantic information about a feature is located in its batch
-        // table (see 3D Tiles specification).
-        for (let i = 0; i < intersects.length; i++) {
-            // interAttributes are glTF attributes of b3dm tiles (i.e.
-            // position, normal, batch id)
-            const interAttributes = intersects[i].object.geometry.attributes;
-            if (interAttributes && interAttributes._BATCHID) {
-                // face is a Face3 object of THREE which is a
-                // triangular face. face.a is its first vertex
-                const vertex = intersects[i].face.a;
-                // get batch id of the face
-                batchID = interAttributes._BATCHID.array[vertex];
-                batchTable = this.findBatchTable(intersects[i].object);
+    getC3DTileFeatureFromIntersectsArray(intersects) {
+        // find closest intersect with an attributes _BATCHID + face != undefined
+        let closestIntersect = null;
+        for (let index = 0; index < intersects.length; index++) {
+            const i = intersects[index];
+            if (i.object.geometry &&
+                i.object.geometry.attributes._BATCHID &&
+                i.face && // need face to get batch id
+                i.layer == this // just to be sure that the right layer intersected
+            ) {
+                closestIntersect = i;
                 break;
             }
         }
 
-        if (batchID === -1) {
-            return;
+        if (!closestIntersect) {
+            return null;
         }
 
-        resultInfo.batchID = batchID;
-        // get information from batch table (including from its extension)
-        Object.assign(resultInfo, batchTable.getInfoById(batchID));
+        // function find the tile id from an object
+        function findTileID(object) {
+            let currentObject = object;
+            let result = currentObject.tileId;
+            while (isNaN(result) && currentObject.parent) {
+                currentObject = currentObject.parent;
+                result = currentObject.tileId;
+            }
 
-        return resultInfo;
+            return result;
+        }
+
+        const tileId = findTileID(closestIntersect.object);
+        // face is a Face3 object of THREE which is a
+        // triangular face. face.a is its first vertex
+        const vertex = closestIntersect.face.a;
+        const batchID = closestIntersect.object.geometry.attributes._BATCHID.array[vertex];
+
+        return this.tilesC3DTileFeatures.get(tileId).get(batchID);
+    }
+
+    /**
+     * Call by {@link 3dTilesProcessing} which handle load and unload of 3DTiles
+     * @param {THREE.Object3D} tileContent - tile as THREE.Object3D
+     */
+    onTileContentLoaded(tileContent) {
+        this.initC3DTileFeatures(tileContent);
+
+        // notify observer
+        this.dispatchEvent({ type: C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED, tileContent });
+    }
+
+    /**
+     * Initialize C3DTileFeatures from tileContent
+     *
+     * @param {THREE.Object3D} tileContent - tile as THREE.Object3D
+     */
+    initC3DTileFeatures(tileContent) {
+        tileContent.traverse((child) => {
+            if (child.geometry && child.geometry.attributes._BATCHID) {
+                this.tilesC3DTileFeatures.set(tileContent.tileId, new Map());// initialize
+                const batchTable = this.findBatchTable(child);
+                if (!batchTable) {
+                    throw new Error('no batchTable');
+                }
+
+                const geometryAttributes = child.geometry.attributes;
+                let currentBatchId = geometryAttributes._BATCHID.array[0];
+                let start = 0;
+                let count = 0;
+
+                const registerBatchIdGroup = () => {
+                    if (this.tilesC3DTileFeatures.get(tileContent.tileId).has(currentBatchId)) {
+                        // already created
+                        const c3DTileFeature = this.tilesC3DTileFeatures.get(tileContent.tileId).get(currentBatchId);
+                        // add new group
+                        c3DTileFeature.groups.push({
+                            start,
+                            count,
+                        });
+                    } else {
+                        // first occurence
+                        const c3DTileFeature = new C3DTFeature(
+                            tileContent.tileId,
+                            currentBatchId,
+                            [{ start, count }], // initialize with current group
+                            batchTable.getInfoById(currentBatchId),
+                        );
+                        this.tilesC3DTileFeatures.get(tileContent.tileId).set(currentBatchId, c3DTileFeature);
+                    }
+                };
+
+                for (let index = 0; index < geometryAttributes.position.array.length; index += geometryAttributes.position.itemSize) {
+                    const batchIndex = index / geometryAttributes.position.itemSize;
+                    const batchId = geometryAttributes._BATCHID.array[batchIndex];
+
+                    // check if batchId is currentBatchId
+                    if (currentBatchId !== batchId) {
+                        registerBatchIdGroup();
+
+                        // reset
+                        currentBatchId = batchId;
+                        start = batchIndex;
+                        count = 0;
+                    }
+
+                    // record this position in current C3DTileFeature
+                    count++;
+
+                    // check if end of the array
+                    if (index + geometryAttributes.position.itemSize >= geometryAttributes.position.array.length) {
+                        registerBatchIdGroup();
+                    }
+                }
+            }
+        });
+
+        this.updateStyle([tileContent.tileId]);// only update tile batchelement
+    }
+
+    /**
+     * Compute world box 3 of a c3DTFeature
+     *
+     * @param {C3DTFeature} c3DTFeature - feature to compute world box3
+     * @param {THREE.Box3} [target] - result instance
+     * @returns {THREE.Box3}
+     */
+    computeWorldBox3(c3DTFeature, target = new THREE.Box3()) {
+        // reset
+        target.max.x = -Infinity;
+        target.max.y = -Infinity;
+        target.max.z = -Infinity;
+        target.min.x = Infinity;
+        target.min.y = Infinity;
+        target.min.z = Infinity;
+
+        const tileContent = this.object3d.getObjectByProperty('tileId', c3DTFeature.tileId);
+        tileContent.traverse((child) => {
+            if (child.geometry && child.geometry.attributes._BATCHID) {
+                c3DTFeature.groups.forEach((group) => {
+                    const positionIndexStart = group.start * 3;
+                    const positionIndexCount = (group.start + group.count) * 3;
+
+                    for (let index = positionIndexStart; index < positionIndexCount; index += 3) {
+                        const x = child.geometry.attributes.position.array[index];
+                        const y = child.geometry.attributes.position.array[index + 1];
+                        const z = child.geometry.attributes.position.array[index + 2];
+
+                        target.max.x = Math.max(x, target.max.x);
+                        target.max.y = Math.max(y, target.max.y);
+                        target.max.z = Math.max(z, target.max.z);
+
+                        target.min.x = Math.min(x, target.min.x);
+                        target.min.y = Math.min(y, target.min.y);
+                        target.min.z = Math.min(z, target.min.z);
+                    }
+                });
+
+                target.applyMatrix4(child.matrixWorld);
+            }
+        });
+
+        return target;
+    }
+
+    /**
+     * Update style of the C3DTFeatures, an allowList of tile id can be passed to only update certain tile.
+     * Note that this function only update THREE.Object3D materials, in order to see style changes you should call view.notifyChange()
+     *
+     * @param {Array<number>|null} [allowTileIdList] - tile ids to allow in updateStyle computation if null all tiles are updated
+     * @returns {boolean} true if style updated false otherwise
+     */
+    updateStyle(allowTileIdList = null) {
+        if (!this._style) {
+            return false;
+        }
+
+        const currentMaterials = [];// list materials used for this update
+        this.object3d.traverse((object) => {
+            if (object.tileId && this.tilesC3DTileFeatures.has(object.tileId)) {
+                // object is a tile content
+                const c3DTileFeatures = this.tilesC3DTileFeatures.get(object.tileId);
+                object.traverse((child) => {
+                    if (child.geometry && child.geometry.attributes._BATCHID) {
+                        // check if tile feature should be updated
+                        if (!(allowTileIdList && !allowTileIdList.includes(object.tileId))) {
+                            // clear
+                            child.geometry.clearGroups();
+                            child.material = [];
+
+                            // eslint-disable-next-line no-unused-vars
+                            for (const [batchId, c3DTileFeature] of c3DTileFeatures) {
+                                /** @type {THREE.Color} */
+                                let color = null;
+                                if (typeof this._style.fill.color === 'function') {
+                                    color = new THREE.Color(this._style.fill.color(c3DTileFeature));
+                                } else {
+                                    color = new THREE.Color(this._style.fill.color);
+                                }
+
+                                /** @type {number} */
+                                let opacity = null;
+                                if (typeof this._style.fill.opacity === 'function') {
+                                    opacity = this._style.fill.opacity(c3DTileFeature);
+                                } else {
+                                    opacity = this._style.fill.opacity;
+                                }
+
+                                const materialId = color.getHexString() + opacity;
+
+                                let material = null;
+                                if (this.#fillColorMaterialsBuffer.has(materialId)) {
+                                    material = this.#fillColorMaterialsBuffer.get(materialId);
+                                } else {
+                                    material = new THREE.MeshStandardMaterial({ color, opacity, transparent: opacity < 1, alphaTest: 0.09 });
+                                    this.#fillColorMaterialsBuffer.set(materialId, material);// bufferize
+                                }
+
+                                // compute materialIndex
+                                let materialIndex = -1;
+                                for (let index = 0; index < child.material.length; index++) {
+                                    const childMaterial = child.material[index];
+                                    if (material.uuid === childMaterial.uuid) {
+                                        materialIndex = index;
+                                        break;
+                                    }
+                                }
+                                if (materialIndex < 0) {
+                                    // not in child.material add it
+                                    child.material.push(material);
+                                    materialIndex = child.material.length - 1;
+                                }
+
+                                // materialIndex groups is computed
+                                c3DTileFeature.groups.forEach((group) => {
+                                    child.geometry.addGroup(group.start, group.count, materialIndex);
+                                });
+                            }
+
+                            optimizeGeometryGroups(child);
+                        }
+
+                        // record material(s) used in child
+                        if (child.material instanceof Array) {
+                            child.material.forEach((material) => {
+                                if (!currentMaterials.includes(material)) {
+                                    currentMaterials.push(material);
+                                }
+                            });
+                        } else if (!currentMaterials.includes(child.material)) {
+                            currentMaterials.push(child.material);
+                        }
+                    }
+                });
+            }
+        });
+
+        // remove buffered materials not in currentMaterials
+        for (const [id, fillMaterial] of this.#fillColorMaterialsBuffer) {
+            if (!currentMaterials.includes(fillMaterial)) {
+                fillMaterial.dispose();
+                this.#fillColorMaterialsBuffer.delete(id);
+            }
+        }
+
+        return true;
+    }
+
+    get materialCount() {
+        return this.#fillColorMaterialsBuffer.size;
+    }
+
+    set style(value) {
+        this._style = value;
+        this.updateStyle();
+    }
+
+    get style() {
+        return this._style;
     }
 }
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -52,7 +52,7 @@ export { default as GeometryLayer } from 'Layer/GeometryLayer';
 export { default as FeatureGeometryLayer } from 'Layer/FeatureGeometryLayer';
 export { default as PointCloudLayer } from 'Layer/PointCloudLayer';
 export { default as PotreeLayer } from 'Layer/PotreeLayer';
-export { default as C3DTilesLayer } from 'Layer/C3DTilesLayer';
+export { default as C3DTilesLayer, C3DTILES_LAYER_EVENTS } from 'Layer/C3DTilesLayer';
 export { default as TiledGeometryLayer } from 'Layer/TiledGeometryLayer';
 export { default as OrientedImageLayer } from 'Layer/OrientedImageLayer';
 export { STRATEGY_MIN_NETWORK_TRAFFIC, STRATEGY_GROUP, STRATEGY_PROGRESSIVE, STRATEGY_DICHOTOMY } from 'Layer/LayerUpdateStrategy';
@@ -96,6 +96,7 @@ export { enableDracoLoader, glTFLoader, legacyGLTFLoader } from 'Parser/B3dmPars
 // 3D Tiles classes and extensions
 // Exported to allow one to implement its own 3D Tiles extension which needs to
 // know the classes it extends
+export { default as C3DTFeature } from './Core/3DTiles/C3DTFeature';
 export { default as C3DTileset } from './Core/3DTiles/C3DTileset';
 export { default as C3DTBoundingVolume } from './Core/3DTiles/C3DTBoundingVolume';
 export { default as C3DTBatchTable } from './Core/3DTiles/C3DTBatchTable';

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -148,10 +148,10 @@ export default {
                     b3dmHeader.FTBinaryLength;
                 const BTBuffer = buffer.slice(sizeBegin, sizeBegin + b3dmHeader.BTJSONLength +
                     b3dmHeader.BTBinaryLength);
-                promises.push(new C3DTBatchTable(BTBuffer, b3dmHeader.BTJSONLength,
-                    b3dmHeader.BTBinaryLength, FTJSON.BATCH_LENGTH, options.registeredExtensions));
+                promises.push(Promise.resolve(new C3DTBatchTable(BTBuffer, b3dmHeader.BTJSONLength,
+                    b3dmHeader.BTBinaryLength, FTJSON.BATCH_LENGTH, options.registeredExtensions)));
             } else {
-                promises.push(Promise.resolve({}));
+                promises.push(Promise.resolve(new C3DTBatchTable()));
             }
 
             const posGltf = headerByteLength +

--- a/src/Utils/ThreeUtils.js
+++ b/src/Utils/ThreeUtils.js
@@ -65,3 +65,52 @@ export default function disposeThreeMaterial(material) {
         textures[i].dispose();
     }
 }
+
+/**
+ * Merge groups of an object3D when it can to reduce number of them + remove unused materials
+ * Reduce draw call https://threejs.org/docs/index.html?q=geometry#api/en/core/BufferGeometry.groups
+ *
+ * @param {THREE.Object3D} object3D - object to get optimize
+ */
+export function optimizeGeometryGroups(object3D) {
+    if (!object3D.geometry) {
+        return;
+    }
+
+    object3D.geometry.groups.sort((a, b) => (a.start - b.start) * -1); // [5,10,7] => [10,7,5]
+    const lastIndex = object3D.geometry.groups.length - 1;
+    let currentMaterialIndex = object3D.geometry.groups[lastIndex].materialIndex; // initialized with the lastest group
+    const usedIndexMaterials = [currentMaterialIndex]; // compute materials actually used by group
+    // for loop descendant to be able to splice in loop without modifying group index
+    for (let index = lastIndex - 1; index >= 0; index--) { // begin at lastIndex - 1 because intialized with lastIndex
+        const group = object3D.geometry.groups[index];
+        if (group.materialIndex !== currentMaterialIndex) {
+            // this is another group (!= materialIndex) take its material as ref to continue
+            currentMaterialIndex = group.materialIndex;
+            usedIndexMaterials.push(currentMaterialIndex);
+            continue;
+        } else {
+            // indeed same group merge with previous group
+            const previousGroup = object3D.geometry.groups[index + 1];
+            previousGroup.count += group.count; // previous group wrap the current one
+            object3D.geometry.groups.splice(index, 1); // remove group
+        }
+    }
+
+    // clean unused material
+    for (let index = object3D.material.length - 1; index >= 0; index--) {
+        if (!usedIndexMaterials.includes(index)) {
+            // update all materialIndex in groups
+            object3D.geometry.groups.forEach((group) => {
+                if (group.materialIndex > index) {
+                    // only materialIndex > at index are modified
+                    group.materialIndex -= 1;
+                }
+            });
+
+            // remove
+            object3D.material.splice(index, 1);
+        }
+    }
+}
+

--- a/src/Utils/gui/C3DTilesStyle.js
+++ b/src/Utils/gui/C3DTilesStyle.js
@@ -1,0 +1,245 @@
+import Style from 'Core/Style';
+import { C3DTILES_LAYER_EVENTS } from 'Layer/C3DTilesLayer';
+import Widget from './Widget';
+
+const DEFAULT_OPTIONS = {
+    width: 200,
+    position: 'top-right',
+};
+
+
+/**
+ * A widget for dynamic 3DTiles styling
+ *
+ * To use it, you need to link the widgets' stylesheet to your html webpage. This stylesheet is included in
+ * [itowns bundles](https://github.com/iTowns/itowns/releases) if you downloaded them, or it can be found in
+ * `node_modules/itowns/examples/css` if you installed iTowns with npm. Otherwise, it can be found at
+ * [this link](https://raw.githubusercontent.com/iTowns/itowns/master/examples/css/widgets.css). See
+ * [this example](http://www.itowns-project.org/itowns/examples/#widgets_3dtiles_style) for more details.
+ *
+ * @extends Widget
+ *
+ * @property    {HTMLElement}   domElement      An html div containing the minimap.
+ * @property    {HTMLElement}   parentElement   The parent HTML container of `this.domElement`.
+ */
+class C3DTilesStyle extends Widget {
+/**
+   *
+   * @param {View} view view
+   * @param {*} options options
+   */
+    constructor(view, options) {
+        super(view, options, DEFAULT_OPTIONS);
+
+        this.domElement.onclick = event => event.stopImmediatePropagation();
+
+        // create select of the C3DTilesLayers
+        const selectC3DTilesLayer = document.createElement('select');
+        this.domElement.appendChild(selectC3DTilesLayer);
+
+        /** @type {Map<HTMLElement, HTMLElement>} */
+        const selectOptionLayerContent = new Map();
+
+        const updateSelectedLayer = () => {
+            for (const [sO, lC] of selectOptionLayerContent) {
+                lC.hidden = sO !== selectC3DTilesLayer.selectedOptions[0];
+            }
+        };
+        selectC3DTilesLayer.onchange = updateSelectedLayer;
+
+        view.getLayers().filter(el => el.isC3DTilesLayer === true).forEach((c3DTilesLayer) => {
+            const selectC3DTilesLayerOption = document.createElement('option');
+            selectC3DTilesLayerOption.innerText = c3DTilesLayer.name;
+            selectC3DTilesLayer.add(selectC3DTilesLayerOption);
+
+            const layerContent = document.createElement('div');
+            this.domElement.appendChild(layerContent);
+
+            // link select option to layer content
+            selectOptionLayerContent.set(selectC3DTilesLayerOption, layerContent);
+
+            // wait for C3DTileFeatures to load
+            c3DTilesLayer.addEventListener(C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED, () => {
+                // reset
+                while (layerContent.firstChild) {
+                    layerContent.firstChild.remove();
+                }
+
+                /** @type {Map<string,Array>} */
+                const buffer = new Map(); // record what are the possible values for a key in batchTable
+                // eslint-disable-next-line no-unused-vars
+                for (const [tileId, tileC3DTileFeatures] of c3DTilesLayer.tilesC3DTileFeatures) {
+                    // eslint-disable-next-line no-unused-vars
+                    for (const [batchId, c3DTileFeature] of tileC3DTileFeatures) {
+                        // eslint-disable-next-line guard-for-in
+                        for (const key in c3DTileFeature.getInfo().batchTable) {
+                            if (!buffer.has(key)) {
+                                buffer.set(key, []);
+                            }
+
+                            // check possible value for this key
+                            const value = c3DTileFeature.getInfo().batchTable[key];
+                            if (!buffer.get(key).includes(value)) {
+                                buffer.get(key).push(value);
+                            }
+                        }
+                    }
+                }
+
+                /** @type {Map<HTMLElement, Function>} */
+                const colorFunctions = new Map();
+
+                const fillColorFunction = (c3DTileFeature) => {
+                    let result = null;
+                    // eslint-disable-next-line no-unused-vars
+                    for (const [keyValue, colorFunction] of colorFunctions) {
+                        result = colorFunction(c3DTileFeature) || result;
+                    }
+                    return result;
+                };
+
+                /** @type {Map<HTMLElement, Function>} */
+                const opacityFunctions = new Map();
+
+                const fillOpacityFunction = (c3DTileFeature) => {
+                    let result = 1;
+                    // eslint-disable-next-line no-unused-vars
+                    for (const [keyValue, opacityFunction] of opacityFunctions) {
+                        result = opacityFunction(c3DTileFeature) || result;
+                    }
+                    return result;
+                };
+
+                const appendInputColorAndOpacity = (getKeyValue, key, possibleValues) => {
+                    const inputColor = document.createElement('input');
+                    inputColor.setAttribute('type', 'color');
+                    layerContent.appendChild(inputColor);
+
+                    inputColor.onchange = () => {
+                        const keyValue = getKeyValue();
+
+                        if (!possibleValues.includes(keyValue)) {
+                            return;
+                        }
+
+                        const colorSelected = inputColor.value;// copy
+                        colorFunctions.set(keyValue, (c3DTileFeature) => {
+                            if (c3DTileFeature.getInfo().batchTable[key] == keyValue) {
+                                return colorSelected;
+                            }
+                            return null;
+                        });
+                        c3DTilesLayer.updateStyle();
+                        view.notifyChange();
+                    };
+
+                    const opacityElement = document.createElement('input');
+                    opacityElement.setAttribute('type', 'range');
+                    opacityElement.min = 0;
+                    opacityElement.max = 1;
+                    opacityElement.step = 0.1;
+                    opacityElement.value = 1;
+                    layerContent.appendChild(opacityElement);
+
+                    opacityElement.onchange = () => {
+                        const keyValue = getKeyValue();
+
+                        if (!possibleValues.includes(keyValue)) {
+                            return;
+                        }
+
+                        const opacitySelected = opacityElement.value;// copy
+                        opacityFunctions.set(keyValue, (c3DTileFeature) => {
+                            if (c3DTileFeature.getInfo().batchTable[key] == keyValue) {
+                                return opacitySelected;
+                            }
+                            return null;
+                        });
+                        c3DTilesLayer.updateStyle();
+                        view.notifyChange();
+                    };
+
+                    return { inputColor, opacityElement };
+                };
+
+                const appendFilterSelect = (key, values) => {
+                    const label = document.createElement('label');
+                    label.innerText = key;
+                    layerContent.appendChild(label);
+
+                    const selectKey = document.createElement('select');
+                    layerContent.appendChild(selectKey);
+                    values.forEach((value) => {
+                        const selectKeyOption = document.createElement('option');
+                        selectKeyOption.value = value;
+                        selectKeyOption.text = value;
+                        selectKey.add(selectKeyOption);
+                    });
+
+                    appendInputColorAndOpacity(() => selectKey.selectedOptions[0].value, key, values);
+                };
+
+                const appendFilterInputText = (key, values) => {
+                    const label = document.createElement('label');
+                    label.innerText = key;
+                    layerContent.appendChild(label);
+
+                    const inputText = document.createElement('input');
+                    inputText.setAttribute('type', 'text');
+                    layerContent.appendChild(inputText);
+
+                    const { inputColor, opacityElement } = appendInputColorAndOpacity(() => inputText.value, key, values);
+
+                    inputText.onchange = () => {
+                        if (!values.includes(inputText.value)) {
+                            return;
+                        }
+
+                        const colorSelected = inputColor.value;// copy
+                        const textSelected = inputText.value;// copy
+                        colorFunctions.set(textSelected, (c3DTileFeature) => {
+                            if (c3DTileFeature.getInfo().batchTable[key] == textSelected) {
+                                return colorSelected;
+                            }
+                            return null;
+                        });
+                        const opacitySelected = opacityElement.value;// copy
+                        opacityFunctions.set(textSelected, (c3DTileFeature) => {
+                            if (c3DTileFeature.getInfo().batchTable[key] == textSelected) {
+                                return opacitySelected;
+                            }
+                            return null;
+                        });
+                        c3DTilesLayer.updateStyle();
+                        view.notifyChange();
+                    };
+                };
+
+                // create ui from buffer
+                for (const [key, values] of buffer) {
+                    if (values.length < C3DTilesStyle.MAX_SELECT_VALUE) {
+                        appendFilterSelect(key, values);
+                    } else {
+                        appendFilterInputText(key, values);
+                    }
+                }
+
+                // set style
+                c3DTilesLayer.style = new Style({
+                    fill: {
+                        color: fillColorFunction,
+                        opacity: fillOpacityFunction,
+                    },
+                });
+            });
+        });
+
+        updateSelectedLayer();
+    }
+
+    static get MAX_SELECT_VALUE() {
+        return 10;
+    }
+}
+
+export default C3DTilesStyle;

--- a/src/Utils/gui/Main.js
+++ b/src/Utils/gui/Main.js
@@ -4,3 +4,4 @@ export { default as Minimap } from './Minimap';
 export { default as Scale } from './Scale';
 export { default as Searchbar } from './Searchbar';
 export { default as Widget } from './Widget';
+export { default as C3DTilesStyle } from './C3DTilesStyle';

--- a/test/functional/3dtiles_batch_table.js
+++ b/test/functional/3dtiles_batch_table.js
@@ -30,22 +30,24 @@ describe('3dtiles_batch_table', function _() {
     // extension picked information are correct for object at { x: 218, y: 90 }
     it('should return the batch table and batch hierarchy picked information',
         async () => {
-            // Picks the object at (218,90) and gets its pickingInfo from
-            // the batch table and the batch table hierarchy
-            const pickingInfo = await page.evaluate(
+            // Picks the object at (218,90) and gets its closest c3DTileFeature
+            const pickResult = await page.evaluate(
                 () => {
                     const intersects = view.pickObjectsAt({
                         x: 218,
                         y: 90,
                     });
                     const layer = view.getLayerById('3d-tiles-bt-hierarchy');
-                    return layer.getInfoFromIntersectObject(intersects);
+                    const c3DTileFeaturePicked = layer.getC3DTileFeatureFromIntersectsArray(intersects);
+                    return {
+                        info: c3DTileFeaturePicked.getInfo(),
+                        batchId: c3DTileFeaturePicked.batchId,
+                    };
                 },
             );
 
             // Create the expected object
             const expectedPickingInfo = {
-                batchID: 29,
                 batchTable: {
                     height: 10,
                     area: 20,
@@ -68,7 +70,8 @@ describe('3dtiles_batch_table', function _() {
                     },
                 },
             };
-
-            assert.deepStrictEqual(pickingInfo, expectedPickingInfo);
+            const expectedBatchId = 29;
+            assert.deepStrictEqual(pickResult.batchId, expectedBatchId);
+            assert.deepStrictEqual(pickResult.info, expectedPickingInfo);
         });
 });

--- a/test/functional/widgets_3dtiles_style.js
+++ b/test/functional/widgets_3dtiles_style.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+describe('Widget C3dTilesStyle', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample(
+            'examples/widgets_3dtiles_style.html',
+            this.fullTitle(),
+        );
+    });
+
+    it('should run', async () => {
+        assert.ok(result);
+    });
+});

--- a/test/unit/3dtileslayerstyle.js
+++ b/test/unit/3dtileslayerstyle.js
@@ -1,0 +1,106 @@
+import assert from 'assert';
+import proj4 from 'proj4';
+import * as THREE from 'three';
+import Extent from 'Core/Geographic/Extent';
+import PlanarView from 'Core/Prefab/PlanarView';
+import Style from 'Core/Style';
+import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
+import C3DTilesSource from 'Source/C3DTilesSource';
+import C3DTilesLayer from 'Layer/C3DTilesLayer';
+import Renderer from './bootstrap';
+
+describe('3DTilesLayer Style', () => {
+    // Define crs
+    proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
+    // Define geographic extent: CRS, min/max X, min/max Y
+    const extent = new Extent('EPSG:3946',
+        1840816.94334, 1843692.32501,
+        5175036.4587, 5177412.82698);
+
+    const renderer = new Renderer();
+
+    const view = new PlanarView(renderer.domElement, extent, { renderer, noControls: true });
+
+    const $3dTilesLayer = new C3DTilesLayer(
+        'id_layer',
+        {
+            source: new C3DTilesSource({
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/' +
+                    '3DTiles/lyon1_with_surface_type_2018/tileset.json',
+            }),
+        },
+        view,
+    );
+
+    // Create a 'fake' tile content for this test purpose
+    const createTileContent = (tileId) => {
+        const geometry = new THREE.SphereGeometry(15, 32, 16);
+        const material = new THREE.MeshBasicMaterial({ color: 0xffff00 });
+
+        // Add _BATCHID geometry attributes
+        const array = [];
+        let currentBatchId = Math.round(Math.random() * 50);
+        for (let index = 0; index < geometry.attributes.position.count; index++) {
+            array.push(currentBatchId);
+
+            // Change randomly batch id
+            if (Math.random() > 0.5) {
+                currentBatchId = Math.round(Math.random() * 50);
+            }
+        }
+        geometry.setAttribute('_BATCHID', new THREE.BufferAttribute(Int32Array.from(array), 1));
+
+        const result = new THREE.Mesh(geometry, material);
+
+        result.batchTable = new C3DTBatchTable();
+        result.tileId = tileId;
+
+        return result;
+    };
+
+    $3dTilesLayer.style = new Style({
+        fill: {
+            color: (c3DTileFeature) => {
+                if (c3DTileFeature.batchId > 1) {
+                    return 'red';
+                } else {
+                    return 'blue';
+                }
+            },
+            opacity: (c3DTileFeature) => {
+                if (c3DTileFeature.getInfo().something) {
+                    return 0.1;
+                } else if (c3DTileFeature.userData.something === 'random') {
+                    return 1;
+                } else {
+                    return 0.5;
+                }
+            },
+        },
+    });
+
+
+    it('Load tile content', function () {
+        for (let index = 0; index < 10; index++) {
+            const tileContent = createTileContent(index);
+            $3dTilesLayer.object3d.add(tileContent);
+            $3dTilesLayer.onTileContentLoaded(tileContent);
+        }
+    });
+
+    it('Set c3DTileFeatures user data', function () {
+        // eslint-disable-next-line no-unused-vars
+        for (const [tileId, tileC3DTileFeatures] of $3dTilesLayer.tilesC3DTileFeatures) {
+            // eslint-disable-next-line no-unused-vars
+            for (const [batchId, c3DTileFeature] of tileC3DTileFeatures) {
+                // eslint-disable-next-line guard-for-in
+                if (Math.random() > 0.5) {
+                    c3DTileFeature.userData.something = 'random';
+                }
+            }
+        }
+        $3dTilesLayer.updateStyle();
+        assert.deepStrictEqual($3dTilesLayer.materialCount, 4);// 4 materials have been created for this styling
+    });
+});


### PR DESCRIPTION
## Description
Add the possiblity to set a Style for a C3DTilesLayer with an api like so:

```
const layer = new C3DTIlesLayer(...., new Style({ fill: { color: function( tileBatchElement) => {
if(tileBatchElement.userData.selected === true) return "blue";
if(tileBatchElement["nameBatchTableAttributes"] === "something") return "red";
return "yellow";
});
```
tileBatchTableElement / tileBatchElement / tileBatchElementController (not sure about the name readability vs semantic) Element could be replace by Object ....
Anyway this object wrap the batchTable properties + some runtime attributes such as box3 or indexStart + count  (to retrieve it easily in geometry.attributes.position.array) + batchId + some userData (so itowns user can implement dynamic style based on its own code logic).

I am going to implement an example + a widget to demonstrate it.

## Motivation and Context
This change is required to simply add dynamic style to a C3DTilesLayer. 
