### PR TITLE
fix(PointCloud): use preSSE for C3DTilesLayer

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -116,8 +116,8 @@ class C3DTilesLayer extends GeometryLayer {
         this.pntsShape = PNTS_SHAPE.CIRCLE;
         this.classification = config.classification;
         this.pntsSizeMode = PNTS_SIZE_MODE.VALUE;
-        this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 3;
-        this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 10;
+        this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 1;
+        this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 7;
         if (config.pntsMode) {
             const exists = Object.values(PNTS_MODE).includes(config.pntsMode);
             if (!exists) {
@@ -194,8 +194,7 @@ class C3DTilesLayer extends GeometryLayer {
     }
 
     preUpdate(context) {
-        this.scale = context.camera._preSSE;
-        return pre3dTilesUpdate.bind(this)();
+        return pre3dTilesUpdate.bind(this)(context);
     }
 
     update(context, layer, node) {

--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -118,7 +118,6 @@ class C3DTilesLayer extends GeometryLayer {
         this.pntsSizeMode = PNTS_SIZE_MODE.VALUE;
         this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 3;
         this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 10;
-
         if (config.pntsMode) {
             const exists = Object.values(PNTS_MODE).includes(config.pntsMode);
             if (!exists) {
@@ -194,7 +193,8 @@ class C3DTilesLayer extends GeometryLayer {
         });
     }
 
-    preUpdate() {
+    preUpdate(context) {
+        this.scale = context.camera._preSSE;
         return pre3dTilesUpdate.bind(this)();
     }
 

--- a/src/Layer/ReferencingLayerProperties.js
+++ b/src/Layer/ReferencingLayerProperties.js
@@ -42,6 +42,12 @@ function ReferLayerProperties(material, layer) {
             });
         }
 
+        if (material.uniforms && material.uniforms.scale != undefined) {
+            Object.defineProperty(material.uniforms.scale, 'value', {
+                get: () => material.layer.scale,
+            });
+        }
+
         Object.defineProperty(material, 'wireframe', {
             get: () => material.layer.wireframe,
         });

--- a/src/Process/3dTilesProcessing.js
+++ b/src/Process/3dTilesProcessing.js
@@ -171,10 +171,11 @@ function cleanup3dTileset(layer, n, depth = 0) {
 }
 
 // this is a layer
-export function pre3dTilesUpdate() {
+export function pre3dTilesUpdate(context) {
     if (!this.visible) {
         return [];
     }
+    this.scale = context.camera._preSSE;
 
     // Elements removed are added in the layer._cleanableTiles list.
     // Since we simply push in this array, the first item is always

--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -36,7 +36,7 @@ function pntsParse(data, layer) {
         const material = layer.material ?
             layer.material.clone() :
             new PointsMaterial({
-                size: 0.05,
+                size: 1,
                 mode: layer.pntsMode,
                 shape: layer.pntsShape,
                 classification: layer.classification,


### PR DESCRIPTION

## Description
Use camera preSSE to compute the point size of a C3DTilesLayer in the ATTENUATED mode

## Motivation and Context
I've noticed a difference between the calculus of the size of the points between Potree & 3Dtiles.
In Potree we use the preSSE for the size computation.
In this previous comment https://github.com/iTowns/itowns/pull/2171#discussion_r1311800499, I had highlighted this difference.
Since then, @ftoromanoff change the default `scale` value in the pointMaterial. 
Right now, the attenuated mode doesn't seem that effective.
