### PR TITLE
fix(C3DTFeature): use correct interleaved buffer getter

### DIFF
--- a/src/Core/3DTiles/C3DTFeature.js
+++ b/src/Core/3DTiles/C3DTFeature.js
@@ -72,13 +72,13 @@ class C3DTFeature {
         target.min.z = Infinity;
 
         this.groups.forEach((group) => {
-            const positionIndexStart = group.start * 3;
-            const positionIndexCount = (group.start + group.count) * 3;
+            const positionIndexStart = group.start * this.object3d.geometry.attributes.position.itemSize;
+            const positionIndexCount = (group.start + group.count) * this.object3d.geometry.attributes.position.itemSize;
 
-            for (let index = positionIndexStart; index < positionIndexCount; index += 3) {
-                const x = this.object3d.geometry.attributes.position.array[index];
-                const y = this.object3d.geometry.attributes.position.array[index + 1];
-                const z = this.object3d.geometry.attributes.position.array[index + 2];
+            for (let index = positionIndexStart; index < positionIndexCount; index++) {
+                const x = this.object3d.geometry.attributes.position.getX(index);
+                const y = this.object3d.geometry.attributes.position.getY(index);
+                const z = this.object3d.geometry.attributes.position.getZ(index);
 
                 target.max.x = Math.max(x, target.max.x);
                 target.max.y = Math.max(y, target.max.y);

--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -258,7 +258,7 @@ class C3DTilesLayer extends GeometryLayer {
         // face is a Face3 object of THREE which is a
         // triangular face. face.a is its first vertex
         const vertex = closestIntersect.face.a;
-        const batchID = closestIntersect.object.geometry.attributes._BATCHID.array[vertex];
+        const batchID = closestIntersect.object.geometry.attributes._BATCHID.getX(vertex);
 
         return this.tilesC3DTileFeatures.get(tileId).get(batchID);
     }


### PR DESCRIPTION
## Description
We should use the getter of threejs to access position in buffer, especially when we have interleaved buffer

## Motivation and Context
Similar to what was done in https://github.com/iTowns/itowns/pull/2266


To note:
I encountered issues related to the batchtable, I wonder if there is some misconception in the treatment of it. I will try to investigate more
