### PR TITLE
fix(points): use param classificationScheme in 3DTiles

### DIFF
--- a/src/Provider/3dTilesProvider.js
+++ b/src/Provider/3dTilesProvider.js
@@ -39,7 +39,7 @@ function pntsParse(data, layer) {
                 size: 1,
                 mode: layer.pntsMode,
                 shape: layer.pntsShape,
-                classification: layer.classification,
+                classificationScheme: layer.classification,
                 sizeMode: layer.pntsSizeMode,
                 minAttenuatedSize: layer.pntsMinAttenuatedSize,
                 maxAttenuatedSize: layer.pntsMaxAttenuatedSize,

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -165,7 +165,7 @@ class PointsMaterial extends THREE.ShaderMaterial {
      * @param      {THREE.Vector2}  [options.intensityRange=new THREE.Vector2(1, 65536)]  intensity range.
      * @param      {THREE.Vector2}  [options.elevationRange=new THREE.Vector2(0, 1000)]  elevation range.
      * @param      {THREE.Vector2}  [options.angleRange=new THREE.Vector2(-90, 90)]  scan angle range.
-     * @param      {Scheme}  [options.classification]  LUT for point classification colorization.
+     * @param      {Scheme}  [options.classificationScheme]  LUT for point classification colorization.
      * @param      {Scheme}  [options.discreteScheme]  LUT for other discret point values colorization.
      * @param      {string}  [options.gradient]  Descrition of the gradient to use for continuous point values.
      *                          (Default value will be the 'SPECTRAL' gradient from Utils/Gradients)


### PR DESCRIPTION
## Description
Use `classificationScheme` parameter for all users of `PointsMaterial` (instead of a mix of `classification` and `classificationScheme` and update the documentation.
This fixes a regression introduced by #2348 where usage of the `classification` parameter caused warnings from `THREE.PointsMaterial`.