### PR TITLE
feat(underground): dynamic opacity to visualize underground and add hideSkirt parameter

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -78,7 +78,9 @@
         "misc_orthographic_camera": "Orthographic camera",
         "misc_custom_controls": "Define custom controls",
         "misc_custom_label": "Custom label popup",
-        "misc_camera_traveling": "Camera traveling"
+        "misc_camera_traveling": "Camera traveling",
+        "underground_25d_map": "Underground visualization"
+
     },
 
     "Widgets": {

--- a/examples/underground_25d_map.html
+++ b/examples/underground_25d_map.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+<html>
+    <head>
+        <title>Planar</title>
+        <link rel="stylesheet" type="text/css" href="./css/example.css">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="description">
+            Underground visualization
+            <ul>
+              <li>Option available in "Layer Planar" controls</li>
+              <li>Enable "Dynamic opacity"</li>
+              <li>Zoom-in to look at underground data</li>
+              <li>Dynamic opactiy triggered by the zoom</li>              
+              <li>Can be enabled in globe view</li>              
+            </ul>
+        </div>
+        <div id="viewerDiv" class="viewer"></div>
+        <script src="./js/GUI/GuiTools.js"></script>
+        <script src="./js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
+        </script>
+        
+        <script>
+            var THREE=itowns.THREE;
+            var linesBus = [];
+
+            Math.Clamp = function clamp(n, min, max) {
+                if(n > max){
+                    return max;
+                } else if(n < min){
+                    return min
+                } else{
+                    return n;
+                }
+                }
+            
+                 // Retrieve the view container
+            const viewerDiv = document.getElementById('viewerDiv');
+    
+            // Define the view geographic extent
+            itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'); 
+            itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+
+            const viewExtent = new itowns.Extent(
+                'EPSG:3946',
+                1837816.94334, 1847692.32501,
+                5170036.4587, 5178412.82698);
+            
+            var placement = {
+                    coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0),
+                    heading: 45,
+                    range: 1800,
+                    tilt: 30,
+                };
+            var options = {placement: placement,            
+                controls : {minDistance : -50, handleCollision : false},    // To handle underground visualization, disable collision and allow camera below the ground
+            };
+            // Create the planar view
+            const view = new itowns.PlanarView(viewerDiv, viewExtent, options);
+            
+            const wmsImagerySource = new itowns.WMSSource({
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                networkOptions: { crossOrigin: 'anonymous' },
+                version: '1.3.0',
+                name: 'Ortho2009_vue_ensemble_16cm_CC46',
+                crs: 'EPSG:3946',
+                extent: viewExtent,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS imagery layer
+            const wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+                transparent: false,
+                source: wmsImagerySource,
+            });
+
+            view.addLayer(wmsImageryLayer);
+            
+            var wmsElevationSource = new itowns.WMSSource({
+                extent: viewExtent,
+                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2012_Altitude_10m_CC46',
+                crs: 'EPSG:3946',
+                width: 256,
+                format: 'image/jpeg',
+            });
+
+            // Add a WMS elevation layer
+            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+                useColorTextureElevation: true,
+                colorTextureElevationMinZ: 144,
+                colorTextureElevationMaxZ: 622,
+                source: wmsElevationSource,
+            });
+
+            view.addLayer(wmsElevationLayer);
+
+
+            function acceptFeatureBus(properties) {
+                if (properties.sens == 'Aller') {
+                    var line = properties.ligne;
+                    if (linesBus.indexOf(line) === -1) {
+                        linesBus.push(line);
+                        return true;
+                    }
+                }
+                return false;
+            }
+            
+            var baseAltitude = 130;
+            var lyonTclBusSource = new itowns.WFSSource({
+                url: 'https://download.data.grandlyon.com/wfs/rdata?',
+                protocol: 'wfs',
+                version: '2.0.0',
+                id: 'tcl_bus',
+                typeName: 'tcl_sytral.tcllignebus',
+                crs: 'EPSG:3946',
+                fetcher: itowns.Fetcher.json,
+                parser: itowns.GeoJsonParser.parse,
+                format: 'geojson',
+            });
+
+            var lyonTclBusLayer = new itowns.FeatureGeometryLayer('WFS Bus lines', {
+                name: 'lyon_tcl_bus',
+                filter: acceptFeatureBus,
+                source: lyonTclBusSource,
+
+                style: new itowns.Style({
+                    stroke: {
+                        base_altitude: baseAltitude,
+                        width: 2,
+
+                    },
+                }),
+            });
+            view.addLayer(lyonTclBusLayer);
+
+            var menuPlanar = new GuiTools('menuDiv', view);
+            debug.createTileDebugUI(menuPlanar.gui, view, undefined, undefined, true);
+
+        </script>
+    </body>
+</html>

