### PR TITLE
fix(test): fix unit tests after 3d-tiles-renderer update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "sinon": "^18.0.0",
         "three": "^0.165.0",
         "typescript": "^5.5.2",
+        "webgl-mock": "^0.1.7",
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
@@ -12659,6 +12660,12 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/webgl-mock": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/webgl-mock/-/webgl-mock-0.1.7.tgz",
+      "integrity": "sha512-7Wlrhvo2bnts5Wt53vy+OD/pJsAXC3Bj4R+qR4eInMaqAyVx3NI8ui3+pKClLy7zVoZVglkzV8PGJUXt2POINg==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "sinon": "^18.0.0",
     "three": "^0.165.0",
     "typescript": "^5.5.2",
+    "webgl-mock": "^0.1.7",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"

--- a/src/Parser/iGLTFLoader.js
+++ b/src/Parser/iGLTFLoader.js
@@ -15,6 +15,10 @@ import { GLTFLoader } from 'ThreeExtended/loaders/GLTFLoader';
  * to a position on the globe (i.e. in GlobeView) to correctly orient a model on a GlobeView.
  */
 class iGLTFLoader extends THREE.Loader {
+    /**
+     * Constructs a new instance of the iGLTFLoader.
+     * @param {THREE.LoadingManager} [manager] - The loadingManager for the loader to use. Default is THREE.DefaultLoadingManager.
+     */
     constructor(manager) {
         super(manager);
         this.legacyGLTFLoader = new LegacyGLTFLoader();

--- a/test/unit/gltfparser.js
+++ b/test/unit/gltfparser.js
@@ -2,14 +2,17 @@ import assert from 'assert';
 import fs from 'fs';
 import iGLTFLoader from 'Parser/iGLTFLoader';
 
-const glb = fs.readFileSync('./test/data/gltf/box.glb');
-const glbArrayBuffer = glb.buffer.slice(glb.byteOffset, glb.byteOffset + glb.byteLength);
-
-if (typeof atob === 'undefined') {
-    global.atob = b64Encoded => Buffer.from(b64Encoded, 'base64').toString('binary');
-}
-
 describe('iGLTFLoader', function () {
+
+    const gltfLoader = new iGLTFLoader();
+
+    const glb = fs.readFileSync('./test/data/gltf/box.glb');
+    const glbArrayBuffer = glb.buffer.slice(glb.byteOffset, glb.byteOffset + glb.byteLength);
+
+    if (typeof atob === 'undefined') {
+        global.atob = b64Encoded => Buffer.from(b64Encoded, 'base64').toString('binary');
+    }
+
     it('should load gltf', function () {
         const onLoad = (result) => {
             assert.ok(result.scene);
@@ -19,6 +22,6 @@ describe('iGLTFLoader', function () {
             assert.fail(e);
         };
 
-        iGLTFLoader.parse(glbArrayBuffer, './test/data/gltf/', onLoad, onError);
+        gltfLoader.parse(glbArrayBuffer, './test/data/gltf/', onLoad, onError);
     });
 });


### PR DESCRIPTION
Proposition that fixes unit tests on the `3d-tiles-migration` branch after `3d-tiles-renderer` update to `0.3.36`. I'm not satisfied with the proposed solution but it works and I think it can be sufficient for this work on 3D Tiles migration I think finding a better solution should be treated seperatly in the future. Let me know if you agree with that (in which case I will open an issue dedicated to this matter).

**Some notes on the implementation and possible improvements:**

Unit tests were not running anymore after `3d-tiles-renderer` update to `0.3.36` because of a newly added [WebGLRenderer import](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/cf5fb0b23005e0da3dee93f4cdc6752cb80767b2/src/three/loaders/gltf/metadata/utilities/TextureReadUtility.js), requiring a gl context which is not available in unit tests they are run in a node environment and not in a browser. The encountered error:
```
TypeError: gl.getExtension is not a function
    at getExtension (file:///home/jailln/Documents/dev/itowns/node_modules/three/build/three.module.js:746:1506)
    at Object.init (file:///home/jailln/Documents/dev/itowns/node_modules/three/build/three.module.js:746:1648)
    at initGLContext (file:///home/jailln/Documents/dev/itowns/node_modules/three/build/three.module.js:1207:926)
    at new WebGLRenderer (file:///home/jailln/Documents/dev/itowns/node_modules/three/build/three.module.js:1207:2396)
    at new <anonymous> (file:///home/jailln/Documents/dev/itowns/node_modules/3d-tiles-renderer/src/three/loaders/gltf/metadata/utilities/TextureReadUtility.js:12:22)
    at file:///home/jailln/Documents/dev/itowns/node_modules/3d-tiles-renderer/src/three/loaders/gltf/metadata/utilities/TextureReadUtility.js:10:35
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:530:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:438:15)
    at async formattedImport (/home/jailln/Documents/dev/itowns/node_modules/mocha/lib/nodejs/esm-utils.js:9:14)
    at async Object.exports.requireOrImport (/home/jailln/Documents/dev/itowns/node_modules/mocha/lib/nodejs/esm-utils.js:42:28)
    at async Object.exports.loadFilesAsync (/home/jailln/Documents/dev/itowns/node_modules/mocha/lib/nodejs/esm-utils.js:100:20)
    at async singleRun (/home/jailln/Documents/dev/itowns/node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at async Object.exports.handler (/home/jailln/Documents/dev/itowns/node_modules/mocha/lib/cli/run.js:370:5)
``` 

Currently, we mock everything that's not available and needed for unit tests in [bootstrap.js](https://github.com/iTowns/itowns/blob/master/test/unit/bootstrap.js). To mock the webgl context, we can either mock it ourselves (but that can be complicated) or rely on an external library. Possible libraries are [webgl-mock](https://www.npmjs.com/package/webgl-mock) or [headless-gl](https://github.com/stackgl/headless-gl). `webgl-mock` is not maintained anymore (last version released 6 years ago). `headless-gl` last activity is more recent but is still not that very active. Both libraries only support webgl 1.0 and [there is no official roadmap on supporting WebGL 2.0](https://github.com/stackgl/headless-gl/issues/109) (although we would not be the only one to need it :grinning: ). This is a major problem since threejs and itowns dropped WebGL 1.0 support. 

In this PR I went for the "quick way" and used `webgl-mock` (only because I found out about `headless-gl` afterwards) and I added the following:
* Implemented `WebGLRenderingContext.getParameter` to return `WebGL 2` for [this](https://github.com/mrdoob/three.js/blob/8448be65d2684d6234889ecfae25253b039df0bd/src/renderers/webgl/WebGLState.js#L345) to work. Note that this is a shortcut and it should return a different value depending on the `paramater` argument to get (e.g. [those two ones](https://github.com/mrdoob/three.js/blob/8448be65d2684d6234889ecfae25253b039df0bd/src/renderers/webgl/WebGLState.js#L360) that are used for `WebGLRenderer` initialization).
* Mocked the only needed WebGL 2 function for the `WebGLRenderer` to get initialized:  `texImage3D`

A better solution would probably be to use `headless-gl` and wait for WebGL 2.0 support (or implement it). We could also  use puppeteer (but that's kind of weird to use puppeteer in unit tests). Note that maplibre also [struggled with this issue](https://github.com/maplibre/maplibre-gl-js/issues/2420) and that they dropped webgl 2.0 unit tests for now (which is not really an option for us here) and that deckgl did the same.