### PR TITLE
fix(3dtiles): support point cloud attenuated mode in OGC3DTiles layer

### DIFF
--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -128,8 +128,8 @@ class OGC3DTilesLayer extends GeometryLayer {
      * @param {String} [config.pntsSizeMode= PNTS_SIZE_MODE.VALUE] {@link PointsMaterial} Point cloud size mode (passed to {@link PointsMaterial}).
      * Only 'VALUE' or 'ATTENUATED' are possible. VALUE use constant size, ATTENUATED compute size depending on distance
      * from point to camera.
-     * @param {Number} [config.pntsMinAttenuatedSize=3] Minimum scale used by 'ATTENUATED' size mode.
-     * @param {Number} [config.pntsMaxAttenuatedSize=10] Maximum scale used by 'ATTENUATED' size mode.
+     * @param {Number} [config.pntsMinAttenuatedSize=1] Minimum scale used by 'ATTENUATED' size mode.
+     * @param {Number} [config.pntsMaxAttenuatedSize=7] Maximum scale used by 'ATTENUATED' size mode.
      */
     constructor(id, config) {
         super(id, new THREE.Group(), { source: config.source });
@@ -186,8 +186,8 @@ class OGC3DTilesLayer extends GeometryLayer {
         this.pntsShape = config.pntsShape ?? PNTS_SHAPE.CIRCLE;
         this.classification = config.classification ?? ClassificationScheme.DEFAULT;
         this.pntsSizeMode = config.pntsSizeMode ?? PNTS_SIZE_MODE.VALUE;
-        this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 3;
-        this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 10;
+        this.pntsMinAttenuatedSize = config.pntsMinAttenuatedSize || 1;
+        this.pntsMaxAttenuatedSize = config.pntsMaxAttenuatedSize || 7;
     }
 
     /**
@@ -303,7 +303,8 @@ class OGC3DTilesLayer extends GeometryLayer {
         }
     }
 
-    preUpdate() {
+    preUpdate(context) {
+        this.scale = context.camera._preSSE;
         this.tilesRenderer.update();
         return null; // don't return any element because 3d-tiles-renderer already updates them
     }


### PR DESCRIPTION
## Description

Fix point size attenuated mode for `OGC3DTilesLayer` - same changes that what was done in #2325 for `C3DTilesLayer`.

I think the `scale` uniform could be renamed to `cameraPreSse` since it is always set to this value and because it doesn't really represent the scale of the point cloud which can be misleading for someone using that material. WDYT ? If we agree on renaming it I can push this in this PR.

cc @AnthonyGlt @airnez 
