### PR TITLE
fix(examples): migrate ign and grandlyon urls

### DIFF
--- a/examples/layers/JSONLayers/Administrative.json
+++ b/examples/layers/JSONLayers/Administrative.json
@@ -6,7 +6,7 @@
   "transparent": true,
   "source": {
     "crs": "EPSG:3857",
-    "url": "https://wxs.ign.fr/administratif/geoportail/wmts",
+    "url": "https://data.geopf.fr/wmts?",
     "format": "image/png",
     "name": "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
     "style": "normal",

--- a/examples/layers/JSONLayers/Cada.json
+++ b/examples/layers/JSONLayers/Cada.json
@@ -5,7 +5,7 @@
   "opacity": 1,
   "transparent": true,
   "source": {
-    "url": "https://wxs.ign.fr/parcellaire/geoportail/wmts",
+    "url": "https://data.geopf.fr/wmts?",
     "crs": "EPSG:3857",
     "networkOptions": {
       "crossOrigin": "omit"

--- a/examples/layers/JSONLayers/Cassini.json
+++ b/examples/layers/JSONLayers/Cassini.json
@@ -1,7 +1,7 @@
 {
     "id":         "Cassini",
     "source": {
-        "url": "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
+        "url": "https://data.geopf.fr/wmts?",
         "crs": "EPSG:3857",
         "networkOptions": {
             "crossOrigin": "anonymous"

--- a/examples/layers/JSONLayers/Denomination.json
+++ b/examples/layers/JSONLayers/Denomination.json
@@ -5,7 +5,7 @@
   "opacity": 1,
   "transparent": true,
   "source": {
-    "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+    "url": "https://data.geopf.fr/wmts?",
     "crs": "EPSG:3857",
     "tileMatrixSet": "PM",
     "format": "image/png",

--- a/examples/layers/JSONLayers/EtatMajor.json
+++ b/examples/layers/JSONLayers/EtatMajor.json
@@ -1,10 +1,10 @@
 {
-    "id":         "Etat major (1850)",
+    "id": "Etat major (1850)",
     "opacity": 1,
     "transparent": true,
     "source": {
         "crs": "EPSG:3857",
-        "url":        "http://wxs.ign.fr/cartes/geoportail/wmts",
+        "url": "https://data.geopf.fr/wmts?",
         "networkOptions": {
             "crossOrigin": "anonymous"
         },

--- a/examples/layers/JSONLayers/IGN_MNS_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNS_HIGHRES.json
@@ -12,7 +12,7 @@
 		"max": 17
 	},
 	"source": {
-		"url": "https://wxs.ign.fr/altimetrie/geoportail/wmts",
+		"url": "https://data.geopf.fr/wmts?",
         "crs": "EPSG:4326",
 		"format": "image/x-bil;bits=32",
 		"attribution" : {

--- a/examples/layers/JSONLayers/IGN_MNT.json
+++ b/examples/layers/JSONLayers/IGN_MNT.json
@@ -8,7 +8,7 @@
         }
     },
     "source": {
-        "url":        "https://wxs.ign.fr/altimetrie/geoportail/wmts",
+        "url": "https://data.geopf.fr/wmts?",
         "crs": "EPSG:4326",
         "format": "image/x-bil;bits=32",
         "attribution" : {

--- a/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
+++ b/examples/layers/JSONLayers/IGN_MNT_HIGHRES.json
@@ -11,7 +11,7 @@
 		}
 	},
 	"source": {
-		"url":        "https://wxs.ign.fr/altimetrie/geoportail/wmts",
+		"url": "https://data.geopf.fr/wmts?",
         "crs": "EPSG:4326",
 		"format": "image/x-bil;bits=32",
 		"attribution" : {

--- a/examples/layers/JSONLayers/Ortho.json
+++ b/examples/layers/JSONLayers/Ortho.json
@@ -1,7 +1,7 @@
 {
     "id":   "Ortho",
     "source": {
-        "url": "https://wxs.ign.fr/decouverte/geoportail/wmts",
+        "url": "https://data.geopf.fr/wmts?",
         "crs": "EPSG:3857",
         "networkOptions": {
             "crossOrigin": "anonymous"

--- a/examples/layers/JSONLayers/Railways.json
+++ b/examples/layers/JSONLayers/Railways.json
@@ -6,7 +6,7 @@
   "transparent": true,
   "source": {
     "crs": "EPSG:3857",
-    "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+    "url": "https://data.geopf.fr/wmts?",
     "format": "image/png",
     "networkOptions": {
       "crossOrigin": "omit"

--- a/examples/layers/JSONLayers/Region.json
+++ b/examples/layers/JSONLayers/Region.json
@@ -2,7 +2,7 @@
     "id"        : "Region",
     "transparent" : true,
     "source": {
-        "url"       : "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/v/wms",
+        "url"       : "https://data.geopf.fr/wms-r/wms?",
         "networkOptions": {
             "crossOrigin": "anonymous"
         },

--- a/examples/layers/JSONLayers/ScanEX.json
+++ b/examples/layers/JSONLayers/ScanEX.json
@@ -4,7 +4,7 @@
     "effect_parameter": 2.5,
     "source": {
         "crs": "EPSG:3857",
-        "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+        "url": "https://data.geopf.fr/wmts?",
         "format": "image/jpeg",
         "name": "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD",
         "attribution" : {

--- a/examples/layers/JSONLayers/Top25.json
+++ b/examples/layers/JSONLayers/Top25.json
@@ -2,7 +2,7 @@
     "id":         "Top25",
     "source": {
         "crs": "EPSG:3857",
-        "url":        "http://wxs.ign.fr/va5orxd0pgzvq3jxutqfuy0b/geoportail/wmts",
+        "url":        "https://data.geopf.fr/wmts?",
         "networkOptions": {
             "crossOrigin": "anonymous"
         },

--- a/examples/layers/JSONLayers/Transport.json
+++ b/examples/layers/JSONLayers/Transport.json
@@ -6,7 +6,7 @@
   "transparent": true,
   "source": {
     "crs": "EPSG:3857",
-    "url": "https://wxs.ign.fr/3ht7xcw6f7nciopo16etuqp2/geoportail/wmts",
+    "url": "https://data.geopf.fr/wmts?",
     "format": "image/png",
     "networkOptions": {
       "crossOrigin": "omit"

--- a/examples/layers/JSONLayers/WORLD_DTM.json
+++ b/examples/layers/JSONLayers/WORLD_DTM.json
@@ -11,7 +11,7 @@
     "source": {
         "format": "image/x-bil;bits=32",
         "crs": "EPSG:4326",
-        "url":        "https://wxs.ign.fr/altimetrie/geoportail/wmts",
+        "url":        "https://data.geopf.fr/wmts?",
         "name": "ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3",
         "tileMatrixSet": "WGS84G",
         "tileMatrixSetLimits": {

--- a/examples/source_stream_wfs_25d.html
+++ b/examples/source_stream_wfs_25d.html
@@ -238,7 +238,7 @@
             }
 
             var wfsBuildingSource = new itowns.WFSSource({
-                url: 'https://wxs.ign.fr/topographie/geoportail/wfs?',
+                url: 'https://data.geopf.fr/wfs/ows?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_V3:batiment',
                 crs: 'EPSG:4326',
@@ -271,7 +271,7 @@
             view.addLayer(wfsBuildingLayer);
 
             var wfsCartoSource = new itowns.WFSSource({
-                url: 'https://wxs.ign.fr/cartovecto/geoportail/wfs?',
+                url: 'https://data.geopf.fr/wfs/ows?',
                 version: '2.0.0',
                 typeName: 'BDCARTO_BDD_WLD_WGS84G:zone_habitat_mairie',
                 crs: 'EPSG:3946',

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -64,16 +64,16 @@
 
             var color = new itowns.THREE.Color();
             var tile;
-            function altitudeLine(properties, contour) {
+            function altitudeLine(properties, ctx) {
                 var result;
                 var z = 0;
-                if (contour) {
-                    result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0, tile);
+                if (ctx.coordinates) {
+                    result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, ctx.coordinates, 0, tile);
                     if (!result) {
-                        result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, contour, 0);
+                        result = itowns.DEMUtils.getTerrainObjectAt(view.tileLayer, ctx.coordinates, 0);
                     }
-                    tile = [result.tile];
                     if (result) {
+                        tile = [result.tile];
                         z = result.coord.z;
                     }
                     return z + 5;
@@ -95,11 +95,12 @@
                 return false;
             }
 
-            var lyonTclBusSource = new itowns.WFSSource({
+            lyonTclBusSource = new itowns.WFSSource({
+                url: "https://data.grandlyon.com/geoserver/sytral/ows?",
                 protocol: 'wfs',
-                url: 'https://download.data.grandlyon.com/wfs/rdata?',
                 version: '2.0.0',
-                typeName: 'tcl_sytral.tcllignebus',
+                id: 'tcl_bus',
+                typeName: "tcl_sytral.tcllignebus_2_0_0",
                 crs: 'EPSG:3946',
                 extent: {
                     west: 1822174.60,
@@ -107,7 +108,7 @@
                     south: 5138876.75,
                     north: 5205890.19,
                 },
-                format: 'geojson',
+                format: 'application/json',
             });
 
             var lyonTclBusLayer = new itowns.FeatureGeometryLayer('WFS Bus lines',{

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -60,7 +60,7 @@
             }
 
             var wfsBuildingSource = new itowns.WFSSource({
-                url: 'https://wxs.ign.fr/topographie/geoportail/wfs?',
+                url: 'https://data.geopf.fr/wfs/ows?',
                 version: '2.0.0',
                 typeName: 'BDTOPO_V3:batiment',
                 crs: 'EPSG:4326',

--- a/src/Layer/ElevationLayer.js
+++ b/src/Layer/ElevationLayer.js
@@ -49,7 +49,7 @@ class ElevationLayer extends RasterLayer {
      * // Create an ElevationLayer
      * const elevation = new ElevationLayer('IGN_MNT', {
      *      source: new WMTSSource({
-     *          "url": "https://wxs.ign.fr/altimetrie/geoportail/wmts",
+     *          "url": "https://data.geopf.fr/wmts?",
      *           "crs": "EPSG:4326",
      *           "format": "image/x-bil;bits=32",
      *           "name": "ELEVATION.ELEVATIONGRIDCOVERAGE",

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -35,7 +35,7 @@ import CRS from 'Core/Geographic/Crs';
  * // Add color layer with WFS source
  * // Create the source
  * const wfsSource = new itowns.WFSSource({
- *     url: 'http://wxs.fr/wfs',
+ *     url: 'https://data.geopf.fr/wfs/ows?',
  *     version: '2.0.0',
  *     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable',
  *     crs: 'EPSG:4326',
@@ -66,7 +66,7 @@ import CRS from 'Core/Geographic/Crs';
  * // Add geometry layer with WFS source
  * // Create the source
  * const wfsSource = new itowns.WFSSource({
- *     url: 'http://wxs.fr/wfs',
+ *     url: 'https://data.geopf.fr/wfs/ows?',
  *     version: '2.0.0',
  *     typeName: 'BDTOPO_BDD_WLD_WGS84G:bati_remarquable',
  *     crs: 'EPSG:4326',

--- a/test/functional/source_stream_wfs_25d.js
+++ b/test/functional/source_stream_wfs_25d.js
@@ -14,7 +14,7 @@ describe('source_stream_wfs_25d', function _() {
         // Test picking a feature geometry property from `wfsBuilding` layer.
         // Picking is done at the given screen coordinates.
         const buildingId = await page.evaluate(() => picking({ x: 97, y: 213 }));
-        assert.equal(buildingId.geojson.id, 'batiment.BATIMENT0000000241634062');
+        assert.equal(buildingId.geojson.id, 'batiment.172147');
     });
     it('should remove GeometryLayer', async () => {
         const countGeometryLayerStart = await page.evaluate(() => view.getLayers(l => l.isGeometryLayer).length);

--- a/test/unit/demutils.js
+++ b/test/unit/demutils.js
@@ -22,7 +22,7 @@ describe('DemUtils', function () {
     const source = new WMTSSource({
         format: 'image/x-bil;bits=32',
         crs: 'EPSG:4326',
-        url: 'https://wxs.ign.fr/altimetrie/geoportail/wmts',
+        url: 'https://data.geopf.fr/wmts?',
         name: 'ELEVATION.ELEVATIONGRIDCOVERAGE.SRTM3',
         tileMatrixSet: 'WGS84G',
         networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {


### PR DESCRIPTION
## Description
Migrate examples urls:
* IGN urls from geoportail to geoplateforme
* some deprecated grand lyon urls.

## Motivation and Context
Fixes examples and tests.