### PR TITLE
fix(3DTiles) addEventListener onTileContentLoaded constructor

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -108,7 +108,7 @@ class C3DTilesLayer extends GeometryLayer {
 
         if (config.onTileContentLoaded) {
             console.warn('DEPRECATED onTileContentLoaded should not be passed at the contruction, use C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED event instead');
-            this.addEventListener(C3DTilesLayer.EVENT_TILE_CONTENT_LOADED, config.onTileContentLoaded);
+            this.addEventListener(C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED, config.onTileContentLoaded);
         }
 
         if (config.overrideMaterials) {


### PR DESCRIPTION
Fix a typo in C3DTilesLayer constructor (`C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED` instead of `C3DTilesLayer.EVENT_TILE_CONTENT_LOADED` which was the old way of referencing this value)

related https://github.com/iTowns/itowns/issues/2121 + https://github.com/iTowns/itowns/issues/2113
