### PR TITLE
doc(WMTSSource): Change the link and the extend to TMSSource

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ The following people have contributed to iTowns.
   * [Adrien Berthet](https://github.com/zarov)
   * [Madec Germerie-Guizouarn](https://github.com/mgermerie)
   * [Mathieu Brédif](https://github.com/mbredif)
+  * [Aymeric Dutremble](https://github.com/a-dutremble)
 
 * [CIRIL Group](https://www.cirilgroup.com/en/):
   * [Vincent Jaillot](https://github.com/jailln)

--- a/src/Source/WMTSSource.js
+++ b/src/Source/WMTSSource.js
@@ -4,9 +4,9 @@ import TMSSource from 'Source/TMSSource';
  * @classdesc
  * An object defining the source of resources to get from a
  * [WMTS]{@link http://www.opengeospatial.org/standards/wmts} server. It inherits
- * from {@link Source}.
+ * from {@link TMSSource}.
  *
- * @extends Source
+ * @extends TMSSource
  *
  * @property {boolean} isWMTSSource - Used to checkout whether this source is a
  * WMTSSource. Default is true. You should not change this, as it is used


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

It is not possible to specify the TileMatrix identifier. In WMTSSource, the identifier corresponds to the zoom level (`%TILEMATRIX`). The changes in this PR make it possible to specify a different identifier using a callback function.

## Motivation and Context
Using other specific sources can be useful. For example, using a WMTS flow from a GeoServer. This allows people who know how to use GetCapabilities to specify a different identifier. This is only a temporary solution. The goal is to automatically implement the retrieval of this information in the GetCapabilities as mentioned in #285.
