### PR TITLE
PointsMaterial as superset of three's PointsMaterial

### DIFF
--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import PointsVS from 'Renderer/Shader/PointsVS.glsl';
 import PointsFS from 'Renderer/Shader/PointsFS.glsl';
-import ShaderUtils from 'Renderer/Shader/ShaderUtils';
 import CommonMaterial from 'Renderer/CommonMaterial';
 import Gradients from 'Utils/Gradients';
 
@@ -190,7 +189,6 @@ class PointsMaterial extends THREE.ShaderMaterial {
         const intensityRange = options.intensityRange || new THREE.Vector2(1, 65536);
         const elevationRange = options.elevationRange || new THREE.Vector2(0, 1000);
         const angleRange = options.angleRange || new THREE.Vector2(-90, 90);
-        const oiMaterial = options.orientedImageMaterial;
         const classificationScheme = options.classification || ClassificationScheme.DEFAULT;
         const discreteScheme = options.discreteScheme || DiscreteScheme.DEFAULT;
         const size = options.size || 0;
@@ -210,7 +208,6 @@ class PointsMaterial extends THREE.ShaderMaterial {
         delete options.intensityRange;
         delete options.elevationRange;
         delete options.angleRange;
-        delete options.orientedImageMaterial;
         delete options.classification;
         delete options.discreteScheme;
         delete options.size;
@@ -274,24 +271,7 @@ class PointsMaterial extends THREE.ShaderMaterial {
         this.gradient = Object.values(gradients)[0];
         CommonMaterial.setUniformProperty(this, 'gradientTexture', this.gradientTexture);
 
-        if (oiMaterial) {
-            this.uniforms.projectiveTextureAlphaBorder = oiMaterial.uniforms.projectiveTextureAlphaBorder;
-            this.uniforms.projectiveTextureDistortion = oiMaterial.uniforms.projectiveTextureDistortion;
-            this.uniforms.projectiveTextureMatrix = oiMaterial.uniforms.projectiveTextureMatrix;
-            this.uniforms.projectiveTexture = oiMaterial.uniforms.projectiveTexture;
-            this.uniforms.mask = oiMaterial.uniforms.mask;
-            this.uniforms.boostLight = oiMaterial.uniforms.boostLight;
-            this.defines.ORIENTED_IMAGES_COUNT = oiMaterial.defines.ORIENTED_IMAGES_COUNT;
-            this.defines.USE_DISTORTION = oiMaterial.defines.USE_DISTORTION;
-            this.defines.DEBUG_ALPHA_BORDER = oiMaterial.defines.DEBUG_ALPHA_BORDER;
-            this.defines.USE_TEXTURES_PROJECTIVE = true;
-            this.defines.USE_BASE_MATERIAL = true;
-            // three loop unrolling of ShaderMaterial only supports integer
-            // bounds, see https://github.com/mrdoob/three.js/issues/28020
-            this.fragmentShader = ShaderUtils.unrollLoops(PointsFS, this.defines);
-        } else {
-            this.fragmentShader = PointsFS;
-        }
+        this.fragmentShader = PointsFS;
 
         if (__DEBUG__) {
             this.defines.DEBUG = 1;
@@ -321,16 +301,6 @@ class PointsMaterial extends THREE.ShaderMaterial {
 
     copy(source) {
         super.copy(source);
-        if (source.uniforms.projectiveTextureAlphaBorder) {
-            // Don't copy oriented image because, it's a link to oriented image material.
-            // It needs a reference to oriented image material.
-            this.uniforms.projectiveTextureAlphaBorder = source.uniforms.projectiveTextureAlphaBorder;
-            this.uniforms.projectiveTextureDistortion = source.uniforms.projectiveTextureDistortion;
-            this.uniforms.projectiveTextureMatrix = source.uniforms.projectiveTextureMatrix;
-            this.uniforms.projectiveTexture = source.uniforms.projectiveTexture;
-            this.uniforms.mask = source.uniforms.mask;
-            this.uniforms.boostLight = source.uniforms.boostLight;
-        }
         return this;
     }
 

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -1,13 +1,23 @@
-#include <itowns/precision_qualifier>
-#include <logdepthbuf_pars_fragment>
+#define USE_COLOR_ALPHA
 
-varying vec4 vColor;
+#include <color_pars_fragment>
+#include <map_particle_pars_fragment>
+#include <alphatest_pars_fragment>
+#include <alphahash_pars_fragment>
+#include <fog_pars_fragment>
+#include <logdepthbuf_pars_fragment>
+#include <clipping_planes_pars_fragment>
+
+uniform vec3 diffuse;
+uniform float opacity;
+
 uniform bool picking;
 uniform int shape;
 
 void main() {
-    #include <logdepthbuf_fragment>
-    //square shape does not require any change.
+
+// Early discard (clipping planes and shape)
+#include <clipping_planes_pars_fragment>
     if (shape == PNTS_SHAPE_CIRCLE) {
         //circular rendering in glsl
         if ((length(gl_PointCoord - 0.5) > 0.5) || (vColor.a == 0.0)) {
@@ -15,5 +25,19 @@ void main() {
         }
     }
 
-    gl_FragColor = vColor;
+#include <logdepthbuf_fragment>
+
+    vec4 diffuseColor = vec4(diffuse, opacity);
+#include <map_particle_fragment>
+#include <color_fragment>
+
+#include <alphatest_fragment>
+#include <alphahash_fragment>
+
+    vec3 outgoingLight = diffuseColor.rgb;
+#include <opaque_fragment> // gl_FragColor
+#include <tonemapping_fragment>
+#include <fog_fragment>
+#include <premultiplied_alpha_fragment>
+
 }

--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -1,8 +1,5 @@
 #include <itowns/precision_qualifier>
 #include <logdepthbuf_pars_fragment>
-#if defined(USE_TEXTURES_PROJECTIVE)
-#include <itowns/projective_texturing_pars_fragment>
-#endif
 
 varying vec4 vColor;
 uniform bool picking;
@@ -18,18 +15,5 @@ void main() {
         }
     }
 
-#if defined(USE_TEXTURES_PROJECTIVE)
-    vec4 color = vColor;
-    if (!picking) {
-        #pragma unroll_loop
-        for (int i = 0; i < ORIENTED_IMAGES_COUNT; i++) {
-            color = projectiveTextureColor(projectiveTextureCoords[ ORIENTED_IMAGES_COUNT - 1 - i ], projectiveTextureDistortion[ ORIENTED_IMAGES_COUNT - 1 - i ], projectiveTexture[ ORIENTED_IMAGES_COUNT - 1 - i ], mask[ORIENTED_IMAGES_COUNT - 1 - i], color);
-        }
-        gl_FragColor = vec4(color.rgb, color.a * opacity);
-    } else {
-        gl_FragColor = color;
-    }
-#else
     gl_FragColor = vColor;
-#endif
 }

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -1,7 +1,4 @@
 #include <itowns/precision_qualifier>
-#if defined(USE_TEXTURES_PROJECTIVE)
-#include <itowns/projective_texturing_pars_vertex>
-#endif
 #include <common>
 #include <logdepthbuf_pars_vertex>
 
@@ -117,8 +114,5 @@ void main() {
         }
     }
 
-#if defined(USE_TEXTURES_PROJECTIVE)
-    #include <itowns/projective_texturing_vertex>
-#endif
     #include <logdepthbuf_vertex>
 }

--- a/src/Renderer/Shader/PointsVS.glsl
+++ b/src/Renderer/Shader/PointsVS.glsl
@@ -37,56 +37,9 @@ attribute float returnNumber;
 attribute float numberOfReturns;
 attribute float scanAngle;
 
-#if defined(NORMAL_OCT16)
-attribute vec2 oct16Normal;
-#elif defined(NORMAL_SPHEREMAPPED)
-attribute vec2 sphereMappedNormal;
-#endif
-
 varying vec4 vColor;
 
-// see https://web.archive.org/web/20150303053317/http://lgdv.cs.fau.de/get/1602
-// and implementation in PotreeConverter (BINPointReader.cpp) and potree (BinaryDecoderWorker.js)
-#if defined(NORMAL_OCT16)
-vec3 decodeOct16Normal(vec2 encodedNormal) {
-    vec2 nNorm = 2. * (encodedNormal / 255.) - 1.;
-    vec3 n;
-    n.z = 1. - abs(nNorm.x) - abs(nNorm.y);
-    if (n.z >= 0.) {
-        n.x = nNorm.x;
-        n.y = nNorm.y;
-    } else {
-        n.x = sign(nNorm.x) - sign(nNorm.x) * sign(nNorm.y) * nNorm.y;
-        n.y = sign(nNorm.y) - sign(nNorm.y) * sign(nNorm.x) * nNorm.x;
-    }
-    return normalize(n);
-}
-#elif defined(NORMAL_SPHEREMAPPED)
-// see http://aras-p.info/texts/CompactNormalStorage.html method #4
-// or see potree's implementation in BINPointReader.cpp
-vec3 decodeSphereMappedNormal(vec2 encodedNormal) {
-    vec2 fenc = 2. * encodedNormal / 255. - 1.;
-    float f = dot(fenc,fenc);
-    float g = 2. * sqrt(1. - f);
-    vec3 n;
-    n.xy = fenc * g;
-    n.z = 1. - 2. * f;
-    return n;
-}
-#endif
-
 void main() {
-
-#if defined(NORMAL_OCT16)
-    vec3  normal = decodeOct16Normal(oct16Normal);
-#elif defined(NORMAL_SPHEREMAPPED)
-    vec3 normal = decodeSphereMappedNormal(sphereMappedNormal);
-#elif defined(NORMAL)
-    // nothing to do
-#else
-    // default to color
-    vec3 normal = color;
-#endif
 
     if (picking) {
         vColor = unique_id;

--- a/test/unit/pointsmaterial.js
+++ b/test/unit/pointsmaterial.js
@@ -1,0 +1,97 @@
+import assert from 'assert';
+import {
+    Color,
+    Matrix3,
+    PointsMaterial as TPointsMaterial,
+    Texture,
+} from 'three';
+import PointsMaterial, { PNTS_SIZE_MODE } from 'Renderer/PointsMaterial';
+
+const uvTransform = new Matrix3().setUvTransform(
+    4, 4, // offset
+    2, 2, // repeat
+    Math.PI, 0, 0, // center
+);
+
+function assertPointsMaterialEqual(m1, m2) {
+    assert.deepEqual(m1.color, m2.color);
+    assert.equal(m1.fog, m2.fog);
+    assert.equal(m1.map, m2.map);
+    assert.equal(m1.size, m2.size);
+    assert.equal(m1.sizeAttenuation, m2.sizeAttenuation);
+}
+
+describe('PointsMaterial', function () {
+    describe('.constructor()', function () {
+        it('should default like a THREE.PointsMaterial', function () {
+            assertPointsMaterialEqual(
+                new TPointsMaterial(),
+                new PointsMaterial(),
+            );
+        });
+    });
+
+    describe('#copy()', function () {
+        it('should copy a THREE.PointsMaterial', function () {
+            const material = new TPointsMaterial();
+
+            // THREE.Material properties
+            material.vertexColors = true;
+            material.transparent = true;
+            material.depthWrite = false;
+
+            // THREE.PointsMaterial properties
+            material.color = new Color(0, 0, 1);
+            material.fog = false;
+            material.map = new Texture();
+            material.size = 10;
+            material.sizeAttenuation = false;
+
+            const copiedMaterial = new PointsMaterial().copy(material);
+            assertPointsMaterialEqual(copiedMaterial, material);
+            assert.equal(copiedMaterial.vertexColors, material.vertexColors);
+            assert.equal(copiedMaterial.transparent, material.transparent);
+            assert.equal(copiedMaterial.depthWrite, material.depthWrite);
+        });
+    });
+
+    describe('#map', function () {
+        it('should update uvTransform from texture matrix', function () {
+            const material = new PointsMaterial();
+            const texture = new Texture();
+
+            texture.matrix = uvTransform;
+            material.map = texture;
+
+            const uniforms = material.uniforms;
+            assert.equal(uniforms.map.value, texture);
+            assert.deepEqual(uniforms.uvTransform.value, texture.matrix);
+        });
+    });
+
+    describe('#alphaMap', function () {
+        it('should update alphaMapTransform from texture matrix', function () {
+            const material = new PointsMaterial();
+            const texture = new Texture();
+
+            texture.matrix = uvTransform;
+            material.alphaMap = texture;
+
+            const uniforms = material.uniforms;
+            assert.equal(uniforms.alphaMap.value, texture);
+            assert.deepEqual(uniforms.alphaMapTransform.value, texture.matrix);
+        });
+    });
+
+    describe('#sizeAttenuation', function () {
+        it('should sync with sizeMode', function () {
+            const material = new PointsMaterial();
+
+            material.sizeAttenuation = false;
+            assert.equal(material.sizeMode, PNTS_SIZE_MODE.VALUE);
+
+            material.sizeMode = PNTS_SIZE_MODE.ATTENUATED;
+            assert.equal(material.sizeAttenuation, true);
+        });
+    });
+});

--- a/test/unit/potree.js
+++ b/test/unit/potree.js
@@ -6,8 +6,6 @@ import View from 'Core/View';
 import GlobeView from 'Core/Prefab/GlobeView';
 import Coordinates from 'Core/Geographic/Coordinates';
 import PotreeNode from 'Core/PotreeNode';
-import PointsMaterial from 'Renderer/PointsMaterial';
-import OrientedImageMaterial from 'Renderer/OrientedImageMaterial';
 import sinon from 'sinon';
 import Fetcher from 'Provider/Fetcher';
 import Renderer from './bootstrap';
@@ -145,24 +143,6 @@ describe('Potree', function () {
                             done();
                         }),
                     ).catch(done);
-            });
-        });
-
-        describe('Point Material and oriented images', () => {
-            const orientedImageMaterial = new OrientedImageMaterial([]);
-            const pMaterial = new PointsMaterial({ orientedImageMaterial });
-            const pMaterial2 = new PointsMaterial();
-            it('instance', () => {
-                assert.ok(pMaterial);
-            });
-            it('copy', () => {
-                pMaterial2.copy(pMaterial);
-                assert.equal(pMaterial2.uniforms.projectiveTextureAlphaBorder.value, 20);
-            });
-            it('update', () => {
-                pMaterial.visible = false;
-                pMaterial2.update(pMaterial);
-                assert.equal(pMaterial2.visible, false);
             });
         });
     });

