### PR TITLE
[coverage] Fix non source-mapped coverage issue

### DIFF
--- a/config/babel-register/babel-hooks.mjs
+++ b/config/babel-register/babel-hooks.mjs
@@ -1,0 +1,104 @@
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+import * as babel from '@babel/core';
+
+/**
+ * This script is a [node:module hook][https://nodejs.org/api/module.html] to
+ * override module resolution and source-code loading to transpile files with
+ * babel.
+ */
+
+// Regular expressions from
+// https://github.com/babel/babel/blob/main/packages/babel-register/src/worker/transform.js
+function escapeRegExp(string) {
+    return string.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
+const nmRE = escapeRegExp(`${path.sep}node_modules${path.sep}`);
+const cwd = path.resolve('.');
+const cwdRE = escapeRegExp(cwd);
+
+/**
+ * @param {string | SharedArrayBuffer | Uint8Array} source
+ * @param {Object} context
+ * @param {string} context.url
+ * @param {string} context.format
+ */
+async function transpile(source, context) {
+    const { url, format } = context;
+    if (format !== 'module' && format !== 'commonjs') {
+        return source;
+    }
+
+    let input;
+    if (typeof source === 'string') {
+        input = source;
+    } else if (Buffer.isBuffer(source)) {
+        input = source.toString('utf-8');
+    } else {
+        input = Buffer.from(source).toString('utf-8');
+    }
+
+    // transformAsync merges options in .babelrc with the ones provided below
+    const transform = await babel.transformAsync(input, {
+        sourceType: 'module',
+        filename: fileURLToPath(url),
+        sourceMaps: 'inline',
+        ast: false,
+        ignore: [
+            // do not transpile files in node_modules
+            new RegExp(`^${cwdRE}(?:${path.sep}.*)?${nmRE}`, 'i'),
+        ],
+    });
+
+    if (!transform?.code) {
+        return;
+    }
+
+    return transform.code;
+}
+
+/**
+ * @param {string} specifier
+ * @param {Object} context
+ * @param {string[]} context.conditions - Export conditions of the relevant
+ * package.json
+ * @param {Object} context.importAttributes - An object whose key-value pairs
+ * represent the attributes for the module to import
+ * @param {string | undefined} context.parentURL - The module importing this
+ * one, or undefined if this is the Node.js entry point
+ * @param {Function} nextResolve - The subsequent resolve hook in the chain, or
+ * the Node.js default resolve hook after the last user-supplied resolve hook
+ */
+export async function resolve(specifier, context, nextResolve) {
+    return nextResolve(specifier, context);
+}
+
+/**
+ * @param {string} url - The URL returned by the resolve chain
+ * @param {Object} context
+ * @param {string[]} context.conditions - Export conditions of the relevant
+ * package.json
+ * @param {string | null | undefined} context.format - The format optionally
+ * supplied by the resolve hook chain
+ * @param {Object} context.importAttributes
+ * @param {function(string, object): Promise<{ format: string, shortCircuit: boolean, source: string }>} nextLoad -
+ * The subsequent load hook in the chain, or the Node.js default load hook after
+ * the last user-supplied load hook
+ */
+export async function load(url, context, nextLoad) {
+    const { format, shortCircuit, source } = await nextLoad(url, context);
+
+    if (format !== 'module' && format !== 'commonjs') {
+        return { format, shortCircuit, source };
+    }
+
+    if (source) {
+        const code = await transpile(source, { format, url });
+        if (code) {
+            return { source: code, format };
+        }
+    }
+
+    return { format, source };
+}

--- a/config/babel-register/register.mjs
+++ b/config/babel-register/register.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module';
+
+register('./babel-hooks.mjs', import.meta.url);

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "babel-plugin-minify-replace": "^0.5.0",
         "babel-plugin-module-extension-resolver": "^1.0.0",
         "babel-plugin-module-resolver": "^5.0.2",
-        "babel-register-esm": "^1.2.5",
         "c8": "^10.1.2",
         "chalk": "^5.3.0",
         "chart.js": "^4.4.3",
@@ -3779,18 +3778,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-register-esm": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/babel-register-esm/-/babel-register-esm-1.2.5.tgz",
-      "integrity": "sha512-WaVd3Rm42kndYnufn8u1SbUUwuCxL2GAQX/7QXUL3w/7PffB+HcXrzmAqk1x01TjhFh/npSZ9Z3MNBc6dDb6Uw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.17.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "babel-plugin-minify-replace": "^0.5.0",
     "babel-plugin-module-extension-resolver": "^1.0.0",
     "babel-plugin-module-resolver": "^5.0.2",
-    "babel-register-esm": "^1.2.5",
     "c8": "^10.1.2",
     "chalk": "^5.3.0",
     "chart.js": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-functional": "mocha -t 100000 --require test/hooks_functional.js --recursive test/functional",
     "test-with-coverage": "c8 -n src -r html cross-env npm run test-unit",
     "test-with-coverage_lcov": "c8 -n src --reporter=lcov cross-env npm run test-unit",
-    "base-test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --file test/unit/bootstrap.js --loader=babel-register-esm",
+    "base-test-unit": "cross-env BABEL_DISABLE_CACHE=1 mocha --file test/unit/bootstrap.js --import=./config/babel-register/register.mjs",
     "build": "cross-env NODE_ENV=production webpack",
     "build-dev": "cross-env NODE_ENV=development webpack",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The coverage was not correct since there was no source-map between the babel-compiled output and the original source code. This led to incorrect coverage reports (issue first found by @ftoromanoff) since those were based on the babel-compiled output.

This PR fixes on our unit tests:
- the aforementioned source-map issue by using our own node module hook instead of the `babel-register-esm` one.
- experimental warnings when using `--experimental-loader` options, we now use `node:module.register()` (not supported by `babel-register-esm`).
- `[BABEL] Note: The code generator has deoptimised the styling of [...]/node_modules/[...] as it exceeds the max of 500KB.` warnings, since we now ignore compilation of modules in `node_modules` (not done by `babel-register-ems` but previously done by `@babel/register`).

Further info:
- [Node module API](https://nodejs.org/api/module.html#hooks)
