### PR TITLE
chore(integration): add release commit to message check

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(feat|feature|features|fix|perf|revert|doc|docs|refactor|refacto|refactoring|test|tests|chore|rename|workflow|example|examples|others)(\([\w\-\.]+\))?: ([\w ])+([\s\S]*)'
+          pattern: '^(feat|feature|features|fix|perf|revert|doc|docs|refactor|refacto|refactoring|test|tests|chore|rename|workflow|example|examples|others)(\([\w\-\.]+\))?: ([\w ])+([\s\S]*)|release v\d+.\d+.\d+'
           error: 'One or several of the pushed commits do not match the conventional commit convention. Please read CONTRIBUTING.md.'
           excludeDescription: true
           excludeTitle: true


### PR DESCRIPTION
## Before contributing

Read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
<!--- Describe your changes in detail -->

In #2163, we added `check-commit-message` action to integration script. This provides us with an automatic checking whether commits name within a pull request respect or disrespect the angular convention, with the commit types we support.

In this pull request, I add the release commit message format to the list of supported commit messages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

Without this modification, publishing a release would be impossible since commit message check would not pass.