### PR TITLE
fix(StateControl): use uncaught key event

### DIFF
--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -324,17 +324,24 @@ class StateControl extends THREE.EventDispatcher {
         viewCoords.copy(this._view.eventToViewCoords(event));
 
         switch (event.pointerType) {
-            case 'mouse':
+            case 'mouse': {
                 this._currentMousePressed = event.button;
 
+                if (this._currentKeyPressed === undefined) {
+                    if (event.ctrlKey) {
+                        this._currentKeyPressed = CONTROL_KEYS.CTRL;
+                    } else if (event.shiftKey) {
+                        this._currentKeyPressed = CONTROL_KEYS.SHIFT;
+                    }
+                }
                 this.currentState = this.inputToState(
                     this._currentMousePressed,
                     this._currentKeyPressed,
                     // Detect if the mouse button was pressed less than 500 ms before, and if the cursor has not moved two much
                     // since previous click. If so, set dblclick to true.
                     event.timeStamp - this._clickTimeStamp < 500
-                        && this._lastMousePressed.button === this._currentMousePressed
-                        && this._lastMousePressed.viewCoords.distanceTo(viewCoords) < 5,
+                    && this._lastMousePressed.button === this._currentMousePressed
+                    && this._lastMousePressed.viewCoords.distanceTo(viewCoords) < 5,
                 );
 
                 this._clickTimeStamp = event.timeStamp;
@@ -342,6 +349,7 @@ class StateControl extends THREE.EventDispatcher {
                 this._lastMousePressed.viewCoords.copy(viewCoords);
 
                 break;
+            }
             // TODO : add touch event management
             default:
         }

--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -8,6 +8,7 @@ const CONTROL_KEYS = {
     SPACE: 32,
     SHIFT: 16,
     CTRL: 17,
+    META: 91,
     S: 83,
 };
 
@@ -332,6 +333,8 @@ class StateControl extends THREE.EventDispatcher {
                         this._currentKeyPressed = CONTROL_KEYS.CTRL;
                     } else if (event.shiftKey) {
                         this._currentKeyPressed = CONTROL_KEYS.SHIFT;
+                    } else if (event.metaKey) {
+                        this._currentKeyPressed = CONTROL_KEYS.META;
                     }
                 }
                 this.currentState = this.inputToState(


### PR DESCRIPTION

## Description
When we click outside of the DOM view, the keyboards events aren't caught.
We can see that in the first video, I click on the Location input, and I do "Ctrl" + left click to rotate the globe, but the "ctrl" event is not caught so the rotation doesn't happen. 


https://github.com/iTowns/itowns/assets/126568810/ebea1210-86a2-4b02-bf6d-ed65b111f651

The second video is with the correction.

https://github.com/iTowns/itowns/assets/126568810/24ce4d7e-93f6-4e7d-a45b-1ba5b08485c6


