### PR TITLE
chore(workflow): fix publish rights with npm provenance

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -142,7 +142,11 @@ jobs:
     needs: [unit-and-coverage-tests, functional-tests, check-commit-message]
     runs-on: ubuntu-latest
     permissions:
+        # id-token: write permission is required for npm provenance:
+        # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
         id-token: write
+        # contents: write is required for git push
+        contents: write
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Add `content: write` permission to publish step

## Motivation and Context

Fixes publish task in integration workflow that was partly broken since adding  `id-token: write` for #2205
