### PR TITLE
refactor(test): handling assert fail messages in tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ The following people have contributed to iTowns.
 
 * [CIRIL Group](https://www.cirilgroup.com/en/):
   * [Vincent Jaillot](https://github.com/jailln)
+  * [Anthony Gullient](https://github.com/AnthonyGlt)
 
 * [Oslandia](http://www.oslandia.com)
   * [Vincent Picavet](https://github.com/vpicavet)

--- a/test/unit/3dtileslayerprocess.js
+++ b/test/unit/3dtileslayerprocess.js
@@ -35,7 +35,7 @@ describe('3Dtiles layer', function () {
             .then((layer) => {
                 assert.equal(layer.root.children.length, 1);
                 done();
-            }, done);
+            }).catch(done);
     });
     it('preUpdate 3dtiles layer', function () {
         const elements = threedTilesLayer.preUpdate(context, new Set([threedTilesLayer]));

--- a/test/unit/3dtileslayerprocessbatchtable.js
+++ b/test/unit/3dtileslayerprocessbatchtable.js
@@ -44,6 +44,6 @@ describe('3Dtiles batch table', function () {
                 const batchLength = viewer.getLayerById('3d-tiles-bt-hierarchy').root.batchTable.batchLength;
                 assert.equal(batchLength, 30);
                 done();
-            }, done);
+            }).catch(done);
     });
 });

