### PR TITLE
Webpack: Stop watching node modules in dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,7 +99,7 @@ module.exports = () => {
             static: {
                 directory: path.resolve(__dirname, './'),
                 watch: {
-                    ignored: path.resolve(__dirname, '.git'),
+                    ignored: [path.resolve(__dirname, '.git'), path.resolve(__dirname, 'node_modules')],
                 },
             },
             client: {


### PR DESCRIPTION
## Description
Prevent webpack from watching for node modules changes in dev mode (inspired from [the official doc](https://webpack.js.org/configuration/watch/#watchoptionsignored))

## Motivation and Context
I sometime get the following error when running `npm start`: `Error: ENOSPC: System limit for number of file watchers reached, especially when I have other projects running with webpack at the same time. I found at that webpack is by default also looking for changes in `node_modules/` which is in 99.9% of cases not useful and increases greatly the number of files to watch.
