### PR TITLE
Missing label support in doc

### DIFF
--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -231,7 +231,8 @@ function defineStyleProperty(style, category, name, value, defaultValue) {
  * then the altitude value is set to 0.
  * @property {Object} [point.model] - 3D model to instantiate at each point position.
  *
- * @property {Object} [text] - All things {@link Label} related.
+ * @property {Object} [text] - All things {@link Label} related. (Supported for Points features, not yet
+ * for Lines and Polygons features.)
  * @property {String|Function} [text.field] - A string representing a property key of
  * a `FeatureGeometry` enclosed in brackets, that will be replaced by the value of the
  * property for each geometry. For example, if each geometry contains a `name` property,

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -138,7 +138,8 @@ class LabelsNode extends THREE.Group {
 /**
  * A layer to handle a bunch of `Label`. This layer can be created on its own,
  * but it is better to use the option `addLabelLayer` on another `Layer` to let
- * it work with it (see the `vector_tile_raster_2d` example).
+ * it work with it (see the `vector_tile_raster_2d` example). Supported for Points features, not yet
+ * for Lines and Polygons features.
  *
  * @property {boolean} isLabelLayer - Used to checkout whether this layer is a
  * LabelLayer.  Default is true. You should not change this, as it is used


### PR DESCRIPTION
`LabelLayer` does not work when the features are Polygons and Lines, and this is not added in the doc.