### PR TITLE
[PointMaterial] Add support for other point attributes

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -48,6 +48,7 @@
                 "OrientedImageLayer",
                 "PointCloudLayer",
                 "PotreeLayer",
+                "CopcLayer",
                 "C3DTilesLayer",
                 "LabelLayer",
                 "GlobeLayer",
@@ -72,7 +73,8 @@
                 "OrientedImageSource",
                 "PotreeSource",
                 "VectorTilesSource",
-                "EntwinePointTileSource"
+                "EntwinePointTileSource",
+                "CopcSource"
             ],
 
             "Provider": [

--- a/examples/config.json
+++ b/examples/config.json
@@ -27,7 +27,8 @@
         "potree_3d_map": "Potree 3D map",
         "laz_dragndrop": "LAS/LAZ viewer",
         "entwine_simple_loader": "Entwine loader",
-        "entwine_3d_loader": "Entwine 3D loader"
+        "entwine_3d_loader": "Entwine 3D loader",
+        "copc_simple_loader": "COPC loader",
     },
 
     "Vector tiles": {

--- a/examples/config.json
+++ b/examples/config.json
@@ -28,7 +28,7 @@
         "laz_dragndrop": "LAS/LAZ viewer",
         "entwine_simple_loader": "Entwine loader",
         "entwine_3d_loader": "Entwine 3D loader",
-        "copc_simple_loader": "COPC loader",
+        "copc_simple_loader": "COPC loader"
     },
 
     "Vector tiles": {

--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -1,0 +1,128 @@
+<html>
+    <head>
+        <meta charset="UTF-8">
+
+        <title>Itowns - COPC loader</title>
+
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                left: 10px;
+            }
+        </style>
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="description">Specify the URL of a COPC file to load:
+            <input type="text" id="url" />
+            <button onclick="readURL()">Load</button>
+            <div>
+                <button onClick="loadAutzen()">Load Autzen Stadium (80mb)</button>
+                <button onClick="loadSofi()">Load SoFI Stadium (2.3gb)</button>
+                <button onClick="loadMillsite()">Load Millsite (1.9gb)</button>
+            <div id="share"></div>
+            </div>
+        </div>
+        <div id="viewerDiv">
+
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script type="text/javascript">
+            let layer; // COPCLayer
+
+            const uri = new URL(location);
+
+            const gui = new dat.GUI();
+
+            const viewerDiv = document.getElementById('viewerDiv');
+            const view = new itowns.View('EPSG:4326', viewerDiv);
+            const controls = new itowns.PlanarControls(view);
+            view.mainLoop.gfxEngine.renderer.setClearColor(0xdddddd);
+
+            setUrl(uri.searchParams.get('copc'));
+
+            function onLayerReady(layer) {
+                const camera = view.camera.camera3D;
+
+                const lookAt = new itowns.THREE.Vector3();
+                const size = new itowns.THREE.Vector3();
+                layer.root.bbox.getSize(size);
+                layer.root.bbox.getCenter(lookAt);
+
+                camera.far = 2.0 * size.length();
+
+                controls.groundLevel = layer.root.bbox.min.z;
+                const position = layer.root.bbox.min.clone().add(
+                    size.multiply({ x: 1, y: 1, z: size.x / size.z }),
+                );
+
+                camera.position.copy(position);
+                camera.lookAt(lookAt);
+                camera.updateProjectionMatrix();
+
+                view.notifyChange(camera);
+            }
+
+
+            function readURL() {
+                const url = document.getElementById('url').value;
+
+                if (url) {
+                    setUrl(url);
+                }
+            }
+
+            function setUrl(url) {
+                if (!url) return;
+
+                const input_url = document.getElementById('url');
+                if (!input_url) return;
+
+                uri.searchParams.set('copc', url);
+                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
+
+                input_url.value = url;
+                load(url);
+            }
+
+
+            function load(url) {
+                const source = new itowns.CopcSource({ url });
+
+                if (layer) {
+                    gui.removeFolder(layer.debugUI);
+                    view.removeLayer('COPC');
+                    view.notifyChange();
+                    layer.delete();
+                }
+
+                layer = new itowns.CopcLayer('COPC', {
+                    source,
+                    crs: view.referenceCrs,
+                    sseThreshold: 2,
+                    pointBudget: 3000000,
+                });
+                view.addLayer(layer).then(onLayerReady);
+                debug.PotreeDebug.initTools(view, layer, gui);
+            }
+
+            function loadAutzen() {
+                setUrl("https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz");
+            }
+
+            function loadSofi() {
+                setUrl("https://s3.amazonaws.com/hobu-lidar/sofi.copc.laz");
+            }
+
+            function loadMillsite() {
+                setUrl("https://s3.amazonaws.com/data.entwine.io/millsite.copc.laz");
+            }
+        </script>
+    </body>
+</html>

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -54,6 +54,7 @@
 
                 view.camera3D.position.copy(position);
                 view.camera3D.lookAt(lookAt);
+                view.camera3D.updateProjectionMatrix();
 
                 controls.options.moveSpeed = size.length();
 
@@ -79,8 +80,10 @@
                 eptSource = new itowns.EntwinePointTileSource({ url });
 
                 if (eptLayer) {
-                    view.removeLayer('ept');
+                    debugGui.removeFolder(eptLayer.debugUI);
+                    view.removeLayer('Entwine Point Tile');
                     view.notifyChange();
+                    eptLayer.delete();
                 }
 
                 eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@tmcw/togeojson": "^5.8.1",
         "@tweenjs/tween.js": "^18.6.4",
+        "copc": "^0.0.5",
         "earcut": "^2.2.4",
         "js-priority-queue": "^0.1.5",
         "pbf": "^3.2.1",
