### PR TITLE
Fix ElevationLayer removal

### DIFF
--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -236,12 +236,15 @@ export function updateLayeredMaterialNodeElevation(context, layer, node, parent)
 }
 
 export function removeLayeredMaterialNodeLayer(layerId) {
+    /**
+     * @param {TileMesh} node - The node to udpate.
+     */
     return function removeLayeredMaterialNodeLayer(node) {
         if (node.material?.removeLayer) {
-            node.material.removeLayer(layerId);
-            if (node.material.elevationLayerIds[0] == layerId) {
+            if (node.material.elevationLayerIds.indexOf(layerId) > -1) {
                 node.setBBoxZ({ min: 0, max: 0 });
             }
+            node.material.removeLayer(layerId);
         }
         if (node.layerUpdateState && node.layerUpdateState[layerId]) {
             delete node.layerUpdateState[layerId];


### PR DESCRIPTION
## Description
`node.material.elevationLayerIds[layerId]` is removed by `node.material.removeLayer(layerId);` so the bbox min and max elevation values were never reset which caused visual artifacts when removing an `ElevationLayer` from the view.

You can use the following example to test the fix: https://gist.github.com/jailln/90c67187a0c8e4e94eb8ea5ac3cc92a0
 
Note that bbox min and max z values should not be reset to 0 but to the min and max of the remaining `ElevationLayers` attached to this `TileMesh`. This is another bug that also implies other changes in this bbox min and max elevation values management so I opened #2282 instead of fixing it now. (also note that the proposed implementation somehow doesn't seem to break anything if there are multiple `ElevationLayer` in the view and one is removed).

## Motivation and Context

Closes #2221


