### PR TITLE
fix(PointCloud): Allow using custom object3d on PointCloudLayer

### DIFF
--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -147,7 +147,7 @@ class PointCloudLayer extends GeometryLayer {
      * name. See the list of properties to know which one can be specified.
      */
     constructor(id, config = {}) {
-        super(id, new THREE.Group(), config);
+        super(id, config.object3d || new THREE.Group(), config);
         this.isPointCloudLayer = true;
         this.protocol = 'pointcloud';
 


### PR DESCRIPTION
## Description
I think it's a missing behaviour, we need to pass custom object3d to place pointCloud at a specific position.

You can see live demo here : https://demo-hackathon.netlify.app/examples/demo_hackathon_orvault_planarview

And how we use custom object for point cloud placement here : https://github.com/bloc-in-bloc/itowns/blob/58636e3319a5ef0385e2b031e61d7d071126a169/examples/demo_hackathon_orvault_planarView.html#L303