### PR TITLE
Use context for all converters (and not only Feature2Mesh)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -15,6 +15,7 @@
                 "FeatureBuildingOptions",
                 "Style",
                 "StyleOptions",
+                "StyleContext",
                 "Label"
             ],
 

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -7,63 +7,10 @@ import Extent from 'Core/Geographic/Extent';
 import Crs from 'Core/Geographic/Crs';
 import OrientationUtils from 'Utils/OrientationUtils';
 import Coordinates from 'Core/Geographic/Coordinates';
+import { StyleContext } from 'Core/Style';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
-
-/**
- * @class
- * @classdesc FeatureContext is a class to store all informations
- * about context to generate the style of each FeatureGeometry.
- *
- * @property {Coordinates}      worldCoord @private Coordinates of the FeatureGeometry in world system.
- * @property {Coordinates}      localCoordinates @private Are the coordinates systeme origin local or global.
- * @property {boolean}          isProjected @private Are the coordinates already been projected.
- * @property {FeatureGeometry}  geometry  @private
- * @property {Object}           globals
- * @property {Object}           collection
- * @property {Coordinates}      coordinates
- */
-export class FeatureContext {
-    #worldCoord = new Coordinates('EPSG:4326', 0, 0, 0);
-    #localCoordinates = new Coordinates('EPSG:4326', 0, 0, 0);
-    #isProjected = true;
-    #geometry = {};
-
-    constructor() {
-        this.globals = {};
-    }
-
-    setGeometry(g) {
-        this.#geometry = g;
-    }
-
-    setCollection(c) {
-        this.collection = c;
-        this.#localCoordinates.setCrs(c.crs);
-    }
-
-    setLocalCoordinatesFromArray(vertices, offset) {
-        this.#isProjected = false;
-        return this.#localCoordinates.setFromArray(vertices, offset);
-    }
-
-    get properties() {
-        return this.#geometry.properties;
-    }
-
-    get coordinates() {
-        if (!this.#isProjected) {
-            this.#isProjected = true;
-            this.#worldCoord.copy(this.#localCoordinates).applyMatrix4(this.collection.matrixWorld);
-            if (this.#localCoordinates.crs == 'EPSG:4978') {
-                return this.#worldCoord.as('EPSG:4326', this.#worldCoord);
-            }
-        }
-        return this.#worldCoord;
-    }
-}
-
-const context = new FeatureContext();
+const context = new StyleContext();
 
 const dim_ref = new THREE.Vector2();
 const dim = new THREE.Vector2();

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -10,7 +10,20 @@ import Coordinates from 'Core/Geographic/Coordinates';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
-class FeatureContext {
+/**
+ * @class
+ * @classdesc FeatureContext is a class to store all informations
+ * about context to generate the style of each FeatureGeometry.
+ *
+ * @property {Coordinates}      worldCoord @private Coordinates of the FeatureGeometry in world system.
+ * @property {Coordinates}      localCoordinates @private Are the coordinates systeme origin local or global.
+ * @property {boolean}          isProjected @private Are the coordinates already been projected.
+ * @property {FeatureGeometry}  geometry  @private
+ * @property {Object}           globals
+ * @property {Object}           collection
+ * @property {Coordinates}      coordinates
+ */
+export class FeatureContext {
     #worldCoord = new Coordinates('EPSG:4326', 0, 0, 0);
     #localCoordinates = new Coordinates('EPSG:4326', 0, 0, 0);
     #isProjected = true;

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -3,6 +3,9 @@ import { FEATURE_TYPES } from 'Core/Feature';
 import Extent from 'Core/Geographic/Extent';
 import Coordinates from 'Core/Geographic/Coordinates';
 import Style from 'Core/Style';
+import { FeatureContext } from 'Converter/Feature2Mesh';
+
+const context = new FeatureContext();
 
 /**
  * Draw polygon (contour, line edge and fill) based on feature vertices into canvas
@@ -74,7 +77,7 @@ const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 function drawFeature(ctx, feature, extent, style, invCtxScale) {
     const extentDim = extent.planarDimensions();
     const scaleRadius = extentDim.x / ctx.canvas.width;
-    const globals = {
+    context.globals = {
         fill: true,
         stroke: true,
         point: true,
@@ -83,7 +86,7 @@ function drawFeature(ctx, feature, extent, style, invCtxScale) {
 
     for (const geometry of feature.geometries) {
         if (Extent.intersectsExtent(geometry.extent, extent)) {
-            const context = { globals, properties: () => geometry.properties };
+            context.setGeometry(geometry);
             const contextStyle = (geometry.properties.style || style).applyContext(context);
 
             if (contextStyle) {

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -2,10 +2,9 @@ import * as THREE from 'three';
 import { FEATURE_TYPES } from 'Core/Feature';
 import Extent from 'Core/Geographic/Extent';
 import Coordinates from 'Core/Geographic/Coordinates';
-import Style from 'Core/Style';
-import { FeatureContext } from 'Converter/Feature2Mesh';
+import Style, { StyleContext } from 'Core/Style';
 
-const context = new FeatureContext();
+const context = new StyleContext();
 
 /**
  * Draw polygon (contour, line edge and fill) based on feature vertices into canvas
@@ -77,12 +76,6 @@ const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 function drawFeature(ctx, feature, extent, style, invCtxScale) {
     const extentDim = extent.planarDimensions();
     const scaleRadius = extentDim.x / ctx.canvas.width;
-    context.globals = {
-        fill: true,
-        stroke: true,
-        point: true,
-        zoom: extent.zoom,
-    };
 
     for (const geometry of feature.geometries) {
         if (Extent.intersectsExtent(geometry.extent, extent)) {
@@ -174,6 +167,13 @@ export default {
 
             // to scale line width and radius circle
             const invCtxScale = Math.abs(1 / scale.x);
+
+            context.globals = {
+                fill: true,
+                stroke: true,
+                point: true,
+                zoom: extent.zoom,
+            };
 
             // Draw the canvas
             for (const feature of collection.features) {

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -986,7 +986,7 @@ class Style {
         if (this.text.field.expression) {
             return readExpression(this.text.field, ctx);
         } else {
-            return this.text.field.replace(/\{(.+?)\}/g, (a, b) => (ctx.properties()[b] || '')).trim();
+            return this.text.field.replace(/\{(.+?)\}/g, (a, b) => (ctx.properties[b] || '')).trim();
         }
     }
 }

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -8,6 +8,9 @@ import Label from 'Core/Label';
 import { FEATURE_TYPES } from 'Core/Feature';
 import { readExpression } from 'Core/Style';
 import { ScreenGrid } from 'Renderer/Label2DRenderer';
+import { FeatureContext } from 'Converter/Feature2Mesh';
+
+const context = new FeatureContext();
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
@@ -240,7 +243,7 @@ class LabelLayer extends GeometryLayer {
         // Converting the extent now is faster for further operation
         extent.as(data.crs, _extent);
         coord.crs = data.crs;
-        const globals = {
+        context.globals = {
             icon: true,
             text: true,
             zoom: extent.zoom,
@@ -271,8 +274,9 @@ class LabelLayer extends GeometryLayer {
                 if (!_extent.isPointInside(coord)) { return; }
 
                 const geometryField = g.properties.style && g.properties.style.text.field;
+
+                context.setGeometry(g);
                 let content;
-                const context = { globals, properties: () => g.properties };
                 if (this.labelDomelement) {
                     content = readExpression(this.labelDomelement, context);
                 } else if (!geometryField && !featureField && !layerField) {

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -6,11 +6,10 @@ import Coordinates from 'Core/Geographic/Coordinates';
 import Extent from 'Core/Geographic/Extent';
 import Label from 'Core/Label';
 import { FEATURE_TYPES } from 'Core/Feature';
-import { readExpression } from 'Core/Style';
+import { readExpression, StyleContext } from 'Core/Style';
 import { ScreenGrid } from 'Renderer/Label2DRenderer';
-import { FeatureContext } from 'Converter/Feature2Mesh';
 
-const context = new FeatureContext();
+const context = new StyleContext();
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 


### PR DESCRIPTION
The PR #2180 propose a new approach of Context for the Style, that is used in Feature2Mesh.
2 others converters also use the initial context;
- Feature2Texture.convert()
- LabelLayer and Label

This PR propose (based on PR #2180 ) to generalize the use of Context to the other converter.

Changes:
- export the FeatureContext 
- move it to Style
- use it for the others converters
- modify FeatureToolTips plugin  to adapt to that change


