### PR TITLE
3D Tiles fixes and perf improvements

### DIFF
--- a/src/Core/3DTiles/C3DTBatchTable.js
+++ b/src/Core/3DTiles/C3DTBatchTable.js
@@ -1,6 +1,6 @@
 import utf8Decoder from 'Utils/Utf8Decoder';
 import binaryPropertyAccessor from './utils/BinaryPropertyAccessor';
-import C3DTilesTypes from './C3DTilesTypes';
+import { C3DTilesTypes } from './C3DTilesEnums';
 
 /** @classdesc
  * A 3D Tiles

--- a/src/Core/3DTiles/C3DTBoundingVolume.js
+++ b/src/Core/3DTiles/C3DTBoundingVolume.js
@@ -1,44 +1,122 @@
 import * as THREE from 'three';
-import Extent from '../Geographic/Extent';
-import OBB from '../../Renderer/OBB';
-import C3DTilesTypes from './C3DTilesTypes';
+import Ellipsoid from 'Core/Math/Ellipsoid';
+import Coordinates from '../Geographic/Coordinates';
+import { C3DTilesTypes, C3DTilesBoundingVolumeTypes } from './C3DTilesEnums';
 
-const matrix = new THREE.Matrix4();
-const center = new THREE.Vector3();
-const size = new THREE.Vector3();
-const extent = new Extent('EPSG:4326', 0, 0, 0, 0);
-const sphereCenter = new THREE.Vector3();
+const ellipsoid = new Ellipsoid();
+
+// bounding box scratch variables
+const boxSize = new THREE.Vector3();
+const boxCenter = new THREE.Vector3();
+
+// Bounding region scratch variables
+const southEastUpCarto = new Coordinates('EPSG:4326');
+const southEastUpVec3 = new THREE.Vector3();
+const northWestBottomCarto = new Coordinates('EPSG:4326');
+const northWestBottomVec3 = new THREE.Vector3();
+const radiusScratch = new THREE.Vector3();
+
+// Culling scratch value
 const worldCoordinateCenter = new THREE.Vector3();
+
+/**
+ * Bounding region is converted to a bounding sphere to simplify and speed computation and culling. This function
+ * computes a sphere enclosing the bounding region.
+ * @param {Object} region - the parsed json from the tile representing the region
+ * @param {THREE.Matrix4} tileMatrixInverse - the inverse transformation matrix of the tile to transform the produced
+ * sphere from a global to a reference local to the tile
+ * @return {THREE.Sphere} a sphere enclosing the given region
+ */
+function initFromRegion(region, tileMatrixInverse) {
+    const east = region[2];
+    const west = region[0];
+    const south = region[1];
+    const north = region[3];
+    const minHeight = region[4];
+    const maxHeight = region[5];
+
+    const eastDeg = THREE.MathUtils.radToDeg(east);
+    const westDeg = THREE.MathUtils.radToDeg(west);
+    const southDeg = THREE.MathUtils.radToDeg(south);
+    const northDeg = THREE.MathUtils.radToDeg(north);
+
+    northWestBottomCarto.setFromValues(westDeg, northDeg, minHeight);
+    ellipsoid.cartographicToCartesian(northWestBottomCarto, northWestBottomVec3);
+
+    southEastUpCarto.setFromValues(eastDeg, southDeg, maxHeight);
+    ellipsoid.cartographicToCartesian(southEastUpCarto, southEastUpVec3);
+
+    const regionCenter = new THREE.Vector3();
+    regionCenter.lerpVectors(northWestBottomVec3, southEastUpVec3, 0.5);
+    const radius = radiusScratch.subVectors(northWestBottomVec3, southEastUpVec3).length() / 2;
+
+    const sphere = new THREE.Sphere(regionCenter, radius);
+    sphere.applyMatrix4(tileMatrixInverse);
+
+    return sphere;
+}
+
+/**
+ * Create a bounding box from a json describing a box in a 3D Tiles tile.
+ * @param {Object} box - the parsed json from the tile representing the box
+ * @return {THREE.Box3} the bounding box of the tile
+ */
+function initFromBox(box) {
+    // box[0], box[1], box[2] = center of the box
+    // box[3], box[4], box[5] = x axis direction and half-length
+    // box[6], box[7], box[8] = y axis direction and half-length
+    // box[9], box[10], box[11] = z axis direction and half-length
+    boxCenter.set(box[0], box[1], box[2]);
+    boxSize.set(box[3], box[7], box[11]).multiplyScalar(2);
+    const box3 = new THREE.Box3();
+    box3.setFromCenterAndSize(boxCenter, boxSize);
+    return box3;
+}
+
+/**
+ * Creats a bounding sphere from a json describing a sphere in a 3D Tiles tile.
+ * @param {Object} sphere - the parsed json from the tile representing the sphere
+ * @returns {THREE.Sphere} the bounding sphere of the tile
+ */
+function initFromSphere(sphere) {
+    const sphereCenter = new THREE.Vector3();
+    sphereCenter.set(sphere[0], sphere[1], sphere[2]);
+    return new THREE.Sphere(sphereCenter, sphere[3]);
+}
 
 /**
  * @classdesc 3D Tiles
  * [bounding volume](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/specification/schema/boundingVolume.schema.json)
+ * Used to represent bounding volumes and viewer request volumes. The input bounding volume (from the dataset) can be a
+ * box, a sphere or a region. Regions are transformed to spheres internally for simplification of parsing and to speed
+ * up computations such as culling.
  * @property {C3DTilesTypes} type - Used by 3D Tiles extensions
  * (e.g. {@link C3DTBatchTableHierarchyExtension}) to know in which context
  * (i.e. for which 3D Tiles class) the parsing of the extension should be done.
- * @property {THREE.Box3} box - Bounding box, defined only if the Bounding Volume
- * is a box.
- * @property {OBB} region - Bounding region, defined only if the Bounding
- * Volume is a region.
- * @property {THREE.Sphere} sphere - Bounding sphere, defined only if the
- * Bounding Volume is a sphere.
+ * @property {String} initialVolumeType - the initial volume type to be able to dissociate spheres
+ * and regions if needed since both are converted to spheres (one of {@link C3DTilesBoundingVolumeTypes})
+ * @property {THREE.Box3|THREE.Sphere} volume - The 3D bounding volume created. Can be a THREE.Box3 for bounding volumes
+ * of types box or a THREE.Sphere for bounding volumes of type sphere or region.
  * @property {object} extensions - 3D Tiles extensions of the bounding volume
  * stored in the following format:
  * {extensioName1: extensionObject1, extensioName2: extensionObject2, ...}
  */
 class C3DTBoundingVolume {
-    constructor(json, inverseTileTransform, registeredExtensions) {
+    constructor(json, tileMatrixInverse, registeredExtensions) {
         this.type = C3DTilesTypes.boundingVolume;
 
-        // Init bounding volume
         if (json.region) {
-            this.initBoundingRegion(json.region, inverseTileTransform);
+            this.initialVolumeType = C3DTilesBoundingVolumeTypes.region;
+            this.volume = initFromRegion(json.region, tileMatrixInverse);
         } else if (json.box) {
-            this.initBoundingBox(json.box);
+            this.initialVolumeType = C3DTilesBoundingVolumeTypes.box;
+            this.volume = initFromBox(json.box);
         } else if (json.sphere) {
-            this.initBoundingSphere(json.sphere);
+            this.initialVolumeType = C3DTilesBoundingVolumeTypes.sphere;
+            this.volume = initFromSphere(json.sphere);
         } else {
-            throw new Error('3D Tiles nodes must have a bounding volume');
+            throw new Error(`Unknown bounding volume type: ${json}. 3D Tiles nodes must have a bounding volume of type
+            region, box or sphere.`);
         }
 
         if (json.extensions) {
@@ -47,73 +125,43 @@ class C3DTBoundingVolume {
         }
     }
 
-    initBoundingRegion(region, inverseTileTransform) {
-        extent.set(THREE.MathUtils.radToDeg(region[0]),
-            THREE.MathUtils.radToDeg(region[2]),
-            THREE.MathUtils.radToDeg(region[1]),
-            THREE.MathUtils.radToDeg(region[3]));
-        const regionBox = new OBB();
-        regionBox.setFromExtent(extent);
-        regionBox.updateZ({ min: region[4], max: region[5] });
-        // at this point box.matrix = box.epsg4978_from_local, so
-        // we transform it in parent_from_local by using parent's
-        // epsg4978_from_local which from our point of view is
-        // epsg4978_from_parent. box.matrix = (epsg4978_from_parent ^ -1) *
-        // epsg4978_from_local =  parent_from_epsg4978 * epsg4978_from_local =
-        // parent_from_local
-        regionBox.matrix.premultiply(inverseTileTransform);
-        // update position, rotation and scale
-        regionBox.matrix.decompose(regionBox.position, regionBox.quaternion, regionBox.scale);
-        this.region = regionBox;
-    }
-
-    initBoundingBox(box) {
-        // box[0], box[1], box[2] = center of the box
-        // box[3], box[4], box[5] = x axis direction and half-length
-        // box[6], box[7], box[8] = y axis direction and half-length
-        // box[9], box[10], box[11] = z axis direction and half-length
-        center.set(box[0], box[1], box[2]);
-        size.set(box[3], box[7], box[11]).multiplyScalar(2);
-        this.box = new THREE.Box3();
-        this.box.setFromCenterAndSize(center, size);
-    }
-
-    initBoundingSphere(sphere) {
-        sphereCenter.set(sphere[0], sphere[1], sphere[2]);
-        this.sphere = new THREE.Sphere(sphereCenter, sphere[3]);
-    }
-
+    /**
+     * Performs camera frustum culling on bounding volumes.
+     * @param {Camera} camera - the camera to perform culling for
+     * @param {THREE.Matrix4} tileMatrixWorld - the world matrix of the tile
+     * @returns {boolean} true if the tile should be culled out (bounding volume not in camera frustum), false otherwise.
+     */
     boundingVolumeCulling(camera, tileMatrixWorld) {
-        if (this.region &&
-            !camera.isBox3Visible(this.region.box3D,
-                matrix.multiplyMatrices(tileMatrixWorld, this.region.matrix))) {
-            return true;
+        if (this.initialVolumeType === C3DTilesBoundingVolumeTypes.box) {
+            return !camera.isBox3Visible(this.volume, tileMatrixWorld);
+        } else if (this.initialVolumeType === C3DTilesBoundingVolumeTypes.sphere ||
+                   this.initialVolumeType === C3DTilesBoundingVolumeTypes.region) {
+            return !camera.isSphereVisible(this.volume, tileMatrixWorld);
+        } else {
+            throw new Error('Unknown bounding volume type.');
         }
-        if (this.box && !camera.isBox3Visible(this.box,
-            tileMatrixWorld)) {
-            return true;
-        }
-        return this.sphere &&
-            !camera.isSphereVisible(this.sphere, tileMatrixWorld);
     }
 
+    /**
+     * Checks if the camera is inside the [viewer request volumes](@link https://github.com/CesiumGS/3d-tiles/tree/main/specification#viewer-request-volume).
+     * @param {Camera} camera - the camera to perform culling for
+     * @param {THREE.Matrix4} tileMatrixWorld - the world matrix of the tile
+     * @returns {boolean} true if the camera is outside the viewer request volume, false otherwise.
+     */
     viewerRequestVolumeCulling(camera, tileMatrixWorld) {
-        if (this.region) {
+        if (this.initialVolumeType === C3DTilesBoundingVolumeTypes.region) {
             console.warn('Region viewerRequestVolume not yet supported');
             return true;
         }
-        if (this.box) {
+        if (this.initialVolumeType === C3DTilesBoundingVolumeTypes.box) {
             console.warn('Bounding box viewerRequestVolume not yet supported');
             return true;
         }
-        if (this.sphere) {
-            worldCoordinateCenter.copy(this.sphere.center);
+        if (this.initialVolumeType === C3DTilesBoundingVolumeTypes.sphere) {
+            worldCoordinateCenter.copy(this.volume.center);
             worldCoordinateCenter.applyMatrix4(tileMatrixWorld);
             // To check the distance between the center sphere and the camera
-            if (!(camera.camera3D.position.distanceTo(worldCoordinateCenter) <=
-                this.sphere.radius)) {
-                return true;
-            }
+            return !(camera.camera3D.position.distanceTo(worldCoordinateCenter) <= this.volume.radius);
         }
         return false;
     }

--- a/src/Core/3DTiles/C3DTilesEnums.js
+++ b/src/Core/3DTiles/C3DTilesEnums.js
@@ -8,10 +8,14 @@
  * @property {String} batchtable - value: 'batchtable'
  * @property {String} boundingVolume - value: 'bounding volume'
  */
-const C3DTilesTypes = {
+export const C3DTilesTypes = {
     tileset: 'tileset',
     batchtable: 'batchtable',
     boundingVolume: 'boundingVolume',
 };
 
-export default C3DTilesTypes;
+export const C3DTilesBoundingVolumeTypes = {
+    region: 'region',
+    box: 'box',
+    sphere: 'sphere',
+};

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -65,7 +65,7 @@ class Coordinates {
      * You can find most projections and their proj4 code at [epsg.io]{@link https://epsg.io/}
      * @param {number|Array<number>|Coordinates|THREE.Vector3} [v0=0] -
      * x or longitude value, or a more complex one: it can be an array of three
-     * numbers, being x/lon, x/lat, z/alt, or it can be `THREE.Vector3`. It can
+     * numbers, being x/lon, y/lat, z/alt, or it can be `THREE.Vector3`. It can
      * also simply be a Coordinates.
      * @param {number} [v1=0] - y or latitude value.
      * @param {number} [v2=0] - z or altitude value.

--- a/src/Main.js
+++ b/src/Main.js
@@ -101,6 +101,6 @@ export { default as C3DTileset } from './Core/3DTiles/C3DTileset';
 export { default as C3DTBoundingVolume } from './Core/3DTiles/C3DTBoundingVolume';
 export { default as C3DTBatchTable } from './Core/3DTiles/C3DTBatchTable';
 export { default as C3DTExtensions } from './Core/3DTiles/C3DTExtensions';
-export { default as C3DTilesTypes } from './Core/3DTiles/C3DTilesTypes';
+export { C3DTilesTypes, C3DTilesBoundingVolumeTypes } from './Core/3DTiles/C3DTilesEnums';
 export { default as C3DTBatchTableHierarchyExtension } from './Core/3DTiles/C3DTBatchTableHierarchyExtension';
 export { process3dTilesNode, $3dTilesCulling, $3dTilesSubdivisionControl } from 'Process/3dTilesProcessing';

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import Extent from 'Core/Geographic/Extent';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
+import { C3DTilesBoundingVolumeTypes } from 'Core/3DTiles/C3DTilesEnums';
 import { C3DTILES_LAYER_EVENTS } from '../Layer/C3DTilesLayer';
 
 /** @module 3dTilesProcessing
@@ -39,23 +39,6 @@ function subdivideNode(context, layer, node, cullingTest) {
     }
 }
 
-const tmpBox3 = new THREE.Box3();
-const tmpSphere = new THREE.Sphere();
-function boundingVolumeToExtent(crs, volume, transform) {
-    if (volume.region) {
-        const box = tmpBox3.copy(volume.region.box3D)
-            .applyMatrix4(volume.region.matrixWorld);
-        return Extent.fromBox3(crs, box);
-    } else if (volume.box) {
-        const box = tmpBox3.copy(volume.box).applyMatrix4(transform);
-        return Extent.fromBox3(crs, box);
-    } else {
-        const sphere = tmpSphere.copy(volume.sphere).applyMatrix4(transform);
-        const box = sphere.getBoundingBox(tmpBox3);
-        return Extent.fromBox3(crs, box);
-    }
-}
-
 const tmpMatrix = new THREE.Matrix4();
 function _subdivideNodeAdditive(context, layer, node, cullingTest) {
     for (const child of layer.tileset.tiles[node.tileId].children) {
@@ -80,12 +63,6 @@ function _subdivideNodeAdditive(context, layer, node, cullingTest) {
         child.promise = requestNewTile(context.view, context.scheduler, layer, child, node, true).then((tile) => {
             node.add(tile);
             tile.updateMatrixWorld();
-
-            // The extent is calculated but it's never used in 3D tiles process
-            const extent = boundingVolumeToExtent(layer.extent.crs, tile.boundingVolume, tile.matrixWorld);
-            tile.traverse((obj) => {
-                obj.extent = extent;
-            });
             layer.onTileContentLoaded(tile);
 
             context.view.notifyChange(child);
@@ -110,6 +87,7 @@ function _subdivideNodeSubstractive(context, layer, node) {
                     childrenTiles[i].loaded = true;
                     node.add(tile);
                     tile.updateMatrixWorld();
+                    // TODO: remove because cannot happen?
                     if (node.additiveRefinement) {
                         context.view.notifyChange(node);
                     }
@@ -142,12 +120,8 @@ export function $3dTilesCulling(layer, camera, node, tileMatrixWorld) {
     }
 
     // For bounding volume
-    if (node.boundingVolume &&
-        node.boundingVolume.boundingVolumeCulling(camera, tileMatrixWorld)) {
-        return true;
-    }
-
-    return false;
+    return !!(node.boundingVolume &&
+        node.boundingVolume.boundingVolumeCulling(camera, tileMatrixWorld));
 }
 
 // Cleanup all 3dtiles|three.js starting from a given node n.
@@ -232,18 +206,13 @@ const boundingVolumeBox = new THREE.Box3();
 const boundingVolumeSphere = new THREE.Sphere();
 export function computeNodeSSE(camera, node) {
     node.distance = 0;
-    if (node.boundingVolume.region) {
-        boundingVolumeBox.copy(node.boundingVolume.region.box3D);
-        boundingVolumeBox.applyMatrix4(node.boundingVolume.region.matrixWorld);
-        node.distance = boundingVolumeBox.distanceToPoint(camera.camera3D.position);
-    } else if (node.boundingVolume.box) {
-        // boundingVolume.box is affected by matrixWorld
-        boundingVolumeBox.copy(node.boundingVolume.box);
+    if (node.boundingVolume.initialVolumeType === C3DTilesBoundingVolumeTypes.box) {
+        boundingVolumeBox.copy(node.boundingVolume.volume);
         boundingVolumeBox.applyMatrix4(node.matrixWorld);
         node.distance = boundingVolumeBox.distanceToPoint(camera.camera3D.position);
-    } else if (node.boundingVolume.sphere) {
-        // boundingVolume.sphere is affected by matrixWorld
-        boundingVolumeSphere.copy(node.boundingVolume.sphere);
+    } else if (node.boundingVolume.initialVolumeType === C3DTilesBoundingVolumeTypes.sphere ||
+               node.boundingVolume.initialVolumeType === C3DTilesBoundingVolumeTypes.region) {
+        boundingVolumeSphere.copy(node.boundingVolume.volume);
         boundingVolumeSphere.applyMatrix4(node.matrixWorld);
         // TODO: see https://github.com/iTowns/itowns/issues/800
         node.distance = Math.max(0.0,
@@ -265,9 +234,6 @@ export function init3dTilesLayer(view, scheduler, layer, rootTile) {
             tile.updateMatrixWorld();
             layer.tileset.tiles[tile.tileId].loaded = true;
             layer.root = tile;
-            // The extent is calculated but it's never used in 3D tiles process
-            layer.extent = boundingVolumeToExtent(layer.crs || view.referenceCrs,
-                tile.boundingVolume, tile.matrixWorld);
             layer.onTileContentLoaded(tile);
         });
 }
@@ -305,6 +271,7 @@ export function process3dTilesNode(cullingTest = $3dTilesCulling, subdivisionTes
             node.visible = false;
             return undefined;
         }
+
 
         // do proper culling
         const isVisible = cullingTest ? (!cullingTest(layer, context.camera, node, node.matrixWorld)) : true;

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -73,9 +73,6 @@ export function configureTile(tile, layer, metadata, parent) {
     }
     tile.viewerRequestVolume = metadata.viewerRequestVolume;
     tile.boundingVolume = metadata.boundingVolume;
-    if (tile.boundingVolume.region) {
-        tile.add(tile.boundingVolume.region);
-    }
     tile.updateMatrixWorld();
 }
 

--- a/test/unit/3dtileslayerprocessbatchtable.js
+++ b/test/unit/3dtileslayerprocessbatchtable.js
@@ -3,7 +3,7 @@ import C3DTilesLayer from 'Layer/C3DTilesLayer';
 import C3DTBatchTableHierarchyExtension from 'Core/3DTiles/C3DTBatchTableHierarchyExtension';
 import C3DTilesSource from 'Source/C3DTilesSource';
 import C3DTExtensions from 'Core/3DTiles/C3DTExtensions';
-import C3DTilesTypes from 'Core/3DTiles/C3DTilesTypes';
+import { C3DTilesTypes } from 'Core/3DTiles/C3DTilesEnums';
 import View from 'Core/View';
 import GlobeView from 'Core/Prefab/GlobeView';
 import { HttpsProxyAgent } from 'https-proxy-agent';


### PR DESCRIPTION
Some 3D tiles fixes:
* Fix a bug that impacted display of 3D tiles with sphere bounding volumes, closes #1859
* Fix display of 3D Tiles bounding volumes of type sphere, closes #1888 and #1853

Perf improvement:
* Improve perfs for 3D tiles with bounding region by converting bounding regions to bounding spheres. Previously, bounding regions where converted to [OBB](https://github.com/iTowns/itowns/blob/master/src/Renderer/OBB.js) and the AABB englobing the OBB was used for culling and SSE computation. Now, they are converted to bounding spheres and the sphere is used for culling and SSE computation. Depending on the cases it can be a bigger approximation than before but it is faster and I didn't see any visual discrepencies. I tested the perf differences on a 3D Tiles photogrammetry tileset (~500Go, 13732 tiles with only bounding regions) that I cannot share unfortunately. On the master, we spend most of our time initializing the bounding region:

![before-PR-0](https://github.com/iTowns/itowns/assets/16967916/22d47188-0ce5-4702-81e1-dd8915308c7f)

![before-PR-1](https://github.com/iTowns/itowns/assets/16967916/b72cd549-51b1-4c7f-9821-d84d06d777cd)

After the PR, we spend most of the time in parsing and preparing for rendering:

![after-PR-0](https://github.com/iTowns/itowns/assets/16967916/ea797dea-d69a-4c9a-a06c-e7a6a1071a52)
![after-PR-1](https://github.com/iTowns/itowns/assets/16967916/14f9d45e-d6e8-484a-bd42-79212e4acb9d)

I also tried to implement a conversion to [threejs' OBB](https://threejs.org/docs/index.html?q=obb#examples/en/math/OBB) and to implement a culling algorithm on OBB (SSE computation for OBB is easy) but didn't succeed completely (can be seen on [the following branch](https://github.com/jailln/itowns/tree/fix/GEO-18291-3dtiles-mel-history-save)). Another way would have been to [improve OBB.setFromExtent](https://github.com/jailln/itowns/blob/fix/GEO-18291-3dtiles-mel-history-save/src/Renderer/OBB.js#L106) which is the culprit but I haven't found another way of implementing it yet. Propositions are welcome :)

BREAKING CHANGE: Remove region, box and sphere properties of C3DTBoundingVolume. They have been replaced by volume property which contains a THREE.Box3 (for box) or a THREE.Sphere (for sphere or region). Initial bounding volume type can be retrieved with the initialVolumeType property.
