### PR TITLE
fix(pointcloud): fix non-world projected elevation

### DIFF
--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -141,7 +141,8 @@ void main() {
             vec2 uv = vec2(i, (1. - i));
             vColor = texture2D(gradientTexture, uv);
         } else if (mode == PNTS_MODE_ELEVATION) {
-            float i = (position.z - elevationRange.x) / (elevationRange.y - elevationRange.x);
+            float z = (modelMatrix * vec4(position, 1.0)).z;
+            float i = (z - elevationRange.x) / (elevationRange.y - elevationRange.x);
             vec2 uv = vec2(i, (1. - i));
             vColor = texture2D(gradientTexture, uv);
         }


### PR DESCRIPTION
## Before contributing

Read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
This PR fixes an issue with the elevation color on our points material. The elevation (z component of the `position` attribute) was not projected in the world space, and used in a gradient where `min` and `max` were in world space.
Two pictures are worth a thousand words (before/after this PR):

![Screenshot 2024-06-24 at 16-03-43 Itowns Examples](https://github.com/iTowns/itowns/assets/75338405/ce96badb-09b1-463e-b52a-92ae1993234d)
![Screenshot 2024-06-24 at 16-03-04 Itowns Examples](https://github.com/iTowns/itowns/assets/75338405/d635dfe5-db1f-4f80-bf77-c4f87b993ef5)
