### PR TITLE
Fix `C3DTilesLayer` and `C3DTFeature`

### DIFF
--- a/examples/widgets_3dtiles_style.html
+++ b/examples/widgets_3dtiles_style.html
@@ -108,11 +108,11 @@
             const material = new itowns.THREE.MeshBasicMaterial( {color: 0x00ff00, opacity: 0.5, transparent: true} );
             const cube = new itowns.THREE.Mesh( geometry, material );
             view.domElement.onclick = (event) => {
-                const intersects = view.pickObjectsAt(event, 0, [$3dTilesLayer]);
+                const intersects = view.pickObjectsAt(event, 5, [$3dTilesLayer]);
                 const c3DTileFeatureClicked = $3dTilesLayer.getC3DTileFeatureFromIntersectsArray(intersects);
 
                 if (c3DTileFeatureClicked) {
-                    const worldBox3 = $3dTilesLayer.computeWorldBox3(c3DTileFeatureClicked);
+                    const worldBox3 = c3DTileFeatureClicked.computeWorldBox3();
                     cube.scale.copy(worldBox3.max.clone().sub(worldBox3.min));
                     worldBox3.getCenter(cube.position);
                     cube.updateMatrixWorld();

--- a/src/Core/3DTiles/C3DTFeature.js
+++ b/src/Core/3DTiles/C3DTFeature.js
@@ -1,23 +1,32 @@
+// eslint-disable-next-line no-unused-vars
+import { Object3D, Box3 } from 'three';
+
 /**
  * C3DTFeature is a feature of a 3DTiles
  *
  * @class      C3DTFeature
- * @param {number} tileId - tile id
+ * @param {number} tileId - tileId
  * @param {number} batchId - batch id
  * @param {Array<{start:number,count:number}>} groups - groups in geometry.attributes matching batchId
  * @param {object} info - info in the batchTable
- * @param {object} [userData={}] - some userData
+ * @param {object} [userData] - some userData
+ * @param {Object3D} object3d - object3d in which feature is present
  * @property {number} tileId - tile id
+ * @property {Object3D} object3d - object3d in which feature is present
  * @property {number} batchId - batch id
  * @property {Array<{start:number,count:number}>} groups - groups in geometry.attributes matching batchId
  * @property {object} info - info in the batchTable
- * @property {object} [userData={}] - some userData
+ * @property {object} [userData] - some userData
  */
 class C3DTFeature {
     #info;
-    constructor(tileId, batchId, groups, info, userData = {}) {
-        /** @type {number} */
-        this.tileId = tileId;
+    constructor(tileId, batchId, groups, info, userData, object3d) {
+        if (!object3d) {
+            console.error('BREAKING CHANGE: C3DTFeature constructor changed from (tileId, batchId, groups, info, userData) to (tileId, batchId, groups, info, userData, object3d)');
+        }
+
+        /** @type {Object3D} */
+        this.object3d = object3d;
 
         /** @type {number} */
         this.batchId = batchId;
@@ -30,6 +39,48 @@ class C3DTFeature {
 
         /** @type {object} */
         this.#info = info;
+
+        /** @type {number} */
+        this.tileId = tileId;
+    }
+
+    /**
+     * Compute world box3 of this
+     *
+     * @param {Box3} target - target of the result
+     * @returns {Box3}
+     */
+    computeWorldBox3(target = new Box3()) {
+        // reset
+        target.max.x = -Infinity;
+        target.max.y = -Infinity;
+        target.max.z = -Infinity;
+        target.min.x = Infinity;
+        target.min.y = Infinity;
+        target.min.z = Infinity;
+
+        this.groups.forEach((group) => {
+            const positionIndexStart = group.start * 3;
+            const positionIndexCount = (group.start + group.count) * 3;
+
+            for (let index = positionIndexStart; index < positionIndexCount; index += 3) {
+                const x = this.object3d.geometry.attributes.position.array[index];
+                const y = this.object3d.geometry.attributes.position.array[index + 1];
+                const z = this.object3d.geometry.attributes.position.array[index + 2];
+
+                target.max.x = Math.max(x, target.max.x);
+                target.max.y = Math.max(y, target.max.y);
+                target.max.z = Math.max(z, target.max.z);
+
+                target.min.x = Math.min(x, target.min.x);
+                target.min.y = Math.min(y, target.min.y);
+                target.min.z = Math.min(z, target.min.z);
+            }
+        });
+
+        target.applyMatrix4(this.object3d.matrixWorld);
+
+        return target;
     }
 
     /**

--- a/src/Utils/gui/C3DTilesStyle.js
+++ b/src/Utils/gui/C3DTilesStyle.js
@@ -67,10 +67,8 @@ class C3DTilesStyle extends Widget {
 
                 /** @type {Map<string,Array>} */
                 const buffer = new Map(); // record what are the possible values for a key in batchTable
-                // eslint-disable-next-line no-unused-vars
-                for (const [tileId, tileC3DTileFeatures] of c3DTilesLayer.tilesC3DTileFeatures) {
-                    // eslint-disable-next-line no-unused-vars
-                    for (const [batchId, c3DTileFeature] of tileC3DTileFeatures) {
+                for (const [, tileC3DTileFeatures] of c3DTilesLayer.tilesC3DTileFeatures) {
+                    for (const [, c3DTileFeature] of tileC3DTileFeatures) {
                         // eslint-disable-next-line guard-for-in
                         for (const key in c3DTileFeature.getInfo().batchTable) {
                             if (!buffer.has(key)) {
@@ -91,8 +89,7 @@ class C3DTilesStyle extends Widget {
 
                 const fillColorFunction = (c3DTileFeature) => {
                     let result = null;
-                    // eslint-disable-next-line no-unused-vars
-                    for (const [keyValue, colorFunction] of colorFunctions) {
+                    for (const [, colorFunction] of colorFunctions) {
                         result = colorFunction(c3DTileFeature) || result;
                     }
                     return result;
@@ -103,8 +100,7 @@ class C3DTilesStyle extends Widget {
 
                 const fillOpacityFunction = (c3DTileFeature) => {
                     let result = 1;
-                    // eslint-disable-next-line no-unused-vars
-                    for (const [keyValue, opacityFunction] of opacityFunctions) {
+                    for (const [, opacityFunction] of opacityFunctions) {
                         result = opacityFunction(c3DTileFeature) || result;
                     }
                     return result;

--- a/test/unit/3dtileslayerstyle.js
+++ b/test/unit/3dtileslayerstyle.js
@@ -92,10 +92,8 @@ describe('3DTilesLayer Style', () => {
     });
 
     it('Set c3DTileFeatures user data', function () {
-        // eslint-disable-next-line no-unused-vars
-        for (const [tileId, tileC3DTileFeatures] of $3dTilesLayer.tilesC3DTileFeatures) {
-            // eslint-disable-next-line no-unused-vars
-            for (const [batchId, c3DTileFeature] of tileC3DTileFeatures) {
+        for (const [, tileC3DTileFeatures] of $3dTilesLayer.tilesC3DTileFeatures) {
+            for (const [, c3DTileFeature] of tileC3DTileFeatures) {
                 // eslint-disable-next-line guard-for-in
                 if (Math.random() > 0.5) {
                     c3DTileFeature.userData.something = 'random';


### PR DESCRIPTION
## Description
`C3DTFeature` reference the `THREE.Object3D` where they belong.
`computeWorldBox3` is now a method of `C3DTFeature` possible due to the latter modification
Some code clean.
`updateStyle` is call after dispacthing event `ON_TILE_CONTENT_LOADED`

## Motivation and Context
`C3DTFeature` reference the `THREE.Object3D` where they belong.
=> tileContent can have different child with feature in it which was not handle by the previous code
`updateStyle` is call after dispacthing event `ON_TILE_CONTENT_LOADED`
=> when listener of this event influences `C3DTilesLayer` style the user does not have to call an extra `updateStyle` of the layer

waiting this to be approved to rename commits name