--- a/examples/underground_25d_map.html
+++ b/examples/underground_25d_map.html
@@ -26,23 +26,12 @@ and open the template in the editor.
         </div>
         <div id="viewerDiv" class="viewer"></div>
         <script src="./js/GUI/GuiTools.js"></script>
-        <script src="./js/GUI/LoadingScreen.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="../dist/debug.js"></script>
 
         <script>
             var THREE = itowns.THREE;
             var linesBus = [];
-
-            Math.Clamp = function clamp(n, min, max) {
-                if (n > max) {
-                    return max;
-                } else if (n < min) {
-                    return min;
-                } else {
-                    return n;
-                }
-            };
 
             // Retrieve the view container
             const viewerDiv = document.getElementById("viewerDiv");

--- a/examples/underground_25d_map.html
+++ b/examples/underground_25d_map.html
@@ -7,20 +7,21 @@ and open the template in the editor.
 <html>
     <head>
         <title>Planar</title>
-        <link rel="stylesheet" type="text/css" href="./css/example.css">
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" type="text/css" href="./css/example.css" />
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
     </head>
     <body>
         <div id="description">
             Underground visualization
+
             <ul>
-              <li>Option available in "Layer Planar" controls</li>
-              <li>Enable "Dynamic opacity"</li>
-              <li>Zoom-in to look at underground data</li>
-              <li>Dynamic opactiy triggered by the zoom</li>              
-              <li>Can be enabled in globe view</li>              
+                <li>Option available in "Layer Planar" controls</li>
+                <li>Enable "Dynamic opacity"</li>
+                <li>Zoom-in to look at underground data</li>
+                <li>Dynamic opactiy triggered by the zoom</li>
+                <li>Can be enabled in globe view</li>
             </ul>
         </div>
         <div id="viewerDiv" class="viewer"></div>
@@ -28,75 +29,84 @@ and open the template in the editor.
         <script src="./js/GUI/LoadingScreen.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="../dist/debug.js"></script>
-        </script>
-        
+
         <script>
-            var THREE=itowns.THREE;
+            var THREE = itowns.THREE;
             var linesBus = [];
 
             Math.Clamp = function clamp(n, min, max) {
-                if(n > max){
+                if (n > max) {
                     return max;
-                } else if(n < min){
-                    return min
-                } else{
+                } else if (n < min) {
+                    return min;
+                } else {
                     return n;
                 }
-                }
-            
-                 // Retrieve the view container
-            const viewerDiv = document.getElementById('viewerDiv');
-    
+            };
+
+            // Retrieve the view container
+            const viewerDiv = document.getElementById("viewerDiv");
+
             // Define the view geographic extent
-            itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'); 
-            itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+            itowns.proj4.defs(
+                "EPSG:2154",
+                "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
+            );
+            itowns.proj4.defs(
+                "EPSG:3946",
+                "+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
+            );
 
             const viewExtent = new itowns.Extent(
-                'EPSG:3946',
-                1837816.94334, 1847692.32501,
-                5170036.4587, 5178412.82698);
-            
+                "EPSG:3946",
+                1837816.94334,
+                1847692.32501,
+                5170036.4587,
+                5178412.82698
+            );
+
             var placement = {
-                    coord: new itowns.Coordinates('EPSG:3946', 1840839, 5172718, 0),
-                    heading: 45,
-                    range: 1800,
-                    tilt: 30,
-                };
-            var options = {placement: placement,            
-                controls : {minDistance : -50, handleCollision : false},    // To handle underground visualization, disable collision and allow camera below the ground
+                coord: new itowns.Coordinates("EPSG:3946", 1840839, 5172718, 0),
+                heading: 45,
+                range: 1800,
+                tilt: 30,
+            };
+            var options = {
+                placement: placement,
+                controls: { minDistance: -50, handleCollision: false }, // To handle underground visualization, disable collision and allow camera below the ground
             };
             // Create the planar view
             const view = new itowns.PlanarView(viewerDiv, viewExtent, options);
-            
+
             const wmsImagerySource = new itowns.WMSSource({
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                networkOptions: { crossOrigin: 'anonymous' },
-                version: '1.3.0',
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                crs: 'EPSG:3946',
+                url: "https://download.data.grandlyon.com/wms/grandlyon",
+                networkOptions: { crossOrigin: "anonymous" },
+                version: "1.3.0",
+                name: "Ortho2009_vue_ensemble_16cm_CC46",
+                crs: "EPSG:3946",
                 extent: viewExtent,
-                format: 'image/jpeg',
+                format: "image/jpeg",
             });
 
             // Add a WMS imagery layer
