### PR TITLE
fix(PotreeDebug): fix oversight

### DIFF
--- a/utils/debug/PotreeDebug.js
+++ b/utils/debug/PotreeDebug.js
@@ -80,7 +80,7 @@ export default {
             styleUI.add({ gradient: gradiantsName[0] }, 'gradient', gradiantsName).name('gradient')
                 .onChange((value) => {
                     layer.material.gradient = layer.material.gradients[value];
-                    setupControllerVisibily(datUi, layer.material.mode);
+                    setupControllerVisibily(layer.debugUI, layer.material.mode);
                     view.notifyChange(layer, true);
                 });
             styleUI.add(layer, 'minIntensityRange', layer.minIntensityRange, layer.maxIntensityRange - 1).name('Intensity min')


### PR DESCRIPTION
An oversight during a previous PR #2262 (forgeting to change on parameter from 'datUi' to 'layer.debugUI') linked to an error message when chaging the gradient that we want the data to be displayed.
![image](https://github.com/iTowns/itowns/assets/47628509/2fa6d3c2-7bb9-4190-be88-a2978379cf4e)
