### PR TITLE
3D tiles: fix a bug and improve perfs

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -308,8 +308,8 @@ class C3DTilesLayer extends GeometryLayer {
                     throw new Error('no batchTable');
                 }
 
-                const geometryAttributes = child.geometry.attributes;
-                let currentBatchId = geometryAttributes._BATCHID.array[0];
+                const batchIdAttribute = child.geometry.getAttribute('_BATCHID');
+                let currentBatchId = batchIdAttribute.getX(0);
                 let start = 0;
                 let count = 0;
 
@@ -336,9 +336,11 @@ class C3DTilesLayer extends GeometryLayer {
                     }
                 };
 
-                for (let index = 0; index < geometryAttributes.position.array.length; index += geometryAttributes.position.itemSize) {
-                    const batchIndex = index / geometryAttributes.position.itemSize;
-                    const batchId = geometryAttributes._BATCHID.array[batchIndex];
+                const positionAttribute = child.geometry.getAttribute('position');
+                const positionAttributeSize = positionAttribute.count * positionAttribute.itemSize;
+                for (let index = 0; index < positionAttributeSize; index += positionAttribute.itemSize) {
+                    const batchIndex = index / positionAttribute.itemSize;
+                    const batchId = batchIdAttribute.getX(batchIndex);
 
                     // check if batchId is currentBatchId
                     if (currentBatchId !== batchId) {
@@ -354,7 +356,7 @@ class C3DTilesLayer extends GeometryLayer {
                     count++;
 
                     // check if end of the array
-                    if (index + geometryAttributes.position.itemSize >= geometryAttributes.position.array.length) {
+                    if (index + positionAttribute.itemSize >= positionAttributeSize) {
                         registerBatchIdGroup();
                     }
                 }

--- a/test/unit/3dtilesbatchtable.js
+++ b/test/unit/3dtilesbatchtable.js
@@ -1,16 +1,8 @@
 import assert from 'assert';
 import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
+import { obj2ArrayBuff } from './utils';
 
 describe('3D Tiles batch table', function () {
-    // encode a javascript object into an arraybuffer (based on the 3D Tiles batch table encoding)
-    function obj2ArrayBuff(obj) {
-        const objJSON = JSON.stringify(obj);
-        const encoder = new TextEncoder();
-        const objUtf8 = encoder.encode(objJSON);
-        const objUint8 = new Uint8Array(objUtf8);
-        return objUint8.buffer;
-    }
-
     it('Should parse JSON batch table from buffer', function () {
         const batchTable = {
             a1: ['bah', 'tah', 'ratata', 'lo'],
@@ -53,5 +45,23 @@ describe('3D Tiles batch table', function () {
         const batchTableObj = new C3DTBatchTable(batchTableBuffer, jsonPartBuffer.byteLength, binPartBuffer.byteLength, 3, {});
 
         assert.deepStrictEqual(expectedBatchTable, batchTableObj.content);
+    });
+
+    it('Should get batch table info for a given id', function () {
+        const batchTableJSON = {
+            name: ['Ferme', 'Mas des Tourelles', 'Mairie'],
+            height: [10, 12, 6],
+        };
+        const batchTableBuffer = obj2ArrayBuff(batchTableJSON);
+        const batchTable = new C3DTBatchTable(batchTableBuffer, batchTableBuffer.byteLength, 0, 4, {});
+
+        const batchInfo = batchTable.getInfoById(0);
+        const expectedBatchInfo = {
+            batchTable: {
+                name: 'Ferme',
+                height: 10,
+            },
+        };
+        assert.deepStrictEqual(batchInfo, expectedBatchInfo);
     });
 });

--- a/test/unit/3dtilesbatchtablehierarchy.js
+++ b/test/unit/3dtilesbatchtablehierarchy.js
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import C3DTBatchTableHierarchyExtension from 'Core/3DTiles/C3DTBatchTableHierarchyExtension';
+
+const batchTableHierarchyJSON = {
+    classes: [
+        {
+            name: 'Wall',
+            length: 6,
+            instances: {
+                color: ['white', 'red', 'yellow', 'gray', 'brown', 'black'],
+            },
+        },
+        {
+            name: 'Building',
+            length: 3,
+            instances: {
+                name: ['unit29', 'unit20', 'unit93'],
+                address: ['100 Main St', '102 Main St', '104 Main St'],
+            },
+        },
+        {
+            name: 'Owner',
+            length: 3,
+            instances: {
+                type: ['city', 'resident', 'commercial'],
+                id: [1120, 1250, 6445],
+            },
+        },
+    ],
+    instancesLength: 12,
+    classIds: [0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2],
+    parentCounts: [1, 3, 2, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+    parentIds: [6, 6, 10, 11, 7, 11, 7, 8, 8, 10, 10, 9],
+};
+
+const batchTableHierarchy = new C3DTBatchTableHierarchyExtension(batchTableHierarchyJSON);
+
+describe('3D Tiles batch table hierarchy extension', function () {
+    it('Should get info for a given id', function () {
+        const expectedInfo = {
+            Wall: {
+                color: 'white',
+            },
+            Building: {
+                name: 'unit29',
+                address: '100 Main St',
+            },
+            Owner: {
+                type: 'resident',
+                id: 1250,
+            },
+        };
+        const info = batchTableHierarchy.getInfoById(0);
+        assert.deepStrictEqual(info, expectedInfo);
+    });
+});

--- a/test/unit/3dtilesfeature.js
+++ b/test/unit/3dtilesfeature.js
@@ -1,0 +1,28 @@
+import assert from 'assert';
+import * as THREE from 'three';
+import C3DTFeature from 'Core/3DTiles/C3DTFeature';
+import C3DTBatchTable from 'Core/3DTiles/C3DTBatchTable';
+import { obj2ArrayBuff } from './utils';
+
+
+describe('3D tiles feature', () => {
+    const obj = new THREE.Object3D();
+    const batchTableJson = {
+        id: [12, 158],
+        height: [13, 22],
+    };
+    const batchTableBuffer = obj2ArrayBuff(batchTableJson);
+    obj.batchTable = new C3DTBatchTable(batchTableBuffer, batchTableBuffer.byteLength, 0, 2, {});
+    const feature = new C3DTFeature(1, 1, { start: 0, count: 6 }, {}, obj);
+
+    it('Get batch table info for feature batch id', function () {
+        const expectedInfo = {
+            batchTable: {
+                id: 158,
+                height: 22,
+            },
+        };
+        const info = feature.getInfo();
+        assert.deepStrictEqual(info, expectedInfo);
+    });
+});

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -13,3 +13,12 @@ export function compareArrayWithEpsilon(arr1, arr2, epsilon) {
     }
     return true;
 }
+
+// encode a javascript object into an arraybuffer (based on the 3D Tiles batch table encoding)
+export function obj2ArrayBuff(obj) {
+    const objJSON = JSON.stringify(obj);
+    const encoder = new TextEncoder();
+    const objUtf8 = encoder.encode(objJSON);
+    const objUint8 = new Uint8Array(objUtf8);
+    return objUint8.buffer;
+}


### PR DESCRIPTION
## Description
This PR introduces two changes:

* Fixes #2074 (that also caused tiles to be removed and never loaded again when removed from the cache): the issue came from accessing threejs buffer attributes array directly instead of using the recommended `getX()` method (which is not the same in the case of [InterleavedBufferAttribute](https://threejs.org/docs/index.html?q=interleaved#api/en/core/InterleavedBufferAttribute).

* Greatly improves 3D tiles perfs (see screenshots below) by reducing loading time overhead due to internal structures pre-filling (mainly for 3D tiles picking and style) -> part of these structures are now filled on first demand.

## Screenshots

Performance profiling on `3dtiles_ion.html` example before the second commit:

![before-PR-getInfoById](https://github.com/iTowns/itowns/assets/16967916/9541a9eb-e3f0-49d7-acca-27ba07c62599)

Performance profiling on `3dtiles_ion.html` example after the second commit:

![afterPR-getInfoById](https://github.com/iTowns/itowns/assets/16967916/d25bb8b3-e40a-400b-8ac9-9554a18d6d01)



