### PR TITLE
(PointCloudLayer) add points filtre based on classification

### DIFF
--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -98,6 +98,16 @@ export default {
                     layer.material.mode = PNTS_MODE[value];
                     update();
                 });
+
+            const classeUI = styleUI.addFolder('Classe Visibility').close();
+            Object.entries(layer.material.classificationScheme).forEach((classe) => {
+                classeUI.add(classe[1], 'visible').name(classe[1].name)
+                    .onChange(() => {
+                        layer.material.recomputeVisibilityTexture();
+                        update();
+                    });
+            });
+
             const gradiantsNames = Object.keys(layer.material.gradients);
             styleUI.add({ gradient: gradiantsNames[0] }, 'gradient', gradiantsNames).name('gradient')
                 .onChange((value) => {

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -418,11 +418,12 @@ class OGC3DTilesLayer extends GeometryLayer {
                 maxAttenuatedSize: this.pntsMaxAttenuatedSize,
             });
             pointsMaterial.copy(material);
-
             material = pointsMaterial;
+            material.depthWrite = false;
         }
 
         if (material) {
+            material.transparent = true;
             ReferLayerProperties(material, this);
         }
 

--- a/packages/Main/src/Layer/PointCloudLayer.js
+++ b/packages/Main/src/Layer/PointCloudLayer.js
@@ -241,7 +241,7 @@ class PointCloudLayer extends GeometryLayer {
         if (this.material) {
             this.material.visible = this.visible;
             this.material.opacity = this.opacity;
-            this.material.transparent = this.opacity < 1 || this.material.userData.needTransparency[this.material.mode];
+            this.material.depthWrite = false;
             this.material.size = this.pointSize;
             this.material.scale = context.camera.preSSE;
             if (this.material.updateUniforms) {

--- a/packages/Main/src/Layer/ReferencingLayerProperties.js
+++ b/packages/Main/src/Layer/ReferencingLayerProperties.js
@@ -1,9 +1,7 @@
 
 // next step is move these properties to Style class
-// and hide transparent mechanism
 function ReferLayerProperties(material, layer) {
     if (layer && layer.isGeometryLayer) {
-        let transparent = material.transparent;
         material.layer = layer;
 
         if (material.uniforms && material.uniforms.opacity != undefined) {
@@ -54,17 +52,6 @@ function ReferLayerProperties(material, layer) {
 
         Object.defineProperty(material, 'wireframe', {
             get: () => material.layer.wireframe,
-        });
-
-        Object.defineProperty(material, 'transparent', {
-            get: () => {
-                const needTransparency = material.userData.needTransparency?.[material.mode] || material.layer.opacity < 1.0;
-                if (transparent != needTransparency) {
-                    material.needsUpdate = true;
-                    transparent = needTransparency;
-                }
-                return transparent;
-            },
         });
     }
 

--- a/packages/Main/src/Renderer/PointsMaterial.js
+++ b/packages/Main/src/Renderer/PointsMaterial.js
@@ -113,7 +113,6 @@ function generateGradientTexture(gradient) {
 }
 
 function recomputeTexture(scheme, texture, nbClass) {
-    let needTransparency;
     const data = texture.image.data;
     const width = texture.image.width;
     if (!nbClass) { nbClass = Object.keys(scheme).length; }
@@ -121,19 +120,15 @@ function recomputeTexture(scheme, texture, nbClass) {
     for (let i = 0; i < width; i++) {
         let color;
         let opacity;
-        let visible = true;
 
         if (scheme[i]) {
             color = scheme[i].color;
-            visible = scheme[i].visible;
             opacity = scheme[i].opacity;
         } else if (scheme[i % nbClass]) {
             color = scheme[i % nbClass].color;
-            visible = scheme[i % nbClass].visible;
             opacity = scheme[i % nbClass].opacity;
         } else if (scheme.DEFAULT) {
             color = scheme.DEFAULT.color;
-            visible = scheme.DEFAULT.visible;
             opacity = scheme.DEFAULT.opacity;
         } else {
             color = white;
@@ -144,12 +139,9 @@ function recomputeTexture(scheme, texture, nbClass) {
         data[j + 0] = parseInt(255 * color.r, 10);
         data[j + 1] = parseInt(255 * color.g, 10);
         data[j + 2] = parseInt(255 * color.b, 10);
-        data[j + 3] = visible ? parseInt(255 * opacity, 10) : 0;
-
-        needTransparency = needTransparency || opacity < 1 || !visible;
+        data[j + 3] = parseInt(255 * opacity, 10);
     }
     texture.needsUpdate = true;
-    return needTransparency;
 }
 
 class PointsMaterial extends THREE.ShaderMaterial {
@@ -211,6 +203,7 @@ class PointsMaterial extends THREE.ShaderMaterial {
         super({
             ...materialOptions,
             fog: true,
+            transparent: true,
             precision: 'highp',
             vertexColors: true,
         });
@@ -222,7 +215,6 @@ class PointsMaterial extends THREE.ShaderMaterial {
         this.vertexShader = PointsVS;
         this.fragmentShader = PointsFS;
 
-        this.userData.needTransparency = {};
         this.gradients = gradients;
         this.gradientTexture = new THREE.CanvasTexture();
 
@@ -257,6 +249,14 @@ class PointsMaterial extends THREE.ShaderMaterial {
         textureLUT.magFilter = THREE.NearestFilter;
         CommonMaterial.setUniformProperty(this, 'discreteTexture', textureLUT);
 
+        // add texture to apply visibility.
+        const dataVisi = new Uint8Array(256 * 1);
+        const textureVisi = new THREE.DataTexture(dataVisi, 256, 1, THREE.RedFormat);
+
+        textureVisi.needsUpdate = true;
+        textureVisi.magFilter = THREE.NearestFilter;
+        CommonMaterial.setUniformProperty(this, 'visibilityTexture', textureVisi);
+
         // Classification and other discrete values scheme
         this.classificationScheme = classificationScheme;
         this.discreteScheme = discreteScheme;
@@ -264,6 +264,7 @@ class PointsMaterial extends THREE.ShaderMaterial {
         // Update classification and discrete Texture
         this.recomputeClassification();
         this.recomputeDiscreteTexture();
+        this.recomputeVisibilityTexture();
 
         // Gradient texture for continuous values
         this.gradient = gradient;
@@ -281,11 +282,6 @@ class PointsMaterial extends THREE.ShaderMaterial {
      * @returns {this}
      */
     copy(source) {
-        // Manually copy this needTransparency if source doesn't have one. Prevents losing it when copying a three
-        // PointsMaterial into this PointsMaterial
-        const needTransparency = source.userData.needTransparency !== undefined ? source.userData.needTransparency
-            : this.userData.needTransparency;
-
         if (source.isShaderMaterial) {
             super.copy(source);
         } else {
@@ -299,8 +295,6 @@ class PointsMaterial extends THREE.ShaderMaterial {
         this.size = source.size;
         this.sizeAttenuation = source.sizeAttenuation;
         this.fog = source.fog;
-
-        this.userData.needTransparency = needTransparency;
 
         return this;
     }
@@ -372,8 +366,7 @@ class PointsMaterial extends THREE.ShaderMaterial {
     }
 
     recomputeClassification() {
-        const needTransparency = recomputeTexture(this.classificationScheme, this.classificationTexture, 256);
-        this.userData.needTransparency[PNTS_MODE.CLASSIFICATION] = needTransparency;
+        recomputeTexture(this.classificationScheme, this.classificationTexture, 256);
         this.dispatchEvent({
             type: 'material_property_changed',
             target: this.uniforms,
@@ -381,11 +374,35 @@ class PointsMaterial extends THREE.ShaderMaterial {
     }
 
     recomputeDiscreteTexture() {
-        const needTransparency = recomputeTexture(this.discreteScheme, this.discreteTexture);
-        this.userData.needTransparency[PNTS_MODE.RETURN_NUMBER] = needTransparency;
-        this.userData.needTransparency[PNTS_MODE.RETURN_TYPE] = needTransparency;
-        this.userData.needTransparency[PNTS_MODE.RETURN_COUNT] = needTransparency;
-        this.userData.needTransparency[PNTS_MODE.POINT_SOURCE_ID] = needTransparency;
+        recomputeTexture(this.discreteScheme, this.discreteTexture);
+        this.dispatchEvent({
+            type: 'material_property_changed',
+            target: this.uniforms,
+        });
+    }
+
+    recomputeVisibilityTexture() {
+        const texture = this.visibilityTexture;
+        const scheme = this.classificationScheme;
+
+        const data = texture.image.data;
+        const width = texture.image.width;
+
+        for (let i = 0; i < width; i++) {
+            let visible;
+
+            if (scheme[i]) {
+                visible  = scheme[i].visible;
+            } else if (scheme.DEFAULT) {
+                visible  = scheme.DEFAULT.visible;
+            } else {
+                visible = true;
+            }
+
+            data[i] = visible ? 255 : 0;
+        }
+        texture.needsUpdate = true;
+
         this.dispatchEvent({
             type: 'material_property_changed',
             target: this.uniforms,

--- a/packages/Main/src/Renderer/Shader/PointsVS.glsl
+++ b/packages/Main/src/Renderer/Shader/PointsVS.glsl
@@ -10,7 +10,7 @@ varying vec4 vColor; // color_pars_vertex
     uniform mat3 uvTransform;
 #endif
 
-#define NB_CLASS 8.
+#define SOURCE_ID_GROUP 8.
 
 uniform float size;
 uniform float scale;
@@ -25,6 +25,8 @@ uniform vec2 angleRange;
 uniform sampler2D classificationTexture;
 uniform sampler2D discreteTexture;
 uniform sampler2D gradientTexture;
+uniform sampler2D visibilityTexture;
+
 uniform int sizeMode;
 uniform float minAttenuatedSize;
 uniform float maxAttenuatedSize;
@@ -39,12 +41,13 @@ attribute float numberOfReturns;
 attribute float scanAngle;
 
 void main() {
+    vec2 uv = vec2(classification/255., 0.5);
+
     vColor = vec4(1.0);
     if (picking) {
         vColor = unique_id;
     } else {
         if (mode == PNTS_MODE_CLASSIFICATION) {
-            vec2 uv = vec2(classification/255., 0.5);
             vColor = texture2D(classificationTexture, uv);
         } else if (mode == PNTS_MODE_NORMAL) {
             vColor.rgb = abs(normal);
@@ -84,7 +87,7 @@ void main() {
             vec2 uv = vec2(numberOfReturns/255., 0.5);
             vColor = texture2D(discreteTexture, uv);
         } else if (mode == PNTS_MODE_POINT_SOURCE_ID) {
-            vec2 uv = vec2(mod(pointSourceID, NB_CLASS)/255., 0.5);
+            vec2 uv = vec2(mod(pointSourceID, SOURCE_ID_GROUP)/255., 0.5);
             vColor = texture2D(discreteTexture, uv);
         } else if (mode == PNTS_MODE_SCAN_ANGLE) {
             float i = (scanAngle - angleRange.x) / (angleRange.y - angleRange.x);
@@ -100,6 +103,10 @@ void main() {
             vec2 uv = vec2(i, (1. - i));
             vColor = texture2D(gradientTexture, uv);
         }
+    }
+
+    if (texture2D(visibilityTexture, uv).r == 0.) {
+        vColor.a = 0.;
     }
 
 #define USE_COLOR_ALPHA


### PR DESCRIPTION
Any classification scheme used for PointCloudLayer havea property 'visible' for each class.
This PR aims at using this value to filter point whichever the visualization mode choosen.

In other word, if a class has its property 'visible' set to false, we want to discard all points having the value in the rendering, (even if we choose to use the 'intensity' rendering)


(In this PR, I used migrate all PointCloud examples to lilGUI instead of datGUI, move to #2546 )

