### PR TITLE
[Deps] Remove unecessary dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,7 +18,9 @@
             ]
         }],
         ["@babel/plugin-proposal-nullish-coalescing-operator"],
-        ["@babel/plugin-transform-runtime"],
+        ["@babel/plugin-transform-runtime", {
+            "regenerator": false
+        }],
         ["minify-replace", {
             "replacements": [{
                 "identifierName": "__DEBUG__",

--- a/.babelrc
+++ b/.babelrc
@@ -17,7 +17,6 @@
                 ".css"
             ]
         }],
-        ["@babel/plugin-proposal-nullish-coalescing-operator"],
         ["@babel/plugin-transform-runtime", {
             "regenerator": false
         }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "earcut": "^2.2.4",
         "js-priority-queue": "^0.1.5",
         "pbf": "^3.2.1",
-        "shpjs": "^4.0.4",
-        "text-encoding-utf-8": "^1.0.2"
+        "shpjs": "^4.0.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.5",
@@ -11990,11 +11989,6 @@
       "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
       "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==",
       "license": "Unlicense"
-    },
-    "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/text-extensions": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,7 @@
         "typescript": "^5.3.3",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^4.15.1",
-        "whatwg-fetch": "^3.6.19"
+        "webpack-dev-server": "^4.15.1"
       },
       "peerDependencies": {
         "proj4": "^2.9.2",
@@ -12891,12 +12890,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.19",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
-      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==",
-      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "replace-in-file": "^7.0.2",
         "three": "^0.159.0",
         "typescript": "^5.3.3",
-        "url-polyfill": "^1.1.12",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1",
@@ -12444,13 +12443,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url-polyfill": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.12.tgz",
-      "integrity": "sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/urlpattern-polyfill": {
       "version": "9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "earcut": "^2.2.4",
         "js-priority-queue": "^0.1.5",
         "pbf": "^3.2.1",
-        "regenerator-runtime": "^0.14.0",
         "shpjs": "^4.0.4",
         "text-encoding-utf-8": "^1.0.2"
       },
@@ -10577,11 +10576,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
       },
       "devDependencies": {
         "@babel/cli": "^7.22.5",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-transform-runtime": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
         "@babel/register": "^7.22.5",
@@ -689,23 +688,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.13.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
-      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "replace-in-file": "^7.0.2",
     "three": "^0.159.0",
     "typescript": "^5.3.3",
-    "url-polyfill": "^1.1.12",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "typescript": "^5.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1",
-    "whatwg-fetch": "^3.6.19"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "earcut": "^2.2.4",
     "js-priority-queue": "^0.1.5",
     "pbf": "^3.2.1",
-    "shpjs": "^4.0.4",
-    "text-encoding-utf-8": "^1.0.2"
+    "shpjs": "^4.0.4"
   },
   "peerDependencies": {
     "proj4": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "earcut": "^2.2.4",
     "js-priority-queue": "^0.1.5",
     "pbf": "^3.2.1",
-    "regenerator-runtime": "^0.14.0",
     "shpjs": "^4.0.4",
     "text-encoding-utf-8": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.22.5",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "@babel/plugin-transform-runtime": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/register": "^7.22.5",

--- a/src/Core/3DTiles/C3DTBatchTable.js
+++ b/src/Core/3DTiles/C3DTBatchTable.js
@@ -1,6 +1,7 @@
-import utf8Decoder from 'Utils/Utf8Decoder';
 import binaryPropertyAccessor from './utils/BinaryPropertyAccessor';
 import { C3DTilesTypes } from './C3DTilesEnums';
+
+const utf8Decoder = new TextDecoder();
 
 /** @classdesc
  * A 3D Tiles

--- a/src/Parser/B3dmParser.js
+++ b/src/Parser/B3dmParser.js
@@ -5,7 +5,6 @@ import { DRACOLoader } from 'ThreeExtended/loaders/DRACOLoader';
 import { KTX2Loader } from 'ThreeExtended/loaders/KTX2Loader';
 import LegacyGLTFLoader from 'Parser/deprecated/LegacyGLTFLoader';
 import shaderUtils from 'Renderer/Shader/ShaderUtils';
-import utf8Decoder from 'Utils/Utf8Decoder';
 import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
 import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
 import { MeshBasicMaterial } from 'three';
@@ -14,6 +13,8 @@ import disposeThreeMaterial from 'Utils/ThreeUtils';
 const matrixChangeUpVectorZtoY = (new THREE.Matrix4()).makeRotationX(Math.PI / 2);
 // For gltf rotation
 const matrixChangeUpVectorZtoX = (new THREE.Matrix4()).makeRotationZ(-Math.PI / 2);
+
+const utf8Decoder = new TextDecoder();
 
 export const glTFLoader = new GLTFLoader();
 

--- a/src/Parser/PntsParser.js
+++ b/src/Parser/PntsParser.js
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
-import utf8Decoder from 'Utils/Utf8Decoder';
 
 import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
+
+const utf8Decoder = new TextDecoder();
 
 export default {
     /** @module PntsParser */

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -3,8 +3,9 @@ import B3dmParser from 'Parser/B3dmParser';
 import PntsParser from 'Parser/PntsParser';
 import Fetcher from 'Provider/Fetcher';
 import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
-import utf8Decoder from 'Utils/Utf8Decoder';
 import PointsMaterial from 'Renderer/PointsMaterial';
+
+const utf8Decoder = new TextDecoder();
 
 function b3dmToMesh(data, layer, url) {
     const urlBase = THREE.LoaderUtils.extractUrlBase(url);

--- a/src/Utils/Utf8Decoder.js
+++ b/src/Utils/Utf8Decoder.js
@@ -1,7 +1,0 @@
-import {
-    TextDecoder as TextDecoderPolyfill,
-} from 'text-encoding-utf-8';
-
-export const TextDecoder = typeof global.TextDecoder === 'function' ? global.TextDecoder : TextDecoderPolyfill;
-
-export default new TextDecoder('utf-8');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,6 @@ module.exports = () => {
         entry: {
             itowns: [
                 'core-js',
-                'regenerator-runtime/runtime',
                 'url-polyfill',
                 'whatwg-fetch',
                 './src/MainBundle.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,6 @@ module.exports = () => {
         entry: {
             itowns: [
                 'core-js',
-                'url-polyfill',
                 'whatwg-fetch',
                 './src/MainBundle.js',
             ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,6 @@ module.exports = () => {
         entry: {
             itowns: [
                 'core-js',
-                'whatwg-fetch',
                 './src/MainBundle.js',
             ],
             debug: {


### PR DESCRIPTION
## Description
Follow-up of #2252 (and proposal #2256) which updates and formalizes the web browser requirements of iTowns.

## Motivation and Context
Following the target update in #2252, the following polyfills are not necessary anymore:
- `TextEncoder` polyfill
- `async/await` polyfill
- babel's null coalescing support plugin

Moreover, the following polyfills on webpack's generated bundle are not needed anymore:
- `fetch` polyfill
- `URL` polyfill

This list may not be exhaustive and I may have forgotten other polyfills.