--- a/test/unit/cameraUtils.js
+++ b/test/unit/cameraUtils.js
@@ -64,7 +64,7 @@ describe('Camera utils unit test', function () {
                 assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
                 assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should set range like expected', function (done) {
         const params = { range: 10000 };
@@ -73,7 +73,7 @@ describe('Camera utils unit test', function () {
                 const range = result.range;
                 assert.ok(equalToFixed(range, params.range, 1));
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should look at coordinate like expected', function (done) {
         const params = { coord: coord.clone() };
@@ -83,7 +83,7 @@ describe('Camera utils unit test', function () {
                 assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
                 assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should tilt like expected', function (done) {
         const params = { tilt: 38 };
@@ -91,7 +91,7 @@ describe('Camera utils unit test', function () {
             .then((result) => {
                 assert.ok(equalToFixed(result.tilt, params.tilt, 4));
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should heading like expected', function (done) {
         const params = { heading: 147 };
@@ -99,7 +99,7 @@ describe('Camera utils unit test', function () {
             .then((result) => {
                 assert.ok(equalToFixed(result.heading, params.heading, 4));
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should heading, tilt, range and coordinate like expected', function (done) {
         const params = { heading: 17, tilt: 80, range: 20000, coord: coord.clone() };
@@ -112,7 +112,7 @@ describe('Camera utils unit test', function () {
                 assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
                 assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
                 done();
-            }, done);
+            }).catch(done);
     });
 
     // TODO: to verify and recode
@@ -129,7 +129,7 @@ describe('Camera utils unit test', function () {
                 assert.ok(equalToFixed(result.coord.longitude, params.coord.longitude, 4));
                 assert.ok(equalToFixed(result.coord.latitude, params.coord.latitude, 4));
                 done();
-            }, done);// neither here
+            }).catch(done);// neither here
     });
     */
 

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -137,7 +137,7 @@ describe('Provide in Sources', function () {
                 assert.equal(textures[0].extent.row, 511);
                 assert.equal(textures[0].extent.col, 512);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should get wmts texture elevation with DataSourceProvider', (done) => {
@@ -167,7 +167,7 @@ describe('Provide in Sources', function () {
                 assert.equal(textures[0].extent.row, 511);
                 assert.equal(textures[0].extent.col, 512);
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should get wms texture with DataSourceProvider', (done) => {
         colorlayer.source = new WMSSource({
@@ -200,7 +200,7 @@ describe('Provide in Sources', function () {
                 assert.equal(e.north, tile.extent.north);
                 assert.equal(e.south, tile.extent.south);
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should get 4 TileMesh from TileProvider', (done) => {
         const tile = new TileMesh(geom, material, planarlayer, extent, zoom);
@@ -217,7 +217,7 @@ describe('Provide in Sources', function () {
                 assert.equal(tiles[0].extent.north, tile.extent.north);
                 assert.equal(tiles[0].extent.south, tile.extent.north * 0.5);
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should get 3 meshs with WFS source and DataSourceProvider', (done) => {
         const tile = new TileMesh(geom, material, planarlayer, extent, featureLayer.zoom.min);
@@ -234,7 +234,7 @@ describe('Provide in Sources', function () {
             .then((features) => {
                 assert.equal(features[0].meshes.children.length, 4);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should get 1 mesh with WFS source and DataSourceProvider and mergeFeatures == true', (done) => {
@@ -260,7 +260,7 @@ describe('Provide in Sources', function () {
                 assert.equal(features[0].meshes.children[1].children.length, 0);
                 assert.equal(featureCountByCb, 2);
                 done();
-            }, done);
+            }).catch(done);
     });
     it('should get 1 texture with WFS source and DataSourceProvider', (done) => {
         const tile = new TileMesh(
@@ -299,7 +299,7 @@ describe('Provide in Sources', function () {
                 assert.equal(textures.length, 1);
                 assert.ok(textures[0].isTexture);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should get updated RasterLayer', (done) => {
@@ -331,6 +331,6 @@ describe('Provide in Sources', function () {
                 tile.material.updateLayersUniforms();
                 assert.equal(tile.material.uniforms.colorTextures.value[0].extent.zoom, 10);
                 done();
-            }, done);
+            }).catch(done);
     });
 });

--- a/test/unit/demutils.js
+++ b/test/unit/demutils.js
@@ -51,7 +51,7 @@ describe('DemUtils', function () {
             .then((l) => {
                 assert.equal('worldelevation', l.id);
                 done();
-            }, done);
+            }).catch(done);
     });
     const tiles = [];
     const extent = new Extent('EPSG:4326', 5.625, 11.25, 45, 50.625);
@@ -69,7 +69,7 @@ describe('DemUtils', function () {
             .then(() => {
                 assert.equal(nodeLayer.textures[0].image.data[0], 357.3833923339844);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('get elevation value at with PRECISE_READ_Z', () => {

--- a/test/unit/entwine.js
+++ b/test/unit/entwine.js
@@ -18,7 +18,7 @@ describe('Entwine Point Tile', function () {
         source.whenReady
             .then(() => {
                 done();
-            }, done);
+            }).catch(done);
     });
 
     describe('Layer', function () {
@@ -45,7 +45,7 @@ describe('Entwine Point Tile', function () {
             View.prototype.addLayer.call(view, layer)
                 .then(() => {
                     done();
-                }, done);
+                }).catch(done);
         });
 
         it('pre updates and finds the root', () => {
@@ -70,7 +70,7 @@ describe('Entwine Point Tile', function () {
                         .then(() => {
                             done();
                         });
-                }, done);
+                }).catch(done);
         });
 
         it('post updates', function () {

--- a/test/unit/feature2mesh.js
+++ b/test/unit/feature2mesh.js
@@ -39,7 +39,7 @@ describe('Feature2Mesh', function () {
                 extentSize.x * extentSize.y,
                 computeAreaOfMesh(mesh.children[0]));
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('square mesh area should match geometry extent minus holes', function (done) {
@@ -54,7 +54,7 @@ describe('Feature2Mesh', function () {
                 noHoleArea - holeArea,
                 meshWithHoleArea);
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('convert points, lines and mesh', function (done) {
@@ -64,6 +64,6 @@ describe('Feature2Mesh', function () {
             assert.equal(mesh.children[1].type, 'Line');
             assert.equal(mesh.children[2].type, 'Mesh');
             done();
-        }, done);
+        }).catch(done);
     });
 });

--- a/test/unit/featureUtils.js
+++ b/test/unit/featureUtils.js
@@ -13,7 +13,7 @@ describe('FeaturesUtils', function () {
         promise.then((collection) => {
             assert.equal(collection.features.length, 3);
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('should correctly compute extent geojson', function (done) {
@@ -24,7 +24,7 @@ describe('FeaturesUtils', function () {
             assert.equal(extent.south, 42.91620643817353);
             assert.equal(extent.north, 43.72744458647463);
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('should correctly filter point', function (done) {
@@ -34,7 +34,7 @@ describe('FeaturesUtils', function () {
             assert.equal(filter.length, 1.0);
             assert.equal(filter[0].type == FEATURE_TYPES.POINT, 1.0);
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('should correctly filter polygon', function (done) {
@@ -44,7 +44,7 @@ describe('FeaturesUtils', function () {
             assert.equal(filter.length, 1.0);
             assert.equal(filter[0].type == FEATURE_TYPES.POLYGON, 1.0);
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('should correctly filter line', function (done) {
@@ -54,13 +54,13 @@ describe('FeaturesUtils', function () {
             assert.equal(filter.length, 1.0);
             assert.equal(filter[0].type == FEATURE_TYPES.LINE, 1.0);
             done();
-        }, done);
+        }).catch(done);
     });
 
     it('should remember individual feature properties', function (done) {
         promise.then((collection) => {
             assert.equal(collection.features[2].geometries[0].properties.my_prop, 14);
             done();
-        }, done);
+        }).catch(done);
     });
 });

--- a/test/unit/featuregeometrylayer.js
+++ b/test/unit/featuregeometrylayer.js
@@ -74,7 +74,7 @@ describe('Layer with Feature process', function () {
             .then((layer) => {
                 assert.ok(layer);
                 done();
-            }, done);
+            }).catch(done);
     });
     it('update', function (done) {
         ariege.whenReady
@@ -85,7 +85,7 @@ describe('Layer with Feature process', function () {
                         assert.equal(ariege.object3d.children.length, 1);
                         done();
                     });
-            }, done);
+            }).catch(done);
     });
 
     it('add layer no proj4', function (done) {
@@ -93,7 +93,7 @@ describe('Layer with Feature process', function () {
             .then((layer) => {
                 assert.ok(layer);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('update no proj4', function (done) {
@@ -106,7 +106,7 @@ describe('Layer with Feature process', function () {
                         assert.equal(ariegeNoProj4.object3d.children.length, 1);
                         done();
                     });
-            }, done);
+            }).catch(done);
     });
 
     it('parsing error without proj4 should be inferior to 1e-5 meter', function (done) {
@@ -129,7 +129,7 @@ describe('Layer with Feature process', function () {
 
                 assert.ok(error < 1e-5);
                 done();
-            }, done);
+            }).catch(done);
     });
 });
 

--- a/test/unit/featuregeometrylayererror.js
+++ b/test/unit/featuregeometrylayererror.js
@@ -68,12 +68,12 @@ files.forEach((geojson, i) => {
             layerProj4.whenReady
                 .then(() => {
                     tile.visible = true;
-                    layerProj4.update(context, layerProj4, tile)
+                    return layerProj4.update(context, layerProj4, tile)
                         .then(() => {
                             assert.equal(layerProj4.object3d.children.length, 1);
                             done();
-                        }, done);
-                }, done);
+                        });
+                }).catch(done);
         });
 
         it('update without proj4', function (done) {
@@ -81,12 +81,12 @@ files.forEach((geojson, i) => {
                 .then(() => {
                     tile.visible = true;
                     context.layer = layerNoProj4;
-                    layerNoProj4.update(context, layerNoProj4, tile)
+                    return layerNoProj4.update(context, layerNoProj4, tile)
                         .then(() => {
                             assert.equal(layerNoProj4.object3d.children.length, 1);
                             done();
-                        }, done);
-                }, done);
+                        });
+                }).catch(done);
         });
 
         it(`parsing error without proj4 should be inferior to ${max_error} meter`, function (done) {
@@ -118,7 +118,7 @@ files.forEach((geojson, i) => {
 
                     assert.ok(error < max_error);
                     done();
-                }, done);
+                }).catch(done);
         });
     });
 });

--- a/test/unit/geoidlayer.js
+++ b/test/unit/geoidlayer.js
@@ -44,7 +44,7 @@ describe('GlobeView', function () {
         view.addLayer(geoidLayer)
             .then(() => {
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('update geoid layer', function (done) {
@@ -55,6 +55,6 @@ describe('GlobeView', function () {
                         assert.equal(tile.geoidHeight, 45.72800064087844);
                         done();
                     });
-            }, done);
+            }).catch(done);
     });
 });

--- a/test/unit/geojson.js
+++ b/test/unit/geojson.js
@@ -20,7 +20,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(collection.features[0].vertices.every((v, i) => ((i + 1) % 3) != 0 || (v + collection.position.z) == 0));
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should respect all z coordinates', function (done) {
@@ -28,7 +28,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(collection.features[0].vertices.every((v, i) => ((i + 1) % 3) != 0 || (v + collection.position.z) != 0));
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should detect if there is the raw elevation data', function (done) {
@@ -36,7 +36,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(collection.features[0].hasRawElevationData);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should detect if there is not the raw elevation data', function (done) {
@@ -44,7 +44,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(!collection.features[0].hasRawElevationData);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should return an empty collection', function (done) {
@@ -60,7 +60,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(collection.features.length == 0);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should return an merged collection', function (done) {
@@ -76,7 +76,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(collection.features.length == 1);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should return an no merged collection', function (done) {
@@ -92,7 +92,7 @@ describe('GeoJsonParser', function () {
             .then((collection) => {
                 assert.ok(collection.features.length == 3);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should return an collection without altitude and normal', function (done) {
@@ -109,7 +109,7 @@ describe('GeoJsonParser', function () {
                 assert.ok(collection.features[0].vertices.length == 32);
                 assert.ok(collection.features[0].normals == undefined);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('parses Point and MultiPoint', function (done) {
@@ -128,6 +128,6 @@ describe('GeoJsonParser', function () {
                 assert.equal(collection.features[1].geometries.length, 1);
                 assert.equal(collection.features[2].geometries.length, 5);
                 done();
-            }, done);
+            }).catch(done);
     });
 });

--- a/test/unit/globecontrol.js
+++ b/test/unit/globecontrol.js
@@ -63,7 +63,7 @@ describe('GlobeControls', function () {
                 assert.equal(e.tilt, tilt);
                 assert.equal((tilt / controls.getTilt()).toFixed(8), 1);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('Set heading', function (done) {
@@ -72,7 +72,7 @@ describe('GlobeControls', function () {
                 assert.equal(e.heading, heading);
                 assert.equal((heading / controls.getHeading()).toFixed(8), 1);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('getCameraOrientation', function () {
@@ -97,7 +97,7 @@ describe('GlobeControls', function () {
             .then(() => {
                 assert.equal(zoom, controls.getZoom());
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('Set range', function (done) {
@@ -106,7 +106,7 @@ describe('GlobeControls', function () {
             .then((e) => {
                 assert.equal((e.range / range).toFixed(8), 1);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('Set scale', function (done) {
@@ -115,7 +115,7 @@ describe('GlobeControls', function () {
             .then(() => {
                 assert.equal((viewer.getScale() / scale).toFixed(8), 1);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('update', function () {
@@ -166,7 +166,7 @@ describe('GlobeControls', function () {
             .then(() => {
                 assert.ok(controls.getRange() < startRange);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('travel out', function (done) {
@@ -179,7 +179,7 @@ describe('GlobeControls', function () {
             .then(() => {
                 assert.ok(controls.getRange() > startRange);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('touch start', function () {
@@ -207,7 +207,7 @@ describe('GlobeControls', function () {
                 assert.equal((e.coord.latitude / placement.coord.latitude).toFixed(8), 1);
                 clearInterval(i);
                 done();
-            }, done);
+            }).catch(done);
 
         if (rig.animationFrameRequester) {
             i = setInterval(rig.animationFrameRequester, 10);

--- a/test/unit/globeview.js
+++ b/test/unit/globeview.js
@@ -48,7 +48,7 @@ describe('GlobeView', function () {
                 const node = viewer.tileLayer.level0Nodes[0];
                 viewer.tileLayer.update(context, viewer.tileLayer, node);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('ObjectRemovalHelper', function (done) {
@@ -58,7 +58,7 @@ describe('GlobeView', function () {
                 ObjectRemovalHelper.removeChildrenAndCleanup(viewer.tileLayer, node);
                 ObjectRemovalHelper.removeChildren(viewer.tileLayer, node);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should get the zoom scale', () => {

--- a/test/unit/orientedimagelayer.js
+++ b/test/unit/orientedimagelayer.js
@@ -56,7 +56,7 @@ describe('Oriented Image Layer', function () {
             .then(() => {
                 assert.equal(olayer.cameras.length, 5);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('PreUpdate oriented image layer', function (done) {
@@ -66,6 +66,6 @@ describe('Oriented Image Layer', function () {
                 olayer.preUpdate(context);
                 assert.equal(olayer.currentPano.id, 482);
                 done();
-            }, done);
+            }).catch(done);
     });
 });

--- a/test/unit/pnts_parser.js
+++ b/test/unit/pnts_parser.js
@@ -40,6 +40,6 @@ describe('pnts parser', function () {
                     155);
 
                 done();
-            }, done);
+            }).catch(done);
     });
 });

--- a/test/unit/potree.js
+++ b/test/unit/potree.js
@@ -49,7 +49,7 @@ describe('Potree', function () {
                 assert.equal(layer.root.children.length, 7);
                 layer.bboxes.visible = true;
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('preupdate potree layer', function () {
@@ -64,7 +64,7 @@ describe('Potree', function () {
             .then(() => {
                 assert.equal(potreeLayer.group.children.length, 1);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('postUpdate potree layer', function () {
@@ -88,19 +88,18 @@ describe('Potree', function () {
                 .then(() => {
                     assert.equal(7, root.children.length);
                     done();
-                }, done);
+                }).catch(done);
         });
 
         it('load child node', function (done) {
             const root = new PotreeNode(numPoints, childrenBitField, potreeLayer);
             root.loadOctree()
-                .then(() => {
-                    root.children[0].load()
-                        .then(() => {
-                            assert.equal(2, root.children[0].children.length);
-                            done();
-                        });
-                }, done);
+                .then(() => root.children[0].load()
+                    .then(() => {
+                        assert.equal(2, root.children[0].children.length);
+                        done();
+                    }),
+                ).catch(done);
         });
     });
 

--- a/test/unit/scheduler.js
+++ b/test/unit/scheduler.js
@@ -38,7 +38,7 @@ describe('Command execution', function () {
             .then((c) => {
                 assert.ok(c.done);
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should execute 100 commands', function (done) {
@@ -53,7 +53,7 @@ describe('Command execution', function () {
                     assert.ok(cmd.done);
                 }
                 done();
-            }, done);
+            }).catch(done);
     });
 
     it('should execute balance commands between layers', function (done) {
@@ -74,6 +74,6 @@ describe('Command execution', function () {
             // layer1 commands must be all finished before layer0 commands
             assert.ok(results.lastIndexOf('layer1') < results.lastIndexOf('layer0'));
             done();
-        }, done);
+        }).catch(done);
     });
 });

--- a/test/unit/source.js
+++ b/test/unit/source.js
@@ -177,7 +177,7 @@ describe('Sources', function () {
                 .then((a) => {
                     assert.equal(Object.keys(a).length, 2);
                     done();
-                }, done);
+                }).catch(done);
         });
 
         it('should return keys OrientedImageSource from request', function () {
@@ -233,7 +233,7 @@ describe('Sources', function () {
                     fetchedData = source.fetchedData;
                     assert.equal(fetchedData.properties.nom, 'Ariège');
                     done();
-                }, done);
+                }).catch(done);
         });
 
         it('should instance FileSource with fetchedData and parse data with a layer', function (done) {


### PR DESCRIPTION
## Description
Catch error when assert is false and avoid timeout.

## Motivation and Context
I was getting a timeout when the assert was wrong for unit tests.

Example of timeout: demutils.js

```
it('add elevation layer', (done) => {
        viewer.addLayer(elevationlayer)
            .then((l) => {
                assert.equal('worldelevation1', l.id);
                done();
            }, done);
    });
 

``` 
I've replaced _worldelevation_ with _worldelevation1_ and it will timeout instead of returning the error.

Following the commit from:
https://github.com/iTowns/itowns/pull/2044



