### PR TITLE
fix(picking): Fix point reference of picking

### DIFF
--- a/src/Core/Picking.js
+++ b/src/Core/Picking.js
@@ -185,7 +185,7 @@ export default {
                         const dist = pointPosCoord.spatialEuclideanDistanceTo(cameraPosCoord);
                         result.push({
                             object: o,
-                            point: pointPos, // the position of the point in the 3D view. Same name and value than what's returned by pickObjectsAt
+                            point: pointPos.clone(), // the position of the point in the 3D view. Same name and value than what's returned by pickObjectsAt
                             index: candidates[i].index,
                             distance: dist,
                             layer,


### PR DESCRIPTION
All points have same reference in the return array of picking method.
