### PR TITLE
Fix dispose rastertile

### DIFF
--- a/src/Renderer/RasterTile.js
+++ b/src/Renderer/RasterTile.js
@@ -79,7 +79,7 @@ class RasterTile extends THREE.EventDispatcher {
         }
     }
 
-    dispose(removeEvent) {
+    dispose(removeEvent = true) {
         if (removeEvent) {
             this.layer.removeEventListener('visible-property-changed', this._handlerCBEvent);
             this.layer.removeEventListener('opacity-property-changed', this._handlerCBEvent);


### PR DESCRIPTION
## Motivation and Context
We try to debug view.dispose (to reload a view with different extent) and we found RasterTile.dispose is called without disposeEvent at true (because it was called from LayerMaterial.removeLayer()).
So maybe it's best approach to let RasterTile.dispose() removeEvent at true if no explicit parameter is passed.

What do you think ?