### PR TITLE
chore: don't watch git hash modification

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ The following people have contributed to iTowns.
 * [CIRIL Group](https://www.cirilgroup.com/en/):
   * [Vincent Jaillot](https://github.com/jailln)
   * [Anthony Gullient](https://github.com/AnthonyGlt)
+  * [Jonathan Garnier](https://github.com/jogarnier)
 
 * [Oslandia](http://www.oslandia.com)
   * [Vincent Picavet](https://github.com/vpicavet)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,12 @@ module.exports = () => {
             devMiddleware: {
                 publicPath: '/dist/',
             },
-            static: path.resolve(__dirname, './'),
+            static: {
+				directory: path.resolve(__dirname, './'),
+				watch: {
+					ignored: path.resolve(__dirname, '.git')
+				}
+			},
             client: {
                 overlay: {
                     errors: true,


### PR DESCRIPTION
Webpack serve command must not watch `/.git` content to avoid constant unwanted page reload.

If you have a  git tool opened on your itowns repo it could try to fetch for new content continually. Each try changes git HEAD hash which was listened by the webpack watch and triggered web page reload