### PR TITLE
feat(TextureSize): Add parameter to define the textureSize

### DIFF
--- a/src/Converter/textureConverter.js
+++ b/src/Converter/textureConverter.js
@@ -28,7 +28,7 @@ export default {
                 undefined;
 
             extentDestination.as(CRS.formatToEPSG(layer.crs), extentTexture);
-            texture = Feature2Texture.createTextureFromFeature(data, extentTexture, 256, layer.style, backgroundColor);
+            texture = Feature2Texture.createTextureFromFeature(data, extentTexture, layer.subdivisionThreshold, layer.style, backgroundColor);
             texture.features = data;
             texture.extent = extentDestination;
         } else if (data.isTexture) {

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -3,7 +3,6 @@ import TiledGeometryLayer from 'Layer/TiledGeometryLayer';
 import { ellipsoidSizes } from 'Core/Math/Ellipsoid';
 import { globalExtentTMS, schemeTiles } from 'Core/Geographic/Extent';
 import BuilderEllipsoidTile from 'Core/Prefab/Globe/BuilderEllipsoidTile';
-import { SIZE_DIAGONAL_TEXTURE } from 'Process/LayeredMaterialNodeProcessing';
 import CRS from 'Core/Geographic/Crs';
 
 // matrix to convert sphere to ellipsoid
@@ -145,7 +144,7 @@ class GlobeLayer extends TiledGeometryLayer {
 
     computeTileZoomFromDistanceCamera(distance, camera) {
         const preSinus =
-            SIZE_DIAGONAL_TEXTURE * (this.sseSubdivisionThreshold * 0.5) / camera._preSSE / ellipsoidSizes.x;
+            this.sizeDiagonalTexture * (this.sseSubdivisionThreshold * 0.5) / camera._preSSE / ellipsoidSizes.x;
 
         let sinus = distance * preSinus;
         let zoom = Math.log(Math.PI / (2.0 * Math.asin(sinus))) / Math.log(2);
@@ -165,7 +164,7 @@ class GlobeLayer extends TiledGeometryLayer {
         const delta = Math.PI / 2 ** zoom;
         const circleChord = 2.0 * ellipsoidSizes.x * Math.sin(delta * 0.5);
         const radius = circleChord * 0.5;
-        const error = radius / SIZE_DIAGONAL_TEXTURE;
+        const error = radius / this.sizeDiagonalTexture;
 
         return camera._preSSE * error / (this.sseSubdivisionThreshold * 0.5) + radius;
     }

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -66,6 +66,7 @@ class Layer extends THREE.EventDispatcher {
      * @param {boolean} [config.addLabelLayer.performance=false] - In case label layer adding, so remove labels that have no chance of being visible.
      * Indeed, even in the best case, labels will never be displayed. By example, if there's many labels.
      * @param {boolean} [config.addLabelLayer.forceClampToTerrain=false] - use elevation layer to clamp label on terrain.
+     * @param {number} [config.subdivisionThreshold=256] - set the texture size and, if applied to the globe, affects the tile subdivision.
      *
      * @example
      * // Add and create a new Layer
@@ -108,6 +109,8 @@ class Layer extends THREE.EventDispatcher {
             config.style = new Style(config.style);
         }
         this.style = config.style || new Style();
+        this.subdivisionThreshold = config.subdivisionThreshold || 256;
+        this.sizeDiagonalTexture =  (2 * (this.subdivisionThreshold * this.subdivisionThreshold)) ** 0.5;
         Object.assign(this, config);
 
         Object.defineProperty(this, 'id', {

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -4,7 +4,6 @@ import { InfoTiledGeometryLayer } from 'Layer/InfoLayer';
 import Picking from 'Core/Picking';
 import convertToTile from 'Converter/convertToTile';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
-import { SIZE_DIAGONAL_TEXTURE } from 'Process/LayeredMaterialNodeProcessing';
 import { ImageryLayers } from 'Layer/Layer';
 import { CACHE_POLICIES } from 'Core/Scheduler/Cache';
 
@@ -100,7 +99,7 @@ class TiledGeometryLayer extends GeometryLayer {
             this.object3d.updateMatrixWorld();
         }));
 
-        this.maxScreenSizeNode = this.sseSubdivisionThreshold * (SIZE_DIAGONAL_TEXTURE * 2);
+        this.maxScreenSizeNode = this.sseSubdivisionThreshold * (this.sizeDiagonalTexture * 2);
     }
 
     get hideSkirt() {
@@ -447,7 +446,7 @@ class TiledGeometryLayer extends GeometryLayer {
 
         // The screen space error is calculated to have a correct texture display.
         // For the projection of a texture's texel to be less than or equal to one pixel
-        const sse = node.screenSize / (SIZE_DIAGONAL_TEXTURE * 2);
+        const sse = node.screenSize / (this.sizeDiagonalTexture * 2);
 
         return this.sseSubdivisionThreshold < sse;
     }

--- a/src/Process/LayeredMaterialNodeProcessing.js
+++ b/src/Process/LayeredMaterialNodeProcessing.js
@@ -2,9 +2,6 @@ import { chooseNextLevelToFetch } from 'Layer/LayerUpdateStrategy';
 import LayerUpdateState from 'Layer/LayerUpdateState';
 import handlingError from 'Process/handlerNodeError';
 
-export const SIZE_TEXTURE_TILE = 256;
-export const SIZE_DIAGONAL_TEXTURE = (2 * (SIZE_TEXTURE_TILE * SIZE_TEXTURE_TILE)) ** 0.5;
-
 function materialCommandQueuePriorityFunction(material) {
     // We know that 'node' is visible because commands can only be
     // issued for visible nodes.


### PR DESCRIPTION
## Related issue:

https://github.com/iTowns/itowns/issues/2292
https://github.com/iTowns/itowns/issues/2312
https://github.com/iTowns/itowns/issues/2309


Replace the const use for subdivision and texture conversion with a customizable parameter `sizeTextureTile`


Example:
For MVT layer
```
 const mvtSource = new itowns.VectorTilesSource({
              style: 'https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json',
              crs: 'EPSG:3857',

          });

  const mvtLayer = new itowns.ColorLayer('mvtLayer',{
      source: mvtSource,
      sizeTextureTile:512,
      addLabelLayer: true,

  });
```

For the globe:

` const view = new itowns.GlobeView(viewerDiv, placement, {sizeTextureTile:512});`


