### PR TITLE
feature: Add Cloud Optimized GeoTIFF (COG) sample

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -127,7 +127,9 @@
             "Plugins": [
                 "DragNDrop",
                 "FeatureToolTip",
-                "TIFFParser"
+                "TIFFParser",
+                "COGSource",
+                "COGParser"
             ],
 
             "Widgets": [

--- a/examples/config.json
+++ b/examples/config.json
@@ -56,7 +56,8 @@
         "source_file_kml_raster": "KML to raster",
         "source_file_kml_raster_usgs": "USGS KML flux to raster",
         "source_file_gpx_raster": "GPX to raster",
-        "source_file_gpx_3d": "GPX to 3D objects"
+        "source_file_gpx_3d": "GPX to 3D objects",
+        "source_file_cog": "Cloud Optimized GeoTIFF (COG)"
     },
 
     "Customize FileSource": {

--- a/examples/js/plugins/COGParser.js
+++ b/examples/js/plugins/COGParser.js
@@ -1,14 +1,25 @@
 /* global itowns, THREE */
 
 /**
+ * @typedef  {Object} GeoTIFFLevel
+ * @property {GeoTIFFImage} image
+ * @property {number} width
+ * @property {number} height
+ * @property {number[]} resolution
+ */
+
+/**
  * Select the best overview level (or the final image) to match the
  * requested extent and pixel width and height.
  *
- * @param {Source} source The COGSource
- * @param {Extent} requestExtent The window extent.
+ * @param {Object} source The COGSource
+ * @param {Extent} source.extent Source extent
+ * @param {GeoTIFFLevel[]} source.levels
+ * @param {THREE.Vector2} source.dimensions
+ * @param {Extent} requestExtent The node extent.
  * @param {number} requestWidth The pixel width of the window.
  * @param {number} requestHeight The pixel height of the window.
- * @returns {Object} The selected zoom level.
+ * @returns {GeoTIFFLevel} The selected zoom level.
  */
 function selectLevel(source, requestExtent, requestWidth, requestHeight) {
     // Number of images  = original + overviews if any
@@ -42,7 +53,8 @@ function selectLevel(source, requestExtent, requestWidth, requestHeight) {
 /**
  * Returns a window in the image's coordinates that matches the requested extent.
  *
- * @param {Source} source The COGSource
+ * @param {Object} source The COGSource
+ * @param {number[]} source.origin Root image origin as an XYZ-vector
  * @param {Extent} extent The window extent.
  * @param {number[]} resolution The spatial resolution of the window.
  * @returns {number[]} The window.
@@ -77,8 +89,10 @@ function makeWindowFromExtent(source, extent, resolution) {
 /**
  * Creates a texture from the pixel buffer(s).
  *
- * @param {Source} source The COGSource
- * @param {Object} buffers The buffers (one buffer per band)
+ * @param {Object} source The COGSource
+ * @param {THREE.TypedArray | THREE.TypedArray[]} buffers The buffers (one buffer per band)
+ * @param {number} buffers.width
+ * @param {number} buffers.height
  * @returns {THREE.DataTexture} The generated texture.
  */
 function createTexture(source, buffers) {
@@ -86,31 +100,22 @@ function createTexture(source, buffers) {
     const pixelCount = width * height;
     const targetDataType = source.dataType;
 
-    let format;
-    let channelCount;
-    switch (buffers.length) {
-        case 1:
-        case 2:
-            format = THREE.RGFormat;
-            channelCount = 2;
-            break;
-        default:
-            format = THREE.RGBAFormat;
-            channelCount = 4;
-            break;
-    }
+    // There is no dedicated code in fragment shader to interpret red and green pairs
+    // So we consider there are 4 channel
+    const format = THREE.RGBAFormat;
+    const channelCount = 4;
 
     let texture;
     switch (targetDataType) {
         case THREE.UnsignedByteType: {
             const buf = new Uint8ClampedArray(pixelCount * channelCount);
-            const data = fillBuffer(source, buf, { noData: source.noData }, source.opaqueByte, buffers);
+            const data = fillBuffer(buffers, buf, source, source.defaultAlpha);
             texture = new THREE.DataTexture(data, width, height, format, THREE.UnsignedByteType);
             break;
         }
         case THREE.FloatType: {
             const buf = new Float32Array(pixelCount * channelCount);
-            const data = fillBuffer(source, buf, { noData: source.noData }, source.opaqueFloat, buffers);
+            const data = fillBuffer(buffers, buf, source, source.defaultAlpha / 255);
             texture = new THREE.DataTexture(data, width, height, format, THREE.FloatType);
             break;
         }
@@ -121,83 +126,75 @@ function createTexture(source, buffers) {
     return texture;
 }
 
-
 // Important note : a lot of code is duplicated to avoid putting
 // conditional branches inside loops, as this can severely reduce performance.
 // Note: we don't use Number.isNan(x) in the loops as it slows down the loop due to function
 // invocation. Instead, we use x !== x, as a NaN is never equal to itself.
 /* eslint no-self-compare: 0 */
-function fillBuffer(source, buffers, options, opaqueValue, pixelData) {
-    let getValue;
-
-    if (options.scaling !== undefined) {
-        const { min, max } = options.scaling;
-        getValue = x => Math.floor(THREE.MathUtils.mapLinear(x, min, max, 0, 255));
-    } else {
-        getValue = x => x;
-    }
-
+function fillBuffer(pixelData, buffers, source, alphaValue) {
+    // 1 color band
     if (pixelData.length === 1) {
         const v = pixelData[0];
         const length = v.length;
         for (let i = 0; i < length; i++) {
-            const idx = i * 2;
+            const idx = i * 4;
             let value;
             let a;
             const raw = v[i];
-            if (raw !== raw || raw === options.noData) {
-                value = source.defaultNoData;
-                a = source.defaultTransparent;
+            if (raw !== raw || raw === source.noData) {
+                value = source.defaultNoColor;
+                a = source.defaultNoAlpha;
             } else {
                 value = raw;
-                a = opaqueValue;
+                a = alphaValue;
             }
             buffers[idx + 0] = value;
-            buffers[idx + 1] = a;
+            buffers[idx + 1] = value;
+            buffers[idx + 2] = value;
+            buffers[idx + 3] = a;
         }
     }
+    // 2 band => color + alpha
     if (pixelData.length === 2) {
         const v = pixelData[0];
         const a = pixelData[1];
         const length = v.length;
         for (let i = 0; i < length; i++) {
-            const idx = i * 2;
+            const idx = i * 4;
             let value;
             const raw = v[i];
-            if (raw !== raw || raw === options.noData) {
-                value = source.defaultNoData;
+            if (raw !== raw || raw === source.noData) {
+                value = source.defaultNoColor;
             } else {
                 value = raw;
             }
             buffers[idx + 0] = value;
-            buffers[idx + 1] = a[i];
+            buffers[idx + 1] = value;
+            buffers[idx + 2] = value;
+            buffers[idx + 3] = a;
         }
     }
+    // 3 band => RGB
     if (pixelData.length === 3) {
         const rChannel = pixelData[0];
         const gChannel = pixelData[1];
         const bChannel = pixelData[2];
         const length = rChannel.length;
-        let a;
         for (let i = 0; i < length; i++) {
             const idx = i * 4;
 
             let r = rChannel[i];
             let g = gChannel[i];
             let b = bChannel[i];
+            let a = alphaValue;
 
-            if ((r !== r || r === options.noData)
-                && (g !== g || g === options.noData)
-                && (b !== b || b === options.noData)) {
-                r = source.defaultNoData;
-                g = source.defaultNoData;
-                b = source.defaultNoData;
-                a = source.defaultTransparent;
-            } else {
-                r = getValue(r);
-                g = getValue(g);
-                b = getValue(b);
-                a = opaqueValue;
+            if ((r !== r || r === source.noData)
+                && (g !== g || g === source.noData)
+                && (b !== b || b === source.noData)) {
+                r = source.defaultNoColor;
+                g = source.defaultNoColor;
+                b = source.defaultNoColor;
+                a = source.defaultNoColor;
             }
 
             buffers[idx + 0] = r;
@@ -206,6 +203,7 @@ function fillBuffer(source, buffers, options, opaqueValue, pixelData) {
             buffers[idx + 3] = a;
         }
     }
+    // 4 band => RGBA
     if (pixelData.length === 4) {
         const rChannel = pixelData[0];
         const gChannel = pixelData[1];
@@ -219,17 +217,13 @@ function fillBuffer(source, buffers, options, opaqueValue, pixelData) {
             let b = bChannel[i];
             let a = aChannel[i];
 
-            if ((r !== r || r === options.noData)
-                && (g !== g || g === options.noData)
-                && (b !== b || b === options.noData)) {
-                r = source.defaultNoData;
-                g = source.defaultNoData;
-                b = source.defaultNoData;
-                a = source.defaultTransparent;
-            } else {
-                r = getValue(r);
-                g = getValue(g);
-                b = getValue(b);
+            if ((r !== r || r === source.noData)
+                && (g !== g || g === source.noData)
+                && (b !== b || b === source.noData)) {
+                r = source.defaultNoColor;
+                g = source.defaultNoColor;
+                b = source.defaultNoColor;
+                a = source.defaultNoAlpha;
             }
 
             buffers[idx + 0] = r;
@@ -271,8 +265,13 @@ const COGParser = (function _() {
          * Parse a COG file and return a `THREE.DataTexture`.
          *
          * @param {Object} data Data passed with the Tile extent
+         * @param {Extent} data.extent
          * @param {Object} options Options (contains source)
-         * @return {Promise} A promise resolving with a `THREE.DataTexture`.
+         * @param {Object} options.in
+         * @param {COGSource} options.in.source
+         * @param {number} options.in.tileWidth
+         * @param {number} options.in.tileHeight
+         * @return {Promise<THREE.DataTexture>} A promise resolving with a `THREE.DataTexture`.
          *
          * @memberof module:COGParser
          */
@@ -282,11 +281,11 @@ const COGParser = (function _() {
             const level = selectLevel(source, nodeExtent, source.tileWidth, source.tileHeight);
             const viewport = makeWindowFromExtent(source, nodeExtent, level.resolution);
 
-            const buffers = await level.image.readRasters({
-                pool: source.pool,
-                fillValue: source.nodata,
-                samples: source.channels,
+            const buffers = await level.image.readRGB({
                 window: viewport,
+                pool: source.pool,
+                enableAlpha: true,
+                interleave: false,
             });
 
             const texture = createTexture(source, buffers);

--- a/examples/js/plugins/COGParser.js
+++ b/examples/js/plugins/COGParser.js
@@ -246,7 +246,7 @@ function fillBuffer(source, buffers, options, opaqueValue, pixelData) {
  * method that takes a COG in and gives a `THREE.DataTexture` that can be
  * displayed in the view.
  *
- * It needs the [geotiff](https://www.npmjs.com/package/geotiff) library to parse the
+ * It needs the [geotiff](https://github.com/geotiffjs/geotiff.js/) library to parse the
  * COG.
  *
  * @example

--- a/examples/js/plugins/COGParser.js
+++ b/examples/js/plugins/COGParser.js
@@ -1,0 +1,306 @@
+/* global itowns, THREE */
+
+/**
+ * Select the best overview level (or the final image) to match the
+ * requested extent and pixel width and height.
+ *
+ * @param {Source} source The COGSource
+ * @param {Extent} requestExtent The window extent.
+ * @param {number} requestWidth The pixel width of the window.
+ * @param {number} requestHeight The pixel height of the window.
+ * @returns {Object} The selected zoom level.
+ */
+function selectLevel(source, requestExtent, requestWidth, requestHeight) {
+    // Number of images  = original + overviews if any
+    const cropped = requestExtent.clone().intersect(source.extent);
+    // Dimensions of the requested extent
+    const extentDimension = cropped.planarDimensions();
+
+    const targetResolution = Math.min(
+        extentDimension.x / requestWidth,
+        extentDimension.y / requestHeight,
+    );
+
+    let level;
+
+    // Select the image with the best resolution for our needs
+    for (let index = source.levels.length - 1; index >= 0; index--) {
+        level = source.levels[index];
+        const sourceResolution = Math.min(
+            source.dimensions.x / level.width,
+            source.dimensions.y / level.height,
+        );
+
+        if (targetResolution >= sourceResolution) {
+            break;
+        }
+    }
+
+    return level;
+}
+
+/**
+ * Returns a window in the image's coordinates that matches the requested extent.
+ *
+ * @param {Source} source The COGSource
+ * @param {Extent} extent The window extent.
+ * @param {number[]} resolution The spatial resolution of the window.
+ * @returns {number[]} The window.
+ */
+function makeWindowFromExtent(source, extent, resolution) {
+    const [oX, oY] = source.origin;
+    const [imageResX, imageResY] = resolution;
+
+    const wnd = [
+        Math.round((extent.west - oX) / imageResX),
+        Math.round((extent.north - oY) / imageResY),
+        Math.round((extent.east - oX) / imageResX),
+        Math.round((extent.south - oY) / imageResY),
+    ];
+
+    const xMin = Math.min(wnd[0], wnd[2]);
+    let xMax = Math.max(wnd[0], wnd[2]);
+    const yMin = Math.min(wnd[1], wnd[3]);
+    let yMax = Math.max(wnd[1], wnd[3]);
+
+    // prevent zero-sized requests
+    if (Math.abs(xMax - xMin) === 0) {
+        xMax += 1;
+    }
+    if (Math.abs(yMax - yMin) === 0) {
+        yMax += 1;
+    }
+
+    return [xMin, yMin, xMax, yMax];
+}
+
+/**
+ * Creates a texture from the pixel buffer(s).
+ *
+ * @param {Source} source The COGSource
+ * @param {Object} buffers The buffers (one buffer per band)
+ * @returns {THREE.DataTexture} The generated texture.
+ */
+function createTexture(source, buffers) {
+    const { width, height } = buffers;
+    const pixelCount = width * height;
+    const targetDataType = source.dataType;
+
+    let format;
+    let channelCount;
+    switch (buffers.length) {
+        case 1:
+        case 2:
+            format = THREE.RGFormat;
+            channelCount = 2;
+            break;
+        default:
+            format = THREE.RGBAFormat;
+            channelCount = 4;
+            break;
+    }
+
+    let texture;
+    switch (targetDataType) {
+        case THREE.UnsignedByteType: {
+            const buf = new Uint8ClampedArray(pixelCount * channelCount);
+            const data = fillBuffer(source, buf, { noData: source.noData }, source.opaqueByte, buffers);
+            texture = new THREE.DataTexture(data, width, height, format, THREE.UnsignedByteType);
+            break;
+        }
+        case THREE.FloatType: {
+            const buf = new Float32Array(pixelCount * channelCount);
+            const data = fillBuffer(source, buf, { noData: source.noData }, source.opaqueFloat, buffers);
+            texture = new THREE.DataTexture(data, width, height, format, THREE.FloatType);
+            break;
+        }
+        default:
+            throw new Error('unsupported data type');
+    }
+
+    return texture;
+}
+
+
+// Important note : a lot of code is duplicated to avoid putting
+// conditional branches inside loops, as this can severely reduce performance.
+// Note: we don't use Number.isNan(x) in the loops as it slows down the loop due to function
+// invocation. Instead, we use x !== x, as a NaN is never equal to itself.
+/* eslint no-self-compare: 0 */
+function fillBuffer(source, buffers, options, opaqueValue, pixelData) {
+    let getValue;
+
+    if (options.scaling !== undefined) {
+        const { min, max } = options.scaling;
+        getValue = x => Math.floor(THREE.MathUtils.mapLinear(x, min, max, 0, 255));
+    } else {
+        getValue = x => x;
+    }
+
+    if (pixelData.length === 1) {
+        const v = pixelData[0];
+        const length = v.length;
+        for (let i = 0; i < length; i++) {
+            const idx = i * 2;
+            let value;
+            let a;
+            const raw = v[i];
+            if (raw !== raw || raw === options.noData) {
+                value = source.defaultNoData;
+                a = source.defaultTransparent;
+            } else {
+                value = raw;
+                a = opaqueValue;
+            }
+            buffers[idx + 0] = value;
+            buffers[idx + 1] = a;
+        }
+    }
+    if (pixelData.length === 2) {
+        const v = pixelData[0];
+        const a = pixelData[1];
+        const length = v.length;
+        for (let i = 0; i < length; i++) {
+            const idx = i * 2;
+            let value;
+            const raw = v[i];
+            if (raw !== raw || raw === options.noData) {
+                value = source.defaultNoData;
+            } else {
+                value = raw;
+            }
+            buffers[idx + 0] = value;
+            buffers[idx + 1] = a[i];
+        }
+    }
+    if (pixelData.length === 3) {
+        const rChannel = pixelData[0];
+        const gChannel = pixelData[1];
+        const bChannel = pixelData[2];
+        const length = rChannel.length;
+        let a;
+        for (let i = 0; i < length; i++) {
+            const idx = i * 4;
+
+            let r = rChannel[i];
+            let g = gChannel[i];
+            let b = bChannel[i];
+
+            if ((r !== r || r === options.noData)
+                && (g !== g || g === options.noData)
+                && (b !== b || b === options.noData)) {
+                r = source.defaultNoData;
+                g = source.defaultNoData;
+                b = source.defaultNoData;
+                a = source.defaultTransparent;
+            } else {
+                r = getValue(r);
+                g = getValue(g);
+                b = getValue(b);
+                a = opaqueValue;
+            }
+
+            buffers[idx + 0] = r;
+            buffers[idx + 1] = g;
+            buffers[idx + 2] = b;
+            buffers[idx + 3] = a;
+        }
+    }
+    if (pixelData.length === 4) {
+        const rChannel = pixelData[0];
+        const gChannel = pixelData[1];
+        const bChannel = pixelData[2];
+        const aChannel = pixelData[3];
+        const length = rChannel.length;
+        for (let i = 0; i < length; i++) {
+            const idx = i * 4;
+            let r = rChannel[i];
+            let g = gChannel[i];
+            let b = bChannel[i];
+            let a = aChannel[i];
+
+            if ((r !== r || r === options.noData)
+                && (g !== g || g === options.noData)
+                && (b !== b || b === options.noData)) {
+                r = source.defaultNoData;
+                g = source.defaultNoData;
+                b = source.defaultNoData;
+                a = source.defaultTransparent;
+            } else {
+                r = getValue(r);
+                g = getValue(g);
+                b = getValue(b);
+            }
+
+            buffers[idx + 0] = r;
+            buffers[idx + 1] = g;
+            buffers[idx + 2] = b;
+            buffers[idx + 3] = a;
+        }
+    }
+    return buffers;
+}
+
+/**
+ * The COGParser module provides a [parse]{@link module:COGParser.parse}
+ * method that takes a COG in and gives a `THREE.DataTexture` that can be
+ * displayed in the view.
+ *
+ * It needs the [geotiff](https://www.npmjs.com/package/geotiff) library to parse the
+ * COG.
+ *
+ * @example
+ * GeoTIFF.fromUrl('http://image.tif')
+ *     .then(COGParser.parse)
+ *     .then(function _(texture) {
+ *         var source = new itowns.FileSource({ features: texture });
+ *         var layer = new itowns.ColorLayer('cog', { source });
+ *         view.addLayer(layer);
+ *     });
+ *
+ * @module COGParser
+ */
+const COGParser = (function _() {
+    if (typeof THREE == 'undefined'  && itowns.THREE) {
+        // eslint-disable-next-line no-global-assign
+        THREE = itowns.THREE;
+    }
+
+    return {
+        /**
+         * Parse a COG file and return a `THREE.DataTexture`.
+         *
+         * @param {Object} data Data passed with the Tile extent
+         * @param {Object} options Options (contains source)
+         * @return {Promise} A promise resolving with a `THREE.DataTexture`.
+         *
+         * @memberof module:COGParser
+         */
+        parse: async function _(data, options) {
+            const source = options.in;
+            const nodeExtent = data.extent.as(source.crs);
+            const level = selectLevel(source, nodeExtent, source.tileWidth, source.tileHeight);
+            const viewport = makeWindowFromExtent(source, nodeExtent, level.resolution);
+
+            const buffers = await level.image.readRasters({
+                pool: source.pool,
+                fillValue: source.nodata,
+                samples: source.channels,
+                window: viewport,
+            });
+
+            const texture = createTexture(source, buffers);
+            texture.flipY = true;
+            texture.extent = data.extent;
+            texture.needsUpdate = true;
+            texture.magFilter = THREE.LinearFilter;
+            texture.minFilter = THREE.LinearFilter;
+
+            return Promise.resolve(texture);
+        },
+    };
+}());
+
+if (typeof module != 'undefined' && module.exports) {
+    module.exports = COGParser;
+}

--- a/examples/js/plugins/COGSource.js
+++ b/examples/js/plugins/COGSource.js
@@ -14,9 +14,6 @@
  * @property {number} zoom.max - The maximum level of the source. Default value is Infinity.
  * @property {string} url - The URL of the COG.
  * @property {GeoTIFF.Pool} pool - Pool use to decode GeoTiff.
- * @property {number} noData - Byte used to determine if it is a byte data or not. Default value is 255.
- * @property {number} defaultNoColor - Color byte value to apply if it's match {@link noData}. Default value is 255.
- * @property {number} defaultNoAlpha - Alpha byte value to apply if it's match {@link noData}. Default value is 0.
  * @property {number} defaultAlpha - Alpha byte value used if no alpha is present in COG. Default value is 255.
  *
  * @example
@@ -54,8 +51,6 @@ class COGSource extends itowns.Source {
         this.fetcher = () => Promise.resolve({});
         this.parser = COGParser.parse;
 
-        this.defaultNoDataColor = source.defaultNoDataColor || 255;
-        this.defaultNoDataAlpha = source.defaultNoDataAlpha || 0;
         this.defaultAlpha = source.defaultAlpha || 255;
 
         this.whenReady = GeoTIFF.fromUrl(this.url)
@@ -63,7 +58,6 @@ class COGSource extends itowns.Source {
                 this.geotiff = geotiff;
                 this.firstImage = await geotiff.getImage();
                 this.origin = this.firstImage.getOrigin();
-                this.noData = source.noData ?? this.firstImage.getGDALNoData();
                 this.dataType = this.selectDataType(this.firstImage.getSampleFormat(), this.firstImage.getBitsPerSample());
 
                 this.tileWidth = this.firstImage.getTileWidth();

--- a/examples/js/plugins/COGSource.js
+++ b/examples/js/plugins/COGSource.js
@@ -1,0 +1,123 @@
+/* global itowns, GeoTIFF, COGParser, THREE  */
+
+/**
+ * @classdesc
+ * An object defining the source of resources to get from a [COG]{@link
+ * https://www.cogeo.org/} file. It
+ * inherits from {@link Source}.
+ *
+ * @extends Source
+ *
+ * @example
+ * // Create the source
+ * const cogSource = new itowns.COGSource({
+ *     url: 'https://cdn.jsdelivr.net/gh/iTowns/iTowns2-sample-data/cog/orvault.tif',
+ * });
+ *
+ * // Create the layer
+ * const colorLayer = new itowns.ColorLayer('COG', {
+ *     source: cogSource,
+ * });
+ *
+ * // Add the layer
+ * view.addLayer(colorLayer);
+ */
+class COGSource extends itowns.Source {
+    /**
+     * @param {Object} source - An object that can contain all properties of a
+     * COGSource and {@link Source}. Only `url` is mandatory.
+     *
+     * @constructor
+     */
+    constructor(source) {
+        super(source);
+
+        if (source.zoom) {
+            this.zoom = source.zoom;
+        } else {
+            this.zoom = { min: 0, max: Infinity };
+        }
+
+        this.url = source.url;
+        this.pool = source.pool || new GeoTIFF.Pool();
+        // We don't use fetcher, we let geotiff.js manage it
+        this.fetcher = () => Promise.resolve({});
+        this.parser = COGParser.parse;
+
+        this.defaultNoData = source.defaultNoData || 255;
+        this.defaultTransparent = source.defaultTransparent || 0;
+        this.opaqueByte = source.opaqueByte || 255;
+        this.opaqueFloat = source.opaqueFloat || 1;
+
+        this.whenReady = GeoTIFF.fromUrl(this.url)
+            .then(async (geotiff) => {
+                this.geotiff = geotiff;
+                this.firstImage = await geotiff.getImage();
+                this.origin = this.firstImage.getOrigin();
+                this.noData = (source.noData !== undefined) ? source.noData : this.firstImage.getGDALNoData();
+                this.dataType = this.selectDataType(this.firstImage.getSampleFormat(), this.firstImage.getBitsPerSample());
+
+                this.channels = [];
+                for (let i = 0; i < this.firstImage.getSamplesPerPixel(); i += 1) {
+                    this.channels.push(i);
+                }
+
+                this.tileWidth = this.firstImage.getTileWidth();
+                this.tileHeight = this.firstImage.getTileHeight();
+
+                // Compute extent
+                const [minX, minY, maxX, maxY] = this.firstImage.getBoundingBox();
+                this.extent = new itowns.Extent(this.crs, minX, maxX, minY, maxY);
+                this.dimensions = this.extent.planarDimensions();
+
+                this.levels = [];
+                this.levels.push(this.makeLevel(this.firstImage, this.firstImage.getResolution()));
+
+                // Number of images (original + overviews)
+                const imageCount = await this.geotiff.getImageCount();
+
+                // We want to preserve the order of the overviews so we await them inside
+                // the loop not to have the smallest overviews coming before the biggest
+                for (let index = 1; index < imageCount; index++) {
+                    // eslint-disable-next-line no-await-in-loop
+                    const image = await this.geotiff.getImage(index);
+                    this.levels.push(this.makeLevel(image, image.getResolution(this.firstImage)));
+                }
+            });
+    }
+
+    selectDataType(format, bitsPerSample) {
+        switch (format) {
+            case 1: // unsigned integer data
+                if (bitsPerSample <= 8) {
+                    return THREE.UnsignedByteType;
+                }
+                break;
+            default:
+                break;
+        }
+        return THREE.FloatType;
+    }
+
+    makeLevel(image, resolution) {
+        return {
+            image,
+            width: image.getWidth(),
+            height: image.getHeight(),
+            resolution,
+        };
+    }
+
+    // We don't use UrlFromExtent, we let geotiff.js manage it
+    urlFromExtent() {
+        return '';
+    }
+
+    extentInsideLimit(extent) {
+        return this.extent.intersectsExtent(extent);
+    }
+}
+
+if (typeof module != 'undefined' && module.exports) {
+    module.exports = COGSource;
+}

--- a/examples/source_file_cog.html
+++ b/examples/source_file_cog.html
@@ -1,41 +1,82 @@
 <html>
-<head>
-    <title>Cloud Optimized GeoTiff</title>
-    <meta charset="UTF-8">
-    <link rel="stylesheet" type="text/css" href="css/example.css">
-    <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+    <head>
+        <title>Cloud Optimized GeoTiff</title>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
-</head>
-<body>
-<div id="viewerDiv"></div>
-<script src="js/GUI/GuiTools.js"></script>
-<script src="../dist/itowns.js"></script>
-<script src="../dist/debug.js"></script>
-<script src="js/GUI/LoadingScreen.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/geotiff"></script>
-<script src="js/plugins/COGParser.js"></script>
-<script src="js/plugins/COGSource.js"></script>
-<script type="text/javascript">
-    itowns.proj4.defs('EPSG:3947', '+proj=lcc +lat_0=47 +lon_0=3 +lat_1=46.25 +lat_2=47.75 +x_0=1700000 +y_0=6200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
-    var viewerDiv = document.getElementById('viewerDiv');
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                left: 10px;
+            }
+        </style>
 
-    // create a source from a Cloud Optimized GeoTiff
-    var cogSource = new COGSource({
-        url: 'https://cdn.jsdelivr.net/gh/bloc-in-bloc/iTowns2-sample-data@add-cog-sample/cog/orvault.tif',
-        crs: 'EPSG:3947'
-    });
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="description">
+            <div>Specify the URL of a COG to load:
+                <input type="text" id="cog_url" />
+            </div>
+            <div>Specify the CRS of the COG:
+                <input type="text" id="cog_crs" />
+            </div>
+            <button onclick="readCOGURL()">Load</button>
+            <button onclick="loadSample()">Load sample</button>
+        </div>
+        <div id="viewerDiv"></div>
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="../dist/debug.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/geotiff"></script>
+        <script src="js/plugins/COGParser.js"></script>
+        <script src="js/plugins/COGSource.js"></script>
+        <script type="text/javascript">
+            itowns.proj4.defs('EPSG:3947', '+proj=lcc +lat_0=47 +lon_0=3 +lat_1=46.25 +lat_2=47.75 +x_0=1700000 +y_0=6200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
+            itowns.proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs +type=crs');
+            itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
-    cogSource.whenReady.then(() => {
-        var view = new itowns.PlanarView(viewerDiv, cogSource.extent, { disableSkirt: true, placement: { tilt: 90 } });
-        setupLoadingScreen(viewerDiv, view);
-        new itowns.PlanarControls(view, {});
-        var cogLayer = new itowns.ColorLayer('cog', {
-            source: cogSource,
-        });
-        view.addLayer(cogLayer);
-    });
-</script>
-</body>
+            var viewerDiv = document.getElementById('viewerDiv');
+
+            function readCOGURL() {
+                var url = document.getElementById('cog_url').value || new URLSearchParams(window.location.search).get('geotiff');
+                var crs = document.getElementById('cog_crs').value || new URLSearchParams(window.location.search).get('crs');
+
+                if (url && crs) {
+                    loadCOG(url, crs);
+                    document.getElementById('cog_url').value = url;
+                    document.getElementById('cog_crs').value = crs;
+                }
+            }
+
+            function loadSample() {
+                document.getElementById('cog_url').value = 'https://cdn.jsdelivr.net/gh/bloc-in-bloc/iTowns2-sample-data@add-cog-sample/cog/orvault.tif';
+                document.getElementById('cog_crs').value = 'EPSG:3947';
+                readCOGURL();
+            }
+
+            function loadCOG(url, crs) {
+                // create a source from a Cloud Optimized GeoTiff
+                var cogSource = new COGSource({
+                    url: url,
+                    crs: crs
+                });
+
+                cogSource.whenReady.then(() => {
+                    var view = new itowns.PlanarView(viewerDiv, cogSource.extent, { disableSkirt: true, placement: { tilt: 90 } });
+                    setupLoadingScreen(viewerDiv, view);
+                    new itowns.PlanarControls(view, {});
+                    var cogLayer = new itowns.ColorLayer('cog', {
+                        source: cogSource,
+                    });
+                    view.addLayer(cogLayer);
+                });
+            }
+
+            readCOGURL();
+        </script>
+    </body>
 </html>

--- a/examples/source_file_cog.html
+++ b/examples/source_file_cog.html
@@ -19,12 +19,10 @@
         <div id="description">
             <div>Specify the URL of a COG to load:
                 <input type="text" id="cog_url" />
+                <button onclick="readCOGURL()">Load</button>
             </div>
-            <div>Specify the CRS of the COG:
-                <input type="text" id="cog_crs" />
-            </div>
-            <button onclick="readCOGURL()">Load</button>
-            <button onclick="loadSample()">Load sample</button>
+            <button onclick="loadRGBSample()">Load RGB sample</button>
+            <button onclick="load1BandSample()">Load 1 band sample</button>
         </div>
         <div id="viewerDiv"></div>
         <script src="js/GUI/GuiTools.js"></script>
@@ -35,26 +33,26 @@
         <script src="js/plugins/COGParser.js"></script>
         <script src="js/plugins/COGSource.js"></script>
         <script type="text/javascript">
-            itowns.proj4.defs('EPSG:3947', '+proj=lcc +lat_0=47 +lon_0=3 +lat_1=46.25 +lat_2=47.75 +x_0=1700000 +y_0=6200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
-            itowns.proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs +type=crs');
             itowns.proj4.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
             var viewerDiv = document.getElementById('viewerDiv');
 
             function readCOGURL() {
                 var url = document.getElementById('cog_url').value || new URLSearchParams(window.location.search).get('geotiff');
-                var crs = document.getElementById('cog_crs').value || new URLSearchParams(window.location.search).get('crs');
 
-                if (url && crs) {
-                    loadCOG(url, crs);
+                if (url) {
+                    loadCOG(url);
                     document.getElementById('cog_url').value = url;
-                    document.getElementById('cog_crs').value = crs;
                 }
             }
 
-            function loadSample() {
+            function loadRGBSample() {
                 document.getElementById('cog_url').value = 'https://cdn.jsdelivr.net/gh/bloc-in-bloc/iTowns2-sample-data@add-cog-sample/cog/orvault.tif';
-                document.getElementById('cog_crs').value = 'EPSG:3947';
+                readCOGURL();
+            }
+
+            function load1BandSample() {
+                document.getElementById('cog_url').value = 'https://oin-hotosm.s3.amazonaws.com/60fbca155a90f10006fd2fc3/0/60fbca155a90f10006fd2fc4.tif';
                 readCOGURL();
             }
 
@@ -62,7 +60,7 @@
                 // create a source from a Cloud Optimized GeoTiff
                 var cogSource = new COGSource({
                     url: url,
-                    crs: crs
+                    crs: "EPSG:2154"
                 });
 
                 cogSource.whenReady.then(() => {

--- a/examples/source_file_cog.html
+++ b/examples/source_file_cog.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+    <title>Cloud Optimized GeoTiff</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="css/example.css">
+    <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+</head>
+<body>
+<div id="viewerDiv"></div>
+<script src="js/GUI/GuiTools.js"></script>
+<script src="../dist/itowns.js"></script>
+<script src="../dist/debug.js"></script>
+<script src="js/GUI/LoadingScreen.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/geotiff"></script>
+<script src="js/plugins/COGParser.js"></script>
+<script src="js/plugins/COGSource.js"></script>
+<script type="text/javascript">
+    itowns.proj4.defs('EPSG:3947', '+proj=lcc +lat_0=47 +lon_0=3 +lat_1=46.25 +lat_2=47.75 +x_0=1700000 +y_0=6200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
+    var viewerDiv = document.getElementById('viewerDiv');
+
+    // create a source from a Cloud Optimized GeoTiff
+    var cogSource = new COGSource({
+        url: 'https://cdn.jsdelivr.net/gh/bloc-in-bloc/iTowns2-sample-data@add-cog-sample/cog/orvault.tif',
+        crs: 'EPSG:3947'
+    });
+
+    cogSource.whenReady.then(() => {
+        var view = new itowns.PlanarView(viewerDiv, cogSource.extent, { disableSkirt: true, placement: { tilt: 90 } });
+        setupLoadingScreen(viewerDiv, view);
+        new itowns.PlanarControls(view, {});
+        var cogLayer = new itowns.ColorLayer('cog', {
+            source: cogSource,
+        });
+        view.addLayer(cogLayer);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description
We need to display Cloud Optimized GeoTIFF ([COG](https://www.cogeo.org/)) with iTowns.
A [pull request](https://github.com/iTowns/itowns/pull/1307) already exist about COG but it seems to be abandoned.
We tried to used PR but we got some trouble with UTIF library to parse COG.
We think [geotiff](https://github.com/geotiffjs/geotiff.js/) is a better library to parse COG.

## Motivation and Context
We need to display heavy georeferenced tif file (geotiff) which come from CAD software.
We think the best solution is to convert geotiff to COG and display it with iTowns.
Maybe it can help [this discussion](https://github.com/iTowns/itowns/discussions/2181) ?

We will change the sample url if [this PR](https://github.com/iTowns/iTowns2-sample-data/pull/17) on itowns data is accepted (or maybe we don't need to change the sample url ?).
