### PR TITLE
chore(deps): bump 3d-tiles-renderer from 0.3.35 to 0.3.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/vector-tile": "^2.0.3",
         "@tmcw/togeojson": "^5.8.1",
         "@tweenjs/tween.js": "^23.1.2",
-        "3d-tiles-renderer": "^0.3.35",
+        "3d-tiles-renderer": "^0.3.36",
         "brotli-compress": "^1.3.3",
         "copc": "^0.0.6",
         "earcut": "^3.0.0",
@@ -3113,9 +3113,9 @@
       "dev": true
     },
     "node_modules/3d-tiles-renderer": {
-      "version": "0.3.35",
-      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.3.35.tgz",
-      "integrity": "sha512-C521P31fcx690yaq+4phNLkFtL5SfQONVUYeZyEyZ+YcpMHwEKDhmZ+PiuAgL9HpRH5xAGAmE8fUBVhKwnTZTA==",
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.3.36.tgz",
+      "integrity": "sha512-CnSOvJW4g5oBtqk9sZuSYFFd9JiKwSKcCOojGTrThsxfyy1sSw+UU+FbQyLyLqyfHGf+oMxPKLXCluY89/lebw==",
       "peerDependencies": {
         "three": ">=0.123.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@mapbox/vector-tile": "^2.0.3",
     "@tmcw/togeojson": "^5.8.1",
     "@tweenjs/tween.js": "^23.1.2",
-    "3d-tiles-renderer": "^0.3.35",
+    "3d-tiles-renderer": "^0.3.36",
     "brotli-compress": "^1.3.3",
     "copc": "^0.0.6",
     "earcut": "^3.0.0",

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -1,5 +1,12 @@
 import * as THREE from 'three';
-import { CesiumIonTilesRenderer, GoogleTilesRenderer, TilesRenderer, GLTFStructuralMetadataExtension, GLTFCesiumRTCExtension } from '3d-tiles-renderer';
+import {
+    TilesRenderer,
+    GLTFStructuralMetadataExtension,
+    GLTFCesiumRTCExtension,
+    CesiumIonAuthPlugin,
+    GoogleCloudAuthPlugin,
+} from '3d-tiles-renderer';
+
 import GeometryLayer from 'Layer/GeometryLayer';
 import iGLTFLoader from 'Parser/iGLTFLoader';
 import { DRACOLoader } from 'ThreeExtended/loaders/DRACOLoader';
@@ -134,14 +141,16 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         this._handlePointsMaterialConfig(config);
 
+        this.tilesRenderer = new TilesRenderer(this.source.url);
         if (config.source.isOGC3DTilesIonSource) {
-            this.tilesRenderer = new CesiumIonTilesRenderer(config.source.assetId, config.source.accessToken);
+            this.tilesRenderer.registerPlugin(new CesiumIonAuthPlugin({
+                apiToken: config.source.accessToken,
+                assetId: config.source.assetId,
+            }));
         } else if (config.source.isOGC3DTilesGoogleSource) {
-            this.tilesRenderer = new GoogleTilesRenderer(config.source.key);
-        } else if (config.source.isOGC3DTilesSource) {
-            this.tilesRenderer = new TilesRenderer(this.source.url);
-        } else {
-            console.error('[OGC3DTilesLayer]: Unsupported source, cannot create OGC3DTilesLayer.');
+            this.tilesRenderer.registerPlugin(new GoogleCloudAuthPlugin({
+                apiToken: config.source.key,
+            }));
         }
 
         this.tilesRenderer.manager.addHandler(/\.gltf$/, itownsGLTFLoader);


### PR DESCRIPTION
## Description
This PR bumps `3d-tiles-renderer` from 0.3.35 to 0.3.36. This release includes some bugfixes as well as support of batch table hierarchy that we pushed upstream.

I don't have Google 3D Tiles key to test the Google plugin...