### PR TITLE
fix(TiledGeometryLayer): handle hideSkirt at creation

### DIFF
--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -70,7 +70,7 @@ class TiledGeometryLayer extends GeometryLayer {
         this.object3d.geoidHeight = 0;
 
         this.protocol = 'tile';
-        this._hideSkirt = false;
+        this._hideSkirt = !!config.hideSkirt;
 
         this.sseSubdivisionThreshold = this.sseSubdivisionThreshold || 1.0;
 
@@ -106,6 +106,9 @@ class TiledGeometryLayer extends GeometryLayer {
         return this._hideSkirt;
     }
     set hideSkirt(value) {
+        if (!this.level0Nodes) {
+            return;
+        }
         this._hideSkirt = value;
         for (const node of this.level0Nodes) {
             node.traverse((obj) => {

--- a/test/unit/tiledGeometryLayer.js
+++ b/test/unit/tiledGeometryLayer.js
@@ -2,6 +2,8 @@ import assert from 'assert';
 import Extent from 'Core/Geographic/Extent';
 import PlanarView from 'Core/Prefab/PlanarView';
 import { CAMERA_TYPE } from 'Renderer/Camera';
+import GlobeView from 'Core/Prefab/GlobeView';
+import Coordinates from 'Core/Geographic/Coordinates';
 import Renderer from './bootstrap';
 
 
@@ -24,5 +26,16 @@ describe('TiledGeometryLayer', function () {
         // orthographic camera
         viewOrtho.tileLayer.subdivision(viewOrtho, viewOrtho.tileLayer, viewOrtho.tileLayer.level0Nodes[0]);
         assert.notEqual(viewOrtho.tileLayer.level0Nodes[0].screenSize, undefined);
+    });
+
+    it('should allow hide skirt', function () {
+        // planar view
+        const viewPlanar = new PlanarView(renderer.domElement, extent, { renderer, hideSkirt: true });
+        assert.ok(viewPlanar);
+
+        // globe view
+        const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 3919 };
+        const viewGlobe = new GlobeView(renderer.domElement, placement, { renderer, hideSkirt: true });
+        assert.ok(viewGlobe);
     });
 });


### PR DESCRIPTION
## Description
Fix concerning https://github.com/iTowns/itowns/issues/2357

The line
https://github.com/iTowns/itowns/blob/982b908a4420ee0308e95a9fe54c7018149a1554/src/Layer/Layer.js#L114

was triggering the `hideSkirt` setter before the complete initialization of the `TiledGeometryLayer` which resulted in a failure.

To correct it, we are now verifying the `level0Nodes` validity and reassigning `hideSkirt` value afterwards.

I've also added a unit test.