### PR TITLE
More tests on crs parameters

### DIFF
--- a/src/Core/Geographic/Crs.js
+++ b/src/Core/Geographic/Crs.js
@@ -2,19 +2,31 @@ import proj4 from 'proj4';
 
 proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
 
+function isString(s) {
+    return typeof s === 'string' || s instanceof String;
+}
+
+function mustBeString(crs) {
+    if (!isString(crs)) {
+        throw new Error(`Crs parameter value must be a string: '${crs}'`);
+    }
+}
+
 function isTms(crs) {
-    return crs.startsWith('TMS');
+    return isString(crs) && crs.startsWith('TMS');
 }
 
 function isEpsg(crs) {
-    return crs.startsWith('EPSG');
+    return isString(crs) && crs.startsWith('EPSG');
 }
 
 function formatToTms(crs) {
+    mustBeString(crs);
     return isTms(crs) ? crs : `TMS:${crs.match(/\d+/)[0]}`;
 }
 
 function formatToEPSG(crs) {
+    mustBeString(crs);
     return isEpsg(crs) ? crs : `EPSG:${crs.match(/\d+/)[0]}`;
 }
 
@@ -28,6 +40,7 @@ function is4326(crs) {
 }
 
 function isGeocentric(crs) {
+    mustBeString(crs);
     const projection = proj4.defs(crs);
     return !projection ? false : projection.projName == 'geocent';
 }
@@ -43,6 +56,7 @@ function _unitFromProj4Unit(projunit) {
 }
 
 function toUnit(crs) {
+    mustBeString(crs);
     switch (crs) {
         case 'EPSG:4326' : return UNIT.DEGREE;
         case 'EPSG:4978' : return UNIT.METER;
@@ -57,9 +71,10 @@ function toUnit(crs) {
 }
 
 function toUnitWithError(crs) {
+    mustBeString(crs);
     const u = toUnit(crs);
-    if (crs === undefined || u === undefined) {
-        throw new Error(`Invalid crs parameter value '${crs}'`);
+    if (u === undefined) {
+        throw new Error(`No unit found for crs: '${crs}'`);
     }
     return u;
 }

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -8,6 +8,7 @@ import ISGParser from 'Parser/ISGParser';
 import VectorTileParser from 'Parser/VectorTileParser';
 import Fetcher from 'Provider/Fetcher';
 import Cache from 'Core/Scheduler/Cache';
+import CRS from 'Core/Geographic/Crs';
 
 export const supportedFetchers = new Map([
     ['image/x-bil;bits=32', Fetcher.textureFloat],
@@ -50,6 +51,9 @@ class InformationsData {
         if (options.projection) {
             console.warn('Source projection parameter is deprecated, use crs instead.');
             options.crs = options.crs || options.projection;
+        }
+        if (options.crs) {
+            CRS.isValid(options.crs);
         }
         this.crs = options.crs;
     }

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -14,7 +14,7 @@ const extent = new Extent(CRS.tms_4326, 0, 0, 0);
  * @extends Source
  *
  * @property {boolean} isTMSSource - Used to checkout whether this source is a
- * TMSSource. Default is true. You should not change this, as it is used
+ * TMSSource. Default is tue. You should not change this, as it is used
  * internally for optimisation.
  * @property {boolean} isInverted - The isInverted property is to be set to the
  * correct value, true or false (default being false) if the computation of the
@@ -78,13 +78,13 @@ class TMSSource extends Source {
      * @constructor
      */
     constructor(source) {
-        if (!source.crs && !source.projection) {
-            throw new Error('New TMSSource/WMTSSource: crs projection is required');
-        }
-
         source.format = source.format || 'image/png';
 
         super(source);
+
+        if (!source.crs) {
+            throw new Error('New TMSSource/WMTSSource: crs is required');
+        }
 
         this.isTMSSource = true;
 

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -14,7 +14,7 @@ const extent = new Extent(CRS.tms_4326, 0, 0, 0);
  * @extends Source
  *
  * @property {boolean} isTMSSource - Used to checkout whether this source is a
- * TMSSource. Default is tue. You should not change this, as it is used
+ * TMSSource. Default is true. You should not change this, as it is used
  * internally for optimisation.
  * @property {boolean} isInverted - The isInverted property is to be set to the
  * correct value, true or false (default being false) if the computation of the


### PR DESCRIPTION
Add function parameters tests to avoid errors such as `crs.startsWith is not a function`