### PR TITLE
[Requirements] Update web browsers requirements for iTowns

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
-    "presets": [["@babel/preset-env", { "modules": "auto" }]],
+    "presets": [
+        ["@babel/preset-env", {
+            "targets": {
+                "browsers": "defaults and supports webgl2"
+            },
+            "modules": "auto"
+        }]
+    ],
     "plugins": [
         ["module-resolver",  { "root": ["./src"] } ],
         ["babel-plugin-inline-import", {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ different data formats (3dTiles, GeoJSON, Vector Tiles, GPX and much more). A
 complete list of features and supported data formats is [available on the
 wiki](https://github.com/iTowns/itowns/wiki/Supported-Features).
 
+It officially targets the last two major versions of both Firefox, Safari and
+Chromium-based browsers (Chrome, Edge, ...) at the date of each release. Older
+browsers supporting WebGL 2.0 may work but we do not offer support.
+
 ![iTowns screenshot](https://raw.githubusercontent.com/iTowns/itowns.github.io/master/images/itownsReleaseXS.jpg)
 
 ## Documentation and examples

--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -17,7 +17,10 @@ global.URL = function URL(url) {
     };
 };
 
-global.Event = () => {};
+// https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-instanceofoperator
+// ES standard requires that left-hand side shall have a prototype method, this
+// is not the case for lambdas.
+global.Event = function () {};
 global.requestAnimationFrame = () => {};
 global.fetch = fetch;
 global.fetch.Promise = Promise;
@@ -184,7 +187,7 @@ global.document.emitEvent = (event, params) => {
 global.document.documentElement = global.document.createElement();
 global.document.body = new DOMElement();
 
-global.XRRigidTransform = () => {};
+global.XRRigidTransform = class {};
 
 class Path2D {
     moveTo() {}


### PR DESCRIPTION
## Description
This PR updates and formalizes the web browser requirements for iTowns.
See proposal #2256.

## Motivation and Context
We are currently using babel's [preset-env](https://babeljs.io/docs/babel-preset-env) plugin to decide which syntax transforms and polyfills are used during the transpilation step. However, we do not set an [output target](https://babeljs.io/docs/options#output-targets) in its configuration which causes
> Babel [to] assume you are targeting the oldest browsers possible [...] @babel/preset-env will transform all ES2015-ES2020 code to be ES5 compatible.
[Source](https://babeljs.io/docs/options#no-targets)

This PR aims to:
- formalize which browsers and versions are supported by iTowns (defaults target as decided by the linked proposal which supports webgl2).
- reduce the transpiled code size by supporting more recent browsers

Removing unnecessary polyfills for modules well-supported by our target is the object of the follow-up PR #2248