@@ -4012,7 +4013,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
+      "version": "1.0.30001576",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
       "dev": true,
       "funding": [
         {
@@ -4027,8 +4030,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/catharsis": {
       "version": "0.9.0",
@@ -4598,6 +4600,28 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copc": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/copc/-/copc-0.0.5.tgz",
+      "integrity": "sha512-6FomlN1gMJ13C1QmLuKpjchXSg/UjdWb1/vTPp6GnrULaEQPtdQw1bSQBF1INvxhjCGz5T6OzV09t/gUJWkjmg==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "laz-perf": "^0.0.5"
+      }
+    },
+    "node_modules/copc/node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/copc/node_modules/laz-perf": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/laz-perf/-/laz-perf-0.0.5.tgz",
+      "integrity": "sha512-unnaoahcikJ+AwOm6BhN0JYi2vRhMF7fns28HIsgIw/o0Gwhaizqoc/+txA397/5oUHlljaCIrwSatzrEKlxJQ=="
     },
     "node_modules/copyfiles": {
       "version": "2.4.1",
@@ -9019,7 +9043,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10603,9 +10626,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.1",
@@ -12151,7 +12174,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
@@ -12600,7 +12622,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -12966,7 +12987,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@tmcw/togeojson": "^5.8.1",
     "@tweenjs/tween.js": "^18.6.4",
+    "copc": "^0.0.5",
     "earcut": "^2.2.4",
     "js-priority-queue": "^0.1.5",
     "pbf": "^3.2.1",

--- a/src/Core/CopcNode.js
+++ b/src/Core/CopcNode.js
@@ -1,0 +1,194 @@
+import * as THREE from 'three';
+import { Hierarchy } from 'copc';
+import PointCloudNode from 'Core/PointCloudNode';
+
+const size = new THREE.Vector3();
+const position = new THREE.Vector3();
+const translation = new THREE.Vector3();
+
+function buildId(depth, x, y, z) {
+    return `${depth}-${x}-${y}-${z}`;
+}
+
+class CopcNode extends PointCloudNode {
+    /**
+     * Constructs a new instance of a COPC Octree node
+     *
+     * @param {number} depth - Depth within the octree
+     * @param {number} x - X position within the octree
+     * @param {number} y - Y position within the octree
+     * @param {number} z - Z position with the octree
+     * @param {number} entryOffset - Offset from the beginning of the file of
+     * the node entry
+     * @param {number} entryLength - Size of the node entry
+     * @param {CopcLayer} layer - Parent COPC layer
+     * @param {number} [numPoints=0] - Number of points given by this entry
+     */
+    constructor(depth, x, y, z, entryOffset, entryLength, layer, numPoints = 0) {
+        super(numPoints, layer);
+        this.isCopcNode = true;
+
+        this.entryOffset = entryOffset;
+        this.entryLength = entryLength;
+        this.layer = layer;
+        this.depth = depth;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    get id() {
+        return buildId(this.depth, this.x, this.y, this.z);
+    }
+
+    get octreeIsLoaded() {
+        return this.numPoints >= 0;
+    }
+
+    /**
+     * @param {number} offset
+     * @param {number} size
+     */
+    async _fetch(offset, size) {
+        return this.layer.source.fetcher(this.layer.source.url, {
+            ...this.layer.source.networkOptions,
+            headers: {
+                ...this.layer.source.networkOptions.headers,
+                range: `bytes=${offset}-${offset + size - 1}`,
+            },
+        });
+    }
+
+    /**
+     * Create an (A)xis (A)ligned (B)ounding (B)ox for the given node given
+     * `this` is its parent.
+     * @param {CopcNode} node - The child node
+     */
+    createChildAABB(node) {
+        // factor to apply, based on the depth difference (can be > 1)
+        const f = 2 ** (node.depth - this.depth);
+
+        // size of the child node bbox (Vector3), based on the size of the
+        // parent node, and divided by the factor
+        this.bbox.getSize(size).divideScalar(f);
+
+        // initialize the child node bbox at the location of the parent node bbox
+        node.bbox.min.copy(this.bbox.min);
+
+        // position of the parent node, if it was at the same depth than the
+        // child, found by multiplying the tree position by the factor
+        position.copy(this).multiplyScalar(f);
+
+        // difference in position between the two nodes, at child depth, and
+        // scale it using the size
+        translation.subVectors(node, position).multiply(size);
+
+        // apply the translation to the child node bbox
+        node.bbox.min.add(translation);
+
+        // use the size computed above to set the max
+        node.bbox.max.copy(node.bbox.min).add(size);
+    }
+
+    /**
+     * Create a CopcNode from the provided subtree and add it as child
+     * of the current node.
+     * @param {number} depth - Child node depth in the octree
+     * @param {number} x - Child node x position in the octree
+     * @param {number} y - Child node y position in the octree
+     * @param {number} z - Child node z position in the octree
+     * @param {Hierarchy.Subtree} hierarchy - Octree's subtree
+     * @param {CopcNode[]} stack - Stack of node candidates for traversal
+     */
+    findAndCreateChild(depth, x, y, z, hierarchy, stack) {
+        const id = buildId(depth, x, y, z);
+
+        let pointCount;
+        let offset;
+        let byteSize;
+
+        const node = hierarchy.nodes[id];
+        if (node) {
+            pointCount = node.pointCount;
+            offset = node.pointDataOffset;
+            byteSize = node.pointDataLength;
+        } else {
+            const page = hierarchy.pages[id];
+            if (!page) { return; }
+            pointCount = -1;
+            offset = page.pageOffset;
+            byteSize = page.pageLength;
+        }
+
+        const child = new CopcNode(
+            depth,
+            x,
+            y,
+            z,
+            offset,
+            byteSize,
+            this.layer,
+            pointCount,
+        );
+        this.add(child);
+        stack.push(child);
+    }
+
+    async loadOctree() {
+        // Load hierarchy
+        const buffer = await this._fetch(this.entryOffset, this.entryLength);
+        const hierarchy = await Hierarchy.parse(new Uint8Array(buffer));
+
+        // Update current node entry from loaded subtree
+        const node = hierarchy.nodes[this.id];
+        if (!node) {
+            return Promise.reject('[CopcNode]: Ill-formed data, entry not found in hierarchy.');
+        }
+        this.numPoints = node.pointCount;
+        this.entryOffset = node.pointDataOffset;
+        this.entryLength = node.pointDataLength;
+
+        // Load subtree entries
+        const stack = [];
+        stack.push(this);
+        while (stack.length) {
+            const node = stack.shift();
+            const depth = node.depth + 1;
+            const x = node.x * 2;
+            const y = node.y * 2;
+            const z = node.z * 2;
+
+            node.findAndCreateChild(depth, x,     y,     z,     hierarchy, stack);
+            node.findAndCreateChild(depth, x + 1, y,     z,     hierarchy, stack);
+            node.findAndCreateChild(depth, x,     y + 1, z,     hierarchy, stack);
+            node.findAndCreateChild(depth, x + 1, y + 1, z,     hierarchy, stack);
+            node.findAndCreateChild(depth, x,     y,     z + 1, hierarchy, stack);
+            node.findAndCreateChild(depth, x + 1, y,     z + 1, hierarchy, stack);
+            node.findAndCreateChild(depth, x,     y + 1, z + 1, hierarchy, stack);
+            node.findAndCreateChild(depth, x + 1, y + 1, z + 1, hierarchy, stack);
+        }
+    }
+
+    /**
+     * Load the COPC Buffer geometry for this node.
+     * @returns {Promise<THREE.BufferGeometry>}
+     */
+    async load() {
+        if (!this.octreeIsLoaded) {
+            await this.loadOctree();
+        }
+
+        const buffer = await this._fetch(this.entryOffset, this.entryLength);
+        const geometry = await this.layer.source.parser(buffer, {
+            in: {
+                ...this.layer.source,
+                pointCount: this.numPoints,
+            },
+            out: this.layer,
+        });
+
+        return geometry;
+    }
+}
+
+export default CopcNode;

--- a/src/Layer/CopcLayer.js
+++ b/src/Layer/CopcLayer.js
@@ -1,0 +1,60 @@
+import * as THREE from 'three';
+import CopcNode from 'Core/CopcNode';
+import PointCloudLayer from 'Layer/PointCloudLayer';
+
+/**
+ * @classdesc
+ * A layer for [Cloud Optimised Point Cloud](https://copc.io) (COPC) datasets.
+ * See {@link PointCloudLayer} class for documentation on base properties.
+ *
+ * @extends {PointCloudLayer}
+ *
+ * @example
+ * // Create a new COPC layer
+ * const copcSource = new CopcSource({
+ *     url: 'https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz',
+ *     crs: 'EPSG:4978',
+ *     colorDepth: 16, // bit-depth of 'color' attribute (either 8 or 16 bits)
+ * });
+ *
+ * const copcLayer = new CopcLayer('COPC', {
+ *     source: copcSource,
+ * });
+ *
+ * View.prototype.addLayer.call(view, copcLayer);
+ */
+class CopcLayer extends PointCloudLayer {
+    /**
+     * @param {string} id - Unique id of the layer.
+     * @param {Object} config - See {@link PointCloudLayer} for base pointcloud
+     * options.
+     */
+    constructor(id, config) {
+        super(id, config);
+        this.isCopcLayer = true;
+
+        const resolve = () => this;
+        this.whenReady = this.source.whenReady.then((/** @type {CopcSource} */ source) => {
+            const { cube, rootHierarchyPage } = source.info;
+            const { pageOffset, pageLength } = rootHierarchyPage;
+
+            this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this, -1);
+            this.root.bbox.min.fromArray(cube, 0);
+            this.root.bbox.max.fromArray(cube, 3);
+
+            this.minElevationRange = source.header.min[2];
+            this.maxElevationRange = source.header.max[2];
+
+            this.scale = new THREE.Vector3(1.0, 1.0, 1.0);
+            this.offset = new THREE.Vector3(0.0, 0.0, 0.0);
+
+            return this.root.loadOctree().then(resolve);
+        });
+    }
+
+    get spacing() {
+        return this.source.info.spacing;
+    }
+}
+
+export default CopcLayer;

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -90,8 +90,18 @@ function changeIntensityRange(layer) {
     }
 }
 
