### PR TITLE
fix example Gpx 3d and functional test

### DIFF
--- a/examples/source_file_gpx_3d.html
+++ b/examples/source_file_gpx_3d.html
@@ -72,18 +72,18 @@
                         out: {
                             crs: view.referenceCrs,
                             structure: '3d',
-                            style: {
-                                stroke : {
+                            style: new itowns.Style({
+                                stroke: {
                                     color: 'red',
                                     width: 2,
                                 },
-                                point : {
+                                point: {
                                     color: 'white',
                                 }
-                            }
+                            }),
                         }
                     }))
-                    .then(itowns.Feature2Mesh.convert({style}))
+                    .then(itowns.Feature2Mesh.convert())
                     .then(function (mesh) {
                         if (mesh) {
                             mesh.updateMatrixWorld();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run lint -- --max-warnings=0 && npm run build && npm run test-with-coverage && npm run test-functional",
     "test-dev": "npm run lint -- --max-warnings=0 && npm run build-dev && npm run test-with-coverage && npm run test-functional",
     "test-unit": "npm run base-test-unit test/unit",
-    "test-functional": "mocha -t 60000 --require test/hooks_functional.js --recursive test/functional",
+    "test-functional": "mocha -t 100000 --require test/hooks_functional.js --recursive test/functional",
     "test-with-coverage": "nyc -n src -r html cross-env npm run test-unit",
     "test-with-coverage_lcov": "nyc -n src --reporter=lcov cross-env npm run test-unit",
     "base-test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --require @babel/register --file test/unit/bootstrap.js",

--- a/test/functional/source_file_gpx_3d.js
+++ b/test/functional/source_file_gpx_3d.js
@@ -6,7 +6,11 @@ describe('source_file_gpx_3d', function _() {
         result = await loadExample('examples/source_file_gpx_3d.html', this.fullTitle());
     });
 
-    it('should run', async () => {
+    it('view initialized', async () => {
         assert.ok(result);
+    });
+
+    it('should wait for the mesh to be added to the scene', async function _it() {
+        await page.waitForFunction(() => view.scene.children.length === 5, { timeout: 10000 });
     });
 });

--- a/test/hooks_functional.js
+++ b/test/hooks_functional.js
@@ -1,7 +1,6 @@
-/* global page, itowns, view, TimeoutError, initialPosition */
+/* global page, itowns, view, initialPosition */
 // eslint-disable-next-line import/no-extraneous-dependencies
 const puppeteer = require('puppeteer');
-// const { TimeoutError } = require('puppeteer/Errors');
 const net = require('net');
 const fs = require('fs');
 const http = require('http');
@@ -125,7 +124,7 @@ const loadExample = async (url, screenshotName) => {
     try {
         await layersAreInitialized();
     } catch (e) {
-        if (e instanceof TimeoutError) {
+        if (e instanceof Error && e.name === 'TimeoutError') {
             await page.evaluate(() => {
                 itowns.CameraUtils.stop(view, view.camera.camera3D);
             });


### PR DESCRIPTION
There is a bug on the source_file_gpx_3d.html example:
- the gpx waypoints doesn't display
- console errors appear
![image](https://github.com/iTowns/itowns/assets/47628509/3fbc1d68-d4b4-4cc0-a539-5feead590066)

As the functional test wasn't well design (we only test that the view is initialized even if the example add extra layer after that), it create error in the github action from time to time.
I change the functionnal test to see if the example is fully loaded and corrected in the example the source of the error.

The error is linked to the fact that a style.fill is needed (at least in parent.style) when we instanciate a new Style:
https://github.com/iTowns/itowns/blob/e56bf65c29189b86b87f8b1a9b1bce2f451ff517/src/Core/Style.js#L508
and the way we set the getter:
https://github.com/iTowns/itowns/blob/e56bf65c29189b86b87f8b1a9b1bce2f451ff517/src/Core/Style.js#L144
Or in this example the style is defined during the parsing. 

This issue is solve in the PR #2135 as we remove the need for a fill.patern and in PR #2006 as we remove the definition of parent Style.