### PR TITLE
3d tiles migration clean

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -57,8 +57,7 @@ function object3DHasFeature(object3d) {
 class C3DTilesLayer extends GeometryLayer {
     #fillColorMaterialsBuffer;
     /**
-     * @deprecated Previous itowns own implementation, now delegated to 3d-tiles-renderer. Use {@link OGC3DTilesLayer} instead.
-     * Constructs a new instance of 3d tiles layer.
+     * @deprecated Deprecated 3D Tiles layer., now delegated to 3d-tiles-renderer. Use {@link OGC3DTilesLayer} instead.
      * @constructor
      * @extends GeometryLayer
      *

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -20,6 +20,41 @@ let lruCache = null;
 let downloadQueue = null;
 let parseQueue = null;
 
+export const OGC3DTILES_LAYER_EVENTS = {
+    /**
+     * Fired when a new root or child tile set is loaded
+     * @event OGC3DTilesLayer#load-tile-set
+     * @type {Object}
+     * @property {Object} tileset - the tileset json parsed in an Object
+     * @property {String} url - tileset url
+     */
+    LOAD_TILE_SET: 'load-tile-set',
+    /**
+     * Fired when a tile model is loaded
+     * @event OGC3DTilesLayer#load-model
+     * @type {Object}
+     * @property {THREE.Group} scene - the model (tile content) parsed in a THREE.GROUP
+     * @property {Object} tile - the tile metadata from the tileset
+     */
+    LOAD_MODEL: 'load-model',
+    /**
+     * Fired when a tile model is disposed
+     * @event OGC3DTilesLayer#dispose-model
+     * @type {Object}
+     * @property {THREE.Group} scene - the model (tile content) that is disposed
+     * @property {Object} tile - the tile metadata from the tileset
+     */
+    DISPOSE_MODEL: 'dispose-model',
+    /**
+     * Fired when a tiles visibility changes
+     * @event OGC3DTilesLayer#tile-visibility-change
+     * @type {Object}
+     * @property {THREE.Group} scene - the model (tile content) parsed in a THREE.GROUP
+     * @property {Object} tile - the tile metadata from the tileset
+     */
+    TILE_VISIBILITY_CHANGE: 'tile-visibility-change',
+};
+
 /**
  * Enable loading 3D Tiles with [Draco](https://google.github.io/draco/) geometry extension.
  *
@@ -95,6 +130,7 @@ class OGC3DTilesLayer extends GeometryLayer {
         this.tilesRenderer.manager.addHandler(/\.gltf$/, itownsGLTFLoader);
 
         this._setupCacheAndQueues();
+        this._setupEvents();
 
         this.object3d.add(this.tilesRenderer.group);
 
@@ -130,6 +166,14 @@ class OGC3DTilesLayer extends GeometryLayer {
             parseQueue = this.tilesRenderer.parseQueue;
         } else {
             this.tilesRenderer.parseQueue = parseQueue;
+        }
+    }
+
+    _setupEvents() {
+        for (const ev of Object.values(OGC3DTILES_LAYER_EVENTS)) {
+            this.tilesRenderer.addEventListener(ev, (e) => {
+                this.dispatchEvent(e);
+            });
         }
     }
 

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -10,7 +10,7 @@ import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
 // Internal instance of GLTFLoader, passed to 3d-tiles-renderer-js to support GLTF 1.0 and 2.0
 // Temporary exported to be used in deprecated B3dmParser
 export const itownsGLTFLoader = new iGLTFLoader();
-// TODO: waiting for https://github.com/NASA-AMMOS/3DTilesRendererJS/pull/626 to be merged to enable this extension
+// TODO: waiting for https://github.com/NASA-AMMOS/3DTilesRendererJS/pull/626 to be released
 // itownsGLTFLoader.register(() => new GLTFMeshFeaturesExtension());
 itownsGLTFLoader.register(() => new GLTFStructuralMetadataExtension());
 itownsGLTFLoader.register(() => new GLTFCesiumRTCExtension());
@@ -51,6 +51,7 @@ export const OGC3DTILES_LAYER_EVENTS = {
      * @type {Object}
      * @property {THREE.Group} scene - the model (tile content) parsed in a THREE.GROUP
      * @property {Object} tile - the tile metadata from the tileset
+     * @property {boolean} visible - the tile visible state
      */
     TILE_VISIBILITY_CHANGE: 'tile-visibility-change',
 };

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { CesiumIonTilesRenderer, GoogleTilesRenderer, TilesRenderer, GLTFMeshFeaturesExtension, GLTFStructuralMetadataExtension, GLTFCesiumRTCExtension } from '3d-tiles-renderer';
+import { CesiumIonTilesRenderer, GoogleTilesRenderer, TilesRenderer, GLTFStructuralMetadataExtension, GLTFCesiumRTCExtension } from '3d-tiles-renderer';
 import GeometryLayer from 'Layer/GeometryLayer';
 import iGLTFLoader from 'Parser/iGLTFLoader';
 import { DRACOLoader } from 'ThreeExtended/loaders/DRACOLoader';

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -140,19 +140,20 @@ class OGC3DTilesLayer extends GeometryLayer {
         this.tilesRenderer.setResolutionFromRenderer(view.camera3D, view.renderer);
         // Setup whenReady to be fullfiled when the root tileset has been loaded
         let rootTilesetLoaded = false;
-        this.tilesRenderer.onLoadTileSet = () => {
+        this.tilesRenderer.addEventListener('load-tile-set', () => {
             view.notifyChange(this);
             if (!rootTilesetLoaded) {
                 rootTilesetLoaded = true;
                 this._res();
             }
-        };
-        this.tilesRenderer.onLoadModel = (model) => {
+        });
+        this.tilesRenderer.addEventListener('load-model', (e) => {
+            const model = e.scene;
             if (model.isPoints) {
                 this._replacePointsMaterial(model);
             }
             view.notifyChange(this);
-        };
+        });
         // Start loading tileset and tiles
         this.tilesRenderer.update();
     }

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -11,6 +11,11 @@ import ReferLayerProperties from 'Layer/ReferencingLayerProperties';
 // Temporary exported to be used in deprecated B3dmParser
 export const itownsGLTFLoader = new iGLTFLoader();
 
