### PR TITLE
Add npm provenance to npm package

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,6 +141,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [unit-and-coverage-tests, functional-tests, check-commit-message]
     runs-on: ubuntu-latest
+    permissions:
+        id-token: write
     steps:
 
       - uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,10 +20,10 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'npm'
 
       # Install packages
@@ -85,10 +85,10 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'npm'
 
       # Install packages
@@ -115,10 +115,10 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'npm'
 
       # Install packages
@@ -153,7 +153,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
 
       - run: npm ci
@@ -257,10 +257,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Message commit
         run: echo "is RELEASE => ${{ github.event.head_commit.message }} !!"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "watch": "cross-env BABEL_DISABLE_CACHE=1 babel --watch src --out-dir lib",
     "changelog": "conventional-changelog -n ./config/conventionalChangelog/config.js -i changelog.md -s",
     "bump": "if [ -z $npm_config_level ]; then grunt bump:minor;  else grunt bump:$npm_config_level; fi && npm run changelog && git add -A && git commit --amend --no-edit",
-    "publish-next": "npm version prerelease --preid next && npm publish --access public --tag=next",
-    "publish-latest": "npm publish --access public --tag=latest"
+    "publish-next": "npm version prerelease --preid next && npm publish --access public --tag=next --provenance",
+    "publish-latest": "npm publish --access public --tag=latest --provenance"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
## Description

Add [npm provenance](https://github.blog/changelog/2023-09-26-npm-provenance-general-availability/) to npm published packages. npm provenance is [only available as of npm cli 9.5.0+](https://docs.npmjs.com/generating-provenance-statements#prerequisites) so I also updated the deployment workflow node version from 16 to 18. 

Tested on my fork (with publication on my npm account).

## Motivation and Context

Use a newly introduced npm feature and explicitely link our npm releases to this repository and to the commit it was created from.

Closes #1963

## Screenshots (if appropriate)

![image](https://github.com/iTowns/itowns/assets/16967916/3acebf54-a034-439f-9f5f-56fdf4d40981)

