### PR TITLE
Migrate from dat.gui to lil-gui

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/3dtiles_basic.html
+++ b/examples/3dtiles_basic.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/3dtiles_batch_table.html
+++ b/examples/3dtiles_batch_table.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/3dtiles_ion.html
+++ b/examples/3dtiles_ion.html
@@ -18,7 +18,7 @@
         </style>
 
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">

--- a/examples/3dtiles_pointcloud.html
+++ b/examples/3dtiles_pointcloud.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">

--- a/examples/customColorLayerEffect.html
+++ b/examples/customColorLayerEffect.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/effects_split.html
+++ b/examples/effects_split.html
@@ -27,7 +27,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/effects_stereo.html
+++ b/examples/effects_stereo.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv">

--- a/examples/entwine_3d_loader.html
+++ b/examples/entwine_3d_loader.html
@@ -14,7 +14,7 @@
         </style>
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">Specify the URL of a Entwine Point Tree to load:

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -14,7 +14,7 @@
         </style>
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">Specify the URL of a Entwine Point Tree to load:
@@ -31,7 +31,7 @@
         <script src="js/GUI/LoadingScreen.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">
-            var debugGui = new dat.GUI();
+            var debugGui = new lil.GUI();
             var viewerDiv = document.getElementById('viewerDiv');
             viewerDiv.style.display = 'block';
             var view = new itowns.View('EPSG:3946', viewerDiv);

--- a/examples/geoid_geoidLayer.html
+++ b/examples/geoid_geoidLayer.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/js/GUI/GuiTools.js
+++ b/examples/js/GUI/GuiTools.js
@@ -4,33 +4,30 @@
  * Description: Classe pour créer un menu.
  */
 
-/* global dat, itowns */
+/* global lil, itowns */
 
