### PR TITLE
[OGC3DTiles] Add support for picking

### DIFF
--- a/examples/3dtiles_basic.html
+++ b/examples/3dtiles_basic.html
@@ -47,7 +47,6 @@
             // -------------------------------------------
             var $3dTilesLayerDiscreteLOD = new itowns.OGC3DTilesLayer('3d-tiles-discrete-lod', {
                 name: 'DiscreteLOD',
-                sseThreshold: 0.05,
                 source: new itowns.OGC3DTilesSource({
                     url: 'https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/master/1.0/TilesetWithDiscreteLOD/tileset.json',
                 }),
@@ -63,22 +62,20 @@
                 source: new itowns.OGC3DTilesSource({
                     url: 'https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/master/1.0/TilesetWithRequestVolume/tileset.json',
                 }),
-                sseThreshold: 1,
             });
-
-            itowns.View.prototype.addLayer.call(view, $3dTilesLayerRequestVolume);
 
             // add an event for picking the 3D Tiles layer and displaying
             // information about the picked feature in an html div
-            // var pickingArgs = {};
-            // pickingArgs.htmlDiv = document.getElementById('featureInfo');
-            // pickingArgs.view = view;
-            // pickingArgs.layer = $3dTilesLayerRequestVolume;
-            // itowns.View.prototype.addLayer.call(view,
-            //     $3dTilesLayerRequestVolume).then(function _() {
-            //         window.addEventListener('mousemove',
-            //             (event) => fillHTMLWithPickingInfo(event, pickingArgs),false);
-            //     });
+            const pickingArgs = {
+                htmlDiv: document.getElementById('featureInfo'),
+                view,
+                layer: $3dTilesLayerRequestVolume,
+            };
+            itowns.View.prototype.addLayer.call(view,
+                $3dTilesLayerRequestVolume).then(function _() {
+                    window.addEventListener('mousemove',
+                        (event) => fillHTMLWithPickingInfo(event, pickingArgs),false);
+                });
 
             // Add the UI Debug
             var d = new debug.Debug(view, menuGlobe.gui);

--- a/examples/3dtiles_pointcloud.html
+++ b/examples/3dtiles_pointcloud.html
@@ -17,6 +17,9 @@
               <li>Use classification to assign colour to each points</li>
               <li>Switch between mode on the left panel</li>
             </ul>
+            <br/>
+            <p><b>Point Information:</b></p>
+            <div id="featureInfo"></div>
         </div>
         <div id="viewerDiv"></div>
         <script src="js/GUI/GuiTools.js"></script>
@@ -63,7 +66,18 @@
                 source: $3dTilesSource,
             });
 
-            itowns.View.prototype.addLayer.call(view, $3dTilesLayerSetePC);
+            const pickingArgs = {
+                htmlDiv: document.getElementById('featureInfo'),
+                view,
+                layer: $3dTilesLayerSetePC,
+            };
+
+            itowns.View.prototype.addLayer.call(view,$3dTilesLayerSetePC)
+                .then(() => {
+                    window.addEventListener('mousemove',
+                        (event) => fillHTMLWithPickingInfo(event, pickingArgs),
+                    false);
+                });
 
             // Add the UI Debug
             // var d = new debug.Debug(view, menuGlobe.gui);

--- a/examples/js/3dTilesHelper.js
+++ b/examples/js/3dTilesHelper.js
@@ -6,27 +6,23 @@
 // pickingArg.layer : the layer on which the picking must be done
 // eslint-disable-next-line
 function fillHTMLWithPickingInfo(event, pickingArg) {
-    if (!pickingArg.layer.isC3DTilesLayer) {
-        console.warn('Function fillHTMLWithPickingInfo only works' +
-            ' for C3DTilesLayer layers.');
-        return;
-    }
+    const { htmlDiv, view, layer } = pickingArg;
 
     // Remove content already in html div
-    while (pickingArg.htmlDiv.firstChild) {
-        pickingArg.htmlDiv.removeChild(pickingArg.htmlDiv.firstChild);
+    while (htmlDiv.firstChild) {
+        htmlDiv.removeChild(htmlDiv.firstChild);
     }
 
     // Get intersected objects
-    const intersects = pickingArg.view.pickObjectsAt(event, 5, pickingArg.layer);
-    if (intersects.length === 0) { return; }
+    const intersects = view.pickObjectsAt(event, 5, layer);
 
     // Get information from intersected objects (from the batch table and
     // eventually the 3D Tiles extensions
-    const closestC3DTileFeature = pickingArg.layer.getC3DTileFeatureFromIntersectsArray(intersects);
+    const closestC3DTileFeature =
+        layer.getC3DTileFeatureFromIntersectsArray(intersects);
 
     if (closestC3DTileFeature) {
         // eslint-disable-next-line
-        pickingArg.htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature.getInfo()));
+        htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature));
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/vector-tile": "^2.0.3",
         "@tmcw/togeojson": "^5.8.1",
         "@tweenjs/tween.js": "^23.1.2",
