### PR TITLE
chore(deps): bump copc and remove unecessary ignore of fs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@tmcw/togeojson": "^5.8.1",
         "@tweenjs/tween.js": "^18.6.4",
-        "copc": "^0.0.5",
+        "copc": "^0.0.6",
         "earcut": "^2.2.4",
         "js-priority-queue": "^0.1.5",
         "pbf": "^3.2.1",
@@ -4505,9 +4505,9 @@
       "license": "MIT"
     },
     "node_modules/copc": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/copc/-/copc-0.0.5.tgz",
-      "integrity": "sha512-6FomlN1gMJ13C1QmLuKpjchXSg/UjdWb1/vTPp6GnrULaEQPtdQw1bSQBF1INvxhjCGz5T6OzV09t/gUJWkjmg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/copc/-/copc-0.0.6.tgz",
+      "integrity": "sha512-hh5dp1cnSom1pdvbeqrHcSLdxboig4hEcV0yCnShNxKO/a/nMDxiRmksRL59ol/o52nDBzub2mk/WhA8lxGKiA==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "laz-perf": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@tmcw/togeojson": "^5.8.1",
     "@tweenjs/tween.js": "^18.6.4",
-    "copc": "^0.0.5",
+    "copc": "^0.0.6",
     "earcut": "^2.2.4",
     "js-priority-queue": "^0.1.5",
     "pbf": "^3.2.1",

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const webpack = require('webpack');
 const ESLintPlugin = require('eslint-webpack-plugin');
 
 const mode = process.env.NODE_ENV;
@@ -81,12 +80,6 @@ module.exports = () => {
         plugins: [
             new ESLintPlugin({
                 files: include,
-            }),
-            // Prevent the generation of module fs for import on copc dependency
-            // See https://webpack.js.org/plugins/ignore-plugin/
-            new webpack.IgnorePlugin({
-                resourceRegExp: /^fs$/,
-                contextRegExp: /copc/,
             }),
         ],
         devServer: {


### PR DESCRIPTION
## Description
This PR bumps `copc` to version `0.0.6` and removes the now unnecessary ignore plugin in our webpack config.

<!--- Describe your changes in detail -->

## Motivation and Context
In connormanning/copc#7, an additional hint was added in the package.json for bundlers to ignore the lazy-loaded `fs` module on browser environments.

This should fix #2273
