### PR TITLE
fix(LASLoader): fix default CDN URL

### DIFF
--- a/src/Parser/LASLoader.js
+++ b/src/Parser/LASLoader.js
@@ -26,7 +26,7 @@ import { Las } from 'copc';
  */
 class LASLoader {
     constructor() {
-        this._wasmPath = 'https://cdn.jsdelivr.net/npm/laz-perf@0.0.6/lib/';
+        this._wasmPath = 'https://cdn.jsdelivr.net/npm/laz-perf@0.0.6/lib';
         this._wasmPromise = null;
     }
 


### PR DESCRIPTION
## Description

Request on jsdelivr failed to to double slash in URL, this causes issue when using the default CDN of `LASLoader`.
