### PR TITLE
Replace Lyon's deprecated sources

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -59,8 +59,8 @@
             // Add a WMS elevation source
             var wmsElevationSource = new itowns.WMSSource({
                 extent: extent,
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                name: 'MNT2012_Altitude_10m_CC46',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2018_Altitude_2m',
                 crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',

--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -38,8 +38,8 @@
             // Add a WMS imagery source
             var wmsImagerySource = new itowns.WMSSource({
                 extent: extent,
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'ortho_latest',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
                 crs: 'EPSG:3946',
                 format: 'image/jpeg',

--- a/examples/misc_compare_25d_3d.html
+++ b/examples/misc_compare_25d_3d.html
@@ -134,8 +134,8 @@
 
             var wmsImagerySource = new itowns.WMSSource({
                 extent: extent,
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'ortho_latest',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
                 crs: 'EPSG:3946',
                 format: 'image/jpeg',

--- a/examples/misc_orthographic_camera.html
+++ b/examples/misc_orthographic_camera.html
@@ -62,8 +62,8 @@
             // add a WMS imagery source
             const wmsImagerySource = new itowns.WMSSource({
                 extent: extent,
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'ortho_latest',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
                 crs: 'EPSG:3946',
                 format: 'image/jpeg',

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -84,8 +84,8 @@
             // Add a WMS elevation source
             var wmsElevationSource = new itowns.WMSSource({
                 extent: extent,
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                name: 'MNT2012_Altitude_10m_CC46',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2018_Altitude_2m',
                 crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -64,10 +64,10 @@
             setupLoadingScreen(viewerDiv, view);
 
             wmsImagerySource = new itowns.WMSSource({
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
                 networkOptions: { crossOrigin: 'anonymous' },
                 version: '1.3.0',
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
+                name: 'ortho_latest',
                 crs: 'EPSG:3946',
                 extent: extent,
                 format: 'image/jpeg',

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -132,11 +132,11 @@
             }
 
             lyonTclBusSource = new itowns.WFSSource({
-                url: 'https://download.data.grandlyon.com/wfs/rdata?',
+                url: "https://data.grandlyon.com/geoserver/sytral/ows?",
                 protocol: 'wfs',
                 version: '2.0.0',
                 id: 'tcl_bus',
-                typeName: 'tcl_sytral.tcllignebus',
+                typeName: "tcl_sytral.tcllignebus_2_0_0",
                 crs: 'EPSG:3946',
                 extent: {
                     west: 1822174.60,
@@ -144,7 +144,7 @@
                     south: 5138876.75,
                     north: 5205890.19,
                 },
-                format: 'geojson',
+                format: 'application/json',
             });
 
             var lyonTclBusLayer = new itowns.FeatureGeometryLayer('lyon_tcl_bus', {

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -59,8 +59,8 @@
             // Add a WMS imagery source
             var wmsImagerySource = new itowns.WMSSource({
                 extent: extent,
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'ortho_latest',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
                 crs: 'EPSG:3946',
                 format: 'image/jpeg',

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -80,8 +80,8 @@
             // Add a WMS elevation source
             var wmsElevationSource = new itowns.WMSSource({
                 extent: extent,
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                name: 'MNT2012_Altitude_10m_CC46',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2018_Altitude_2m',
                 crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',

--- a/examples/view_multi_25d.html
+++ b/examples/view_multi_25d.html
@@ -29,18 +29,37 @@
             var parent;
             var index;
             var wms;
+            var wmsUrl;
             var obj;
             var offset;
             var tileLayer;
             var config;
 
-            var wmsLayers = [
-                'fpc_fond_plan_communaut.fpcilot',
-                'pvo_patrimoine_voirie.pvochausseetrottoir',
-                'Ortho2009_vue_ensemble_16cm_CC46',
-                'pos_opposable.poshauvoi',
-                'MNT2015_Ombrage_2m',
-                'cad_cadastre.cadilot',
+            var wmsSources = [
+                {
+                    name: 'fpc_fond_plan_communaut.fpcilot',
+                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                },
+                {
+                    name: 'pvo_patrimoine_voirie.pvochausseetrottoir',
+                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                },
+                {
+                    name: 'ortho_latest',
+                    url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
+                },
+                {
+                    name: 'pos_opposable.poshauvoi',
+                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                },
+                {
+                    name: 'MNT2015_Ombrage_2m',
+                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                },
+                {
+                    name: 'cad_cadastre.cadilot',
+                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                },
             ];
 
             var cubeTransformations = [
@@ -106,8 +125,8 @@
                 url: 'https://download.data.grandlyon.com/wms/grandlyon',
             });
 
-            for (index = 0; index < wmsLayers.length; index++) {
-                wms = wmsLayers[index];
+            for (index = 0; index < wmsSources.length; index++) {
+                wms = wmsSources[index];
                 obj = new itowns.THREE.Object3D();
                 offset = extent.center().toVector3().negate().applyEuler(cubeTransformations[index].rotation);
                 offset.add(cubeTransformations[index].position.divide(scale));
@@ -116,24 +135,24 @@
                 parent.add(obj);
                 obj.updateMatrixWorld(true);
 
-                tileLayer = new itowns.PlanarLayer('planar' + wms + index,
+                tileLayer = new itowns.PlanarLayer('planar' + wms.name + index,
                     extent, obj, { disableSkirt: true });
 
                 view.addLayer(tileLayer);
 
                 var colorSource = new itowns.WMSSource({
-                    url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                    url: wms.url,
                     version: '1.3.0',
-                    name: wms,
+                    name: wms.name,
                     crs: 'EPSG:3946',
                     format: 'image/jpeg',
                     extent,
                 });
-                var colorLayer = new itowns.ColorLayer('wms_imagery' + wms + index, {
+                var colorLayer = new itowns.ColorLayer('wms_imagery' + wms.name + index, {
                     source: colorSource,
                 });
                 view.addLayer(colorLayer, tileLayer);
-                var elevationLayer = new itowns.ElevationLayer('wms_elevation' + wms + index, {
+                var elevationLayer = new itowns.ElevationLayer('wms_elevation' + wms.name + index, {
                     source: elevationSource,
                     useColorTextureElevation: true,
                     colorTextureElevationMinZ: 144,

--- a/examples/view_multi_25d.html
+++ b/examples/view_multi_25d.html
@@ -118,11 +118,11 @@
             var elevationSource = new itowns.WMSSource({
                 extent,
                 version: '1.3.0',
-                name: 'MNT2012_Altitude_10m_CC46',
+                name: 'MNT2018_Altitude_2m',
                 crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
             });
 
             for (index = 0; index < wmsSources.length; index++) {

--- a/examples/widgets_3dtiles_style.html
+++ b/examples/widgets_3dtiles_style.html
@@ -39,8 +39,8 @@
             // Add a WMS imagery source
             const wmsImagerySource = new itowns.WMSSource({
                 extent: extent,
-                name: 'Ortho2009_vue_ensemble_16cm_CC46',
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
+                name: 'ortho_latest',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
                 version: '1.3.0',
                 crs: 'EPSG:3946',
                 format: 'image/jpeg',
@@ -110,7 +110,7 @@
             view.domElement.onclick = (event) => {
                 const intersects = view.pickObjectsAt(event, 0, [$3dTilesLayer]);
                 const c3DTileFeatureClicked = $3dTilesLayer.getC3DTileFeatureFromIntersectsArray(intersects);
-                
+
                 if (c3DTileFeatureClicked) {
                     const worldBox3 = $3dTilesLayer.computeWorldBox3(c3DTileFeatureClicked);
                     cube.scale.copy(worldBox3.max.clone().sub(worldBox3.min));

--- a/examples/widgets_3dtiles_style.html
+++ b/examples/widgets_3dtiles_style.html
@@ -60,8 +60,8 @@
             // Add a WMS elevation source
             const wmsElevationSource = new itowns.WMSSource({
                 extent: extent,
-                url: 'https://download.data.grandlyon.com/wms/grandlyon',
-                name: 'MNT2012_Altitude_10m_CC46',
+                url: 'https://imagerie.data.grandlyon.com/wms/grandlyon',
+                name: 'MNT2018_Altitude_2m',
                 crs: 'EPSG:3946',
                 width: 256,
                 format: 'image/jpeg',

--- a/test/functional/source_stream_wfs_25d.js
+++ b/test/functional/source_stream_wfs_25d.js
@@ -11,7 +11,8 @@ describe('source_stream_wfs_25d', function _() {
     });
 
     it('should pick the correct building', async () => {
-        // test picking
+        // Test picking a feature geometry property from `wfsBuilding` layer.
+        // Picking is done at the given screen coordinates.
         const buildingId = await page.evaluate(() => picking({ x: 97, y: 213 }));
         assert.equal(buildingId.geojson.id, 'batiment.BATIMENT0000000241634062');
     });

--- a/test/functional/view_25d_map.js
+++ b/test/functional/view_25d_map.js
@@ -11,6 +11,10 @@ describe('view_25d_map', function _() {
     });
 
     it('should subdivise planar correctly', async () => {
+        // Test that there is a given number of "visible" tiles (i.e.
+        // `material.visible` property of a tile is set) for each tested level.
+        // Uses the property `view.tileLayer.info.displayed.tiles` of type
+        // InfoTiledGeometryLayer to retrieve such information
         const displayedTiles = await page.evaluate(() => {
             r = {};
             [...view.tileLayer.info.displayed.tiles]


### PR DESCRIPTION
## Description
This PR replaces [Grand Lyon](https://data.grandlyon.com/)'s deprecated layers with new ones.

## Motivation and Context
Due to the deprecation of [https://download.data.grandlyon.com](https://download.data.grandlyon.com) in favor of [https://imagerie.data.grandlyon.com](https://imagerie.data.grandlyon.com) for imagery layers, some examples and test cases are now broken. This means that all CI are now failing.