### PR TITLE
fix(pointcloud): Fix point cloud distance to camera whatever point cloud inital placement is

### DIFF
--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -253,7 +253,8 @@ class PointCloudLayer extends GeometryLayer {
         }
 
         elt.notVisibleSince = undefined;
-        point.copy(context.camera.camera3D.position).sub(this.object3d.position);
+        point.copy(context.camera.camera3D.position).sub(this.object3d.getWorldPosition(new THREE.Vector3()));
+        point.applyQuaternion(this.object3d.getWorldQuaternion(new THREE.Quaternion()).invert());
 
         // only load geometry if this elements has points
         if (elt.numPoints !== 0) {


### PR DESCRIPTION
Fix point cloud distance to camera whatever point cloud inital placement is

## Description
Quick fix to compute camera distance to point (used for refresh the point cloud) whatever the initial placement of the point cloud is. 
This is used when the point cloud is inside a custom object with orientation and position.
Fix issue -> See : https://github.com/iTowns/itowns/issues/2175 (point cloud placement)
Related PR -> https://github.com/iTowns/itowns/pull/2361 (point cloud placement)
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In our scene, we want the point cloud to be placed wherever with any rotation. The previous code assumed an identity rotation and a local placement ; and the refresh didn't happened whith custom orientation and position because the point compute was wrong, leading to wrong distance to camera thus leading to no refresh.

So now, the point cloud object can be placed wherever with any rotations and still be refresh according to camera's position.

<!--- Please also state your testing environment (browser, version and anything relevant) here -->
MacOS - Chrome - latest itowns version (2.43.2)

## Screenshots (if appropriate)

Before : 
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/93734e09-b122-42d5-9fe6-6cc2ff5e30c6">

Fixed : 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/80c42b9f-c895-4ef6-a37a-1027d0fac196">


