### PR TITLE
Fix color layer rendering issue when using white to invisible effect

### DIFF
--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -27,13 +27,23 @@ import { deprecatedColorLayerOptions } from 'Core/Deprecated/Undeprecator';
  * @property {number} opacity - property to adjust transparency, opacity is between 0. and 1.
  * @property {boolean} transparent - specify if the layer could be transparent.
  * @property {boolean} noTextureParentOutsideLimit - don't parent texture if it's outside limit.
- * @property {number} effect_type - type effect to apply on raster color.
- * if `effect_type` equals:
- * * `0`: no special effect.
- * * `1`: light color to invisible effect.
- * * `2`: white color to invisible effect.
- * * `3`: custom shader effect (defined `ShaderChunk.customBodyColorLayer` and `ShaderChunk.customHeaderColorLayer`).
- * @property {number} effect_parameter - amount value used with effect applied on raster color.
+ * @property {number} effect_type - type effect to apply on the raster color.
+ * If `effect_type` equals:
+ * * `0`: no effect.
+ * * `1`: light color to invisible effect: transparency effect is stronger for
+ *   light colors (whose distance is closer to white). This effect can be
+ *   amplified by `effect_parameter`.
+ * * `2`: white color to invisible effect: white color is considered as
+ *   transparent.
+ * * `3`: custom shader effect: set `ShaderChunk.customBodyColorLayer` and
+ *   `ShaderChunk.customHeaderColorLayer` to add your own glsl code in
+ *   respectively the color layer function body and at top-level.
+ * @property {number} effect_parameter - value used as parameter of certain type
+ * of effects. If `effect_type` equals:
+ * * `0`: unused.
+ * * `1`: used to amplify the transparency effect.
+ * * `2`: unused.
+ * * `3`: could be used by your own glsl code.
  */
 class ColorLayer extends RasterLayer {
     /**

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -90,6 +90,9 @@ class ColorLayer extends RasterLayer {
         this.transparent = config.transparent || (this.opacity < 1.0);
         this.noTextureParentOutsideLimit = config.source ? config.source.isFileSource : false;
 
+        this.effect_type = config.effect_type ?? 0;
+        this.effect_parameter = config.effect_parameter ?? 1.0;
+
         // Feature options
         this.buildExtent = true;
         this.structure = '2d';

--- a/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
+++ b/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
@@ -23,10 +23,10 @@ float getBorderDistance(vec2 uv) {
 
 float tolerance = 0.99;
 
-vec4 applyWhiteToInvisibleEffect(vec4 color, float intensity) {
+vec4 applyWhiteToInvisibleEffect(vec4 color) {
     float a = dot(color.rgb, vec3(0.333333333));
     if (a >= tolerance) {
-        color.a *= 1.0 - pow(abs(a), intensity);
+        color.a = 0.0;
     }
     return color;
 }
@@ -72,7 +72,7 @@ vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer lay
         if (layer.effect_type == 1) {
             color = applyLightColorToInvisibleEffect(color, layer.effect_parameter);
         } else if (layer.effect_type == 2) {
-            color = applyWhiteToInvisibleEffect(color, layer.effect_parameter);
+            color = applyWhiteToInvisibleEffect(color);
         }
     }
     color.a *= layer.opacity;


### PR DESCRIPTION
## Description

Using `effect_type = 2`, which should set white color to transparent, renders it as black (more context in #2236). This PR fixes this issue and document more thoroughly `effect_type` and `effect_parameter` properties.

## Context

In this context, `effect_parameter` is passed as the `intensity` parameter of `applyWhiteToInvisibleEffect` and is used in [line 29](https://github.com/iTowns/itowns/blob/6737c930764c721d2770025f6da76e9ade67f6e8/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl#L29) of the shader. Since we do not set a default value to `effect_parameter` it is passed as undefined to the shader (which could lead to implementation-defined behavior).

Moreover, this PR remove the `intensity` parameter of `applyWhiteToInvisibleEffect` as it is used as exponent of a value $= 1.0$ (see [line 29](https://github.com/iTowns/itowns/blob/6737c930764c721d2770025f6da76e9ade67f6e8/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl#L29)). Removing it should cause no breaking change.

## Related issues

closes #2236 
