### PR TITLE
Remove assignement of all config properties in base Layer class

### DIFF
--- a/examples/layers/JSONLayers/GeoidMNT.json
+++ b/examples/layers/JSONLayers/GeoidMNT.json
@@ -4,7 +4,9 @@
     "updateStrategy": {
         "type": 0
     },
-    "zmin": -12000,
+    "clampValues": {
+        "min": -12000
+    },
     "source": {
         "url": "https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/geoid/geoid/bil/%TILEMATRIX/geoid_%COL_%ROW.bil",
         "format": "image/x-bil;bits=32",

--- a/examples/source_file_geojson_3d.html
+++ b/examples/source_file_geojson_3d.html
@@ -54,7 +54,6 @@
                     crs: 'EPSG:4326',
                     format: 'application/json',
                 }),
-                transparent: true,
                 opacity: 0.7,
                 zoom: { min: 10 },
                 style: {

--- a/examples/source_stream_wfs_raster.html
+++ b/examples/source_stream_wfs_raster.html
@@ -53,12 +53,6 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
 
-            function isValidData(data) {
-                if(data.features[0].geometries.length < 1000) {
-                    return data;
-                }
-            }
-
             var wfsBuildingSource = new itowns.WFSSource({
                 url: 'https://data.geopf.fr/wfs/ows?',
                 version: '2.0.0',
@@ -102,7 +96,6 @@
                         width: 2.0,
                     },
                 },
-                isValidData: isValidData,
                 source: wfsBuildingSource,
                 zoom: { max: 20, min: 13 },
             });

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -122,7 +122,7 @@ export default {
 
             c.width = sizeTexture;
             c.height = sizeTexture;
-            const ctx = c.getContext('2d');
+            const ctx = c.getContext('2d', { willReadFrequently: true });
             if (backgroundColor) {
                 ctx.fillStyle = backgroundColor.getStyle();
                 ctx.fillRect(0, 0, sizeTexture, sizeTexture);

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -29,7 +29,9 @@ const spaceColor = new THREE.Color(0x030508);
 const limitAlti = 600000;
 const mfogDistance = ellipsoidSizes.x * 160.0;
 
-
+/**
+ * @extends GeometryLayer
+ */
 class Atmosphere extends GeometryLayer {
     /**
     * It's layer to simulate Globe atmosphere.
@@ -38,8 +40,6 @@ class Atmosphere extends GeometryLayer {
     * The atmospheric-scattering it is taken from :
     * * [Atmosphere Shader From Space (Atmospheric scattering)](http://stainlessbeer.weebly.com/planets-9-atmospheric-scattering.html)
     * * [Accurate Atmospheric Scattering (NVIDIA GPU Gems 2)](https://developer.nvidia.com/gpugems/gpugems2/part-ii-shading-lighting-and-shadows/chapter-16-accurate-atmospheric-scattering).
-    *
-    * @extends GeometryLayer
     *
     * @param {string} id - The id of the layer Atmosphere.
     * @param {Object} [options] - options layer.

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -8,13 +8,12 @@ import PlanarTileBuilder from './PlanarTileBuilder';
  * @property {boolean} isPlanarLayer - Used to checkout whether this layer is a
  * PlanarLayer. Default is true. You should not change this, as it is used
  * internally for optimisation.
+ * @extends TiledGeometryLayer
  */
 class PlanarLayer extends TiledGeometryLayer {
     /**
      * A {@link TiledGeometryLayer} to use with a {@link PlanarView}. It has
      * specific method for updating and subdivising its grid.
-     *
-     * @extends TiledGeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
@@ -34,17 +33,28 @@ class PlanarLayer extends TiledGeometryLayer {
      * @throws {Error} `object3d` must be a valid `THREE.Object3d`.
      */
     constructor(id, extent, object3d, config = {}) {
+        const {
+            minSubdivisionLevel = 0,
+            maxSubdivisionLevel = 5,
+            ...tiledConfig
+        } = config;
+
         const tileMatrixSets = [extent.crs];
         if (!globalExtentTMS.get(extent.crs)) {
             // Add new global extent for this new crs projection.
             globalExtentTMS.set(extent.crs, extent);
         }
-        config.tileMatrixSets = tileMatrixSets;
-        super(id, object3d || new THREE.Group(), [extent], new PlanarTileBuilder({ crs: extent.crs }), config);
+
+        const builder = new PlanarTileBuilder({ crs: extent.crs });
+        super(id, object3d || new THREE.Group(), [extent], builder, {
+            tileMatrixSets,
+            ...tiledConfig,
+        });
         this.isPlanarLayer = true;
         this.extent = extent;
-        this.minSubdivisionLevel = this.minSubdivisionLevel == undefined ? 0 : this.minSubdivisionLevel;
-        this.maxSubdivisionLevel = this.maxSubdivisionLevel == undefined ? 5 : this.maxSubdivisionLevel;
+
+        this.minSubdivisionLevel = minSubdivisionLevel;
+        this.maxSubdivisionLevel = maxSubdivisionLevel;
     }
 }
 

--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -54,11 +54,13 @@ function object3DHasFeature(object3d) {
     return object3d.geometry && object3d.geometry.attributes._BATCHID;
 }
 
+/**
+ * @extends GeometryLayer
+ */
 class C3DTilesLayer extends GeometryLayer {
     #fillColorMaterialsBuffer;
     /**
      * @deprecated Deprecated 3D Tiles layer. Use {@link OGC3DTilesLayer} instead.
-     * @extends GeometryLayer
      *
      * @example
      * // Create a new 3d-tiles layer from a web server
@@ -86,7 +88,7 @@ class C3DTilesLayer extends GeometryLayer {
      * {@link View} that already has a layer going by that id.
      * @param      {object}  config   configuration, all elements in it
      * will be merged as is in the layer.
-     * @param {C3TilesSource} config.source The source of 3d Tiles.
+     * @param {C3DTilesSource} config.source The source of 3d Tiles.
      *
      * name.
      * @param {Number} [config.sseThreshold=16] The [Screen Space Error](https://github.com/CesiumGS/3d-tiles/blob/main/specification/README.md#geometric-error)
@@ -143,8 +145,8 @@ class C3DTilesLayer extends GeometryLayer {
             if (!exists) { console.warn("The points cloud size mode doesn't exist. Use 'VALUE' or 'ATTENUATED' instead."); } else { this.pntsSizeMode = config.pntsSizeMode; }
         }
 
-        /** @type {Style} */
-        this.style = config.style || null;
+        /** @type {Style | null} */
+        this._style = config.style || null;
 
         /** @type {Map<string, THREE.MeshStandardMaterial>} */
         this.#fillColorMaterialsBuffer = new Map();

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -44,14 +44,14 @@ import { deprecatedColorLayerOptions } from 'Core/Deprecated/Undeprecator';
  * * `1`: used to amplify the transparency effect.
  * * `2`: unused.
  * * `3`: could be used by your own glsl code.
+ *
+ * @extends RasterLayer
  */
 class ColorLayer extends RasterLayer {
     /**
      * A simple layer, usually managing a texture to display on a view. For example,
      * it can be an aerial view of the ground or a simple transparent layer with the
      * roads displayed.
-     *
-     * @extends Layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
@@ -91,16 +91,45 @@ class ColorLayer extends RasterLayer {
      */
     constructor(id, config = {}) {
         deprecatedColorLayerOptions(config);
-        super(id, config);
+
+        const {
+            effect_type = 0,
+            effect_parameter = 1.0,
+            transparent,
+            ...rasterConfig
+        } = config;
+
+        super(id, rasterConfig);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
         this.isColorLayer = true;
-        this.defineLayerProperty('visible', true);
-        this.defineLayerProperty('opacity', 1.0);
-        this.defineLayerProperty('sequence', 0);
-        this.transparent = config.transparent || (this.opacity < 1.0);
+
+        /**
+         * @type {boolean}
+         */
+        this.visible = true;
+        this.defineLayerProperty('visible', this.visible);
+
+        /**
+         * @type {number}
+         */
+        this.opacity = 1.0;
+        this.defineLayerProperty('opacity', this.opacity);
+
+        /**
+         * @type {number}
+         */
+        this.sequence = 0;
+        this.defineLayerProperty('sequence', this.sequence);
+
+        this.transparent = transparent || (this.opacity < 1.0);
         this.noTextureParentOutsideLimit = config.source ? config.source.isFileSource : false;
 
-        this.effect_type = config.effect_type ?? 0;
-        this.effect_parameter = config.effect_parameter ?? 1.0;
+        this.effect_type = effect_type;
+        this.effect_parameter = effect_parameter;
 
         // Feature options
         this.buildExtent = true;

--- a/src/Layer/CopcLayer.js
+++ b/src/Layer/CopcLayer.js
@@ -30,6 +30,11 @@ class CopcLayer extends PointCloudLayer {
      */
     constructor(id, config) {
         super(id, config);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
         this.isCopcLayer = true;
 
         const resolve = () => this;

--- a/src/Layer/ElevationLayer.js
+++ b/src/Layer/ElevationLayer.js
@@ -22,13 +22,13 @@ import { RasterElevationTile } from 'Renderer/RasterTile';
  * ```
  * @property {number} colorTextureElevationMinZ - elevation minimum in `useColorTextureElevation` mode.
  * @property {number} colorTextureElevationMaxZ - elevation maximum in `useColorTextureElevation` mode.
+ *
+ * @extends RasterLayer
  */
 class ElevationLayer extends RasterLayer {
     /**
      * A simple layer, managing an elevation texture to add some reliefs on the
      * plane or globe view for example.
-     *
-     * @extends Layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
@@ -59,14 +59,52 @@ class ElevationLayer extends RasterLayer {
      * view.addLayer(elevation);
      */
     constructor(id, config = {}) {
-        super(id, config);
+        const {
+            scale = 1.0,
+            noDataValue,
+            clampValues,
+            useRgbaTextureElevation,
+            useColorTextureElevation,
+            colorTextureElevationMinZ,
+            colorTextureElevationMaxZ,
+            bias,
+            mode,
+            ...rasterConfig
+        } = config;
+
+        super(id, rasterConfig);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
+        this.isElevationLayer = true;
+
+        this.noDataValue = noDataValue;
+
         if (config.zmin || config.zmax) {
             console.warn('Config using zmin and zmax are deprecated, use {clampValues: {min, max}} structure.');
         }
-        this.zmin = config.clampValues?.min ?? config.zmin;
-        this.zmax = config.clampValues?.max ?? config.zmax;
-        this.isElevationLayer = true;
-        this.defineLayerProperty('scale', this.scale || 1.0);
+
+        /**
+         * @type {number | undefined}
+         */
+        this.zmin = clampValues?.min ?? config.zmin;
+
+        /**
+         * @type {number | undefined}
+         */
+        this.zmax = clampValues?.max ?? config.zmax;
+
+        this.defineLayerProperty('scale', scale);
+
+        this.useRgbaTextureElevation = useRgbaTextureElevation;
+        this.useColorTextureElevation = useColorTextureElevation;
+        this.colorTextureElevationMinZ = colorTextureElevationMinZ;
+        this.colorTextureElevationMaxZ = colorTextureElevationMaxZ;
+
+        this.bias = bias;
+        this.mode = mode;
     }
 
     /**

--- a/src/Layer/EntwinePointTileLayer.js
+++ b/src/Layer/EntwinePointTileLayer.js
@@ -11,12 +11,12 @@ bboxMesh.geometry.boundingBox = box3;
  * @property {boolean} isEntwinePointTileLayer - Used to checkout whether this
  * layer is a EntwinePointTileLayer. Default is `true`. You should not change
  * this, as it is used internally for optimisation.
+ *
+ * @extends PointCloudLayer
  */
 class EntwinePointTileLayer extends PointCloudLayer {
     /**
      * Constructs a new instance of Entwine Point Tile layer.
-     *
-     * @extends PointCloudLayer
      *
      * @example
      * // Create a new point cloud layer
@@ -37,15 +37,22 @@ class EntwinePointTileLayer extends PointCloudLayer {
      * contains three elements `name, protocol, extent`, these elements will be
      * available using `layer.name` or something else depending on the property
      * name. See the list of properties to know which one can be specified.
-     * @param {string} [config.crs=ESPG:4326] - The CRS of the {@link View} this
+     * @param {string} [config.crs='ESPG:4326'] - The CRS of the {@link View} this
      * layer will be attached to. This is used to determine the extent of this
      * layer. Default to `EPSG:4326`.
-     * @param {number} [config.skip=1] - Read one point from every `skip` points
-     * - see {@link LASParser}.
      */
     constructor(id, config) {
         super(id, config);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
         this.isEntwinePointTileLayer = true;
+
+        /**
+         * @type {THREE.Vector3}
+         */
         this.scale = new THREE.Vector3(1, 1, 1);
 
         const resolve = this.addInitializationStep();

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -176,9 +176,14 @@ class LabelLayer extends GeometryLayer {
      * except for the `Style.text.anchor` parameter which can help place the label.
      */
     constructor(id, config = {}) {
-        const domElement = config.domElement;
-        delete config.domElement;
-        super(id, config.object3d || new THREE.Group(), config);
+        const {
+            domElement,
+            performance = true,
+            forceClampToTerrain = false,
+            margin,
+            ...geometryConfig
+        } = config;
+        super(id, config.object3d || new THREE.Group(), geometryConfig);
 
         this.isLabelLayer = true;
         this.domElement = new DomNode();
@@ -186,8 +191,9 @@ class LabelLayer extends GeometryLayer {
         this.domElement.dom.id = `itowns-label-${this.id}`;
         this.buildExtent = true;
         this.crs = config.source.crs;
-        this.performance = config.performance || true;
-        this.forceClampToTerrain = config.forceClampToTerrain || false;
+        this.performance = performance;
+        this.forceClampToTerrain = forceClampToTerrain;
+        this.margin = margin;
 
         this.toHide = new THREE.Group();
 

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -100,16 +100,24 @@ class OrientedImageLayer extends GeometryLayer {
      * a tecture is need for each camera, for each panoramic.
      */
     constructor(id, config = {}) {
+        const {
+            backgroundDistance,
+            background = createBackground(backgroundDistance),
+            onPanoChanged = () => {},
+            getCamerasNameFromFeature = () => {},
+            ...geometryOptions
+        } = config;
+
         /* istanbul ignore next */
         if (config.projection) {
             console.warn('OrientedImageLayer projection parameter is deprecated, use crs instead.');
             config.crs = config.crs || config.projection;
         }
-        super(id, new THREE.Group(), config);
+        super(id, new THREE.Group(), geometryOptions);
 
         this.isOrientedImageLayer = true;
 
-        this.background = config.background || createBackground(config.backgroundDistance);
+        this.background = background;
 
         if (this.background) {
             // Add layer id to easily identify the objects later on (e.g. to delete the geometries when deleting the layer)
@@ -122,10 +130,10 @@ class OrientedImageLayer extends GeometryLayer {
         this.currentPano = undefined;
 
         // store a callback to fire event when current panoramic change
-        this.onPanoChanged = config.onPanoChanged || (() => {});
+        this.onPanoChanged = onPanoChanged;
 
         // function to get cameras name from panoramic feature
-        this.getCamerasNameFromFeature = config.getCamerasNameFromFeature || (() => {});
+        this.getCamerasNameFromFeature = getCamerasNameFromFeature;
 
         const resolve = this.addInitializationStep();
 

--- a/src/Layer/Potree2Layer.js
+++ b/src/Layer/Potree2Layer.js
@@ -113,12 +113,12 @@ function parseAttributes(jsonAttributes) {
  * @property {boolean} isPotreeLayer - Used to checkout whether this layer
  * is a Potree2Layer. Default is `true`. You should not change this, as it is
  * used internally for optimisation.
+ *
+ * @extends PointCloudLayer
  */
 class Potree2Layer extends PointCloudLayer {
     /**
      * Constructs a new instance of Potree2 layer.
-     *
-     * @extends PointCloudLayer
      *
      * @example
      * // Create a new point cloud layer
@@ -146,6 +146,11 @@ class Potree2Layer extends PointCloudLayer {
      */
     constructor(id, config) {
         super(id, config);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
         this.isPotreeLayer = true;
 
         const resolve = this.addInitializationStep();

--- a/src/Layer/PotreeLayer.js
+++ b/src/Layer/PotreeLayer.js
@@ -11,12 +11,12 @@ bboxMesh.geometry.boundingBox = box3;
  * @property {boolean} isPotreeLayer - Used to checkout whether this layer
  * is a PotreeLayer. Default is `true`. You should not change this, as it is
  * used internally for optimisation.
+ *
+ * @extends PointCloudLayer
  */
 class PotreeLayer extends PointCloudLayer {
     /**
      * Constructs a new instance of Potree layer.
-     *
-     * @extends PointCloudLayer
      *
      * @example
      * // Create a new point cloud layer
@@ -38,12 +38,17 @@ class PotreeLayer extends PointCloudLayer {
      * contains three elements `name, protocol, extent`, these elements will be
      * available using `layer.name` or something else depending on the property
      * name. See the list of properties to know which one can be specified.
-     * @param {string} [config.crs=ESPG:4326] - The CRS of the {@link View} this
+     * @param {string} [config.crs='ESPG:4326'] - The CRS of the {@link View} this
      * layer will be attached to. This is used to determine the extent of this
      * layer.  Default to `EPSG:4326`.
      */
     constructor(id, config) {
         super(id, config);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
         this.isPotreeLayer = true;
 
         const resolve = this.addInitializationStep();

--- a/src/Layer/RasterLayer.js
+++ b/src/Layer/RasterLayer.js
@@ -5,8 +5,20 @@ import { CACHE_POLICIES } from 'Core/Scheduler/Cache';
 
 class RasterLayer extends Layer {
     constructor(id, config) {
-        config.cacheLifeTime = config.cacheLifeTime ?? CACHE_POLICIES.TEXTURE;
-        super(id, config);
+        const {
+            cacheLifeTime = CACHE_POLICIES.TEXTURE,
+            minFilter,
+            magFilter,
+            ...layerConfig
+        } = config;
+
+        super(id, {
+            ...layerConfig,
+            cacheLifeTime,
+        });
+
+        this.minFilter = minFilter;
+        this.magFilter = magFilter;
     }
 
     convert(data, extentDestination) {

--- a/test/unit/dataSourceProvider.js
+++ b/test/unit/dataSourceProvider.js
@@ -83,8 +83,6 @@ describe('Provide in Sources', function () {
         nodeLayerElevation = material.getLayer(elevationlayer.id);
 
         featureLayer = new GeometryLayer('geom', new THREE.Group(), {
-            update: FeatureProcessing.update,
-            convert: Feature2Mesh.convert(),
             crs: 'EPSG:4978',
             mergeFeatures: false,
             zoom: { min: 10 },
@@ -96,6 +94,8 @@ describe('Provide in Sources', function () {
                 },
             }),
         });
+        featureLayer.update = FeatureProcessing.update;
+        featureLayer.convert = Feature2Mesh.convert();
 
         featureLayer.source = new WFSSource({
             url: 'http://domain.com',

--- a/test/unit/layeredmaterialnodeprocessing.js
+++ b/test/unit/layeredmaterialnodeprocessing.js
@@ -40,16 +40,17 @@ describe('updateLayeredMaterialNodeImagery', function () {
         source,
         crs: 'EPSG:4326',
         info: { update: () => {} },
+    });
+    layer.tileMatrixSets = [
+        'EPSG:4326',
+        'EPSG:3857',
+    ];
+    layer.parent = {
         tileMatrixSets: [
             'EPSG:4326',
             'EPSG:3857',
         ],
-        parent: { tileMatrixSets: [
-            'EPSG:4326',
-            'EPSG:3857',
-        ],
-        },
-    });
+    };
 
     const nodeLayer = new RasterColorTile(material, layer);
     material.getLayer = () => nodeLayer;

--- a/test/unit/layerupdatestrategy.js
+++ b/test/unit/layerupdatestrategy.js
@@ -43,16 +43,17 @@ describe('Handling no data source error', function () {
         source,
         crs: 'EPSG:4326',
         info: { update: () => {} },
+    });
+    layer.tileMatrixSets = [
+        'EPSG:4326',
+        'EPSG:3857',
+    ];
+    layer.parent = {
         tileMatrixSets: [
             'EPSG:4326',
             'EPSG:3857',
         ],
-        parent: { tileMatrixSets: [
-            'EPSG:4326',
-            'EPSG:3857',
-        ],
-        },
-    });
+    };
 
     const nodeLayer = new RasterColorTile(material, layer);
     nodeLayer.level = 10;

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -63,11 +63,11 @@ export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) 
     }
 
     const boundingVolumeLayer = new GeometryLayer(boundingVolumeID, new THREE.Object3D(), {
-        update: debugIdUpdate,
         visible: false,
         cacheLifeTime: Infinity,
         source: false,
     });
+    boundingVolumeLayer.update = debugIdUpdate;
 
     View.prototype.addLayer.call(view, boundingVolumeLayer, _3dTileslayer).then((l) => {
         gui.add(l, 'visible').name('Bounding boxes').onChange(() => {

--- a/utils/debug/TileDebug.js
+++ b/utils/debug/TileDebug.js
@@ -156,8 +156,8 @@ export default function createTileDebugUI(datDebugTool, view, layer, debugInstan
 
     class DebugLayer extends GeometryLayer {
         constructor(id, options = {}) {
-            options.update = debugIdUpdate;
             super(id, options.object3d || new THREE.Group(), options);
+            this.update = debugIdUpdate;
             this.isDebugLayer = true;
         }
 


### PR DESCRIPTION
## Description

This PR aims to remove the call to `Object.assign(this, config)` in the `Layer` class and move-up all properties initialisation in their respective classes. The goal of this refactoring is triple: ease the understanding of itowns logic (side-effects, initialisation, etc...), type-checking and a first step to clean-up configurations and layers.

Closes #2368