### PR TITLE
Fix `View.pickObjectAt()`

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -741,7 +741,7 @@ class View extends THREE.EventDispatcher {
     pickObjectsAt(mouseOrEvt, radius = 0, where) {
         const sources = [];
 
-        if (!where || where.length === 0) {
+        if (!where) {
             where = this.getLayers(l => l.isGeometryLayer);
         }
         if (!Array.isArray(where)) {


### PR DESCRIPTION
## Description
`pickObjectAt` returns an empty array if parameter `where` is an empty array.

## Motivation and Context
`where` is a parameter of `pickObjectAt` to specify the layers to perform a pick.
The problem:  If `where` is an empty array, the function picks on all layers by default.

```js
const intersects = view.pickObjectsAt(
  event,
  0,
  view.getLayers().filter((el) => el.isC3DTilesLayer)
);
```
Here, if the application had dynamic layers¹ and no C3DTilesLayers in the `View`, `intersects` should be an empty array.

¹ *remove/add layers at runtime*