-dat.GUI.prototype.removeFolder = function removeFolder(name) {
-    const folder = this.__folders[name];
-    if (!folder) {
-        return;
-    }
-    folder.close();
-    this.__ul.removeChild(folder.domElement.parentNode);
-    delete this.__folders[name];
-    this.onResize();
+lil.GUI.prototype.findFolderByTitle = function findFolderByTitle(name) {
+    return this.folders.find(f => f.$title.innerText === name);
 };
 
-dat.GUI.prototype.colorLayerFolder = function colorLayerFolder(name, value) {
-    const folder = this.__folders[name];
+lil.GUI.prototype.removeFolder = function removeFolder(name) {
+    const folder = this.findFolderByTitle(name);
     if (!folder) {
         return;
     }
-    const title = folder.__ul.getElementsByClassName('title')[0];
+    folder.destroy();
+};
+
+lil.GUI.prototype.colorLayerFolder = function colorLayerFolder(name, value) {
+    const folder = this.findFolderByTitle(name);
+    if (!folder) {
+        return;
+    }
+    const title = folder.$title;
 
     if (title.style) {
         title.style.background = value;
     }
-};
-
-dat.GUI.prototype.hasFolder = function hasFolder(name) {
-    return this.__folders[name];
 };
 
 function GuiTools(domId, view, w) {
@@ -38,12 +35,16 @@ function GuiTools(domId, view, w) {
         const width = w || 245;
         const element = document.createElement('div');
         element.id = 'menuDiv';
-        this.gui = new dat.GUI({ autoPlace: false, width: width });
+        this.gui = new lil.GUI({ autoPlace: false, width: width });
+        this.gui.close();
         element.appendChild(this.gui.domElement);
         document.body.appendChild(element);
         this.colorGui = this.gui.addFolder('Color Layers');
         this.elevationGui = this.gui.addFolder('Elevation Layers');
         this.geoidGui = this.gui.addFolder('Geoid Layers');
+        this.elevationGui.close();
+        this.colorGui.close();
+        this.geoidGui.close();
         this.elevationGui.hide();
         this.colorGui.hide();
         this.geoidGui.hide();
@@ -80,9 +81,9 @@ GuiTools.prototype.addLayersGUI = function fnAddLayersGUI() {
 };
 
 GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {
-    if (this.colorGui.hasFolder(layer.id)) { return; }
     this.colorGui.show();
     const folder = this.colorGui.addFolder(layer.id);
+    folder.close();
     folder.add({ visible: layer.visible }, 'visible').onChange((function updateVisibility(value) {
         layer.visible = value;
         this.view.notifyChange(layer);
@@ -98,9 +99,9 @@ GuiTools.prototype.addImageryLayerGUI = function addImageryLayerGUI(layer) {
 };
 
 GuiTools.prototype.addElevationLayerGUI = function addElevationLayerGUI(layer) {
-    if (this.elevationGui.hasFolder(layer.id)) { return; }
     this.elevationGui.show();
     const folder = this.elevationGui.addFolder(layer.id);
+    folder.close();
     folder.add({ frozen: layer.frozen }, 'frozen').onChange(function refreshFrozenGui(value) {
         layer.frozen = value;
     });
@@ -111,9 +112,9 @@ GuiTools.prototype.addElevationLayerGUI = function addElevationLayerGUI(layer) {
 };
 
 GuiTools.prototype.addGeoidLayerGUI = function addGeoidLayerGUI(layer) {
-    if (this.geoidGui.hasFolder(layer.id)) { return; }
     this.geoidGui.show();
     const folder = this.geoidGui.addFolder(layer.id);
+    folder.close();
     folder.add({ frozen: layer.frozen }, 'frozen').onChange(function refreshFrozenGui(value) {
         layer.frozen = value;
     });

--- a/examples/laz_dragndrop.html
+++ b/examples/laz_dragndrop.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv">

--- a/examples/mars.html
+++ b/examples/mars.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/misc_camera_animation.html
+++ b/examples/misc_camera_animation.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/misc_camera_traveling.html
+++ b/examples/misc_camera_traveling.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
     	<div id="description">

--- a/examples/misc_clamp_ground.html
+++ b/examples/misc_clamp_ground.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/misc_collada.html
+++ b/examples/misc_collada.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/misc_colorlayer_visibility.html
+++ b/examples/misc_colorlayer_visibility.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/example.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/misc_compare_25d_3d.html
+++ b/examples/misc_compare_25d_3d.html
@@ -45,7 +45,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/misc_custom_controls.html
+++ b/examples/misc_custom_controls.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
 </head>
 <body>
 <div id="description">

--- a/examples/misc_custom_label.html
+++ b/examples/misc_custom_label.html
@@ -25,7 +25,7 @@
     </style>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
 </head>
 <body>
 <div id="description">

--- a/examples/misc_georeferenced_images.html
+++ b/examples/misc_georeferenced_images.html
@@ -17,7 +17,7 @@
         </style>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
         <script src="js/OrientedImageHelper.js"></script>
     </head>
     <body>

--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css" />
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">

--- a/examples/misc_orthographic_camera.html
+++ b/examples/misc_orthographic_camera.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">

--- a/examples/plugins_drag_n_drop.html
+++ b/examples/plugins_drag_n_drop.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv">

--- a/examples/plugins_pyramidal_tiff.html
+++ b/examples/plugins_pyramidal_tiff.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/plugins_vrt.html
+++ b/examples/plugins_vrt.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.0.1/papaparse.min.js"></script>
     </head>
     <body>

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -34,7 +34,7 @@
         </div>
 
         <div>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
             <script src="../dist/itowns.js"></script>
             <script src="js/GUI/LoadingScreen.js"></script>
             <script src="../dist/debug.js"></script>
@@ -52,7 +52,7 @@
                 viewerDiv = document.getElementById('viewerDiv');
                 viewerDiv.style.display = 'block';
 
-                debugGui = new dat.GUI();
+                debugGui = new lil.GUI();
 
                 // TODO: do we really need to disable logarithmicDepthBuffer ?
                 view = new itowns.View('EPSG:3946', viewerDiv);

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -32,7 +32,7 @@
     <body>
         <div id="viewerDiv"></div>
         <div id="info"></div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/GUI/LoadingScreen.js"></script>
         <script src="../dist/debug.js"></script>
@@ -46,7 +46,7 @@
             viewerDiv = document.getElementById('viewerDiv');
             viewerDiv.style.display = 'block';
 
-            debugGui = new dat.GUI();
+            debugGui = new lil.GUI();
 
             var placement = {
                 coord: new itowns.Coordinates('EPSG:4326',  4.631512, 43.675626),

--- a/examples/source_file_from_fetched_data.html
+++ b/examples/source_file_from_fetched_data.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
 </head>
 <body>
 <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_from_format.html
+++ b/examples/source_file_from_format.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
 </head>
 <body>
 <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_from_methods.html
+++ b/examples/source_file_from_methods.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
 </head>
 <body>
 <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_from_parsed_data.html
+++ b/examples/source_file_from_parsed_data.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
 </head>
 <body>
 <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_geojson_3d.html
+++ b/examples/source_file_geojson_3d.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_geojson_raster.html
+++ b/examples/source_file_geojson_raster.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_geojson_raster_2.html
+++ b/examples/source_file_geojson_raster_2.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_gpx_raster.html
+++ b/examples/source_file_gpx_raster.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_kml_raster.html
+++ b/examples/source_file_kml_raster.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_kml_raster_usgs.html
+++ b/examples/source_file_kml_raster_usgs.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/source_file_shapefile.html
+++ b/examples/source_file_shapefile.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/vector_tile_3d_mesh.html
+++ b/examples/vector_tile_3d_mesh.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/vector_tile_3d_mesh_mapbox.html
+++ b/examples/vector_tile_3d_mesh_mapbox.html
@@ -10,7 +10,7 @@
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
         <link rel="stylesheet" type="text/css" href="css/mapbox.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/vector_tile_dragndrop.html
+++ b/examples/vector_tile_dragndrop.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/vector_tile_raster_3d.html
+++ b/examples/vector_tile_raster_3d.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/view_25d_map.html
+++ b/examples/view_25d_map.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="description">

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/view_3d_mns_map.html
+++ b/examples/view_3d_mns_map.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/view_immersive.html
+++ b/examples/view_immersive.html
@@ -18,7 +18,7 @@
         </div>
         <div id="viewerDiv"></div>
         <script src="../dist/itowns.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
         <script src="js/GUI/GuiTools.js"></script>
         <script src="../dist/debug.js"></script>
         <script type="text/javascript">

--- a/examples/widgets_3dtiles_style.html
+++ b/examples/widgets_3dtiles_style.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
         <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv" class="viewer"></div>

--- a/examples/widgets_minimap.html
+++ b/examples/widgets_minimap.html
@@ -13,7 +13,7 @@
         can be found here : https://raw.githubusercontent.com/iTowns/itowns/master/examples/css/widgets.css -->
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <!-- Add a description -->

--- a/examples/widgets_navigation.html
+++ b/examples/widgets_navigation.html
@@ -13,7 +13,7 @@
         can be found here : https://raw.githubusercontent.com/iTowns/itowns/master/examples/css/widgets.css -->
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <div id="viewerDiv"></div>

--- a/examples/widgets_scale.html
+++ b/examples/widgets_scale.html
@@ -13,7 +13,7 @@
         can be found here : https://raw.githubusercontent.com/iTowns/itowns/master/examples/css/widgets.css -->
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <!-- Create a container for itowns viewer -->

--- a/examples/widgets_searchbar.html
+++ b/examples/widgets_searchbar.html
@@ -13,7 +13,7 @@
         can be found here : https://raw.githubusercontent.com/iTowns/itowns/master/examples/css/widgets.css -->
         <link rel="stylesheet" type="text/css" href="css/widgets.css">
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19.1/dist/lil-gui.umd.min.js"></script>
     </head>
     <body>
         <!-- Create a container for itowns viewer -->

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -28,11 +28,8 @@ describe('GlobeControls with globe example', function _() {
                 };
 
             // Hide GUI :
-            debugMenu.gui.remove(cRL);
-            minimap.hide();
-            navigation.hide();
-            searchbar.hide();
-            scale.hide();
+            debugMenu.gui.close();
+            // Hide GUI :
         });
 
         middleWidth = await page.evaluate(() => window.innerWidth / 2);

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -47,6 +47,7 @@ function Debug(view, datDebugTool, chartDivContainer) {
 
     // DEBUG CONTROLS
     const gui = datDebugTool.addFolder('Debug Tools');
+    gui.close();
 
     const state = {
         displayCharts: false,

--- a/utils/debug/GeometryDebug.js
+++ b/utils/debug/GeometryDebug.js
@@ -34,6 +34,7 @@ export default {
 
     createGeometryDebugUI(datDebugTool, view, layer) {
         const gui = datDebugTool.addFolder(`Layer ${layer.id}`);
+        gui.close();
         gui.add(layer, 'visible').name('Visible').onChange(() => view.notifyChange(layer));
         gui.add(layer, 'opacity', 0, 1).name('Opacity').onChange(() => view.notifyChange(layer));
         return gui;

--- a/utils/debug/PotreeDebug.js
+++ b/utils/debug/PotreeDebug.js
@@ -4,6 +4,7 @@ export default {
     initTools(view, layer, datUi) {
         const update = () => view.notifyChange(layer, true);
         layer.debugUI = datUi.addFolder(`${layer.id}`);
+        layer.debugUI.close();
 
         layer.debugUI.add(layer, 'visible').name('Visible').onChange(update);
         layer.debugUI.add(layer, 'sseThreshold').name('SSE threshold').onChange(update);
@@ -20,6 +21,7 @@ export default {
         layer.dbgDisplayParents = true;
 
         const styleUI = layer.debugUI.addFolder('Styling');
+        styleUI.close();
         if (layer.material.mode != undefined) {
             styleUI.add(layer.material, 'mode', PNTS_MODE).name('Display mode').onChange(update);
             styleUI.add(layer, 'maxIntensityRange', 0, 1).name('Intensity max').onChange(update);
@@ -42,6 +44,7 @@ export default {
 
         // UI
         const debugUI = layer.debugUI.addFolder('Debug');
+        debugUI.close();
         debugUI.add(layer.bboxes, 'visible').name('Display Bounding Boxes').onChange(update);
         debugUI.add(layer, 'dbgStickyNode').name('Sticky node name').onChange(update);
         debugUI.add(layer, 'dbgDisplaySticky').name('Display sticky node').onChange(update);


### PR DESCRIPTION
## Before contributing

Read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
Follow-up of #2197, this PR migrates our examples and [`GuiTools`](https://github.com/iTowns/itowns/blob/master/examples/js/GUI/GuiTools.js), from `dat.gui` to [`lil-gui`](https://lil-gui.georgealways.com/) (used by three.js).