-        "3d-tiles-renderer": "^0.3.35",
+        "3d-tiles-renderer": "^0.3.36",
         "brotli-compress": "^1.3.3",
         "copc": "^0.0.6",
         "earcut": "^3.0.0",
@@ -3113,9 +3113,9 @@
       "dev": true
     },
     "node_modules/3d-tiles-renderer": {
-      "version": "0.3.35",
-      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.3.35.tgz",
-      "integrity": "sha512-C521P31fcx690yaq+4phNLkFtL5SfQONVUYeZyEyZ+YcpMHwEKDhmZ+PiuAgL9HpRH5xAGAmE8fUBVhKwnTZTA==",
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.3.36.tgz",
+      "integrity": "sha512-CnSOvJW4g5oBtqk9sZuSYFFd9JiKwSKcCOojGTrThsxfyy1sSw+UU+FbQyLyLqyfHGf+oMxPKLXCluY89/lebw==",
       "peerDependencies": {
         "three": ">=0.123.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@mapbox/vector-tile": "^2.0.3",
     "@tmcw/togeojson": "^5.8.1",
     "@tweenjs/tween.js": "^23.1.2",
-    "3d-tiles-renderer": "^0.3.35",
+    "3d-tiles-renderer": "^0.3.36",
     "brotli-compress": "^1.3.3",
     "copc": "^0.0.6",
     "earcut": "^3.0.0",

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -1,5 +1,12 @@
 import * as THREE from 'three';
-import { CesiumIonTilesRenderer, GoogleTilesRenderer, TilesRenderer, GLTFStructuralMetadataExtension, GLTFCesiumRTCExtension } from '3d-tiles-renderer';
+import {
+    TilesRenderer,
+    GLTFStructuralMetadataExtension,
+    GLTFCesiumRTCExtension,
+    CesiumIonAuthPlugin,
+    GoogleCloudAuthPlugin,
+} from '3d-tiles-renderer';
+
 import GeometryLayer from 'Layer/GeometryLayer';
 import iGLTFLoader from 'Parser/iGLTFLoader';
 import { DRACOLoader } from 'ThreeExtended/loaders/DRACOLoader';
@@ -134,14 +141,16 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         this._handlePointsMaterialConfig(config);
 
+        this.tilesRenderer = new TilesRenderer(this.source.url);
         if (config.source.isOGC3DTilesIonSource) {
-            this.tilesRenderer = new CesiumIonTilesRenderer(config.source.assetId, config.source.accessToken);
+            this.tilesRenderer.registerPlugin(new CesiumIonAuthPlugin({
+                apiToken: config.source.accessToken,
+                assetId: config.source.assetId,
+            }));
         } else if (config.source.isOGC3DTilesGoogleSource) {
-            this.tilesRenderer = new GoogleTilesRenderer(config.source.key);
-        } else if (config.source.isOGC3DTilesSource) {
-            this.tilesRenderer = new TilesRenderer(this.source.url);
-        } else {
-            console.error('[OGC3DTilesLayer]: Unsupported source, cannot create OGC3DTilesLayer.');
+            this.tilesRenderer.registerPlugin(new GoogleCloudAuthPlugin({
+                apiToken: config.source.key,
+            }));
         }
 
         this.tilesRenderer.manager.addHandler(/\.gltf$/, itownsGLTFLoader);


### PR DESCRIPTION
## Description

This PR add support for picking on new `OGC3DTilesLayer`. It is compatible with the old interface of `C3DTilesLayer` except that `getC3DTileFeatureFromIntersectsArrays`  (please rename this 40 chars method name...) now returns an object containing features for the closest intersection instead of an old `C3DTilesFeature` instance.

This PR also add picking for points data, which was not supported on the old implementation (you could try it live with `3dtiles_pointcloud` example).

Note that we are waiting for NASA-AMMOS/3DTilesRendererJS#627 to be merged and new version of `3d-tiles-renderer` before merging this PR. =)