--- a/test/unit/potree2.js
+++ b/test/unit/potree2.js
@@ -5,8 +5,6 @@ import Potree2BinParser from 'Parser/Potree2BinParser';
 import View from 'Core/View';
 import HttpsProxyAgent from 'https-proxy-agent';
 import Potree2Node from 'Core/Potree2Node';
-import PointsMaterial from 'Renderer/PointsMaterial';
-import OrientedImageMaterial from 'Renderer/OrientedImageMaterial';
 import { Vector3 } from 'three';
 import Renderer from './bootstrap';
 
@@ -107,24 +105,6 @@ describe('Potree2', function () {
                         done();
                     }),
                 ).catch(done);
-        });
-    });
-
-    describe('Point Material and oriented images', () => {
-        const orientedImageMaterial = new OrientedImageMaterial([]);
-        const pMaterial = new PointsMaterial({ orientedImageMaterial });
-        const pMaterial2 = new PointsMaterial();
-        it('instance', () => {
-            assert.ok(pMaterial);
-        });
-        it('copy', () => {
-            pMaterial2.copy(pMaterial);
-            assert.equal(pMaterial2.uniforms.projectiveTextureAlphaBorder.value, 20);
-        });
-        it('update', () => {
-            pMaterial.visible = false;
-            pMaterial2.update(pMaterial);
-            assert.equal(pMaterial2.visible, false);
         });
     });
 