-            const wmsImageryLayer = new itowns.ColorLayer('wms_imagery', {
+            const wmsImageryLayer = new itowns.ColorLayer("wms_imagery", {
                 transparent: false,
                 source: wmsImagerySource,
             });
 
             view.addLayer(wmsImageryLayer);
-            
+
             var wmsElevationSource = new itowns.WMSSource({
                 extent: viewExtent,
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                name: 'MNT2012_Altitude_10m_CC46',
-                crs: 'EPSG:3946',
+                url: "https://download.data.grandlyon.com/wms/grandlyon",
+                name: "MNT2012_Altitude_10m_CC46",
+                crs: "EPSG:3946",
                 width: 256,
-                format: 'image/jpeg',
+                format: "image/jpeg",
             });
 
             // Add a WMS elevation layer
-            var wmsElevationLayer = new itowns.ElevationLayer('wms_elevation', {
+            var wmsElevationLayer = new itowns.ElevationLayer("wms_elevation", {
                 useColorTextureElevation: true,
                 colorTextureElevationMinZ: 144,
                 colorTextureElevationMaxZ: 622,
@@ -105,9 +115,8 @@ and open the template in the editor.
 
             view.addLayer(wmsElevationLayer);
 
-
             function acceptFeatureBus(properties) {
-                if (properties.sens == 'Aller') {
+                if (properties.sens == "Aller") {
                     var line = properties.ligne;
                     if (linesBus.indexOf(line) === -1) {
                         linesBus.push(line);
@@ -116,38 +125,45 @@ and open the template in the editor.
                 }
                 return false;
             }
-            
+
             var baseAltitude = 130;
             var lyonTclBusSource = new itowns.WFSSource({
-                url: 'https://download.data.grandlyon.com/wfs/rdata?',
-                protocol: 'wfs',
-                version: '2.0.0',
-                id: 'tcl_bus',
-                typeName: 'tcl_sytral.tcllignebus',
-                crs: 'EPSG:3946',
+                url: "https://download.data.grandlyon.com/wfs/rdata?",
+                protocol: "wfs",
+                version: "2.0.0",
+                id: "tcl_bus",
+                typeName: "tcl_sytral.tcllignebus",
+                crs: "EPSG:3946",
                 fetcher: itowns.Fetcher.json,
                 parser: itowns.GeoJsonParser.parse,
-                format: 'geojson',
+                format: "geojson",
             });
 
-            var lyonTclBusLayer = new itowns.FeatureGeometryLayer('WFS Bus lines', {
-                name: 'lyon_tcl_bus',
-                filter: acceptFeatureBus,
-                source: lyonTclBusSource,
+            var lyonTclBusLayer = new itowns.FeatureGeometryLayer(
+                "WFS Bus lines",
+                {
+                    name: "lyon_tcl_bus",
+                    filter: acceptFeatureBus,
+                    source: lyonTclBusSource,
 
-                style: new itowns.Style({
-                    stroke: {
-                        base_altitude: baseAltitude,
-                        width: 2,
-
-                    },
-                }),
-            });
+                    style: new itowns.Style({
+                        stroke: {
+                            base_altitude: baseAltitude,
+                            width: 2,
+                        },
+                    }),
+                }
+            );
             view.addLayer(lyonTclBusLayer);
 
-            var menuPlanar = new GuiTools('menuDiv', view);
-            debug.createTileDebugUI(menuPlanar.gui, view, undefined, undefined, true);
-
+            var menuPlanar = new GuiTools("menuDiv", view);
+            debug.createTileDebugUI(
+                menuPlanar.gui,
+                view,
+                undefined,
+                undefined,
+                true
+            );
         </script>
     </body>
 </html>

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -369,12 +369,9 @@ class PlanarControls extends THREE.EventDispatcher {
         }
         if (onMovement) {
             this.view.dispatchEvent({ type: PLANAR_CONTROL_EVENT.MOVED });
+            this.view.dispatchEvent({ type: VIEW_EVENTS.CAMERA_MOVED });
         }
         deltaMousePosition.set(0, 0);
-
-        this.view.dispatchEvent({
-            type: VIEW_EVENTS.CAMERA_MOVED,
-        });
     }
 
     /**

--- a/src/Controls/PlanarControls.js
+++ b/src/Controls/PlanarControls.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
+import { VIEW_EVENTS } from 'Core/View';
+import CameraUtils from 'Utils/CameraUtils';
 
 // event keycode
 export const keys = {
@@ -369,6 +371,10 @@ class PlanarControls extends THREE.EventDispatcher {
             this.view.dispatchEvent({ type: PLANAR_CONTROL_EVENT.MOVED });
         }
         deltaMousePosition.set(0, 0);
+
+        this.view.dispatchEvent({
+            type: VIEW_EVENTS.CAMERA_MOVED,
+        });
     }
 
     /**
@@ -415,6 +421,15 @@ class PlanarControls extends THREE.EventDispatcher {
      */
     initiatePan() {
         this.state = STATE.PAN;
+    }
+
+
+    /**
+     * Returns the {@linkcode Coordinates} of the central point on screen in the crs of the view. See {@linkcode Coordinates} for conversion.
+     * @return {Coordinates} coordinate
+     */
+    getLookAtCoordinate() {
+        return CameraUtils.getTransformCameraLookingAtTarget(this.view, this.camera).coord;
     }
 
     /**

--- a/src/Converter/convertToTile.js
+++ b/src/Converter/convertToTile.js
@@ -41,12 +41,14 @@ export default {
         const builder = layer.builder;
         const parent = requester;
         const level = (parent !== undefined) ? (parent.level + 1) : 0;
+        layer.segments = layer.segments || 16;
 
         const paramsGeometry = {
             extent,
             level,
-            segment: layer.segments || 16,
+            segment: layer.segments,
             disableSkirt: layer.disableSkirt,
+            hideSkirt: layer.hideSkirt,
         };
 
         return newTileGeometry(builder, paramsGeometry).then((result) => {

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -124,7 +124,9 @@ class GlobeView extends View {
             CameraUtils.transformCameraToLookAtTarget(this, this.camera.camera3D, placement);
         } else {
             this.controls = new GlobeControls(this, placement, options.controls);
+            this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
         }
+
         this.addLayer(new Atmosphere('atmosphere', options.atmosphere));
 
         // GlobeView needs this.camera.resize to set perpsective matrix camera

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -124,9 +124,7 @@ class GlobeView extends View {
             CameraUtils.transformCameraToLookAtTarget(this, this.camera.camera3D, placement);
         } else {
             this.controls = new GlobeControls(this, placement, options.controls);
-            this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
         }
-
         this.addLayer(new Atmosphere('atmosphere', options.atmosphere));
 
         // GlobeView needs this.camera.resize to set perpsective matrix camera

--- a/src/Core/Prefab/TileBuilder.js
+++ b/src/Core/Prefab/TileBuilder.js
@@ -51,7 +51,9 @@ export default function newTileGeometry(builder, params) {
 
         const geometry = new TileGeometry(params, buffers);
         geometry.OBB = new OBB(geometry.boundingBox.min, geometry.boundingBox.max);
-
+        if (params.hideSkirt) {
+            geometry.setDrawRange(0, params.segment * params.segment * 2 * 3);//  bufferIndex = (nSeg) * (nSeg) * 2 * 3 (computeBufferTileGeometry.js)
+        }
         geometry._count = 0;
         geometry.dispose = () => {
             geometry._count--;

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -112,7 +112,7 @@ class TileMesh extends THREE.Mesh {
     onBeforeRender() {
         if (this.layer.hideSkirt) {
             this.geometry.setDrawRange(0, this.layer.segments * this.layer.segments * 2 * 3);  //  bufferIndex = (nSeg) * (nSeg) * 2 * 3 (computeBufferTileGeometry.js)
-        } else if (this.geometry.drawRange.count != Infinity) {
+        } else if (this.layer.hideSkirt == false && this.geometry.drawRange.count != Infinity) {
             this.geometry.setDrawRange(0, Infinity);
         }
 

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -110,6 +110,12 @@ class TileMesh extends THREE.Mesh {
     }
 
     onBeforeRender() {
+        if (this.layer.hideSkirt) {
+            this.geometry.setDrawRange(0, this.layer.segments * this.layer.segments * 2 * 3);  //  bufferIndex = (nSeg) * (nSeg) * 2 * 3 (computeBufferTileGeometry.js)
+        } else if (this.geometry.drawRange.count != Infinity) {
+            this.geometry.setDrawRange(0, Infinity);
+        }
+
         if (this.material.layersNeedUpdate) {
             this.material.updateLayersUniforms();
         }

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -147,8 +147,6 @@ class View extends THREE.EventDispatcher {
      * This color is applied to terrain if there isn't color layer on terrain extent (by example on pole).
      * @param {boolean} [options.enableFocusOnStart=true] - enable focus on dom element on start.
      * @param {boolean} [options.undergroundVisualisation=false] - enable underground visualisation.
-     * @param {number} [options.altitudeForZeroOpacity=420] - Altitude (used for underground visualization) at which the ground is full hidden.
-     * @param {number} [options.altitudeForFullOpacity=2400] - Altitude (used for underground visualization) at which the ground is full shown.
      * @constructor
      */
     constructor(crs, viewerDiv, options = {}) {
@@ -241,17 +239,7 @@ class View extends THREE.EventDispatcher {
         });
 
         // configure dynamic opacity
-        if (options.altitudeForZeroOpacity === undefined || options.altitudeForZeroOpacity === null) {
-            this.altitudeForZeroOpacity = 420;
-        } else {
-            this.altitudeForZeroOpacity = options.altitudeForZeroOpacity;
-        }
 
-        if (options.altitudeForFullOpacity === undefined || options.altitudeForFullOpacity === null) {
-            this.altitudeForFullOpacity = 2400;
-        } else {
-            this.altitudeForFullOpacity = options.altitudeForFullOpacity;
-        }
         this.undergroundVisualisation = options.undergroundVisualisation == true;
 
         if (this.undergroundVisualisation) {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -311,28 +311,6 @@ class View extends THREE.EventDispatcher {
     }
 
 
-
-    /**
-     * Update layer opacity depending on camera position.
-     *
-     * @param {Event} event Event used to get camera target position.
-     */
-    #updateTiledLayerOpacity(event) {
-        var cameraTargetPosition;
-        if (event && event.coord) {
-            cameraTargetPosition = event.coord;
-        } else {
-            cameraTargetPosition = this.controls.getLookAtCoordinate();
-        }
-        var cameraTargetPosition2 = new Coordinates(cameraTargetPosition.crs, cameraTargetPosition).as('EPSG:4978');
-        var cameraPosition = this.camera.position('EPSG:4978');
-
-        const distance = Math.sqrt(((cameraTargetPosition2.x - cameraPosition.x) * (cameraTargetPosition2.x - cameraPosition.x)  + (cameraTargetPosition2.y - cameraPosition.y) * (cameraTargetPosition2.y - cameraPosition.y) + (cameraTargetPosition2.z - cameraPosition.z) * (cameraTargetPosition2.z - cameraPosition.z)));
-
-        var opacity = THREE.MathUtils.clamp((distance - this.altitudeForZeroOpacity) / (this.altitudeForFullOpacity - this.altitudeForZeroOpacity), 0, 1);
-        this.tileLayer.opacity = opacity;
-    }
-
     /**
      * Add layer in viewer.
      * The layer id must be unique.
@@ -1162,8 +1140,8 @@ class View extends THREE.EventDispatcher {
     setUndergroundVisualization(trigger) {
         const atmo = this.getLayerById('atmosphere');
         if (trigger) {
-            this.#updateTiledLayerOpacity();
-            this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, this.#updateTiledLayerOpacity);
+            this.tileLayer.updateTiledLayerOpacity({ target: this });
+            this.addEventListener(VIEW_EVENTS.CAMERA_MOVED,  this.tileLayer.updateTiledLayerOpacity);
             this.tileLayer.hideSkirt = true;
 
 
@@ -1172,7 +1150,7 @@ class View extends THREE.EventDispatcher {
                 atmo.visible = false;
             }
         } else {
-            this.removeEventListener(VIEW_EVENTS.CAMERA_MOVED, this.#updateTiledLayerOpacity);
+            this.removeEventListener(VIEW_EVENTS.CAMERA_MOVED,  this.tileLayer.updateTiledLayerOpacity);
             this.tileLayer.hideSkirt = false;
 
             if (atmo) {

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -7,7 +7,7 @@ import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import { SIZE_DIAGONAL_TEXTURE } from 'Process/LayeredMaterialNodeProcessing';
 import { ImageryLayers } from 'Layer/Layer';
 import { CACHE_POLICIES } from 'Core/Scheduler/Cache';
-import Coordinates from 'Core/Geographic/Coordinates';
+import CameraUtils from 'Utils/CameraUtils';
 
 
 const subdivisionVector = new THREE.Vector3();
@@ -145,10 +145,7 @@ class TiledGeometryLayer extends GeometryLayer {
             return;
         }
         const view = event.target;
-        var cameraTargetPosition = event?.coord || view.controls.getLookAtCoordinate();
-        var cameraTargetPosition2 = new Coordinates(cameraTargetPosition.crs, cameraTargetPosition);
-        var cameraPosition = view.camera.position('EPSG:4978');
-        const distance = cameraTargetPosition2.spatialEuclideanDistanceTo(cameraPosition);
+        const distance = CameraUtils.getTransformCameraLookingAtTarget(view, view.controls.camera).range;
         this.opacity = THREE.MathUtils.clamp((distance - this.altitudeForZeroOpacity) / (this.altitudeForFullOpacity - this.altitudeForZeroOpacity), 0, 1);
     }
 

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -130,12 +130,12 @@ class TiledGeometryLayer extends GeometryLayer {
         if (event == null) {
             return;
         }
-        const target = event.target;
-        var cameraTargetPosition = event?.coord || target.controls.getLookAtCoordinate();
+        const view = event.target;
+        var cameraTargetPosition = event?.coord || view.controls.getLookAtCoordinate();
         var cameraTargetPosition2 = new Coordinates(cameraTargetPosition.crs, cameraTargetPosition);
-        var cameraPosition = target.camera.position('EPSG:4978');
+        var cameraPosition = view.camera.position('EPSG:4978');
         const distance = cameraTargetPosition2.spatialEuclideanDistanceTo(cameraPosition);
-        this.opacity = THREE.MathUtils.clamp((distance - target.altitudeForZeroOpacity) / (target.altitudeForFullOpacity - target.altitudeForZeroOpacity), 0, 1);
+        this.opacity = THREE.MathUtils.clamp((distance - view.altitudeForZeroOpacity) / (view.altitudeForFullOpacity - view.altitudeForZeroOpacity), 0, 1);
     }
 
     /**

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -127,6 +127,9 @@ class TiledGeometryLayer extends GeometryLayer {
      * @param {Event} event Event used to get camera target position.
      */
     _updateTiledLayerOpacity(event) {
+        if (event == null) {
+            return;
+        }
         const target = event.target;
         var cameraTargetPosition = event?.coord || target.controls.getLookAtCoordinate();
         var cameraTargetPosition2 = new Coordinates(cameraTargetPosition.crs, cameraTargetPosition);

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -7,6 +7,8 @@ import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import { SIZE_DIAGONAL_TEXTURE } from 'Process/LayeredMaterialNodeProcessing';
 import { ImageryLayers } from 'Layer/Layer';
 import { CACHE_POLICIES } from 'Core/Scheduler/Cache';
+import Coordinates from 'Core/Geographic/Coordinates';
+
 
 const subdivisionVector = new THREE.Vector3();
 const boundingSphereCenter = new THREE.Vector3();
@@ -98,15 +100,8 @@ class TiledGeometryLayer extends GeometryLayer {
             this.object3d.updateMatrixWorld();
         }));
 
-        let _hideSkirt = this.hideSkirt;
 
-        Object.defineProperty(this, 'hideSkirt', {
-            get: () => _hideSkirt,
-            set: (value) => {
-                _hideSkirt = value;
-                this.#hideExistingSkirt(value);
-            },
-        });
+        this.updateTiledLayerOpacity = this._updateTiledLayerOpacity.bind(this);
     }
 
     /**
@@ -124,6 +119,20 @@ class TiledGeometryLayer extends GeometryLayer {
      */
     pickObjectsAt(view, coordinates, radius = this.options.defaultPickingRadius, target = []) {
         return Picking.pickTilesAt(view, coordinates, radius, this, target);
+    }
+
+    /**
+     * Update layer opacity depending on camera position.
+     *
+     * @param {Event} event Event used to get camera target position.
+     */
+    _updateTiledLayerOpacity(event) {
+        const target = event.target;
+        var cameraTargetPosition = event?.coord || target.controls.getLookAtCoordinate();
+        var cameraTargetPosition2 = new Coordinates(cameraTargetPosition.crs, cameraTargetPosition);
+        var cameraPosition = target.camera.position('EPSG:4978');
+        const distance = cameraTargetPosition2.spatialEuclideanDistanceTo(cameraPosition);
+        this.opacity = THREE.MathUtils.clamp((distance - target.altitudeForZeroOpacity) / (target.altitudeForFullOpacity - target.altitudeForZeroOpacity), 0, 1);
     }
 
     /**
@@ -274,20 +283,6 @@ class TiledGeometryLayer extends GeometryLayer {
 
     convert(requester, extent) {
         return convertToTile.convert(requester, extent, this);
-    }
-
-    #hideExistingSkirt(value) {
-        for (const node of this.level0Nodes) {
-            node.traverse((obj) => {
-                if (obj.isTileMesh) {
-                    if (value) {
-                        obj.geometry.setDrawRange(0, this.segments * this.segments * 2 * 3);  //  bufferIndex = (nSeg) * (nSeg) * 2 * 3 (computeBufferTileGeometry.js)
-                    } else {
-                        obj.geometry.setDrawRange(0, Infinity);
-                    }
-                }
-            });
-        }
     }
 
     countColorLayersTextures(...layers) {

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -97,6 +97,16 @@ class TiledGeometryLayer extends GeometryLayer {
             this.object3d.add(...level0s);
             this.object3d.updateMatrixWorld();
         }));
+
+        let _hideSkirt = this.hideSkirt;
+
+        Object.defineProperty(this, 'hideSkirt', {
+            get: () => _hideSkirt,
+            set: (value) => {
+                _hideSkirt = value;
+                this.#hideExistingSkirt(value);
+            },
+        });
     }
 
     /**
@@ -264,6 +274,20 @@ class TiledGeometryLayer extends GeometryLayer {
 
     convert(requester, extent) {
         return convertToTile.convert(requester, extent, this);
+    }
+
+    #hideExistingSkirt(value) {
+        for (const node of this.level0Nodes) {
+            node.traverse((obj) => {
+                if (obj.isTileMesh) {
+                    if (value) {
+                        obj.geometry.setDrawRange(0, this.segments * this.segments * 2 * 3);  //  bufferIndex = (nSeg) * (nSeg) * 2 * 3 (computeBufferTileGeometry.js)
+                    } else {
+                        obj.geometry.setDrawRange(0, Infinity);
+                    }
+                }
+            });
+        }
     }
 
     countColorLayersTextures(...layers) {

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -58,6 +58,8 @@ class TiledGeometryLayer extends GeometryLayer {
      * available using `layer.name` or something else depending on the property
      * name.
      * @param {Source} [config.source] - Description and options of the source.
+     * @param {number} [config.altitudeForZeroOpacity=420] - Altitude (used for underground visualization) at which the ground is full hidden.
+     * @param {number} [config.altitudeForFullOpacity=2400] - Altitude (used for underground visualization) at which the ground is full shown.
      *
      * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
@@ -99,7 +101,19 @@ class TiledGeometryLayer extends GeometryLayer {
             this.object3d.add(...level0s);
             this.object3d.updateMatrixWorld();
         }));
+        // configure dynamic opacity
 
+        if (config.altitudeForZeroOpacity === undefined || config.altitudeForZeroOpacity === null) {
+            this.altitudeForZeroOpacity = 420;
+        } else {
+            this.altitudeForZeroOpacity = config.altitudeForZeroOpacity;
+        }
+
+        if (config.altitudeForFullOpacity === undefined || config.altitudeForFullOpacity === null) {
+            this.altitudeForFullOpacity = 2400;
+        } else {
+            this.altitudeForFullOpacity = config.altitudeForFullOpacity;
+        }
 
         this.updateTiledLayerOpacity = this._updateTiledLayerOpacity.bind(this);
     }
@@ -135,7 +149,7 @@ class TiledGeometryLayer extends GeometryLayer {
         var cameraTargetPosition2 = new Coordinates(cameraTargetPosition.crs, cameraTargetPosition);
         var cameraPosition = view.camera.position('EPSG:4978');
         const distance = cameraTargetPosition2.spatialEuclideanDistanceTo(cameraPosition);
-        this.opacity = THREE.MathUtils.clamp((distance - view.altitudeForZeroOpacity) / (view.altitudeForFullOpacity - view.altitudeForZeroOpacity), 0, 1);
+        this.opacity = THREE.MathUtils.clamp((distance - this.altitudeForZeroOpacity) / (this.altitudeForFullOpacity - this.altitudeForZeroOpacity), 0, 1);
     }
 
     /**

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -337,7 +337,7 @@ class CameraRig extends THREE.Object3D {
 }
 
 export function getRig(camera) {
-    rigs[camera.uuid] = rigs[camera.uuid] || new CameraRig(camera);
+    rigs[camera.uuid] = rigs[camera.uuid] || new CameraRig();
     return rigs[camera.uuid];
 }
 

--- a/test/functional/underground_25d_map.js
+++ b/test/functional/underground_25d_map.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+
+describe('underground_25d_map', function _() {
+    let result;
+    before(async () => {
+        result = await loadExample('examples/underground_25d_map.html', this.fullTitle());
+    });
+
+    it('should run', async () => {
+        assert.ok(result);
+    });
+
+    it('should decrease opacity while zooming', async () => {
+        const opacity0 = await page.evaluate(() => {
+            let opacity;
+            const layer = view.getLayers(l => l.isPlanarLayer)[0];
+            if (layer) {
+                opacity = layer.opacity;
+            }
+            return opacity;
+        });
+
+        await page.evaluate(() => view.setUndergroundVisualization(true));
+        const params = { range: 1000 };
+        await page.evaluate((p) => {
+            const camera = view.camera.camera3D;
+            return itowns.CameraUtils.transformCameraToLookAtTarget(
+                view, camera, p,
+            ).then();
+        }, params);
+        const opacity1 = await page.evaluate(() => {
+            let opacity;
+            const layer = view.getLayers(l => l.isPlanarLayer)[0];
+            if (layer) {
+                opacity = layer.opacity;
+            }
+            return opacity;
+        });
+        assert.ok(opacity0 !== undefined && opacity0 > 0);
+        assert.ok(opacity1 < opacity0);
+    });
+
+    it('should restore opacity when disabled', async () => {
+        const opacity0 = await page.evaluate(() => {
+            let opacity;
+            const layer = view.getLayers(l => l.isPlanarLayer)[0];
+            if (layer) {
+                opacity = layer.opacity;
+            }
+            return opacity;
+        });
+        await page.evaluate(() => view.setUndergroundVisualization(false));
+        const opacity1 = await page.evaluate(() => {
+            let opacity;
+            const layer = view.getLayers(l => l.isPlanarLayer)[0];
+            if (layer) {
+                opacity = layer.opacity;
+            }
+            return opacity;
+        });
+        assert.ok(opacity1 > opacity0);
+    });
+});

--- a/test/unit/underground.js
+++ b/test/unit/underground.js
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import PlanarView from 'Core/Prefab/PlanarView';
+import { CAMERA_TYPE } from 'Renderer/Camera';
+import Extent from 'Core/Geographic/Extent';
+import CameraUtils from 'Utils/CameraUtils';
+import Renderer from './bootstrap';
+
+
+describe('Underground Visualization', function () {
+    const renderer = new Renderer();
+    const extent = new Extent('EPSG:4326', -100, 100, -100, 100);
+
+    const view = new PlanarView(renderer.domElement, extent, { renderer, camera: { type: CAMERA_TYPE.ORTHOGRAPHIC } });
+
+    it('should decrease opacity while zooming', function () {
+        var opacity0;
+        const layer = view.getLayers(l => l.isPlanarLayer)[0];
+        if (layer) {
+            opacity0 = layer.opacity;
+        }
+
+        view.setUndergroundVisualization(true);
+        const params = { range: 1000 };
+        const camera = view.camera.camera3D;
+        CameraUtils.transformCameraToLookAtTarget(
+            view, camera, params,
+        );
+
+        var opacity1;
+        if (layer) {
+            opacity1 = layer.opacity;
+        }
+
+        assert.ok(opacity0 !== undefined && opacity0 > 0);
+        assert.ok(opacity1 < opacity0);
+    });
+
+
+    it('should restore opacity when disabled', async () => {
+        var opacity0;
+        const layer = view.getLayers(l => l.isPlanarLayer)[0];
+        if (layer) {
+            opacity0 = layer.opacity;
+        }
+        view.setUndergroundVisualization(false);
+        var opacity1;
+        if (layer) {
+            opacity1 = layer.opacity;
+        }
+        assert.ok(opacity1 > opacity0);
+    });
+});

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -68,6 +68,7 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
 
     layer.showOutline = false;
     layer.wireframe = false;
+    layer.dynamicOpacity = false;
     const state = {
         objectChart: true,
         visibilityChart: true,
@@ -81,6 +82,11 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
         applyToNodeFirstMaterial(view, layer.object3d, layer, (material) => {
             material.showOutline = newValue;
         });
+    });
+
+    // dynamic tiles opacity
+    gui.add(layer, 'dynamicOpacity').name('Dynamic opacity').onChange(() => {
+        view.setUndergroundVisualization(layer.dynamicOpacity);
     });
 
     // tiles wireframe


### PR DESCRIPTION
## Description
Visualizing underground data using dynamic opacity. Hide the layers' skirt without removing it while loading new ones. This is done using the new parameter _hideSkirt_ of TiledGeometryLayer.
The gound's opacity is dynamically changed while zooming.

## Motivation and Context
Feature useful for underground data visualization. It's working for planar and globe view.
**Added exemple and functional test**

## Screenshots

![Capture d'écran 2023-04-17 121734](https://user-images.githubusercontent.com/126568810/232458642-2eed0361-1813-4669-9667-0c55fef8689f.png)
![Capture d'écran 2023-04-17 121749](https://user-images.githubusercontent.com/126568810/232458655-6e80fe8e-fe5f-450b-8118-ba0fd9ce0b26.png)
![Capture d'écran 2023-04-17 121808](https://user-images.githubusercontent.com/126568810/232458669-e1719590-852a-4648-bd3b-a58ebd09bd90.png)

https://user-images.githubusercontent.com/126568810/232477757-ebf04efa-a062-4997-b3c5-b7d1f6edc8b1.mp4

