### PR TITLE
Bug fix: On Windows Glob path not well handle during npm install

### DIFF
--- a/config/replace.config.mjs
+++ b/config/replace.config.mjs
@@ -10,7 +10,7 @@ const patchBatchID = /JOINTS_0: +'skinIndex',/g;
 const patchGLTFLoader = 'JOINTS_0: \'skinIndex\',\n\t\t_BATCHID: \'_BATCHID\',';
 
 replace({
-    files: fileGLTFLoader,
+    files: fileGLTFLoader.replaceAll('\\','/'),
     from: patchBatchID,
     to: patchGLTFLoader,
 }).then((t) => {


### PR DESCRIPTION
Launching npm install on Windows send an error:

```
D:\itowns\node_modules\replace-in-file\lib\helpers\glob-async.js:27
        return reject(new Error('No files match the pattern: ' + pattern));
                      ^

Error: No files match the pattern: D:\itowns\src\ThreeExtended\loaders\GLTFLoader.js
    at D:\itowns\node_modules\replace-in-file\lib\helpers\glob-async.js:27:23
    at f (D:\itowns\node_modules\once\once.js:25:25)
    at Glob.<anonymous> (D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:148:7)
    at Glob.emit (node:events:390:28)
    at Glob._finish (D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:194:8)
    at done (D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:179:14)
    at Glob._processSimple2 (D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:688:12)
    at D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:676:10
    at Glob._stat2 (D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:772:12)
    at lstatcb_ (D:\itowns\node_modules\replace-in-file\node_modules\glob\glob.js:764:12)
```
The reson of the bug is because the \ are not handled in Glob during the replace-in-file.

The fix I propose is to replace all \ by / before applying the replace-in-file.