### PR TITLE
fix(points): support point classification up to 256 classes

### DIFF
--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -299,7 +299,7 @@ class PointsMaterial extends THREE.ShaderMaterial {
     }
 
     recomputeClassification() {
-        const needTransparency = recomputeTexture(this.classificationScheme, this.classificationTexture, 32);
+        const needTransparency = recomputeTexture(this.classificationScheme, this.classificationTexture, 256);
         this.userData.needTransparency[PNTS_MODE.CLASSIFICATION] = needTransparency;
         this.dispatchEvent({
             type: 'material_property_changed',


### PR DESCRIPTION
## Description

This PR fixes our points material to conform to LAS 1.4 specification.

As of LAS 1.4 Point Data Record Format > 6 supports up to 256 different classes. The spec says that:
> Point Data Record Format 6 contains the core 30 bytes that are shared by Point Data Record Formats 6 to 10. The difference to the core 20 bytes of Point Data Record Formats 0 to 5 is that [...] there are more bits for
point classifications to support up to 256 classes, [...]

![Capture d’écran du 2024-06-04 15-58-00](https://github.com/iTowns/itowns/assets/75338405/adee64b2-ef4f-4a6f-8a74-9fbedb3e5a6b)
