### PR TITLE
remove camera argument from CameraRig

### DIFF
--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -337,7 +337,7 @@ class CameraRig extends THREE.Object3D {
 }
 
 export function getRig(camera) {
-    rigs[camera.uuid] = rigs[camera.uuid] || new CameraRig(camera);
+    rigs[camera.uuid] = rigs[camera.uuid] || new CameraRig();
     return rigs[camera.uuid];
 }
 


### PR DESCRIPTION
Useless `camera` argument because the constructor doesn't take argument and a new camera is assigned.

Will it be useful to keep the camera instead of creating a new one ?