+function changeElevationRange(layer) {
+    if (layer.material.elevationRange) {
+        layer.material.elevationRange.set(
+            layer.minElevationRange,
+            layer.maxElevationRange,
+        );
+    }
+}
+
 /**
  * The basis for all point clouds related layers.
+ * @extends GeometryLayer
  *
  * @property {boolean} isPointCloudLayer - Used to checkout whether this layer
  * is a PointCloudLayer. Default is `true`. You should not change this, as it is
@@ -121,6 +131,12 @@ function changeIntensityRange(layer) {
  * @property {number} [maxIntensityRange=1] - The maximal intensity of the
  * layer. Changing this value will affect the material, if it has the
  * corresponding uniform. The value is normalized between 0 and 1.
+ * @property {number} [minElevationRange=0] - The minimal elevation of the
+ * layer. Changing this value will affect the material, if it has the
+ * corresponding uniform.
+ * @property {number} [maxElevationRange=1] - The maximal elevation of the
+ * layer. Changing this value will affect the material, if it has the
+ * corresponding uniform.
  */
 class PointCloudLayer extends GeometryLayer {
     /**
@@ -129,7 +145,6 @@ class PointCloudLayer extends GeometryLayer {
      * directly, but rather implemented using `extends`.
      *
      * @constructor
-     * @extends GeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
@@ -160,6 +175,8 @@ class PointCloudLayer extends GeometryLayer {
 
         this.defineLayerProperty('minIntensityRange', config.minIntensityRange || 0, changeIntensityRange);
         this.defineLayerProperty('maxIntensityRange', config.maxIntensityRange || 1, changeIntensityRange);
+        this.defineLayerProperty('minElevationRange', config.minElevationRange || 0, changeElevationRange);
+        this.defineLayerProperty('maxElevationRange', config.maxElevationRange || 1, changeElevationRange);
 
         this.material = config.material || {};
         if (!this.material.isMaterial) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -61,6 +61,7 @@ export { default as GlobeLayer } from 'Core/Prefab/Globe/GlobeLayer';
 export { default as PlanarLayer } from 'Core/Prefab/Planar/PlanarLayer';
 export { default as LabelLayer } from 'Layer/LabelLayer';
 export { default as EntwinePointTileLayer } from 'Layer/EntwinePointTileLayer';
+export { default as CopcLayer } from 'Layer/CopcLayer';
 export { default as GeoidLayer } from 'Layer/GeoidLayer';
 
 // Sources provided by default in iTowns

--- a/src/Main.js
+++ b/src/Main.js
@@ -78,6 +78,7 @@ export { default as PotreeSource } from 'Source/PotreeSource';
 export { default as C3DTilesSource } from 'Source/C3DTilesSource';
 export { default as C3DTilesIonSource } from 'Source/C3DTilesIonSource';
 export { default as EntwinePointTileSource } from 'Source/EntwinePointTileSource';
+export { default as CopcSource } from 'Source/CopcSource';
 
 // Parsers provided by default in iTowns
 // Custom parser can be implemented as wanted, as long as the main function

--- a/src/Parser/LAZLoader.js
+++ b/src/Parser/LAZLoader.js
@@ -1,0 +1,139 @@
+import { LazPerf } from 'laz-perf';
+import * as copc from 'copc';
+
+/**
+ * @typedef {Object} Header - Partial LAS header.
+ * @property {number} header.pointDataRecordFormat - Type of point data
+ * records contained by the buffer.
+ * @property {number} header.pointDataRecordLength - Size (in bytes) of the
+ * point data records. If the specified size is larger than implied by the
+ * point data record format (see above) the remaining bytes are user-specfic
+ * "extra bytes". Those are described by an Extra Bytes VLR.
+ * @property {number[]} header.scale - Scale factors (an array `[xScale,
+ * yScale, zScale]`) multiplied to the X, Y, Z point record values.
+ * @property {number[]} header.offset - Offsets (an array `[xOffset,
+ * xOffset, zOffset]`) added to the scaled X, Y, Z point record values.
+ */
+
+class LAZLoader {
+    constructor() {
+        this._wasmPath = 'https://unpkg.com/laz-perf@0.0.6/lib/';
+        this._wasmPromise = null;
+    }
+
+    _initDecoder() {
+        if (this._wasmPromise) {
+            return this._wasmPromise;
+        }
+
+        this._wasmPromise = LazPerf.create({
+            locateFile: file => `${this._wasmPath}/${file}`,
+        });
+
+        return this._wasmPromise;
+    }
+
+    _parseView(view, options) {
+        const colorDepth = options.colorDepth ?? 16;
+
+        const getPosition = ['X', 'Y', 'Z'].map(view.getter);
+        const getIntensity = view.getter('Intensity');
+        const getReturnNumber = view.getter('ReturnNumber');
+        const getNumberOfReturns = view.getter('NumberOfReturns');
+        const getClassification = view.getter('Classification');
+        const getPointSourceID = view.getter('PointSourceId');
+        const getColor = view.dimensions.Red ?
+            ['Red', 'Green', 'Blue'].map(view.getter) : undefined;
+
+        const positions = new Float32Array(view.pointCount * 3);
+        const intensities = new Uint16Array(view.pointCount);
+        const returnNumbers = new Uint8Array(view.pointCount);
+        const numberOfReturns = new Uint8Array(view.pointCount);
+        const classifications = new Uint8Array(view.pointCount);
+        const pointSourceIDs = new Uint16Array(view.pointCount);
+        const colors = getColor ? new Uint8Array(view.pointCount * 4) : undefined;
+
+        for (let i = 0; i < view.pointCount; i++) {
+            // `getPosition` apply scale and offset transform to the X, Y, Z
+            // values. See https://github.com/connormanning/copc.js/blob/master/src/las/extractor.ts.
+            const [x, y, z] = getPosition.map(f => f(i));
+            positions[i * 3] = x;
+            positions[i * 3 + 1] = y;
+            positions[i * 3 + 2] = z;
+
+            intensities[i] = getIntensity(i);
+            returnNumbers[i] = getReturnNumber(i);
+            numberOfReturns[i] = getNumberOfReturns(i);
+
+            if (getColor) {
+                // Note that we do not infer color depth as it is expensive
+                // (i.e. traverse the whole view to check if there exists a red,
+                // green or blue value > 255).
+                let [r, g, b] = getColor.map(f => f(i));
+
+                if (colorDepth === 16) {
+                    r /= 256;
+                    g /= 256;
+                    b /= 256;
+                }
+
+                colors[i * 4] = r;
+                colors[i * 4 + 1] = g;
+                colors[i * 4 + 2] = b;
+                colors[i * 4 + 3] = 255;
+            }
+
+            classifications[i] = getClassification(i);
+            pointSourceIDs[i] = getPointSourceID(i);
+        }
+
+        return {
+            position: positions,
+            intensity: intensities,
+            returnNumber: returnNumbers,
+            numberOfReturns,
+            classification: classifications,
+            pointSourceID: pointSourceIDs,
+            color: colors,
+        };
+    }
+
+    /**
+     * Set LazPerf decoder path.
+     * @param {string} path - path to `laz-perf.wasm` folder.
+     */
+    set lazPerf(path) {
+        this._wasmPath = path;
+        this._wasmPromise = null;
+    }
+
+    /**
+     * Parse a LAZ chunk. Note that this function is **CPU-bound** and shall be
+     * parallelised in a dedicated worker.
+     * @param {Uint8Array} data - Chunk data.
+     * @param {Object} options - Parsing options.
+     * @property {Header} options.header - Partial LAS header.
+     * @property {number} options.pointCount - Number of points in this data
+     * chunk.
+     * @property {copc.Las.ExtraBytes[]} [options.eb] - Extra bytes LAS VLRs
+     * headers.
+     * @property {8 | 16} [options.colorDepth=16] - Color depth (in bits).
+     * Either 8 or 16 bits.
+     */
+    async parseChunk(data, options) {
+        const { header, eb, pointCount } = options;
+        const { pointDataRecordFormat, pointDataRecordLength } = header;
+
+        const bytes = new Uint8Array(data);
+        const pointData = await copc.Las.PointData.decompressChunk(bytes, {
+            pointCount,
+            pointDataRecordFormat,
+            pointDataRecordLength,
+        }, this._initDecoder());
+
+        const view = copc.Las.View.create(pointData, header, eb);
+        return this._parseView(view, options);
+    }
+}
+
+export default LAZLoader;

--- a/src/Parser/LAZParser.js
+++ b/src/Parser/LAZParser.js
@@ -1,0 +1,94 @@
+import * as THREE from 'three';
+import LAZLoader from 'Parser/LAZLoader';
+
+/** @type {LazLoader?} */
+let loader = null;
+
+async function parseChunk(pointData, options) {
+    const lazLoader = loader ?? (loader = new LAZLoader());
+    return lazLoader.parseChunk(pointData, options.in);
+}
+
+/** The LAZParser module provides a [parseChunk]{@link
+ * module:LASParser.parseChunk} method that takes a LAZ (LASZip) chunk in, and
+ * gives a `THREE.BufferGeometry` containing all the necessary attributes to be
+ * displayed in iTowns. It uses the
+ * [copc.js](https://github.com/connormanning/copc.js/) library.
+ *
+ * @module LAZParser
+ */
+export default {
+    /**
+     * @typedef {Object} Header - Partial LAS header.
+     * @property {number} header.pointDataRecordFormat - Type of point data
+     * records contained by the buffer.
+     * @property {number} header.pointDataRecordLength - Size (in bytes) of the
+     * point data records. If the specified size is larger than implied by the
+     * point data record format (see above) the remaining bytes are user-specfic
+     * "extra bytes". Those are described by an Extra Bytes VLR.
+     * @property {number[]} header.scale - Scale factors (an array `[xScale,
+     * yScale, zScale]`) multiplied to the X, Y, Z point record values.
+     * @property {number[]} header.offset - Offsets (an array `[xOffset,
+     * xOffset, zOffset]`) added to the scaled X, Y, Z point record values.
+     */
+
+    /**
+     * @typedef {Object} ParsingOptions - Options of the parser.
+     * @property {Object} in - Options from the source input.
+     * @property {number} in.pointCount - Number of points in this data
+     * chunk.
+     * @property {8 | 16} [in.colorDepth=16] - Color depth (in bits). Either 8
+     * or 16 bits.
+     * @property {Header} in.header - Partial LAS header.
+     * @property {copc.Las.ExtraBytes[]} [in.eb] - Extra bytes LAS VLRs headers.
+     */
+
+    /*
+     * Set then laz-perf decoder path.
+     * @param {string} path - path to `laz-perf.wasm` folder.
+     */
+    setLazPerf(path) {
+        const lazLoader = loader ?? (loader = new LAZLoader());
+        lazLoader.lazPerf = path;
+    },
+
+    /**
+     * Parse a LAZ chunk.
+     * @param {Uint8Array} data - Chunk data.
+     * @param {ParsingOptions} options - Parsing options.
+     * @returns {BufferGeometry} - The corresponding geometry.
+     */
+    async parseChunk(data, options) {
+        const attrs = await parseChunk(data, options);
+
+        const geometry = new THREE.BufferGeometry();
+        geometry.userData = options.in.header;
+        geometry.userData.vertexCount = options.in.pointCount;
+
+        const positionBuffer = new THREE.BufferAttribute(attrs.position, 3);
+        geometry.setAttribute('position', positionBuffer);
+
+        const intensityBuffer = new THREE.BufferAttribute(attrs.intensity, 1, true);
+        geometry.setAttribute('intensity', intensityBuffer);
+
+        const returnNumber = new THREE.BufferAttribute(attrs.returnNumber, 1);
+        geometry.setAttribute('returnNumber', returnNumber);
+
+        const numberOfReturns = new THREE.BufferAttribute(attrs.numberOfReturns, 1);
+        geometry.setAttribute('numberOfReturns', numberOfReturns);
+
+        const classBuffer = new THREE.BufferAttribute(attrs.classification, 1, true);
+        geometry.setAttribute('classification', classBuffer);
+
+        const pointSourceID = new THREE.BufferAttribute(attrs.pointSourceID, 1);
+        geometry.setAttribute('pointSourceID', pointSourceID);
+
+        if (attrs.color) {
+            const colorBuffer = new THREE.BufferAttribute(attrs.color, 4, true);
+            geometry.setAttribute('color', colorBuffer);
+        }
+
+        geometry.computeBoundingBox();
+        return geometry;
+    },
+};

--- a/src/Provider/PointCloudProvider.js
+++ b/src/Provider/PointCloudProvider.js
@@ -36,7 +36,12 @@ export default {
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            if (!layer.isEntwinePointTileLayer) {
+            if (!layer.isEntwinePointTileLayer && !layer.isCopcLayer) {
+                // TODO: Harmonize properties of all PointCloudLayers
+                // Since both EPT and COPC Layer apply scaling at parsing, they
+                // should set a `layer.scale` at `THREE.Vector(1.0, 1.0, 1.0)`.
+                // For the `offset`, see if possible to move this property
+                // upward in Potree layer.
                 points.position.copy(node.bbox.min);
                 points.scale.copy(layer.scale);
             }

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -28,6 +28,49 @@ export const PNTS_SIZE_MODE = {
 
 const white = new THREE.Color(1.0,  1.0,  1.0);
 
+// Viridis color scheme
+// Adapted from matplotlib
+// https://github.com/matplotlib/matplotlib/blob/d60de5ed4d374d688463a1a49684f6cd1dbdd0d5/lib/matplotlib/_cm_listed.py#L774
+const viridis = [
+    '#440154', '#440255', '#440357', '#450558', '#45065a', '#45085b', '#46095c',
+    '#460b5e', '#460c5f', '#460e61', '#470f62', '#471163', '#471265', '#471466',
+    '#471567', '#471669', '#47186a', '#48196b', '#481a6c', '#481c6e', '#481d6f',
+    '#481e70', '#482071', '#482172', '#482273', '#482374', '#472575', '#472676',
+    '#472777', '#472878', '#472a79', '#472b7a', '#472c7b', '#462d7c', '#462f7c',
+    '#46307d', '#46317e', '#45327f', '#45347f', '#453580', '#453681', '#443781',
+    '#443982', '#433a83', '#433b83', '#433c84', '#423d84', '#423e85', '#424085',
+    '#414186', '#414286', '#404387', '#404487', '#3f4587', '#3f4788', '#3e4888',
+    '#3e4989', '#3d4a89', '#3d4b89', '#3d4c89', '#3c4d8a', '#3c4e8a', '#3b508a',
+    '#3b518a', '#3a528b', '#3a538b', '#39548b', '#39558b', '#38568b', '#38578c',
+    '#37588c', '#37598c', '#365a8c', '#365b8c', '#355c8c', '#355d8c', '#345e8d',
+    '#345f8d', '#33608d', '#33618d', '#32628d', '#32638d', '#31648d', '#31658d',
+    '#31668d', '#30678d', '#30688d', '#2f698d', '#2f6a8d', '#2e6b8e', '#2e6c8e',
+    '#2e6d8e', '#2d6e8e', '#2d6f8e', '#2c708e', '#2c718e', '#2c728e', '#2b738e',
+    '#2b748e', '#2a758e', '#2a768e', '#2a778e', '#29788e', '#29798e', '#287a8e',
+    '#287a8e', '#287b8e', '#277c8e', '#277d8e', '#277e8e', '#267f8e', '#26808e',
+    '#26818e', '#25828e', '#25838d', '#24848d', '#24858d', '#24868d', '#23878d',
+    '#23888d', '#23898d', '#22898d', '#228a8d', '#228b8d', '#218c8d', '#218d8c',
+    '#218e8c', '#208f8c', '#20908c', '#20918c', '#1f928c', '#1f938b', '#1f948b',
+    '#1f958b', '#1f968b', '#1e978a', '#1e988a', '#1e998a', '#1e998a', '#1e9a89',
+    '#1e9b89', '#1e9c89', '#1e9d88', '#1e9e88', '#1e9f88', '#1ea087', '#1fa187',
+    '#1fa286', '#1fa386', '#20a485', '#20a585', '#21a685', '#21a784', '#22a784',
+    '#23a883', '#23a982', '#24aa82', '#25ab81', '#26ac81', '#27ad80', '#28ae7f',
+    '#29af7f', '#2ab07e', '#2bb17d', '#2cb17d', '#2eb27c', '#2fb37b', '#30b47a',
+    '#32b57a', '#33b679', '#35b778', '#36b877', '#38b976', '#39b976', '#3bba75',
+    '#3dbb74', '#3ebc73', '#40bd72', '#42be71', '#44be70', '#45bf6f', '#47c06e',
+    '#49c16d', '#4bc26c', '#4dc26b', '#4fc369', '#51c468', '#53c567', '#55c666',
+    '#57c665', '#59c764', '#5bc862', '#5ec961', '#60c960', '#62ca5f', '#64cb5d',
+    '#67cc5c', '#69cc5b', '#6bcd59', '#6dce58', '#70ce56', '#72cf55', '#74d054',
+    '#77d052', '#79d151', '#7cd24f', '#7ed24e', '#81d34c', '#83d34b', '#86d449',
+    '#88d547', '#8bd546', '#8dd644', '#90d643', '#92d741', '#95d73f', '#97d83e',
+    '#9ad83c', '#9dd93a', '#9fd938', '#a2da37', '#a5da35', '#a7db33', '#aadb32',
+    '#addc30', '#afdc2e', '#b2dd2c', '#b5dd2b', '#b7dd29', '#bade27', '#bdde26',
+    '#bfdf24', '#c2df22', '#c5df21', '#c7e01f', '#cae01e', '#cde01d', '#cfe11c',
+    '#d2e11b', '#d4e11a', '#d7e219', '#dae218', '#dce218', '#dfe318', '#e1e318',
+    '#e4e318', '#e7e419', '#e9e419', '#ece41a', '#eee51b', '#f1e51c', '#f3e51e',
+    '#f6e61f', '#f8e621', '#fae622', '#fde724',
+];
+
 /**
  * Every lidar point can have a classification assigned to it that defines
  * the type of object that has reflected the laser pulse. Lidar points can be
@@ -232,8 +275,12 @@ class PointsMaterial extends THREE.RawShaderMaterial {
 
         context.rect(0, 0, width, 1);
         const gradient = context.createLinearGradient(0, 0, width, 1);
-        gradient.addColorStop(0, '#000000');
-        gradient.addColorStop(1, '#ffffff');
+        const scheme = viridis;
+        const length = scheme.length;
+        for (let i = 0; i < length; ++i) {
+            gradient.addColorStop(i / length, scheme[i]);
+        }
+
         context.fillStyle = gradient;
         context.fill();
 

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -10,6 +10,10 @@ export const PNTS_MODE = {
     INTENSITY: 1,
     CLASSIFICATION: 2,
     NORMAL: 3,
+    RETURN_NUMBER: 4,
+    NUMBER_OF_RETURNS: 5,
+    POINT_SOURCE_ID: 6,
+    ELEVATION: 7,
 };
 
 export const PNTS_SHAPE = {
@@ -68,6 +72,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
      * @param      {number}  [options.mode=PNTS_SHAPE.CIRCLE]  rendered points shape.
      * @param      {THREE.Vector4}  [options.overlayColor=new THREE.Vector4(0, 0, 0, 0)]  overlay color.
      * @param      {THREE.Vector2}  [options.intensityRange=new THREE.Vector2(0, 1)]  intensity range.
+     * @param      {THREE.Vector2}  [options.elevationRange=new THREE.Vector2(0, 1)] - elevation range.
      * @param      {boolean}  [options.applyOpacityClassication=false]  apply opacity classification on all display mode.
      * @param      {Classification}  [options.classification] -  define points classification.
      * @param      {number}  [options.sizeMode=PNTS_SIZE_MODE.VALUE]  point cloud size mode. Only 'VALUE' or 'ATTENUATED' are possible. VALUE use constant size, ATTENUATED compute size depending on distance from point to camera.
@@ -83,6 +88,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
      */
     constructor(options = {}) {
         const intensityRange = options.intensityRange || new THREE.Vector2(0, 1);
+        const elevationRange = options.elevationRange || new THREE.Vector2(0, 1);
         const oiMaterial = options.orientedImageMaterial;
         const classification = options.classification || ClassificationScheme.DEFAULT;
         const applyOpacityClassication = options.applyOpacityClassication == undefined ? false : options.applyOpacityClassication;
@@ -95,6 +101,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
 
         delete options.orientedImageMaterial;
         delete options.intensityRange;
+        delete options.elevationRange;
         delete options.classification;
         delete options.applyOpacityClassication;
         delete options.size;
@@ -121,6 +128,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
         CommonMaterial.setUniformProperty(this, 'opacity', this.opacity);
         CommonMaterial.setUniformProperty(this, 'overlayColor', options.overlayColor || new THREE.Vector4(0, 0, 0, 0));
         CommonMaterial.setUniformProperty(this, 'intensityRange', intensityRange);
+        CommonMaterial.setUniformProperty(this, 'elevationRange', elevationRange);
         CommonMaterial.setUniformProperty(this, 'applyOpacityClassication', applyOpacityClassication);
         CommonMaterial.setUniformProperty(this, 'sizeMode', sizeMode);
         CommonMaterial.setUniformProperty(this, 'scale', scale);

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -25,6 +25,9 @@ uniform mat4 modelMatrix;
 uniform vec2 intensityRange;
 uniform vec2 elevationRange;
 
+uniform sampler2D classificationLUT;
+uniform sampler2D gradient;
+
 uniform float size;
 uniform float scale;
 
@@ -34,7 +37,6 @@ uniform float opacity;
 uniform vec4 overlayColor;
 uniform bool applyOpacityClassication;
 attribute vec4 unique_id;
-uniform sampler2D classificationLUT;
 uniform int sizeMode;
 uniform float minAttenuatedSize;
 uniform float maxAttenuatedSize;
@@ -104,9 +106,9 @@ void main() {
         }
 
         if (mode == PNTS_MODE_INTENSITY) {
-            // adapt the grayscale knowing the range
+            // adapt the gradient knowing the range
             float i = (intensity - intensityRange.x) / (intensityRange.y - intensityRange.x);
-            vColor.rgb = vec3(i, i, i);
+            vColor.rgb = texture2D(gradient, vec2(i, 0.5)).rgb;
         } else if (mode == PNTS_MODE_NORMAL) {
             vColor.rgb = abs(normal);
         } else if (mode == PNTS_MODE_COLOR) {
@@ -114,20 +116,20 @@ void main() {
             vColor.rgb = mix(color, overlayColor.rgb, overlayColor.a);
         } else if (mode == PNTS_MODE_RETURN_NUMBER) {
             float n = returnNumber / RETURN_NUMBER_MAX;
-            vColor.rgb = vec3(n, n, n);
+            vColor.rgb = texture2D(gradient, vec2(n, 0.5)).rgb;
         } else if (mode == PNTS_MODE_NUMBER_OF_RETURNS) {
             float n = numberOfReturns / RETURN_NUMBER_MAX;
-            vColor.rgb = vec3(n, n, n);
+            vColor.rgb = texture2D(gradient, vec2(n, 0.5)).rgb;
         } else if (mode == PNTS_MODE_POINT_SOURCE_ID) {
             // group ids by their 4 least significant bits
             float i = mod(pointSourceID, 16.) / 16.;
-            vColor.rgb = vec3(i, i, i);
+            vColor.rgb = texture2D(gradient, vec2(i, 0.5)).rgb;
         } else if (mode == PNTS_MODE_ELEVATION) {
             // apply scale and offset transform
             vec4 model = modelMatrix * vec4(position, 1.0);
             float z = (model.z - elevationRange.x) / (elevationRange.y - elevationRange.x);
-            // adapt the grayscale knowing the range
-            vColor.rgb = vec3(z, z, z);
+            // adapt the gradient knowing the range
+            vColor.rgb = texture2D(gradient, vec2(z, 0.5)).rgb;
         }
     }
 

--- a/src/Source/CopcSource.js
+++ b/src/Source/CopcSource.js
@@ -1,0 +1,121 @@
+import { Binary, Info, Las } from 'copc';
+import Extent from 'Core/Geographic/Extent';
+import Fetcher from 'Provider/Fetcher';
+import LAZParser from 'Parser/LAZParser';
+import Source from 'Source/Source';
+import * as THREE from 'three';
+
+/**
+ * @param {function(number, number):Promise<Uint8Array>} fetcher
+ */
+async function getHeaders(fetcher) {
+    const header =
+        Las.Header.parse(await fetcher(0, Las.Constants.minHeaderLength));
+    const vlrs = await Las.Vlr.walk(fetcher, header);
+
+    // info VLR: required by COPC
+    const infoVlr = Las.Vlr.find(vlrs, 'copc', 1);
+    if (!infoVlr) { return Promise.reject('COPC info VLR is required'); }
+    const info = Info.parse(await Las.Vlr.fetch(fetcher, infoVlr));
+
+    // OGC Coordinate System WKT: required by LAS1.4
+    const wktVlr = Las.Vlr.find(vlrs, 'LASF_Projection', 2112);
+    if (!wktVlr) { return Promise.reject('LAS1.4 WKT VLR is required'); }
+    const wkt = Binary.toCString(await Las.Vlr.fetch(fetcher, wktVlr));
+
+    // Extra bytes: optional by LAS1.4
+    const ebVlr = Las.Vlr.find(vlrs, 'LASF_Spec', 4);
+    const eb = ebVlr ?
+        Las.ExtraBytes.parse(await Las.Vlr.fetch(fetcher, ebVlr)) :
+        [];
+
+    return { header, info, wkt, eb };
+}
+
+/**
+ * @classdesc
+ * A source for [Cloud Optimised Point Cloud](https://copc.io/) (COPC) data.
+ * Such data consists of a [LAZ 1.4](https://www.ogc.org/standard/las/) file
+ * that stores compressed points data organized in a clustered octre.
+ *
+ * A freshly created source fetches and parses portions of the file
+ * corresponding to the LAS 1.4 header, all the Variable Length Record (VLR)
+ * headers as well the following VLRs:
+ * - COPC [`info`](https://copc.io/#info-vlr) record (mandatory)
+ * - LAS 1.4 `OGC Coordinate System WKT` record (mandatory, see [Las 1.4
+ *   spec](https://portal.ogc.org/files/?artifact_id=74523))
+ * - LAS 1.4 `Extra Bytes` record (optional, see [Las 1.4
+ *   spec](https://portal.ogc.org/files/?artifact_id=74523))
+ *
+ * @extends {Source}
+ *
+ * @property {boolean} isCopcSource - Read-only flag to check that a given
+ * object is of type CopcSource.
+ * @property {Object} header - LAS header of the source.
+ * @property {Object[]} eb - List of headers of each Variable Length Records
+ * (VLRs).
+ * @property {Object} info - COPC `info` VLR.
+ * @property {number[]} info.cube - Bouding box of the octree as a 6-elements.
+ * tuple `[minX, minY, minZ, maxX, maxY, maxZ]`. Computed from `center_x`,
+ * `center_y`, `center_z` and `halfSize` properties.
+ * @property {Object} info.rootHierarchyPage - Hierarchy page of the root node.
+ * @property {number} info.rootHierarchyPage.pageOffset - Absolute Offset to the
+ * root node data chunk.
+ * @property {number} info.rootHierarchyPage.pageOffset - Size (in bytes) of the
+ * root node data chunk.
+ * @property {number[]} gpsTimeRange - A 2-element tuple denoting the minimum
+ * and maximum values of attribute `gpsTime`.
+ */
+class CopcSource extends Source {
+    /**
+     * @param {Object} config - Source configuration
+     * @param {string} config.url - URL of the COPC ressource.
+     * @param {8 | 16} [config.colorDepth=16] - Encoding of the `color`
+     * attribute. Either `8` or `16` bits.
+     * @param {string} [config._lazPerfBaseUrl] - (experimental) Overrides base
+     * url of the `las-zip.wasm` file of the `laz-perf` library.
+     * @param {string} [config.crs='EPSG:4326'] - Native CRS of the COPC
+     * ressource. Note that this is not for now inferred from the COPC header.
+     * @param {RequestInit} [config.networkOptions] - Fetch options (passed
+     * directly to `fetch()`), see [the syntax for more information]{@link
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * @param {Object} [config.attribution] - Attribution of the data.
+     *
+     * @constructor
+     */
+    constructor(config) {
+        super(config);
+
+        this.isCopcSource = true;
+
+        this.parser = LAZParser.parseChunk;
+        this.fetcher = Fetcher.arrayBuffer;
+
+        this.colorDepth = config.colorDepth ?? 16;
+
+        const get = (/** @type {number} */ begin, /** @type {number} */ end) =>
+            this.fetcher(this.url, {
+                ...this.networkOptions,
+                headers: {
+                    ...this.networkOptions.headers,
+                    range: `bytes=${begin}-${end - 1}`,
+                },
+            }).then(buffer => new Uint8Array(buffer));
+        this.whenReady = getHeaders(get).then((metadata) => {
+            this.header = metadata.header;
+            this.info = metadata.info;
+            this.eb = metadata.eb;
+            // TODO: use wkt definition in `metadata.wkt` to infer/define crs
+            this.crs = config.crs || 'EPSG:4326';
+
+            const bbox = new THREE.Box3();
+            bbox.min.fromArray(this.info.cube, 0);
+            bbox.max.fromArray(this.info.cube, 3);
+            this.extent = Extent.fromBox3(this.crs, bbox);
+
+            return this;
+        });
+    }
+}
+
+export default CopcSource;

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -85,6 +85,8 @@ let uid = 0;
  * To extend a Source, it is necessary to implement two functions:
  * `urlFromExtent` and `extentInsideLimit`.
  *
+ * @extends InformationsData
+ *
  * @property {boolean} isSource - Used to checkout whether this source is a
  * Source. Default is true. You should not change this, as it is used internally
  * for optimisation.
@@ -126,7 +128,6 @@ class Source extends InformationsData {
      * Source. Only the `url` property is mandatory.
      *
      * @constructor
-     * @extends InformationsData
      */
     constructor(source) {
         super(source);
@@ -145,6 +146,7 @@ class Source extends InformationsData {
         this.isVectorSource = (source.parser || supportedParsers.get(source.format)) != undefined;
         this.networkOptions = source.networkOptions || { crossOrigin: 'anonymous' };
         this.attribution = source.attribution;
+        /** @type {Promise<any>} */
         this.whenReady = Promise.resolve();
         this._featuresCaches = {};
         if (source.extent && !(source.extent.isExtent)) {

--- a/test/functional/copc_simple_loader.js
+++ b/test/functional/copc_simple_loader.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+describe('copc_simple_loader', function _() {
+    let result;
+
+    before(async () => {
+        result = await loadExample(
+            'examples/copc_simple_loader.html',
+            this.fullTitle(),
+        );
+    });
+
+    it('sould run', async () => {
+        assert.ok(result);
+    });
+});

--- a/test/unit/copc.js
+++ b/test/unit/copc.js
@@ -1,0 +1,129 @@
+import assert from 'assert';
+import HttpsProxyAgent from 'https-proxy-agent';
+import View from 'Core/View';
+import CopcSource from 'Source/CopcSource';
+import CopcLayer from 'Layer/CopcLayer';
+import Renderer from './bootstrap';
+
+describe('Cloud Optimized Point Cloud', function () {
+    let view;
+    let source;
+    let layer;
+    let context;
+
+    describe('Source', async function () {
+        before(async function () {
+            source = new CopcSource({
+                url: 'https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz',
+                networkOptions: process.env.HTTPS_PROXY ?
+                    { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } :
+                    {},
+                _lazPerfBaseUrl: './node_modules/laz-perf/lib/',
+            });
+        });
+
+        it('loads the COPC metadata', async function () {
+            await source.whenReady;
+        }).timeout(10000);
+
+        it('correctly loads LAS header block', async function () {
+            const header = {
+                fileSignature: 'LASF',
+                fileSourceId: 0,
+                globalEncoding: 16,
+                projectId: '00000000-0000-0000-0000000000000000',
+                majorVersion: 1,
+                minorVersion: 4,
+                systemIdentifier: '',
+                generatingSoftware: '',
+                fileCreationDayOfYear: 1,
+                fileCreationYear: 1,
+                headerLength: 375,
+                pointDataOffset: 1736,
+                vlrCount: 3,
+                pointDataRecordFormat: 7,
+                pointDataRecordLength: 36,
+                pointCount: 10653336,
+                pointCountByReturn: [
+                    9100899, 1238442, 283980,
+                    30015,         0,      0,
+                    0,             0,      0,
+                    0,             0,      0,
+                    0,             0,      0,
+                ],
+                scale: [0.01, 0.01, 0.01],
+                offset: [637290.75, 851209.9, 510.7],
+                min: [635577.79, 848882.15, 406.14],
+                max: [639003.73, 853537.66, 615.26],
+                waveformDataOffset: 0,
+                evlrOffset: 81114086,
+                evlrCount: 1,
+            };
+
+            assert.deepStrictEqual(source.header, header);
+        });
+
+        it('correctly loads COPC info VLR', async function () {
+            const info = {
+                cube: [
+                    635577.79,
+                    848882.15,
+                    406.1400000000003,
+                    640233.3,
+                    853537.66,
+                    5061.65000000001,
+                ],
+                spacing: 36.37117187500007,
+                rootHierarchyPage: { pageOffset: 81114146, pageLength: 8896 },
+                gpsTimeRange: [245369.89656857715, 245369.89656857715],
+            };
+
+            assert.deepStrictEqual(source.info, info);
+        });
+
+        it('correctly loads EVLR', async function () {
+            const eb = [];
+
+            assert.deepStrictEqual(source.eb, eb);
+        });
+    });
+
+    describe('Layer', async function () {
+        before(async function () {
+            const renderer = new Renderer();
+            view = new View('EPSG:4978', renderer.domElement, {
+                renderer,
+            });
+
+            layer = new CopcLayer('copc', { source });
+
+            context = {
+                camera: view.camera,
+                engine: view.mainLoop.gfxEngine,
+                scheduler: view.mainLoop.scheduler,
+                geometryLayer: layer,
+                view,
+            };
+        });
+
+        it('is correctly added to the view', async function () {
+            view.addLayer(layer);
+            await layer.whenReady;
+        });
+
+        it('pre updates and returns the root', async function () {
+            const element = layer.preUpdate(context, new Set([layer]));
+            assert.strictEqual(element.length, 1);
+            assert.deepStrictEqual(element[0], layer.root);
+        });
+
+        it('updates on the root and fails', async function () {
+            layer.update(context, layer, layer.root);
+            assert.strictEqual(layer.root.promise, undefined);
+        });
+
+        it('post updates', async function () {
+            layer.postUpdate(context, layer);
+        });
+    });
+});

--- a/test/unit/lazparser.js
+++ b/test/unit/lazparser.js
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import LAZParser from 'Parser/LAZParser';
+import Fetcher from 'Provider/Fetcher';
+
+describe('LAZParser', function () {
+    let lazChunk;
+
+    before(async function () {
+        const networkOptions = process.env.HTTPS_PROXY ? {
+            agent: new HttpsProxyAgent(process.env.HTTPS_PROXY),
+            headers: { range: 'bytes=79462688-80225945' },
+        } : {
+            headers: { range: 'bytes=79462688-80225945' },
+        };
+        const url = 'https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz';
+        lazChunk = await Fetcher.arrayBuffer(url, networkOptions);
+        LAZParser.setLazPerf('./node_modules/laz-perf/lib');
+    });
+
+    it('parses a laz file to a THREE.BufferGeometry', async function () {
+        const min = [635577.79, 848882.15, 406.14];
+        const max = [639003.73, 853537.66, 615.26];
+
+        const header = {
+            pointDataRecordFormat: 7,
+            pointDataRecordLength: 36,
+            scale: [0.01, 0.01, 0.01],
+            offset: [637290.75, 851209.9, 510.7],
+        };
+        const bufferGeometry = await LAZParser.parseChunk(lazChunk, {
+            in: {
+                pointCount: 61201,
+                header,
+                eb: [],
+            },
+            out: {},
+        });
+
+        const epsilon = 0.1;
+
+        assert.ok(bufferGeometry.boundingBox.min.x + epsilon >= min[0]);
+        assert.ok(bufferGeometry.boundingBox.min.y + epsilon >= min[1]);
+        assert.ok(bufferGeometry.boundingBox.min.z + epsilon >= min[2]);
+        assert.ok(bufferGeometry.boundingBox.max.x - epsilon <= max[0]);
+        assert.ok(bufferGeometry.boundingBox.max.y - epsilon <= max[1]);
+        assert.ok(bufferGeometry.boundingBox.max.z - epsilon <= max[2]);
+    });
+});

--- a/utils/debug/PotreeDebug.js
+++ b/utils/debug/PotreeDebug.js
@@ -39,6 +39,16 @@ export default {
         if (layer.material.picking != undefined) {
             styleUI.add(layer.material, 'picking').name('Display picking id').onChange(update);
         }
+        layer.whenReady.then(() => {
+            const minElevation = layer.minElevationRange;
+            const maxElevation = layer.maxElevationRange;
+            styleUI.add(layer, 'minElevationRange', minElevation, maxElevation)
+                .name('Min elevation')
+                .onChange(update);
+            styleUI.add(layer, 'maxElevationRange', minElevation, maxElevation)
+                .name('Max elevation')
+                .onChange(update);
+        });
 
         // UI
         const debugUI = layer.debugUI.addFolder('Debug');


### PR DESCRIPTION
## Description
This PR adds support the following LAS point attributes in `PointMaterial`:
- `return number` and `number of returns` as discrete values between 0 and 7 included.
- `point source id` .
- `elevation` as a gradient between a user-provided `minElevationRange` and `maxElevationRange`.

It also aims to provide:
- an API for the end-user to customize color gradients (including the `intensity` attribute) and look-up table (à la `ClassificationScheme`).
- sane color defaults.

## Screenshots
TODO