### PR TITLE
Fix: COPC example - trouble with elevation display mode

### DIFF
--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -109,7 +109,8 @@
                     pointBudget: 3000000,
                 });
                 view.addLayer(layer).then(onLayerReady);
-                debug.PointCloudDebug.initTools(view, layer, gui);
+                layer.whenReady
+                    .then(() => debug.PointCloudDebug.initTools(view, layer, gui));
             }
 
             function loadAutzen() {


### PR DESCRIPTION
min and max elevation where set up before the data was read and thus were set to the default value (0 - 1000) instead of the correct ones.

![Uploading image.png…]()