### PR DESCRIPTION
## Motivation and Context
`itowns` pointclouds currently uses a custom points material that greatly diverges from the default material provided by `three`. This divergence leads to complications, especially when using our material in places where the default material is expected (e.g. our on-going work on `3d-tiles-renderer`). To address this, this PR propose refactoring our custom material into a superset of the `three` default points material.

## Description
The exhaustive list of changes in this PR:
- [x] Add support of all relevant `Material` properties  (`alphaTest`, `clippingPlanes`, `toneMapped`, `vertexColors`)
- [x] Add support of `diffuse` property (replacing the old `overlayColor`)
- [x] Add support of `fog` properties (enabled by default)
- [x] Add support of `map` texture properties
- [x] Add support of `alphaMap` and `alphaTest` properties
- [x] Add support of `clippingPlanes` properties
- [x] Cleanup of some unused code (`update`)
- [x] BREAKING CHANGE: Remove support of non-tested and non-documented `orientedImageMaterial`
- [x] BREAKING CHANGE: Remove support of `overlayColor` (replaced by the standard `diffuse` property)
- [x] Use a single `normal` uniform (as `NORMAL_OCT16P` and `NORMAL_SPHEREMAPPED` are unused or at best hidden behind undocumented flags)

Changes in a future PR?
- Add support in the parser (e.g. `PotreeParser`) to decode encoded normals
- Add define guards against different kind of color mode (but will introduce a breaking change) since we'll need to manually trigger recompile (or get from cache) using `material.needsUpdate = true`.
- Dedupe similar uniforms (multiple ranges, multiple textures)
