### PR TITLE
change in base_altitude use for definition of a global Style function.

### DIFF
--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -129,8 +129,8 @@ export class FeatureGeometry {
     }
 
     baseAltitude(feature, coordinates) {
-        const base_altitude = feature.style[typeToStyleProperty[feature.type]].base_altitude || 0;
-        return isNaN(base_altitude) ? base_altitude(this.properties, coordinates) : base_altitude;
+        const baseAltitude = feature.baseAltitude[typeToStyleProperty[feature.type]];
+        return isNaN(baseAltitude) ? baseAltitude(this.properties, coordinates) : baseAltitude;
     }
 
     /**
@@ -198,6 +198,10 @@ function push3DValues(value0, value1, value2 = 0) {
     this.vertices[this._pos++] = value2;
 }
 
+function baseAltitudeDefault(properties, coordinates) {
+    return coordinates?.z || 0;
+}
+
 /**
  *
  * This class improves and simplifies the construction and conversion of geographic data structures.
@@ -260,6 +264,7 @@ class Feature {
         this._pos = 0;
         this._pushValues = (this.size === 3 ? push3DValues : push2DValues).bind(this);
         this.style = new Style({}, collection.style);
+        this.baseAltitude = collection.baseAltitude;
 
         this.altitude = {
             min: Infinity,
@@ -371,6 +376,11 @@ export class FeatureCollection extends THREE.Object3D {
         this.size = options.structure == '3d' ? 3 : 2;
         this.filterExtent = options.filterExtent;
         this.style = options.style;
+        this.baseAltitude = {
+            fill: (options.style?.fill?.base_altitude) || baseAltitudeDefault,
+            stroke: (options.style?.stroke?.base_altitude) || baseAltitudeDefault,
+            point: (options.style?.point?.base_altitude) || baseAltitudeDefault,
+        };
         this.isInverted = false;
         this.matrixWorldInverse = new THREE.Matrix4();
         this.center = new Coordinates('EPSG:4326', 0, 0);

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -13,10 +13,6 @@ const inv255 = 1 / 255;
 const canvas = (typeof document !== 'undefined') ? document.createElement('canvas') : {};
 const style_properties = {};
 
-function base_altitudeDefault(properties, coordinates = { z: 0 }) {
-    return coordinates.z;
-}
-
 function mapPropertiesFromContext(mainKey, from, to, context) {
     to[mainKey] = to[mainKey] || {};
     for (const key of style_properties[mainKey]) {
@@ -502,8 +498,9 @@ class Style {
         defineStyleProperty(this, 'fill', 'color', params.fill.color);
         defineStyleProperty(this, 'fill', 'opacity', params.fill.opacity, 1.0);
         defineStyleProperty(this, 'fill', 'pattern', params.fill.pattern);
-        defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude, base_altitudeDefault);
+        defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude);
         defineStyleProperty(this, 'fill', 'extrusion_height', params.fill.extrusion_height);
+
 
         if (typeof this.fill.pattern == 'string') {
             Fetcher.texture(this.fill.pattern).then((pattern) => {
@@ -516,7 +513,7 @@ class Style {
         defineStyleProperty(this, 'stroke', 'opacity', params.stroke.opacity, 1.0);
         defineStyleProperty(this, 'stroke', 'width', params.stroke.width, 1.0);
         defineStyleProperty(this, 'stroke', 'dasharray', params.stroke.dasharray, []);
-        defineStyleProperty(this, 'stroke', 'base_altitude', params.stroke.base_altitude, base_altitudeDefault);
+        defineStyleProperty(this, 'stroke', 'base_altitude', params.stroke.base_altitude);
 
         this.point = {};
         defineStyleProperty(this, 'point', 'color', params.point.color);
@@ -524,8 +521,8 @@ class Style {
         defineStyleProperty(this, 'point', 'opacity', params.point.opacity, 1.0);
         defineStyleProperty(this, 'point', 'radius', params.point.radius, 2.0);
         defineStyleProperty(this, 'point', 'width', params.point.width, 0.0);
-        defineStyleProperty(this, 'point', 'base_altitude', params.point.base_altitude, base_altitudeDefault);
         defineStyleProperty(this, 'point', 'model', params.point.model);
+        defineStyleProperty(this, 'point', 'base_altitude', params.point.base_altitude);
 
         this.text = {};
         defineStyleProperty(this, 'text', 'field', params.text.field);

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -251,8 +251,8 @@ class LabelLayer extends GeometryLayer {
             const featureField = f.style.text.field;
 
             // determine if altitude style is specified by the user
-            const altitudeStyle = f.style.point.base_altitude;
-            const isDefaultElevationStyle = altitudeStyle instanceof Function && altitudeStyle.name == 'base_altitudeDefault';
+            const altitudeStyle = f.baseAltitude.point;
+            const isDefaultElevationStyle = altitudeStyle instanceof Function && altitudeStyle.name == 'baseAltitudeDefault';
 
             // determine if the altitude needs update with ElevationLayer
             labels.needsAltitude = labels.needsAltitude || this.forceClampToTerrain === true || (isDefaultElevationStyle && !f.hasRawElevationData);


### PR DESCRIPTION
The purpose of this PR is tho prepare for the possibility of using a global function for the style.

base_altitude is a Style sub-property for the positioning of feature on the elevation axe.
In opposition to the other style sub-properties (apart from extruded_height) which are used at the convert phase, base_altitude is used at the feature Instanciation (during the parsing).

To be able to use a global function for style we thus need to find a way to move base_altitde properties out of the style used during the convert.



