### PR TITLE
Fix pointcloud node subdivision for orthographic projections

### DIFF
--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -184,7 +184,7 @@ class PointCloudLayer extends GeometryLayer {
             this.material.opacity = this.opacity;
             this.material.transparent = this.opacity < 1;
             this.material.size = this.pointSize;
-            this.material.preSSE = context.camera.preSSE;
+            this.material.scale = context.camera.preSSE;
             if (this.material.updateUniforms) {
                 this.material.updateUniforms();
             }

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -108,7 +108,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
 
         this.vertexShader = PointsVS;
 
-        this.scale = options.scale || 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
+        const scale = options.scale || 0.05 * 0.5 / Math.tan(1.0 / 2.0); // autosizing scale
 
         CommonMaterial.setDefineMapping(this, 'PNTS_MODE', PNTS_MODE);
         CommonMaterial.setDefineMapping(this, 'PNTS_SHAPE', PNTS_SHAPE);
@@ -123,7 +123,7 @@ class PointsMaterial extends THREE.RawShaderMaterial {
         CommonMaterial.setUniformProperty(this, 'intensityRange', intensityRange);
         CommonMaterial.setUniformProperty(this, 'applyOpacityClassication', applyOpacityClassication);
         CommonMaterial.setUniformProperty(this, 'sizeMode', sizeMode);
-        CommonMaterial.setUniformProperty(this, 'preSSE', 1.0);
+        CommonMaterial.setUniformProperty(this, 'scale', scale);
         CommonMaterial.setUniformProperty(this, 'minAttenuatedSize', minAttenuatedSize);
         CommonMaterial.setUniformProperty(this, 'maxAttenuatedSize', maxAttenuatedSize);
 

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -8,7 +8,7 @@
 #include <logdepthbuf_pars_vertex>
 
 uniform float size;
-uniform float preSSE;
+uniform float scale;
 
 uniform bool picking;
 uniform int mode;
@@ -109,7 +109,7 @@ void main() {
         bool isPerspective = isPerspectiveMatrix(projectionMatrix);
 
         if (isPerspective) {
-            gl_PointSize *= preSSE / -mvPosition.z;
+            gl_PointSize *= scale / -mvPosition.z;
             gl_PointSize = clamp(gl_PointSize, minAttenuatedSize, maxAttenuatedSize);
         }
     }

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -103,12 +103,15 @@ void main() {
     #include <begin_vertex>
     #include <project_vertex>
 
-    if (sizeMode == PNTS_SIZE_MODE_VALUE) {
-        gl_PointSize = size;
-    } else if (sizeMode == PNTS_SIZE_MODE_ATTENUATED) {
-        gl_PointSize = size;
-        gl_PointSize *= (preSSE / -mvPosition.z);
-        gl_PointSize = clamp(gl_PointSize, minAttenuatedSize, maxAttenuatedSize);
+    gl_PointSize = size;
+
+    if (sizeMode == PNTS_SIZE_MODE_ATTENUATED) {
+        bool isPerspective = isPerspectiveMatrix(projectionMatrix);
+
+        if (isPerspective) {
+            gl_PointSize *= preSSE / -mvPosition.z;
+            gl_PointSize = clamp(gl_PointSize, minAttenuatedSize, maxAttenuatedSize);
+        }
     }
 
 #if defined(USE_TEXTURES_PROJECTIVE)


### PR DESCRIPTION
## Description
For now, point cloud layer's screen-space error (SSE) calculation is only valid for perspective cameras. This causes issues when using an orthographic camera (e.g. #2232: point cloud not updating).

This PR fixes two issues:
- do not compute point attenuation when using an orthographic projection
- add a new way to compute SSE when using an orthographic projection

## Related issues

closes #2232