### PR TITLE
Feature/add bbox url precision

### DIFF
--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -89,12 +89,19 @@ export default {
      * // http://server.geo/wms/BBOX=12,35,14,46&FORMAT=jpg&SERVICE=WMS
      *
      * @param {Extent} bbox - the bounding box
-     * @param {Source} source
+     * @param {Object} source
+     * @param {string} source.crs
+     * @param {number} source.bboxDigits
+     * @param {string} source.url
+     * @param {string} source.axisOrder
      *
      * @return {string} the formed url
      */
     bbox: function bbox(bbox, source) {
-        const precision = ((source.bboxUrlPrecision === undefined) && (source.crs == 'EPSG:4326')) ? 9 : source.bboxUrlPrecision;
+        let precision = source.crs == 'EPSG:4326' ? 9 : 2;
+        if (source.bboxDigits !== undefined) {
+            precision = source.bboxDigits;
+        }
         bbox.as(source.crs, extent);
         const w = extent.west.toFixed(precision);
         const s = extent.south.toFixed(precision);

--- a/src/Provider/URLBuilder.js
+++ b/src/Provider/URLBuilder.js
@@ -94,7 +94,7 @@ export default {
      * @return {string} the formed url
      */
     bbox: function bbox(bbox, source) {
-        const precision = source.crs == 'EPSG:4326' ? 9 : 2;
+        const precision = ((source.bboxUrlPrecision === undefined) && (source.crs == 'EPSG:4326')) ? 9 : source.bboxUrlPrecision;
         bbox.as(source.crs, extent);
         const w = extent.west.toFixed(precision);
         const s = extent.south.toFixed(precision);

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -104,6 +104,7 @@ let uid = 0;
  * @property {string} crs - The crs projection of the resources.
  * @property {string} attribution - The intellectual property rights for the
  * resources.
+ * @property {string} bboxUrlPrecision - The bbox decimal precision used in URL
  * @property {Extent} extent - The extent of the resources.
  * @property {function} parser - The method used to parse the resources attached
  * to the layer. iTowns provides some parsers, visible in the `Parser/` folder.
@@ -145,6 +146,7 @@ class Source extends InformationsData {
         this.isVectorSource = (source.parser || supportedParsers.get(source.format)) != undefined;
         this.networkOptions = source.networkOptions || { crossOrigin: 'anonymous' };
         this.attribution = source.attribution;
+        this.bboxUrlPrecision = source.bboxUrlPrecision === undefined ? 2 : source.bboxUrlPrecision;
         this.whenReady = Promise.resolve();
         this._featuresCaches = {};
         if (source.extent && !(source.extent.isExtent)) {

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -104,7 +104,6 @@ let uid = 0;
  * @property {string} crs - The crs projection of the resources.
  * @property {string} attribution - The intellectual property rights for the
  * resources.
- * @property {string} bboxUrlPrecision - The bbox decimal precision used in URL
  * @property {Extent} extent - The extent of the resources.
  * @property {function} parser - The method used to parse the resources attached
  * to the layer. iTowns provides some parsers, visible in the `Parser/` folder.
@@ -146,7 +145,6 @@ class Source extends InformationsData {
         this.isVectorSource = (source.parser || supportedParsers.get(source.format)) != undefined;
         this.networkOptions = source.networkOptions || { crossOrigin: 'anonymous' };
         this.attribution = source.attribution;
-        this.bboxUrlPrecision = source.bboxUrlPrecision === undefined ? 2 : source.bboxUrlPrecision;
         this.whenReady = Promise.resolve();
         this._featuresCaches = {};
         if (source.extent && !(source.extent.isExtent)) {

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -23,6 +23,7 @@ import CRS from 'Core/Geographic/Crs';
  * is 0.
  * @property {number} zoom.max - The maximum level of the source. Default value
  * is 21.
+ * @property {string} bboxDigits - The bbox digits precision used in URL
  * @property {Object} vendorSpecific - An object containing vendor specific
  * parameters. See for example a [list of these parameters for GeoServer]{@link
  * https://docs.geoserver.org/latest/en/user/services/wfs/vendor.html}. This
@@ -123,6 +124,7 @@ class WFSSource extends Source {
         this.isWFSSource = true;
         this.typeName = source.typeName;
         this.version = source.version || '2.0.2';
+        this.bboxDigits = source.bboxDigits;
 
         // Add ? at the end of the url if it is not already in the given URL
         if (!this.url.endsWith('?')) {

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -33,6 +33,7 @@ import URLBuilder from 'Provider/URLBuilder';
  * is 0.
  * @property {number} zoom.max - The maximum level of the source. Default value
  * is 21.
+ * @property {string} bboxDigits - The bbox digits precision used in URL
  * @property {Object} vendorSpecific - An object containing vendor specific
  * parameters. See for example a [list of these parameters for GeoServer]{@link
  * https://docs.geoserver.org/latest/en/user/services/wms/vendor.html}. This
@@ -99,6 +100,7 @@ class WMSSource extends Source {
         this.height = source.height || source.width || 256;
         this.version = source.version || '1.3.0';
         this.transparent = source.transparent || false;
+        this.bboxDigits = source.bboxDigits;
 
         if (!source.axisOrder) {
         // 4326 (lat/long) axis order depends on the WMS version used

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -34,7 +34,7 @@ describe('URL creations', function () {
         layer.crs = 'EPSG:4326';
         layer.axisOrder = 'wesn';
         layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
-        layer.bboxUrlPrecision = 4;
+        layer.bboxDigits = 4;
         const result = URLBuilder.bbox(extent, layer);
         assert.equal(result, 'http://server.geo/wms/BBOX=12.1235,14.9876,35.4590,46.9877&FORMAT=jpg&SERVICE=WMS');
     });

--- a/test/unit/provider_url.js
+++ b/test/unit/provider_url.js
@@ -29,6 +29,16 @@ describe('URL creations', function () {
         assert.equal(result, 'http://server.geo/wms/BBOX=12.000000000,14.000000000,35.000000000,46.000000000&FORMAT=jpg&SERVICE=WMS');
     });
 
+    it('should correctly replace %bbox by 12.1235,14.9876,35.4589,46.9877', function () {
+        const extent = new Extent('EPSG:4326', 12.123466, 14.98764, 35.45898, 46.987674);
+        layer.crs = 'EPSG:4326';
+        layer.axisOrder = 'wesn';
+        layer.url = 'http://server.geo/wms/BBOX=%bbox&FORMAT=jpg&SERVICE=WMS';
+        layer.bboxUrlPrecision = 4;
+        const result = URLBuilder.bbox(extent, layer);
+        assert.equal(result, 'http://server.geo/wms/BBOX=12.1235,14.9876,35.4590,46.9877&FORMAT=jpg&SERVICE=WMS');
+    });
+
     it('shouldn\'t use the scientific notation', function () {
         const extent = new Extent('EPSG:4326', 1 / 9999999999, 14, 35, 46);
         layer.crs = 'EPSG:4326';


### PR DESCRIPTION
## Description
When we try to use a custom WMS source (omniscale provider) we got some mistake if the coordinate in BBOX url is rounded.

## Motivation and Context
We would like to set custom precision of BBOX passed in url to solve our problem.
In our case if bbox precision is `9` it's work.

```
sourceMap = new itowns.WMSSource({
    url: `https://maps.omniscale.net/v2/${omniscaleKey}/style.default/map`,
    name: "osm",
    format: "image/png",
    crs: "EPSG:2154",
    extent: extent,
    version: '1.1.0',
    bboxUrlPrecision: 9
});
```

## Screenshots
`bboxUrlPrecision: 2`
![Capture d’écran 2023-12-19 à 16 34 09](https://github.com/iTowns/itowns/assets/39763266/dff1e15f-7e92-4f8b-9116-646d94df12b8)

`bboxUrlPrecision: 9`
![Capture d’écran 2023-12-19 à 16 33 44](https://github.com/iTowns/itowns/assets/39763266/566cee97-d282-4498-8c2f-94887f9c904b)



