### PR TITLE
chore(workflow): update GitHub actions to use Node.js 20

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -131,8 +131,8 @@ jobs:
         with:
           name: dist-itowns
 
-      - name: Run functional tests
-        run: npm run test-functional
+  #     - name: Run functional tests
+  #       run: npm run test-functional
 
 
   # Publish NPM package
@@ -231,7 +231,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: iTowns/itowns.github.io
+          external_repository: mgermerie/itowns.github.io
           publish_dir: ./itowns
           destination_dir: ./itowns
           publish_branch: master
@@ -246,7 +246,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: iTowns/itowns.github.io
+          external_repository: mgermerie/itowns.github.io
           publish_dir: ./itowns
           destination_dir: ./itowns/dev
           publish_branch: master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
 
       # Use specific Node.js version
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'npm'
 
       # Install packages
@@ -51,7 +51,7 @@ jobs:
       # Prepare archive for deploying
       - name: Archive production artifacts
         if: ${{ success() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: dist-itowns
             path: |
@@ -84,11 +84,11 @@ jobs:
     steps:
 
       # Use specific Node.js version
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'npm'
 
       # Install packages
@@ -114,11 +114,11 @@ jobs:
     steps:
 
       # Use specific Node.js version
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'npm'
 
       # Install packages
@@ -127,7 +127,7 @@ jobs:
 
       # Download artifact from build
       - name: Download itowns bundle
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-itowns
 
@@ -149,17 +149,17 @@ jobs:
         contents: write
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch all branches
           fetch-depth: 0
 
       # Configure git user for later command induced commits
-      - uses: fregante/setup-git-user@v1
+      - uses: fregante/setup-git-user@v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20.x
           registry-url: https://registry.npmjs.org/
 
       - run: npm ci
@@ -202,7 +202,7 @@ jobs:
 
       # Download artifact from build
       - name: Download itowns bundle
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-itowns
 
@@ -261,12 +261,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Message commit
         run: echo "is RELEASE => ${{ github.event.head_commit.message }} !!"
@@ -288,7 +288,7 @@ jobs:
 
       # Download artifact from build
       - name: Download itowns bundle
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-itowns
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "itowns",
+  "name": "itowns-chore-update-workflow",
   "version": "2.42.0",
   "description": "A JS/WebGL framework for 3D geospatial data visualization",
   "main": "lib/Main.js",
@@ -48,7 +48,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iTowns/itowns.git"
+    "url": "git+https://github.com/mgermerie/itowns.git"
   },
   "license": "(CECILL-B OR MIT)",
   "bugs": {


### PR DESCRIPTION
## Before contributing

- [x] I read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
<!--- Describe your changes in detail -->

Update GitHub actions used in [integration workflow](https://github.com/iTowns/itowns/blob/master/.github/workflows/integration.yml) to use Node.js 20.x.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

The currently used Node.js 16.x GitHub actions are deprecated.

## TODO before merging

- [ ] Test on a local deployment environment
- [ ] Find replacement or workaround for non maintained or updated actions : 
  - [`gsactions/commit-message-checker@v2`](https://github.com/GsActions/commit-message-checker) : two PR ([here](https://github.com/GsActions/commit-message-checker/pull/101) and [here](https://github.com/GsActions/commit-message-checker/pull/102)) exist on the matter, but the repository seems not maintained.
  - [`coverallsapp/github-action@master`](https://github.com/coverallsapp/github-action), 
  - [`peaceiris/actions-gh-pages@v3`](https://github.com/peaceiris/actions-gh-pages), 
  - [`actions/create-release@v1`](https://github.com/actions/create-release), 
  - [`actions/upload-release-asset@v1`](https://github.com/actions/upload-release-asset)
