### PR TITLE
Intancing pickGeometryAt

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -774,6 +774,11 @@ class View extends THREE.EventDispatcher {
         return results;
     }
 
+    pickGeometryAt(mouseOrEvt, radius = 0, where) {
+        const layer = this.getLayerById(where);
+        return layer.selectGeometry(mouseOrEvt, radius, this);
+    }
+
     /**
      * Return the current zoom scale at the central point of the view. This
      * function compute the scale of a map.

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -116,6 +116,13 @@ class ColorLayer extends RasterLayer {
     update(context, layer, node, parent) {
         return updateLayeredMaterialNodeImagery(context, this, node, parent);
     }
+
+    selectGeometry(mouseOrEvt, radius, view) {
+        const results = view.pickFeaturesAt(mouseOrEvt, radius, this.id);
+        if (results[this.id].length) {
+            return results[this.id][0].geometry;
+        }
+    }
 }
 
 export default ColorLayer;

--- a/src/Layer/FeatureGeometryLayer.js
+++ b/src/Layer/FeatureGeometryLayer.js
@@ -61,6 +61,23 @@ class FeatureGeometryLayer extends GeometryLayer {
             this.object3d.clear();
         }
     }
+
+    selectGeometry(mouseOrEvt, radius, view) {
+        const results = view.pickObjectsAt(mouseOrEvt, radius, this.id);
+        if (results.length) {
+            if (results[0].object.isLine) {
+                const batchId = results[0].object.geometry.attributes.batchId.array[results[0].object.geometry.index.array[results[0].index]];
+                return { geometry: results[0].object.feature.geometries[batchId], mesh: results[0].object };
+            } else if (results[0].object.isPoints) {
+                const batchId = results[0].object.geometry.attributes.batchId.array[results[0].index];
+                return { geometry: results[0].object.feature.geometries[batchId], mesh: results[0].object };
+            } else if (results[0].object.isMesh) {
+                const batchId = results[0].object.geometry.attributes.batchId.array[results[0].face.a];
+                return { geometry: results[0].object.feature.geometries[batchId], mesh: results[0].object };
+            }
+        }
+        return undefined;
+    }
 }
 
 export default FeatureGeometryLayer;

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -258,6 +258,10 @@ class Layer extends THREE.EventDispatcher {
     delete(clearCache) {
         console.warn('Function delete doesn\'t exist for this layer');
     }
+
+    selectGeometry() {
+        throw new Error('selectGeometry is not supported yet in this type of layer');
+    }
 }
 
 export default Layer;


### PR DESCRIPTION
## Description
This function complete the previous tools by returning the object `FeatureGeometry` when you select a geometry on your screen.

To use it, it's mandatory to create a batchId when instantiating the layer. Without the batchId, all the `FeatureGeometry` in the layer cannot be differentiated.
This feature only work for `ColorLayer` and `FeatureGeometryLayer` for now.

Currently, `pickObjectAt` and `pickFeaturesAt` return a specific object. In this function, we return the object `FeatureGeometry` and for `FeatureGeometryLayer` we return the 3d mesh too.

