### PR TITLE
[Ogc3dtiles] Fix tests

### DIFF
--- a/examples/3dtiles_25d.html
+++ b/examples/3dtiles_25d.html
@@ -81,14 +81,14 @@
             // extension of gltf. We need to enable it.
             itowns.enableDracoLoader('./libs/draco/');
 
-            var $3dTilesLayer = new itowns.OGC3DTilesLayer(
+            var $3dTilesLayer = new itowns.C3DTilesLayer(
                 '3d-tiles-layer-building', {
                     name: 'Lyon-2015-building',
-                    source: new itowns.OGC3DTilesSource({
+                    source: new itowns.C3DTilesSource({
                         url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/' +
                             '3DTiles/lyon_1_3946_textured_draco/tileset.json',
                     }),
-                });
+                }, view);
 
             // Lights
             var dirLight = new itowns.THREE.DirectionalLight(0xffffff, 1);

--- a/examples/3dtiles_basic.html
+++ b/examples/3dtiles_basic.html
@@ -45,34 +45,33 @@
 
             // Create a new Layer 3d-tiles For DiscreteLOD
             // -------------------------------------------
-            var $3dTilesLayerDiscreteLOD = new itowns.OGC3DTilesLayer('3d-tiles-discrete-lod', {
+            var $3dTilesLayerDiscreteLOD = new itowns.C3DTilesLayer('3d-tiles-discrete-lod', {
                 name: 'DiscreteLOD',
-                source: new itowns.OGC3DTilesSource({
+                sseThreshold: 0.05,
+                source: new itowns.C3DTilesSource({
                     url: 'https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/master/1.0/TilesetWithDiscreteLOD/tileset.json',
                 }),
-                sseThreshold: 0.05,
-            });
+            }, view);
 
             itowns.View.prototype.addLayer.call(view, $3dTilesLayerDiscreteLOD);
 
             // Create a new Layer 3d-tiles For Viewer Request Volume
             // -----------------------------------------------------
 
-            var $3dTilesLayerRequestVolume = new itowns.OGC3DTilesLayer('3d-tiles-request-volume', {
+            var $3dTilesLayerRequestVolume = new itowns.C3DTilesLayer('3d-tiles-request-volume', {
                 name: 'RequestVolume',
-                source: new itowns.OGC3DTilesSource({
+                source: new itowns.C3DTilesSource({
                     url: 'https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/master/1.0/TilesetWithRequestVolume/tileset.json',
                 }),
                 sseThreshold: 1,
-            });
+            }, view);
 
             // add an event for picking the 3D Tiles layer and displaying
             // information about the picked feature in an html div
-            const pickingArgs = {
-                htmlDiv: document.getElementById('featureInfo'),
-                view,
-                layer: $3dTilesLayerRequestVolume,
-            };
+            var pickingArgs = {};
+            pickingArgs.htmlDiv = document.getElementById('featureInfo');
+            pickingArgs.view = view;
+            pickingArgs.layer = $3dTilesLayerRequestVolume;
             itowns.View.prototype.addLayer.call(view,
                 $3dTilesLayerRequestVolume).then(function _() {
                     window.addEventListener('mousemove',
@@ -82,8 +81,8 @@
             // Add the UI Debug
             var d = new debug.Debug(view, menuGlobe.gui);
             debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer, d);
-            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD, d);
-            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume, d);
+            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerDiscreteLOD);
+            debug.create3dTilesDebugUI(menuGlobe.gui, view, $3dTilesLayerRequestVolume);
             d.zoom = function() {
                 view.camera3D.position.set(1215013.9, -4736315.5, 4081597.5);
                 view.camera3D.quaternion.set(0.9108514448729665, 0.13456816437801225, 0.1107206134840362, 0.3741416847378546);

--- a/examples/3dtiles_batch_table.html
+++ b/examples/3dtiles_batch_table.html
@@ -49,14 +49,22 @@
                         .then(menuGlobe.addLayerGUI.bind(menuGlobe));
                 });
 
+	        // Create a new 3D tiles layer with batch table hierarchy extension
+            const extensions = new itowns.C3DTExtensions();
+            extensions.registerExtension("3DTILES_batch_table_hierarchy",
+                { [itowns.C3DTilesTypes.batchtable]:
+                    itowns.C3DTBatchTableHierarchyExtension });
+
             // Create the 3D Tiles layer
-            var $3dTilesLayerBTHierarchy = new itowns.OGC3DTilesLayer(
+            var $3dTilesLayerBTHierarchy = new itowns.C3DTilesLayer(
                 '3d-tiles-bt-hierarchy', {
                     name: 'BTHierarchy',
-                    source: new itowns.OGC3DTilesSource({
+                    source: new itowns.C3DTilesSource({
                         url: 'https://raw.githubusercontent.com/AnalyticalGraphicsInc/cesium/master/Apps/SampleData/Cesium3DTiles/Hierarchy/BatchTableHierarchy/tileset.json',
                     }),
-                });
+                    registeredExtensions: extensions,
+                },
+            view);
 
             // add an event for picking the 3D Tiles layer and displaying
             // information about the picked feature in an html div

--- a/examples/3dtiles_ion.html
+++ b/examples/3dtiles_ion.html
@@ -22,9 +22,9 @@
     </head>
     <body>
         <div id="description">
-            <p><b>This example displays a dataset representing extruded OSM buildings from Cesium ion
+            <p><b>This example displays a dataset representing extruded OSM buildings from Cesium ion 
                 with Cesium default access token. Zoom to any place in the world to see the buildings. <br>
-                Buildings may appear to "fly" above the ground in some places, this is due to the combination
+                Buildings may appear to "fly" above the ground in some places, this is due to the combination 
                 of precision errors of this dataset and of the 3D terrain we use in this example. </b>
             </p>
         </div>
@@ -53,7 +53,7 @@
                 diffuse: new itowns.THREE.Color(0xa0d5fc)
             };
             var view = new itowns.GlobeView(viewerDiv, placement, viewOptions);
-
+            
             // Setup loading screen
             setupLoadingScreen(viewerDiv, view);
 
@@ -91,19 +91,19 @@
             extensions.registerExtension("3DTILES_batch_table_hierarchy",
                 { [itowns.C3DTilesTypes.batchtable]:
                     itowns.C3DTBatchTableHierarchyExtension });
-
-            // Create a 3D Tiles layer from Cesium ion server with Cesium default access token and assetId of the
+            
+            // Create a 3D Tiles layer from Cesium ion server with Cesium default access token and assetId of the 
             // OSM buildings dataset.
-            var threeDTilesIonSource = new itowns.OGC3DTilesIonSource({
+            var threeDTilesIonSource = new itowns.C3DTilesIonSource({
                 accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzOTkxZjY3NS0yNDU4LTQ3MTAtOGQ2NC1lOGI4YmY5ODhhYjQiLCJpZCI6Mzg4OTQsImlhdCI6MTYwNjkyMDkwOH0.aVrPA4xnpbSUlqfJ9RkSWmZtms_hnSRz7m596h1R7ew',
                 assetId: 96188
             });
             threeDTilesIonSource.whenReady.then(displayAttributions); // Add attributions returned by cesium ion server
-            var threeDTilesIonLayer = new itowns.OGC3DTilesLayer('3d-tiles-cesium-ion', {
+            var threeDTilesIonLayer = new itowns.C3DTilesLayer('3d-tiles-cesium-ion', {
                 name: '3D Tiles from Cesium Ion',
                 source: threeDTilesIonSource,
-                // registeredExtensions: extensions,
-            });
+                registeredExtensions: extensions,
+            }, view);
 
             itowns.View.prototype.addLayer.call(view, threeDTilesIonLayer);
 

--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -1,0 +1,150 @@
+<html>
+    <head>
+        <title>Itowns - 3D Tiles loader</title>
+
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                right: 10px;
+            }
+        </style>
+
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+    </head>
+    <body>
+        <div id="viewerDiv"></div>
+        <div id="description">Specify the URL of a tileset to load:
+            <input type="text" id="url" />
+            <button onclick="setURL(document.getElementById('url').value)">
+                Load
+            </button>
+            <hr />
+            <p><b>Feature Information:</b></p>
+            <div id="featureInfo"></div>
+        </div>
+
+        <script src="js/GUI/GuiTools.js"></script>
+        <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script>
+
+        <script type="importmap">
+            {
+                "imports": {
+                    "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
+                    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
+                }
+            }
+		</script>
+
+        <script type="module">
+            import { AmbientLight } from 'three';
+            import {
+                zoomToLayer,
+                fillHTMLWithPickingInfo,
+            } from './jsm/OGC3DTilesHelper.js';
+
+            const {
+                TMSSource, WMTSSource, OGC3DTilesSource,
+                ColorLayer, ElevationLayer, OGC3DTilesLayer,
+                GlobeView, Coordinates, Fetcher,
+            } = itowns;
+
+            const uri = new URL(location);
+            const state = {
+                // URL to tileset JSON
+                tileset: uri.searchParams.get('tileset'),
+                // Cesium ION /
+                assetId: uri.searchParams.get('assetId'),
+            };
+
+            function setURL(url) {
+                if (!url) return;
+
+                uri.searchParams.set('tileset', url);
+                history.pushState(null, '', `?${uri.searchParams.toString()}`);
+
+                location.reload();
+            }
+
+            // ---- CREATE A GlobeView FOR SUPPORTING DATA VISUALIZATION ----
+
+            // Define camera initial position
+            const placement = {
+                coord: new Coordinates('EPSG:4326', 2.351323, 48.856712),
+                range: 12500000,
+            };
+
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+            const viewerDiv = document.getElementById('viewerDiv');
+
+            // Create a GlobeView
+            const view = new GlobeView(viewerDiv, placement, {});
+
+            // Add ambient light to globally illuminates all objects
+            const light = new AmbientLight(0x404040, 15);
+            view.scene.add(light);
+
+            // Setup loading screen
+            setupLoadingScreen(viewerDiv, view);
+
+            // Setup debug menu
+            const menuGlobe = new GuiTools('menuDiv', view, 300);
+            debug.createTileDebugUI(menuGlobe.gui, view, view.tileLayer);
+
+
+            // ---- ADD A BASEMAP ----
+
+            // Add one imagery layer to the scene. This layer's properties are
+            // defined in a json file, but it cou   ld be defined as a plain js
+            // object. See `Layer` documentation for more info.
+            Fetcher.json('./layers/JSONLayers/OPENSM.json').then((config) => {
+                const layer = new ColorLayer('Ortho', {
+                    ...config,
+                    source: new TMSSource(config.source),
+                });
+                view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
+            });
+
+            // ---- ADD 3D TILES TILESET ----
+
+            // Enable various compression support for 3D Tiles tileset:
+            // - `KHR_draco_mesh_compression` mesh compression extension
+            // - `KHR_texture_basisu` texture compresion extension
+            itowns.enableDracoLoader('./libs/draco/');
+            itowns.enableKtx2Loader('./lib/basis/', view.renderer);
+
+            if (state.tileset) {
+                const source = new OGC3DTilesSource({ url: state.tileset });
+                const layer = new OGC3DTilesLayer('3DTiles', {
+                    source,
+                });
+
+                // Add an event for picking the 3D Tiles layer and displaying
+                // information about the picked feature in an html div
+                const pickingArgs = {
+                    htmlDiv: document.getElementById('featureInfo'),
+                    view,
+                    layer,
+                };
+
+                // Add the layer to our view
+                view.addLayer(layer).then((layer) => {
+                    zoomToLayer(view, layer);
+                    window.addEventListener('click',
+                        (event) => fillHTMLWithPickingInfo(event, pickingArgs), false);
+                });
+
+                debug.createOGC3DTilesDebugUI(menuGlobe.gui, view, layer);
+            }
+
+            window.setURL = setURL;
+        </script>
+    </body>
+</html>

--- a/examples/3dtiles_pointcloud.html
+++ b/examples/3dtiles_pointcloud.html
@@ -17,9 +17,6 @@
               <li>Use classification to assign colour to each points</li>
               <li>Switch between mode on the left panel</li>
             </ul>
-            <br/>
-            <p><b>Point Information:</b></p>
-            <div id="featureInfo"></div>
         </div>
         <div id="viewerDiv"></div>
         <script src="js/GUI/GuiTools.js"></script>
@@ -52,32 +49,39 @@
                 var layer = new itowns.ColorLayer('Ortho', config);
                 view.addLayer(layer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
             });
-
+            function updatePointCloudSize({tileContent}) {
+                tileContent.traverse(function (obj) {
+                    if (obj.isPoints) {
+                        obj.material.size = 2.0;
+                    }
+                });
+            }
             // Create a new Layer 3d-tiles For Pointcloud
             // -------------------------------------------
-            var $3dTilesSource = new itowns.OGC3DTilesSource({
+            var $3dTilesSource = new itowns.C3DTilesSource({
                     url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/pnts-sete-2021-0756_6256/tileset.json',
                 });
-            var $3dTilesLayerSetePC = new itowns.OGC3DTilesLayer('3d-tiles-sete', {
+            var $3dTilesLayerSetePC = new itowns.C3DTilesLayer('3d-tiles-sete', {
                 name: 'SetePC',
+                sseThreshold: 5,
                 pntsMode: itowns.PNTS_MODE.CLASSIFICATION,
                 pntsShape : itowns.PNTS_SHAPE.CIRCLE,
-                pntsSizeMode: itowns.PNTS_SIZE_MODE.ATTENUATED,
                 source: $3dTilesSource,
-            });
+            }, view);
 
-            const pickingArgs = {
-                htmlDiv: document.getElementById('featureInfo'),
-                view,
-                layer: $3dTilesLayerSetePC,
-            };
+            $3dTilesLayerSetePC.addEventListener(
+                itowns.C3DTILES_LAYER_EVENTS.ON_TILE_CONTENT_LOADED,
+                updatePointCloudSize,
+            );
 
-            itowns.View.prototype.addLayer.call(view,$3dTilesLayerSetePC)
-                .then(() => {
-                    window.addEventListener('mousemove',
-                        (event) => fillHTMLWithPickingInfo(event, pickingArgs),
-                    false);
-                });
+            itowns.View.prototype.addLayer.call(view, $3dTilesLayerSetePC);
+            function switchMode(){
+                let pntsLayer = view.getLayerById("3d-tiles-sete");
+                if(pntsLayer){
+                    pntsLayer.pntsMode = pntsLayer.pntsMode === itowns.PNTS_MODE.COLOR ? itowns.PNTS_MODE.CLASSIFICATION : itowns.PNTS_MODE.COLOR;
+                    view.notifyChange(view.camera3D);
+                }
+            }
 
             // Add the UI Debug
             var d = new debug.Debug(view, menuGlobe.gui);

--- a/examples/config.json
+++ b/examples/config.json
@@ -22,6 +22,10 @@
         "3dtiles_pointcloud": "Pointcloud classification"
     },
 
+    "3D Tiles (new)": {
+        "3dtiles_loader": "3D Tiles tileset loader"
+    },
+
     "Pointcloud": {
         "potree_25d_map": "Potree 2.5D map",
         "potree2_25d_map": "Potree 2.5D map 2.0 format",

--- a/examples/js/3dTilesHelper.js
+++ b/examples/js/3dTilesHelper.js
@@ -6,23 +6,27 @@
 // pickingArg.layer : the layer on which the picking must be done
 // eslint-disable-next-line
 function fillHTMLWithPickingInfo(event, pickingArg) {
-    const { htmlDiv, view, layer } = pickingArg;
+    if (!pickingArg.layer.isC3DTilesLayer) {
+        console.warn('Function fillHTMLWithPickingInfo only works' +
+            ' for C3DTilesLayer layers.');
+        return;
+    }
 
     // Remove content already in html div
-    while (htmlDiv.firstChild) {
-        htmlDiv.removeChild(htmlDiv.firstChild);
+    while (pickingArg.htmlDiv.firstChild) {
+        pickingArg.htmlDiv.removeChild(pickingArg.htmlDiv.firstChild);
     }
 
     // Get intersected objects
-    const intersects = view.pickObjectsAt(event, 5, layer);
+    const intersects = pickingArg.view.pickObjectsAt(event, 5, pickingArg.layer);
+    if (intersects.length === 0) { return; }
 
     // Get information from intersected objects (from the batch table and
     // eventually the 3D Tiles extensions
-    const closestC3DTileFeature =
-        layer.getC3DTileFeatureFromIntersectsArray(intersects);
+    const closestC3DTileFeature = pickingArg.layer.getC3DTileFeatureFromIntersectsArray(intersects);
 
     if (closestC3DTileFeature) {
         // eslint-disable-next-line
-        htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature));
+        pickingArg.htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature.getInfo()));
     }
 }

--- a/examples/jsm/.eslintrc.cjs
+++ b/examples/jsm/.eslintrc.cjs
@@ -1,0 +1,38 @@
+module.exports = {
+    extends: [
+        'eslint-config-airbnb-base',
+        'eslint-config-airbnb-base/rules/strict',
+        '../.eslintrc.cjs',
+    ],
+    parserOptions: {
+        ecmaVersion: 13,
+        sourceType: 'module',
+        ecmaFeatures: {
+            impliedStrict: true,
+        },
+    },
+    env: {
+        browser: true,
+        es6: true,
+        amd: true,
+        commonjs: true,
+    },
+    globals: {
+        itowns: true,
+    },
+    rules: {
+        'prefer-arrow-callback': 'off',
+        'object-shorthand': 'off',
+        'no-param-reassign': ['error', { props: false }],
+        'no-mixed-operators': ['error', { allowSamePrecedence: true }],
+        'prefer-template': 'off',
+        'prefer-rest-params': 'off',
+        'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
+
+        // deactivated rules for `examples/`
+        'no-console': 'off',
+        // TODO reactivate all the following rules
+        'no-underscore-dangle': 'off',
+
+    },
+};

--- a/examples/jsm/OGC3DTilesHelper.js
+++ b/examples/jsm/OGC3DTilesHelper.js
@@ -1,0 +1,106 @@
+import { MathUtils, Vector3 } from 'three';
+
+const { Coordinates, Extent, CameraUtils } = itowns;
+
+/**
+ * Function allowing picking on a given 3D tiles layer and filling an html div
+ * with information on the picked feature.
+ * @param {MouseEvent} event
+ * @param {Object} pickingArg
+ * @param {HTMLDivElement} pickingArg.htmlDiv - div element which contains the
+ * picked information
+ * @param {GlobeView} picking.view - iTowns view where the picking must be done
+ * @param {OGC3DTilesLayer} pickingArg.layer - the layer on which the picking
+ * must be done
+ */
+export function fillHTMLWithPickingInfo(event, pickingArg) {
+    const { htmlDiv, view, layer } = pickingArg;
+
+    // Remove content already in html div
+    while (htmlDiv.firstChild) {
+        htmlDiv.removeChild(htmlDiv.firstChild);
+    }
+
+    // Get intersected objects
+    const intersects = view.pickObjectsAt(event, 5, layer);
+
+    // Get information from intersected objects (from the batch table and
+    // eventually the 3D Tiles extensions
+    const closestC3DTileFeature =
+        layer.getC3DTileFeatureFromIntersectsArray(intersects);
+
+    if (closestC3DTileFeature) {
+        // eslint-disable-next-line
+        htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature));
+    }
+}
+
+function zoomToSphere(view, tile, sphere) {
+    const transform = tile.cached.transform;
+
+    const center = new Vector3().fromArray(sphere).applyMatrix4(transform);
+    const radius = sphere[3] * transform.getMaxScaleOnAxis();
+
+    // Get the distance to sphere where the diameter cover the whole screen
+    // This is similar to SSE computation where sse = screen height.
+    const fov = view.camera3D.fov * MathUtils.DEG2RAD;
+    const distance = radius * Math.tan(fov * 2);
+
+    return {
+        coord: new Coordinates('EPSG:4978', center),
+        range: distance + radius,
+    };
+}
+
+function zoomToBox(view, tile, box) {
+    const radius = Math.max(
+        new Vector3().fromArray(box, 3).length(),
+        new Vector3().fromArray(box, 6).length(),
+        new Vector3().fromArray(box, 9).length(),
+    );
+
+    // Approximate zoomToBox with sphere
+    const sphere = [box[0], box[1], box[2], radius];
+    return zoomToSphere(view, tile, sphere);
+}
+
+function zoomToRegion(view, region) {
+    const extent = new Extent('EPSG:4326',
+        region[0] * MathUtils.RAD2DEG, // west
+        region[2] * MathUtils.RAD2DEG, // east
+        region[1] * MathUtils.RAD2DEG, // south
+        region[3] * MathUtils.RAD2DEG, // north
+    );
+
+    return CameraUtils.getCameraTransformOptionsFromExtent(
+        view,
+        view.camera3D,
+        extent,
+    );
+}
+
+function zoomToTile(view, tile) {
+    const { region, box, sphere } = tile.boundingVolume;
+
+    let cameraTransform;
+    if (region) {
+        cameraTransform = zoomToRegion(view, region);
+    } else if (box) {
+        cameraTransform = zoomToBox(view, tile, box);
+    } else {
+        cameraTransform = zoomToSphere(view, tile, sphere);
+    }
+
+    view.controls.lookAtCoordinate({
+        coord: cameraTransform.coord,
+        range: 1.25 * cameraTransform.range, // zoom out a little bit
+        tilt: 60,
+    });
+}
+
+export function zoomToLayer(view, layer) {
+    const tilesets = layer.tilesRenderer.tileSets;
+    const root = tilesets[Object.keys(tilesets)[0]].root;
+
+    zoomToTile(view, root);
+}

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -326,10 +326,12 @@ class OGC3DTilesLayer extends GeometryLayer {
         /** @type{number|null} */
         let batchId;
         if (object.isPoints && index) {
-            batchId = index;
+            batchId = object.geometry.getAttribute('_BATCHID')?.getX(index) ?? index;
         } else if (object.isMesh && face) {
-            batchId = object.geometry.getAttribute('_BATCHID').getX(face.a);
-        } else {
+            batchId = object.geometry.getAttribute('_BATCHID')?.getX(face.a);
+        }
+
+        if (batchId === undefined) {
             return null;
         }
 

--- a/test/unit/gltfparser.js
+++ b/test/unit/gltfparser.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 import iGLTFLoader from 'Parser/iGLTFLoader';
 
 describe('iGLTFLoader', function () {
-
     const gltfLoader = new iGLTFLoader();
 
     const glb = fs.readFileSync('./test/data/gltf/box.glb');

--- a/utils/debug/3dTilesDebug.js
+++ b/utils/debug/3dTilesDebug.js
@@ -1,7 +1,11 @@
-import { DebugTilesPlugin } from '3d-tiles-renderer';
-
+import * as THREE from 'three';
+import View from 'Core/View';
+import GeometryLayer from 'Layer/GeometryLayer';
+import { C3DTilesBoundingVolumeTypes } from 'Core/3DTiles/C3DTilesEnums';
 import { PNTS_MODE, PNTS_SHAPE, PNTS_SIZE_MODE } from 'Renderer/PointsMaterial';
 import GeometryDebug from './GeometryDebug';
+
+const bboxMesh = new THREE.Mesh();
 
 export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) {
     const gui = GeometryDebug.createGeometryDebugUI(datDebugTool, view, _3dTileslayer);
@@ -9,42 +13,78 @@ export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) 
     // add wireframe
     GeometryDebug.addWireFrameCheckbox(gui, view, _3dTileslayer);
 
-    gui.add({ frozen: _3dTileslayer.frozen }, 'frozen').onChange(((value) => {
-        _3dTileslayer.frozen = value;
-        view.notifyChange(_3dTileslayer);
-    }));
+    // Bounding box control
+    const boundingVolumeID = `${_3dTileslayer.id}_bounding_volume_debug`;
 
-    // Add debug plugin
-    const debugTilesPlugin = new DebugTilesPlugin();
-    _3dTileslayer.tilesRenderer.registerPlugin(debugTilesPlugin);
+    function debugIdUpdate(context, layer, node) {
+        // Tile (https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/tile.schema.json) containing
+        // metadata for the tile
+        const tile = node.userData.metadata;
 
-    gui.add(debugTilesPlugin, 'displayBoxBounds').name('Bounding boxes').onChange(() => {
-        view.notifyChange(view.camera3D);
+        // Get helper from the node if it has already been computed
+        let helper = node.userData.boundingVolumeHelper;
+
+        // Hide bounding volumes if 3D Tiles layer is hidden
+        if (helper) {
+            helper.visible = !!(layer.visible && node.visible);
+            return;
+        }
+
+        if (layer.visible && node.visible && tile.boundingVolume) {
+            if (tile.boundingVolume.initialVolumeType === C3DTilesBoundingVolumeTypes.box) {
+                bboxMesh.geometry.boundingBox = tile.boundingVolume.volume;
+                helper = new THREE.BoxHelper(bboxMesh);
+                helper.material.linewidth = 2;
+                // compensate GLTF orientation correction based on gltfUpAxis only for b3dm tiles
+                if (tile.content?.uri && tile.content?.uri.endsWith('b3dm')) {
+                    const gltfUpAxis = _3dTileslayer.tileset.asset.gltfUpAxis;
+                    if (gltfUpAxis === undefined || gltfUpAxis === 'Y') {
+                        helper.rotation.x = -Math.PI * 0.5;
+                    } else if (gltfUpAxis === 'X') {
+                        helper.rotation.z = -Math.PI * 0.5;
+                    }
+                    helper.updateMatrix();
+                }
+            } else if (tile.boundingVolume.initialVolumeType === C3DTilesBoundingVolumeTypes.sphere ||
+                       tile.boundingVolume.initialVolumeType === C3DTilesBoundingVolumeTypes.region) {
+                const geometry = new THREE.SphereGeometry(tile.boundingVolume.volume.radius, 32, 32);
+                const material = new THREE.MeshBasicMaterial({ wireframe: true, color: Math.random() * 0xffffff });
+                helper = new THREE.Mesh(geometry, material);
+            } else {
+                console.warn(`[3D Tiles Debug]: Unknown bounding volume: ${tile.boundingVolume}`);
+                return;
+            }
+
+            node.userData.boundingVolumeHelper = helper;
+
+            node.parent.add(helper);
+            helper.updateMatrixWorld(true);
+        }
+    }
+
+    const boundingVolumeLayer = new GeometryLayer(boundingVolumeID, new THREE.Object3D(), {
+        update: debugIdUpdate,
+        visible: false,
+        cacheLifeTime: Infinity,
+        source: false,
     });
 
-    gui.add(debugTilesPlugin, 'displaySphereBounds').name('Bounding spheres').onChange(() => {
-        view.notifyChange(view.camera3D);
-    });
-
-    gui.add(debugTilesPlugin, 'displayRegionBounds').name('Bounding regions').onChange(() => {
-        view.notifyChange(view.camera3D);
+    View.prototype.addLayer.call(view, boundingVolumeLayer, _3dTileslayer).then((l) => {
+        gui.add(l, 'visible').name('Bounding boxes').onChange(() => {
+            view.notifyChange(view.camera3D);
+        });
     });
 
     // The sse Threshold for each tile
     gui.add(_3dTileslayer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
         view.notifyChange(view.camera3D);
     });
+    gui.add({ frozen: _3dTileslayer.frozen }, 'frozen').onChange(((value) => {
+        _3dTileslayer.frozen = value;
+        view.notifyChange(_3dTileslayer);
+    }));
 
-    function setupPntsDebug({ scene }) {
-        let hasPnts = false;
-        scene.traverse((obj) => {
-            if (obj.isPoints) {
-                hasPnts = true;
-            }
-        });
-
-        if (!hasPnts) { return; }
-
+    if (_3dTileslayer.hasPnts) {
         const _3DTILES_PNTS_MODE = {
             CLASSIFICATION: PNTS_MODE.CLASSIFICATION,
             COLOR: PNTS_MODE.COLOR,
@@ -66,9 +106,5 @@ export default function create3dTilesDebugUI(datDebugTool, view, _3dTileslayer) 
         gui.add(_3dTileslayer, 'pntsMaxAttenuatedSize', 0, 15).name('Max attenuated size').onChange(() => {
             view.notifyChange(view.camera.camera3D);
         });
-
-        _3dTileslayer.removeEventListener('load-model', setupPntsDebug);
     }
-
-    _3dTileslayer.addEventListener('load-model', setupPntsDebug);
 }

--- a/utils/debug/Main.js
+++ b/utils/debug/Main.js
@@ -2,4 +2,5 @@ export { default as Debug } from './Debug';
 export { default as PointCloudDebug } from './PointCloudDebug';
 export { default as createTileDebugUI } from './TileDebug';
 export { default as create3dTilesDebugUI } from './3dTilesDebug';
+export { default as createOGC3DTilesDebugUI } from './OGC3DTilesDebug';
 export { default as GeometryDebug } from './GeometryDebug';

--- a/utils/debug/OGC3DTilesDebug.js
+++ b/utils/debug/OGC3DTilesDebug.js
@@ -1,0 +1,74 @@
+import { DebugTilesPlugin } from '3d-tiles-renderer';
+
+import { PNTS_MODE, PNTS_SHAPE, PNTS_SIZE_MODE } from 'Renderer/PointsMaterial';
+import GeometryDebug from './GeometryDebug';
+
+export default function createOGC3DTilesDebugUI(datDebugTool, view, _3dTileslayer) {
+    const gui = GeometryDebug.createGeometryDebugUI(datDebugTool, view, _3dTileslayer);
+
+    // add wireframe
+    GeometryDebug.addWireFrameCheckbox(gui, view, _3dTileslayer);
+
+    gui.add({ frozen: _3dTileslayer.frozen }, 'frozen').onChange(((value) => {
+        _3dTileslayer.frozen = value;
+        view.notifyChange(_3dTileslayer);
+    }));
+
+    // Add debug plugin
+    const debugTilesPlugin = new DebugTilesPlugin();
+    _3dTileslayer.tilesRenderer.registerPlugin(debugTilesPlugin);
+
+    gui.add(debugTilesPlugin, 'displayBoxBounds').name('Bounding boxes').onChange(() => {
+        view.notifyChange(view.camera3D);
+    });
+
+    gui.add(debugTilesPlugin, 'displaySphereBounds').name('Bounding spheres').onChange(() => {
+        view.notifyChange(view.camera3D);
+    });
+
+    gui.add(debugTilesPlugin, 'displayRegionBounds').name('Bounding regions').onChange(() => {
+        view.notifyChange(view.camera3D);
+    });
+
+    // The sse Threshold for each tile
+    gui.add(_3dTileslayer, 'sseThreshold', 0, 100).name('sseThreshold').onChange(() => {
+        view.notifyChange(view.camera3D);
+    });
+
+    function setupPntsDebug({ scene }) {
+        let hasPnts = false;
+        scene.traverse((obj) => {
+            if (obj.isPoints) {
+                hasPnts = true;
+            }
+        });
+
+        if (!hasPnts) { return; }
+
+        const _3DTILES_PNTS_MODE = {
+            CLASSIFICATION: PNTS_MODE.CLASSIFICATION,
+            COLOR: PNTS_MODE.COLOR,
+        };
+        gui.add(_3dTileslayer, 'pntsMode', _3DTILES_PNTS_MODE).name('Display mode').onChange(() => {
+            _3dTileslayer.pntsMode = +_3dTileslayer.pntsMode;
+            view.notifyChange(view.camera.camera3D);
+        });
+        gui.add(_3dTileslayer, 'pntsShape', PNTS_SHAPE).name('Points Shape').onChange(() => {
+            view.notifyChange(view.camera.camera3D);
+        });
+        gui.add(_3dTileslayer, 'pntsSizeMode', PNTS_SIZE_MODE).name('Pnts size mode').onChange(() => {
+            view.notifyChange(view.camera.camera3D);
+        });
+
+        gui.add(_3dTileslayer, 'pntsMinAttenuatedSize', 0, 15).name('Min attenuated size').onChange(() => {
+            view.notifyChange(view.camera.camera3D);
+        });
+        gui.add(_3dTileslayer, 'pntsMaxAttenuatedSize', 0, 15).name('Max attenuated size').onChange(() => {
+            view.notifyChange(view.camera.camera3D);
+        });
+
+        _3dTileslayer.removeEventListener('load-model', setupPntsDebug);
+    }
+
+    _3dTileslayer.addEventListener('load-model', setupPntsDebug);
+}


### PR DESCRIPTION
This PR fixes test errors on the `3d-tiles-migration` branch :
- Revert original 3D Tiles examples to those on master
- Add new 3D Tiles example for the new 3D Tiles implementation with picking support and zoom to tileset feature
- Fix a linting issue in a unit test.
