### PR TITLE
fix(PointCloud): Fix clipping point cloud

### DIFF
--- a/src/Renderer/Shader/PointsFS.glsl
+++ b/src/Renderer/Shader/PointsFS.glsl
@@ -17,7 +17,7 @@ uniform int shape;
 void main() {
 
 // Early discard (clipping planes and shape)
-#include <clipping_planes_pars_fragment>
+#include <clipping_planes_fragment>
     if (shape == PNTS_SHAPE_CIRCLE) {
         //circular rendering in glsl
         if ((length(gl_PointCoord - 0.5) > 0.5)) {


### PR DESCRIPTION
## Description
Actually ClippingPlanes on PointMaterial doesn't clip the point cloud (point cloud totally disappear).
It seems it was a mistake on PointsFS.glsl.
As shown in [this discussion ](https://stackoverflow.com/questions/42532545/add-clipping-to-three-shadermaterial) it need to use ```#include <clipping_planes_fragment>``` in main function and ```#include clipping_planes_pars_fragment.glsl``` only on top.

## Motivation and Context
We need to clip point cloud with ClippingPlanes.

## Screenshots
![Capture d’écran 2024-08-23 à 15 24 35](https://github.com/user-attachments/assets/751f9b96-7881-47c3-a676-b92035bd9205)
![Capture d’écran 2024-08-23 à 15 24 42](https://github.com/user-attachments/assets/469a2959-7d54-453c-a9bf-d3fadd1fe190)
