### PR TITLE
feat(3DTiles) add C3DTILES_LAYER_EVENTS.ON_TILE_REQUESTED

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -12,9 +12,17 @@ export const C3DTILES_LAYER_EVENTS = {
     /**
      * Fires when a tile content has been loaded
      * @event C3DTilesLayer#on-tile-content-loaded
-     * @property type {string} on-tile-content-loaded
+     * @type {object}
+     * @property {THREE.Object3D} tileContent - object3D of the tile
      */
     ON_TILE_CONTENT_LOADED: 'on-tile-content-loaded',
+    /**
+     * Fires when a tile is requested
+     * @event C3DTilesLayer#on-tile-requested
+     * @type {object}
+     * @property {object} metadata - tile
+     */
+    ON_TILE_REQUESTED: 'on-tile-requested',
 };
 
 const update = process3dTilesNode();

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import Extent from 'Core/Geographic/Extent';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
+import { C3DTILES_LAYER_EVENTS } from '../Layer/C3DTilesLayer';
 
 /** @module 3dTilesProcessing
 */
@@ -16,6 +17,8 @@ function requestNewTile(view, scheduler, geometryLayer, metadata, parent, redraw
         metadata,
         redraw,
     };
+
+    geometryLayer.dispatchEvent({ type: C3DTILES_LAYER_EVENTS.ON_TILE_REQUESTED, metadata });
 
     return scheduler.execute(command);
 }


### PR DESCRIPTION
## Description
When 3DTilesProcessing is requesting new tile, the C3DTilesLayer dispatch an event ON_TILE_REQUESTED.

## Motivation and Context
The motivation here is to allow itowns user to know when a 3DTiles is loading (has been requested) allowing to display feedbacks.

![SideBar Widget example](https://github.com/iTowns/itowns/assets/14295096/428b98c9-394a-429d-ac09-fe4caef2cf0f)