+// Instantiated by the first tileset. Used to share cache and download and parse queues between tilesets
+let lruCache = null;
+let downloadQueue = null;
+let parseQueue = null;
+
 /**
  * Enable loading 3D Tiles with [Draco](https://google.github.io/draco/) geometry extension.
  *
@@ -49,19 +54,11 @@ export function enableKtx2Loader(path, renderer) {
     itownsGLTFLoader.setKTX2Loader(ktx2Loader);
 }
 
-// TODO: This syntax is currently not possible with the current 3d-tiles-renderer-js API -> open a PR
-// It will allow to share cache and download/parse queue between tilesets
-// const lruCache = new LRUCache();
-// const downloadQueue = new PriorityQueue();
-// const parseQueue = new PriorityQueue();
-
 class OGC3DTilesLayer extends GeometryLayer {
     constructor(id, config) {
         super(id, new THREE.Group(), { source: config.source });
         this.isOGC3DTilesLayer = true;
 
-        // TODO: should this really be done here and like this (i.e. each option is passed in individually?)
-        //  I think we should use the Style API instead :)
         this._handlePointsMaterialConfig(config);
 
         if (config.source.isOGC3DTilesIonSource) {
@@ -76,23 +73,50 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         this.tilesRenderer.manager.addHandler(/\.gltf$/, itownsGLTFLoader);
 
-        // Set cache, download and parse queues to be shared amongst 3D tiles layers (waiting for 3d-tiles-renderer-js api change)
-        // this.tilesRenderer.lruCache = lruCache;
-        // this.tilesRenderer.downloadQueue = downloadQueue;
-        // this.tilesRenderer.parseQueue = parseQueue;
+        this._setupCacheAndQueues();
 
         this.object3d.add(this.tilesRenderer.group);
 
-        // Add an initialization step that is resolved when the root tileset is loaded (see this._setup below)
+        // Add an initialization step that is resolved when the root tileset is loaded (see this._setup below), meaning
+        // that the layer will be marked ready when the tileset has been loaded.
         this._res = this.addInitializationStep();
     }
 
-    // TODO: what happens if the layer is added to multiple views? Should we store multiple tilesRenderer?
-    // How does it work for other layer types?
+    // Store points material config so they can be used later to substitute points tiles material by our own PointsMaterial
+    // These properties should eventually be managed through the Style API (see https://github.com/iTowns/itowns/issues/2336)
+    _handlePointsMaterialConfig(config) {
+        this.pntsMode = config.pntsMode;
+        this.pntsShape = config.pntsShape;
+        this.classification = config.classification;
+        this.pntsSizeMode = config.pntsSizeMode;
+        this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 3;
+        this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 10;
+    }
+
+    // Sets the lruCache and download and parse queues so they are shared amongst all tilesets
+    _setupCacheAndQueues() {
+        if (lruCache === null) {
+            lruCache = this.tilesRenderer.lruCache;
+        } else {
+            this.tilesRenderer.lruCache = lruCache;
+        }
+        if (downloadQueue === null) {
+            downloadQueue = this.tilesRenderer.downloadQueue;
+        } else {
+            this.tilesRenderer.downloadQueue = downloadQueue;
+        }
+        if (parseQueue === null) {
+            parseQueue = this.tilesRenderer.parseQueue;
+        } else {
+            this.tilesRenderer.parseQueue = parseQueue;
+        }
+    }
+
+    // Setup 3D tiles renderer js TilesRenderer with the camera, binds events and start updating. Executed when the
+    // layer has been added to the view.
     _setup(view) {
         this.tilesRenderer.setCamera(view.camera3D);
         this.tilesRenderer.setResolutionFromRenderer(view.camera3D, view.renderer);
-        // TODO: should we store the tileset and our own list of models? or at least provide an API to access them
         // Setup whenReady to be fullfiled when the root tileset has been loaded
         let rootTilesetLoaded = false;
         this.tilesRenderer.onLoadTileSet = () => {
@@ -112,8 +136,7 @@ class OGC3DTilesLayer extends GeometryLayer {
         this.tilesRenderer.update();
     }
 
-    // TODO: Not fond of this implementation, I would rather add the possibility to pass a PointsMaterial to
-    //  3d-tiles-renderer-js TilesRenderer instead
+    // Replaces points tiles material with our own PointsMaterial
     _replacePointsMaterial(model) {
         if (!model || !model.isPoints) { return; }
         const oldMat = model.material;
@@ -134,7 +157,6 @@ class OGC3DTilesLayer extends GeometryLayer {
         oldMat.dispose();
         ReferLayerProperties(model.material, this);
         // Setup classification bufferAttribute
-        // TODO: add the possibility to configure the classification attribute name
         if (model.batchTable) {
             const classificationData =  model.batchTable.getData('Classification');
             if (classificationData) {
@@ -143,19 +165,8 @@ class OGC3DTilesLayer extends GeometryLayer {
         }
     }
 
-    _handlePointsMaterialConfig(config) {
-        this.pntsMode = config.pntsMode;
-        this.pntsShape = config.pntsShape;
-        this.classification = config.classification;
-        this.pntsSizeMode = config.pntsSizeMode;
-        this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 3;
-        this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 10;
-    }
-
     preUpdate() {
         this.tilesRenderer.update();
-        // const str = `Downloading: ${this.tilesRenderer.stats.downloading} Parsing: ${this.tilesRenderer.stats.parsing} Visible: ${this.tilesRenderer.visibleTiles.size}`;
-        // console.log(str);
         return null; // don't return any element because 3d-tiles-renderer updates them
     }
 
@@ -167,7 +178,21 @@ class OGC3DTilesLayer extends GeometryLayer {
         this.tilesRenderer.dispose();
     }
 
-    // TODO Methods: attach; detach; getObjectToUpdateForAttachedLayers; getC3DTileFeatureFromIntersectsArray?
+    // eslint-disable-next-line no-unused-vars
+    attach(layer) {
+        console.warn('[OGC3DTilesLayer]: Attaching / detaching layers is not yet implemented for OGC3DTilesLayer.');
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    detach(layer) {
+        console.warn('[OGC3DTilesLayer]: Attaching / detaching layers is not yet implemented for OGC3DTilesLayer.');
+        return true;
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    getObjectToUpdateForAttachedLayers(obj) {
+        return null;
+    }
 }
 
 export default OGC3DTilesLayer;

--- a/src/Main.js
+++ b/src/Main.js
@@ -54,7 +54,7 @@ export { default as PointCloudLayer } from 'Layer/PointCloudLayer';
 export { default as PotreeLayer } from 'Layer/PotreeLayer';
 export { default as Potree2Layer } from 'Layer/Potree2Layer';
 export { default as C3DTilesLayer, C3DTILES_LAYER_EVENTS } from 'Layer/C3DTilesLayer';
-export { default as OGC3DTilesLayer, enableDracoLoader, enableKtx2Loader } from 'Layer/OGC3DTilesLayer';
+export { default as OGC3DTilesLayer, OGC3DTILES_LAYER_EVENTS, enableDracoLoader, enableKtx2Loader } from 'Layer/OGC3DTilesLayer';
 export { default as TiledGeometryLayer } from 'Layer/TiledGeometryLayer';
 export { default as OrientedImageLayer } from 'Layer/OrientedImageLayer';
 export { STRATEGY_MIN_NETWORK_TRAFFIC, STRATEGY_GROUP, STRATEGY_PROGRESSIVE, STRATEGY_DICHOTOMY } from 'Layer/LayerUpdateStrategy';


### PR DESCRIPTION
* clean / document `OGC3DTilesLayer`
* share cache and queues amongst 3D tiles layers
* Propagate 3d-tiles-renderer events through `OGC3DtilesLayer`
* Attaching / dettaching layer 
* Register supported 3D tiles extensions