### PR TITLE
fix(TiledGeometryLayer): remove subdivision checking code

### DIFF
--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -44,8 +44,6 @@ class GlobeLayer extends TiledGeometryLayer {
      * level for this tiled layer.
      * @param {number} [config.sseSubdivisionThreshold=1] - Threshold level for
      * the SSE.
-     * @param {number} [config.maxDeltaElevationLevel=4] - Maximum delta between
-     * two elevations tile.
      *
      * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
@@ -68,8 +66,6 @@ class GlobeLayer extends TiledGeometryLayer {
         this.options.defaultPickingRadius = 5;
         this.minSubdivisionLevel = this.minSubdivisionLevel == undefined ? 2 : this.minSubdivisionLevel;
         this.maxSubdivisionLevel = this.maxSubdivisionLevel == undefined ? 19 : this.maxSubdivisionLevel;
-        this.maxDeltaElevationLevel = this.maxDeltaElevationLevel || 4.0;
-
         this.extent = this.schemeTile[0].clone();
 
         for (let i = 1; i < this.schemeTile.length; i++) {

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -32,8 +32,6 @@ class PlanarLayer extends TiledGeometryLayer {
      * name.
      * @param {number} [config.maxSubdivisionLevel=5] - Maximum subdivision
      * level for this tiled layer.
-     * @param {number} [config.maxDeltaElevationLevel=4] - Maximum delta between
-     * two elevations tile.
      *
      * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
@@ -50,7 +48,6 @@ class PlanarLayer extends TiledGeometryLayer {
         this.extent = extent;
         this.minSubdivisionLevel = this.minSubdivisionLevel == undefined ? 0 : this.minSubdivisionLevel;
         this.maxSubdivisionLevel = this.maxSubdivisionLevel == undefined ? 5 : this.maxSubdivisionLevel;
-        this.maxDeltaElevationLevel = this.maxDeltaElevationLevel || 4.0;
     }
 }
 

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -86,6 +86,10 @@ class TiledGeometryLayer extends GeometryLayer {
             throw new Error(`Cannot init tiled layer without builder for layer ${this.id}`);
         }
 
+        if (config.maxDeltaElevationLevel) {
+            console.warn('Config using maxDeltaElevationLevel is deprecated. The parameter maxDeltaElevationLevel is not longer used');
+        }
+
         this.level0Nodes = [];
         const promises = [];
 
@@ -415,23 +419,6 @@ class TiledGeometryLayer extends GeometryLayer {
         if (this.maxSubdivisionLevel <= node.level) {
             return false;
         }
-
-        // Prevent to subdivise the node if the current elevation level
-        // we must avoid a tile, with level 20, inherits a level 3 elevation texture.
-        // The induced geometric error is much too large and distorts the SSE
-        const nodeLayer = node.material.getElevationLayer();
-        if (nodeLayer) {
-            const currentTexture = nodeLayer.textures[0];
-            if (currentTexture && currentTexture.extent) {
-                const offsetScale = nodeLayer.offsetScales[0];
-                const ratio = offsetScale.z;
-                // ratio is node size / texture size
-                if (ratio < 1 / 2 ** this.maxDeltaElevationLevel) {
-                    return false;
-                }
-            }
-        }
-
         subdivisionVector.setFromMatrixScale(node.matrixWorld);
         boundingSphereCenter.copy(node.boundingSphere.center).applyMatrix4(node.matrixWorld);
         const distance = Math.max(


### PR DESCRIPTION
## Description
I removed the subdivision checking code.
This code was blocking the subdivision of the tiles when no terrain was available at a certain zoom level

## Motivation and Context
This MR is the correction of this issue https://github.com/iTowns/itowns/issues/2159
