### PR TITLE
fix(3DTiles) tileId == 0 can update style

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -359,7 +359,7 @@ class C3DTilesLayer extends GeometryLayer {
 
         const currentMaterials = [];// list materials used for this update
         this.object3d.traverse((object) => {
-            if (object.tileId && this.tilesC3DTileFeatures.has(object.tileId)) {
+            if (this.tilesC3DTileFeatures.has(object.tileId)) {
                 // object is a tile content
                 const c3DTileFeatures = this.tilesC3DTileFeatures.get(object.tileId);
                 object.traverse((child) => {


### PR DESCRIPTION
## Description
TileContent with tileId == 0 could not update style since in a condition statement 0 <=> undefined <=> false <=> null, moreover the first check in this condition is useless because if this.tilesC3DTileFeatures Map has(object.tileId) it means that object.tileId is a valid tileId so I simply remove it.