### PR TITLE
fix(tests): prevent overwriting `navigator.userAgent`

### DIFF
--- a/test/unit/bootstrap.js
+++ b/test/unit/bootstrap.js
@@ -23,9 +23,13 @@ global.fetch = fetch;
 global.fetch.Promise = Promise;
 
 // this could be replaced by jsdom.Navigator in https://github.com/iTowns/itowns/pull/1412
-global.navigator = {
-    userAgent: 'firefox',
-};
+// Checking if global.navigator exists targets node versions <21.1.0. Since node
+// <21.1.0, global.navigator is read-only.
+if (!global.navigator) {
+    global.navigator = {
+        userAgent: 'firefox',
+    };
+}
 
 class DOMElement {
     constructor() {


### PR DESCRIPTION
## Before contributing

- [x] I have read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
<!--- Describe your changes in detail -->

As discussed in #2254, the `navigator.userAgent` has been made read-only in [node 21.1.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V21.md#2023-10-24-version-2110-current-targos) (see [this commit](https://github.com/nodejs/node/commit/5a52c518ef)).

In this PR, we check if navigator is already set (allegedly by node). If that's the case, we don't overwrite it.
