### PR TITLE
fix(PlanarLayer): Fix delete new extent from globalExtentTMS const

### DIFF
--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -11,6 +11,7 @@ import PlanarTileBuilder from './PlanarTileBuilder';
  * internally for optimisation.
  */
 class PlanarLayer extends TiledGeometryLayer {
+    #hasNewExtent;
     /**
      * A {@link TiledGeometryLayer} to use with a {@link PlanarView}. It has
      * specific method for updating and subdivising its grid.
@@ -40,17 +41,27 @@ class PlanarLayer extends TiledGeometryLayer {
     constructor(id, extent, object3d, config = {}) {
         const tms = CRS.formatToTms(extent.crs);
         const tileMatrixSets = [tms];
+        let hasNewExtent = false;
         if (!globalExtentTMS.get(extent.crs)) {
             // Add new global extent for this new crs projection.
             globalExtentTMS.set(extent.crs, extent);
+            hasNewExtent = true;
         }
         config.tileMatrixSets = tileMatrixSets;
         super(id, object3d || new THREE.Group(), [extent], new PlanarTileBuilder({ crs: extent.crs }), config);
         this.isPlanarLayer = true;
+        this.#hasNewExtent = hasNewExtent;
         this.extent = extent;
         this.minSubdivisionLevel = this.minSubdivisionLevel == undefined ? 0 : this.minSubdivisionLevel;
         this.maxSubdivisionLevel = this.maxSubdivisionLevel == undefined ? 5 : this.maxSubdivisionLevel;
         this.maxDeltaElevationLevel = this.maxDeltaElevationLevel || 4.0;
+    }
+
+    delete(clearCache) {
+        super.delete(clearCache);
+        if (this.#hasNewExtent) {
+            globalExtentTMS.delete(this.extent.crs);
+        }
     }
 }
 


### PR DESCRIPTION
Proposed fix for #2244 

## Motivation and Context

When PlanarLayer is deleted, it doesn't remove extent from globalExtentTMS const.
It's why we got some trouble when we try to reload itowns with new extent. It keep previous extent added to globalExtentTMS.

I don't know if it's better to reset globalExtentTMS when view is disposed or remove extent from globalExtentTMS if PlanarLayer is deleted.

I think my fix may cause a problem if two PlanarLayer use the same extent and one was deleted.

What do you think ?