### PR TITLE
[Docs] Fix non-strict jsdoc comments

### DIFF
--- a/docs/publish.js
+++ b/docs/publish.js
@@ -66,7 +66,7 @@ function sortByPackage(members, navList) {
 
     for (const type in members) {
         const member = members[type];
-        if (!member || type == 'globals' || type == 'tutorials') { continue; }
+        if (!member || type == 'tutorials') { continue; }
         member.forEach((m) => {
             const p = invertedNavList[m.name] || invertedNavList[m.memberof];
             if (!p) { return; }

--- a/docs/tmpl/page.tmpl
+++ b/docs/tmpl/page.tmpl
@@ -20,7 +20,7 @@
 <section>
 
 <article>
-<?js if (content.kind === 'class' || content.kind === 'module') { ?>
+<?js if (content.kind === 'class' || content.kind === 'module' || content.kind === 'typedef') { ?>
     <h1>
         <?js= content.name ?>
         <?js if (content.augments && content.augments.length) { ?>

--- a/src/Controls/FirstPersonControls.js
+++ b/src/Controls/FirstPersonControls.js
@@ -47,7 +47,6 @@ function moveCameraVerticalGlobe(value) {
 
 class FirstPersonControls extends THREE.EventDispatcher {
     /**
-     * @Constructor
      * @param {View} view
      * @param {object} options
      * @param {boolean} options.focusOnClick - whether or not to focus the renderer domElement on click

--- a/src/Controls/FlyControls.js
+++ b/src/Controls/FlyControls.js
@@ -90,7 +90,6 @@ function onDocumentMouseWheel(event) {
  */
 class FlyControls extends THREE.EventDispatcher {
     /**
-     * @Constructor
      * @param {View} view
      * @param {object} options
      * @param {boolean} options.focusOnClick - whether or not to focus the renderer domElement on click

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -1137,11 +1137,11 @@ class GlobeControls extends THREE.EventDispatcher {
      * Zoom parameter is ignored if range is set
      * The tilt's interval is between 4 and 89.5 degree
      *
-     * @param      {CameraUtils~CameraTransformOptions|Extent}   params camera transformation to apply
-     * @param      {number}   [params.zoom]   zoom
-     * @param      {number}   [params.scale]   scale
-     * @param      {boolean}  isAnimated  Indicates if animated
-     * @return     {Promise}  A promise that resolves when transformation is complete
+     * @param {CameraUtils~CameraTransformOptions|Extent} [params] - camera transformation to apply
+     * @param {number} [params.zoom] - zoom
+     * @param {number} [params.scale] - scale
+     * @param {boolean} [isAnimated] - Indicates if animated
+     * @return {Promise} A promise that resolves when transformation is complete
      */
     lookAtCoordinate(params = {}, isAnimated = this.isAnimationEnabled()) {
         this.player.stop();

--- a/src/Controls/StreetControls.js
+++ b/src/Controls/StreetControls.js
@@ -77,7 +77,7 @@ function computeTime(distance) {
 }
 
 /**
- * @classdesc Camera controls that can follow a path.
+ * Camera controls that can follow a path.
  * It is used to simulate a street view.
  * It stores a currentPosition and nextPosition, and do a camera traveling to go to next position.
  * It also manages picking on the ground and on other object, like building.
@@ -111,7 +111,6 @@ function computeTime(distance) {
  */
 class StreetControls extends FirstPersonControls {
     /**
-     * @constructor
      * @param { View } view - View where this control will be used
      * @param { Object } options - Configuration of this controls
      * @param { number } [options.wallMaxDistance=1000] - Maximum distance to click on a wall, in meter.

--- a/src/Converter/Feature2Mesh.js
+++ b/src/Converter/Feature2Mesh.js
@@ -554,7 +554,7 @@ function createInstancedMesh(mesh, count, ptsIn) {
 }
 
 /**
- * Convert a [Feature]{@link Feature} of type POINT to a Instanced meshes
+ * Convert a {@link Feature} of type POINT to a Instanced meshes
  *
  * @param {Object} feature
  * @returns {THREE.Mesh} mesh or GROUP of THREE.InstancedMesh
@@ -578,7 +578,7 @@ function pointsToInstancedMeshes(feature) {
 }
 
 /**
- * Convert a [Feature]{@link Feature} to a Mesh
+ * Convert a {@link Feature} to a Mesh
  * @param {Feature} feature - the feature to convert
  * @param {Object} options - options controlling the conversion
  *

--- a/src/Core/3DTiles/C3DTBatchTable.js
+++ b/src/Core/3DTiles/C3DTBatchTable.js
@@ -3,7 +3,7 @@ import { C3DTilesTypes } from './C3DTilesEnums';
 
 const utf8Decoder = new TextDecoder();
 
-/** @classdesc
+/**
  * A 3D Tiles
  * [batch
  * table](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification/TileFormats/BatchTable).

--- a/src/Core/3DTiles/C3DTBatchTableHierarchyExtension.js
+++ b/src/Core/3DTiles/C3DTBatchTableHierarchyExtension.js
@@ -1,7 +1,6 @@
 
 
 /**
- * @classdesc
  * Batch Table part of the 3D Tiles
  * [Batch Table Hierarchy Extension](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/extensions/3DTILES_batch_table_hierarchy)
  * @property {object} classes - The classes as defined in the specification.

--- a/src/Core/3DTiles/C3DTBoundingVolume.js
+++ b/src/Core/3DTiles/C3DTBoundingVolume.js
@@ -85,7 +85,6 @@ function initFromSphere(sphere) {
 }
 
 /**
- * @classdesc 3D Tiles
  * [bounding volume](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/specification/schema/boundingVolume.schema.json)
  * Used to represent bounding volumes and viewer request volumes. The input bounding volume (from the dataset) can be a
  * box, a sphere or a region. Regions are transformed to spheres internally for simplification of parsing and to speed
@@ -143,7 +142,7 @@ class C3DTBoundingVolume {
     }
 
     /**
-     * Checks if the camera is inside the [viewer request volumes](@link https://github.com/CesiumGS/3d-tiles/tree/main/specification#viewer-request-volume).
+     * Checks if the camera is inside the [viewer request volumes](https://github.com/CesiumGS/3d-tiles/tree/main/specification#viewer-request-volume).
      * @param {Camera} camera - the camera to perform culling for
      * @param {THREE.Matrix4} tileMatrixWorld - the world matrix of the tile
      * @returns {boolean} true if the camera is outside the viewer request volume, false otherwise.

--- a/src/Core/3DTiles/C3DTExtensions.js
+++ b/src/Core/3DTiles/C3DTExtensions.js
@@ -1,11 +1,11 @@
-/** @classdesc
+/**
  * Class for managing
  * [3D Tiles extensions](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/extensions).
  * Extensions used in a 3D Tiles tileset must be registered in the iTowns' layer
  * holding the tileset by the user with the {@link registerExtension}
  * method. The extension must be registered together with a class holding the
  * code to interpret the extension.
- * An example of extension class is {@link $3DTBatchTableHierarchyExtension}.
+ * An example of extension class is {@link C3DTBatchTableHierarchyExtension}.
  * This extension has only one part situated in the batch table (but other
  * extensions can have multiple parts, stored in different 3D Tiles classes
  * such as tileset or bounding volume).
@@ -40,7 +40,7 @@ class C3DTExtensions {
      * corresponding to this class. These extension managers should be able
      * to parse the extension fragment (done in the constructor) and should
      * have a getInfoById method if they are related to the batch table class.
-     * See {@link $3DTBatchTableHierarchyExtension} for an example of
+     * See {@link C3DTBatchTableHierarchyExtension} for an example of
      * extension class.
      */
     registerExtension(extensionName, extensionManagers) {

--- a/src/Core/3DTiles/C3DTileset.js
+++ b/src/Core/3DTiles/C3DTileset.js
@@ -8,7 +8,7 @@ import { C3DTilesTypes } from './C3DTilesEnums';
 // to a reference local to the tile.
 const tileMatrixInverse = new THREE.Matrix4();
 
-/** @classdesc
+/**
  * A 3D Tiles
  *  [Tileset](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/specification/schema/tileset.schema.json).
  * @property {C3DTilesTypes} type - Used by 3D Tiles extensions

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -31,6 +31,7 @@ export const FEATURE_TYPES = {
 };
 
 /**
+ * @typedef {Object} FeatureBuildingOptions
  * @property {string} crs - The CRS to convert the input coordinates to.
  * @property {string} [structure='2d'] - data structure type : 2d or 3d.
  * If the structure is 3d, the feature have 3 dimensions by vertices positions and
@@ -47,8 +48,7 @@ export const FEATURE_TYPES = {
  * @property {Style} style - The style to inherit when creating
  * style for all new features.
  *
-*/
-export class FeatureBuildingOptions {}
+ */
 
 /**
  * @property {Extent} extent - The 2D extent containing all the points

--- a/src/Core/Feature.js
+++ b/src/Core/Feature.js
@@ -329,8 +329,8 @@ const alignYtoEast = new THREE.Quaternion();
  * @property {boolean} isInverted - This option is to be set to the
  * correct value, true or false (default being false), if the computation of
  * the coordinates needs to be inverted to same scheme as OSM, Google Maps
- * or other system. See [this link]{@link
- * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates}
+ * or other system. See [this link](
+ * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates)
  * for more informations.
  * @property {THREE.Matrix4} matrixWorldInverse - The matrix world inverse.
  * @property {Coordinates} center - The local center coordinates in `EPSG:4326`.
@@ -432,7 +432,7 @@ export class FeatureCollection extends THREE.Object3D {
     }
 
     /**
-     * Remove features that don't have [FeatureGeometry]{@link FeatureGeometry}.
+     * Remove features that don't have {@link FeatureGeometry}.
      */
     removeEmptyFeature() {
         this.features = this.features.filter(feature => feature.geometries.length);

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -27,10 +27,22 @@ function proj4cache(crsIn, crsOut) {
 }
 
 /**
- * A Coordinates object, defined by a [crs]{@link http://inspire.ec.europa.eu/theme/rs}
+ * A Coordinates object, defined by a [crs](http://inspire.ec.europa.eu/theme/rs)
  * and three values. These values are accessible through `x`, `y` and `z`,
  * although it can also be accessible through `latitude`, `longitude` and
  * `altitude`. To change a value, prefer the `set()` method below.
+ *
+ * `EPSG:4978` and `EPSG:4326` are supported by default. To use another CRS,
+ * you have to declare it with `proj4`. You can find most projections and their
+ * proj4 code at [epsg.io](https://epsg.io/).
+ *
+ * @example
+ * new Coordinates('EPSG:4978', 20885167, 849862, 23385912); //Geocentric coordinates
+ * new Coordinates('EPSG:4326', 2.33, 48.24, 24999549); //Geographic coordinates
+ *
+ * @example
+ * // Declare EPSG:3946 with proj4
+ * itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
  *
  * @property {boolean} isCoordinates - Used to checkout whether this coordinates
  * is a Coordinates. Default is true. You should not change this, as it is used
@@ -47,22 +59,10 @@ function proj4cache(crsIn, crsOut) {
  * @property {number} altitude - The third value of the coordinate.
  * @property {THREE.Vector3} geodesicNormal - The geodesic normal of the
  * coordinate.
- *
- * @example
- * new Coordinates('EPSG:4978', 20885167, 849862, 23385912); //Geocentric coordinates
- *
- * @example
- * new Coordinates('EPSG:4326', 2.33, 48.24, 24999549); //Geographic coordinates
  */
 class Coordinates {
     /**
-     * @constructor
-     *
-     * @param {string} crs - A supported Coordinate Reference System. 'EPSG:4978' and 'EPSG:4326' are
-     * supported by default. To use another CRS, you have to declare it with proj4. For instance:
-     * @example
-     * itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-     * You can find most projections and their proj4 code at [epsg.io]{@link https://epsg.io/}
+     * @param {string} crs - A supported Coordinate Reference System.
      * @param {number|Array<number>|Coordinates|THREE.Vector3} [v0=0] -
      * x or longitude value, or a more complex one: it can be an array of three
      * numbers, being x/lon, y/lat, z/alt, or it can be `THREE.Vector3`. It can
@@ -285,7 +285,7 @@ class Coordinates {
     }
 
     /**
-     * Returns coordinates in the wanted [CRS]{@link http://inspire.ec.europa.eu/theme/rs}.
+     * Returns coordinates in the wanted [CRS](http://inspire.ec.europa.eu/theme/rs).
      *
      * @param {string} crs - The CRS to convert the Coordinates into.
      * @param {Coordinates} [target] - The target to put the converted

--- a/src/Core/Geographic/Extent.js
+++ b/src/Core/Geographic/Extent.js
@@ -43,7 +43,9 @@ for (let i = cardinals.length - 1; i >= 0; i--) {
 
 const _c = new Coordinates('EPSG:4326', 0, 0);
 
+/** @private */
 export const globalExtentTMS = new Map();
+/** @private */
 export const schemeTiles = new Map();
 
 function getInfoTms(crs) {

--- a/src/Core/Geographic/GeoidGrid.js
+++ b/src/Core/Geographic/GeoidGrid.js
@@ -24,13 +24,13 @@ function biLinearInterpolation(indexes, getData) {
 
 /**
  * An instance of `GeoidGrid` allows accessing some geoid height grid data from geographic instances (like some
- * `{@link Coordinates}`). The geoid height grid data must contain geoid height values for a set of geographic points
+ * {@link Coordinates}). The geoid height grid data must contain geoid height values for a set of geographic points
  * regularly dispatched on a planar surface.
  *
  * @property    {Extent}        extent      The geographic extent of the geoid height grid data.
  * @property    {THREE.Vector2} step        The distance between two consecutive points of the geoid height grid. The
-                                            * `x` value stands for the distance along the West-East direction, and the
-                                            * `y` value stands for the distance along the South-North direction.
+ * `x` value stands for the distance along the West-East direction, and the
+ * `y` value stands for the distance along the South-North direction.
  * @property    {THREE.Vector2} dimensions  The planar dimensions of the geoid height grid data extent.
  * @property    {THREE.Vector2} dataSize    The number of values in the gridded data along the West-East direction (`x`
                                             * axis) and the South-North direction (`y` axis).
@@ -72,21 +72,21 @@ class GeoidGrid {
     /**
      * @param   {Extent}        extent      The geographic extent of the geoid height grid data.
      * @param   {THREE.Vector2} step        The distance between two consecutive points of the geoid height grid. The
-                                            * `x` value stands for the distance along the West-East direction, and the
-                                            * `y` value stands for the distance along the South-North direction.
+     * `x` value stands for the distance along the West-East direction, and the
+     * `y` value stands for the distance along the South-North direction.
      * @param   {function}      getData     A method that allows reading a value in the geoid height grid from its
-                                            * vertical and horizontal indexes. The lower an index, the lower the
-                                            * coordinate on the corresponding axis - 0 being the index of the minimal
-                                            * coordinate of the gridded data on a given axis. In other words :
-                                            * - `getData(0, 0)` must return the geoid height value at the SOUTH-WEST
-                                            *   corner of your data extent.
-                                            * - `getData(0, j)` must return a geoid height on the southern limit of your
-                                            *   data extent.
-                                            * - `getData(i, 0)` must return a geoid height on the western limit of your
-                                            *   data extent.
-                                            * - if your gridded data has dimensions (rowNumber, colNumber),
-                                            *   `getData(rowNumber - 1, colNumber - 1)` must return the geoid height at
-                                            *   the NORTH-EAST corner of your data extent.
+     * vertical and horizontal indexes. The lower an index, the lower the
+     * coordinate on the corresponding axis - 0 being the index of the minimal
+     * coordinate of the gridded data on a given axis. In other words :
+     * - `getData(0, 0)` must return the geoid height value at the SOUTH-WEST
+     *   corner of your data extent.
+     * - `getData(0, j)` must return a geoid height on the southern limit of your
+     *   data extent.
+     * - `getData(i, 0)` must return a geoid height on the western limit of your
+     *   data extent.
+     * - if your gridded data has dimensions (rowNumber, colNumber),
+     *   `getData(rowNumber - 1, colNumber - 1)` must return the geoid height at
+     *   the NORTH-EAST corner of your data extent.
      */
     constructor(
         extent,
@@ -105,12 +105,12 @@ class GeoidGrid {
     }
 
     /**
-     * Get the value of the geoid height at given geographic `{@link Coordinates}`. The geoid height value is
+     * Get the value of the geoid height at given geographic {@link Coordinates}. The geoid height value is
      * bi-linearly interpolated from the gridded data accessed by the `GeoidGrid` instance.
      *
      * @param   {Coordinates}   coordinates     Geographic coordinates to get the geoid height value at.
      *
-     * @returns {number}    The geoid height value at the given `{@link Coordinates}`, bi-interpolated from the gridded
+     * @returns {number}    The geoid height value at the given {@link Coordinates}, bi-interpolated from the gridded
                             * data accessed by the `GeoidGrid` instance.
      */
     getHeightAtCoordinates(coordinates) {

--- a/src/Core/Prefab/Globe/Atmosphere.js
+++ b/src/Core/Prefab/Globe/Atmosphere.js
@@ -37,9 +37,8 @@ class Atmosphere extends GeometryLayer {
      *
     * The atmospheric-scattering it is taken from :
     * * [Atmosphere Shader From Space (Atmospheric scattering)](http://stainlessbeer.weebly.com/planets-9-atmospheric-scattering.html)
-    * * [Accurate Atmospheric Scattering (NVIDIA GPU Gems 2)]{@link https://developer.nvidia.com/gpugems/gpugems2/part-ii-shading-lighting-and-shadows/chapter-16-accurate-atmospheric-scattering}.
+    * * [Accurate Atmospheric Scattering (NVIDIA GPU Gems 2)](https://developer.nvidia.com/gpugems/gpugems2/part-ii-shading-lighting-and-shadows/chapter-16-accurate-atmospheric-scattering).
     *
-    * @constructor
     * @extends GeometryLayer
     *
     * @param {string} id - The id of the layer Atmosphere.

--- a/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/src/Core/Prefab/Globe/GlobeLayer.js
@@ -24,7 +24,6 @@ class GlobeLayer extends TiledGeometryLayer {
      * A {@link TiledGeometryLayer} to use with a {@link GlobeView}. It has
      * specific method for updating and subdivising its grid.
      *
-     * @constructor
      * @extends TiledGeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -68,7 +68,6 @@ class GlobeView extends View {
     /**
      * Creates a view of a globe.
      *
-     * @constructor
      * @extends View
      *
      * @example <caption><b>Instance GlobeView.</b></caption>
@@ -82,8 +81,8 @@ class GlobeView extends View {
      * @param {HTMLDivElement} viewerDiv - Where to attach the view and display it
      * in the DOM.
      * @param {CameraTransformOptions|Extent} placement - An object to place view
-     * @param {object=} options - See options of {@link View}.
-     * @param {Object} options.controls - See options of {@link GlobeControls}
+     * @param {object} [options] - See options of {@link View}.
+     * @param {Object} [options.controls] - See options of {@link GlobeControls}
      */
     constructor(viewerDiv, placement = {}, options = {}) {
         THREE.Object3D.DEFAULT_UP.set(0, 0, 1);

--- a/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/src/Core/Prefab/Planar/PlanarLayer.js
@@ -15,7 +15,6 @@ class PlanarLayer extends TiledGeometryLayer {
      * A {@link TiledGeometryLayer} to use with a {@link PlanarView}. It has
      * specific method for updating and subdivising its grid.
      *
-     * @constructor
      * @extends TiledGeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Core/Prefab/PlanarView.js
+++ b/src/Core/Prefab/PlanarView.js
@@ -8,7 +8,6 @@ import PlanarLayer from './Planar/PlanarLayer';
 
 class PlanarView extends View {
     /**
-     * @constructor
      * @extends View
      *
      * @example <caption><b>Instance with placement on the ground.</b></caption>
@@ -19,9 +18,9 @@ class PlanarView extends View {
      * @param {HTMLDivElement} viewerDiv - Where to attach the view and display it
      * in the DOM.
      * @param {Extent} extent - The ground extent.
-     * @param {object=} options - See options of {@link View}.
+     * @param {Object} [options] - See options of {@link View}.
      * @param {boolean} [options.noControls=false] - If true, no controls are associated to the view.
-     * @param {object=} [options.controls] - options for the {@link PlanarControls} associated to the view, if
+     * @param {Object} [options.controls] - options for the {@link PlanarControls} associated to the view, if
      * `options.noControls` is false.
      * @param {CameraUtils~CameraTransformOptions|Extent} [options.placement] - The
      * {@link CameraUtils~CameraTransformOptions} to apply to view's camera or the extent it must display at

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -8,7 +8,7 @@ import Coordinates from 'Core/Geographic/Coordinates';
 
 import itowns_stroke_single_before from './StyleChunk/itowns_stroke_single_before.css';
 
-export const cacheStyle = new Cache();
+const cacheStyle = new Cache();
 
 const matrix = document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGMatrix();
 const canvas = document.createElement('canvas');
@@ -169,8 +169,7 @@ function defineStyleProperty(style, category, parameter, userValue, defaultValue
 }
 
 /**
- * @class
- * @classdesc StyleContext stores metadata of one FeatureGeometry that are needed for its style computation:
+ * StyleContext stores metadata of one FeatureGeometry that are needed for its style computation:
  * type of feature and what is needed (fill, stroke or draw a point, etc.) as well as where to get its
  * properties and its coordinates (for base_altitude).
  *
@@ -320,12 +319,12 @@ function _addIcon(icon, domElement, opt) {
  * @property {Image|Canvas|String|Object|Function} [fill.pattern] - Defines a pattern to fill the
  * surface with. It can be an `Image` to use directly, an url to fetch the pattern or an object containing
  * the url of the image to fetch and the transformation to apply.
- * from. See [this example] (http://www.itowns-project.org/itowns/examples/#source_file_geojson_raster)
+ * from. See [this example](http://www.itowns-project.org/itowns/examples/#source_file_geojson_raster)
  * for how to use.
  * @property {Image|String} [fill.pattern.source] - The image or the url to fetch the pattern image
  * @property {Object} [fill.pattern.cropValues] - The x, y, width and height (in pixel) of the sub image to use.
- * @property {THREE.Color} [fill.pattern.color] - Can be any [valid color string]
- * (https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+ * @property {THREE.Color} [fill.pattern.color] - Can be any
+ * [valid color string](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
  * It will change the color of the white pixels of the source image.
  * @property {Number|Function} [fill.opacity] - The opacity of the color or of the
  * pattern. Can be between `0.0` and `1.0`. Default is `1.0`.
@@ -446,8 +445,7 @@ function _addIcon(icon, domElement, opt) {
 */
 
 /**
- * @class
- * @classdesc A Style is a class that defines the visual appearance of {@link
+ * A Style is a class that defines the visual appearance of {@link
  * FeatureCollection} and {@link Feature}. It is taken into account when drawing
  * them in textures that will be placed onto tiles.
  *
@@ -618,8 +616,7 @@ class Style {
     /**
      * @param {StyleOptions} [params={}] An object that contain any properties
      * (order, zoom, fill, stroke, point, text or/and icon)
-     * and sub properties of a Style (@see {@link StyleOptions}).
-     * @constructor
+     * and sub properties of a Style ({@link StyleOptions}).
      */
     constructor(params = {}) {
         this.isStyle = true;

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -299,8 +299,11 @@ function _addIcon(icon, domElement, opt) {
 }
 
 /**
+ * An object that can contain any properties (order, zoom, fill, stroke, point,
+ * text or/and icon) and sub properties of a Style.<br/>
+ * Used for the instanciation of a {@link Style}.
+ *
  * @typedef {Object} StyleOptions
- * @memberof StyleOptions
  *
  * @property {Number} [order] - Order of the features that will be associated to
  * the style. It can helps sorting and prioritizing features if needed.
@@ -441,15 +444,6 @@ function _addIcon(icon, domElement, opt) {
  * @property {Number|Function} [icon.opacity] - The opacity of the icon. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
 */
-
-/**
- * @description An object that can contain any properties
- * (order, zoom, fill, stroke, point, text or/and icon)
- * and sub properties of a Style.<br/>
- * Used for the instanciation of a {@link Style}.
- * @hideconstructor
- */
-export class StyleOptions {}
 
 /**
  * @class

--- a/src/Core/TileMesh.js
+++ b/src/Core/TileMesh.js
@@ -5,7 +5,6 @@ import { geoidLayerIsVisible } from 'Layer/GeoidLayer';
 /**
  * A TileMesh is a THREE.Mesh with a geometricError and an OBB
  * The objectId property of the material is the with the id of the TileMesh
- * @constructor
  * @param {TileGeometry} geometry - the tile geometry
  * @param {THREE.Material} material - a THREE.Material compatible with THREE.Mesh
  * @param {Layer} layer - the layer the tile is added to

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -147,21 +147,19 @@ class View extends THREE.EventDispatcher {
      *
      * @param {string} crs - The default CRS of Three.js coordinates. Should be a cartesian CRS.
      * @param {HTMLElement} viewerDiv - Where to instanciate the Three.js scene in the DOM
-     * @param {Object=} options - Optional properties.
+     * @param {Object} [options] - Optional properties.
      * @param {object} [options.camera] - Options for the camera associated to the view. See {@link Camera} options.
-     * @param {?MainLoop} options.mainLoop - {@link MainLoop} instance to use, otherwise a default one will be constructed
-     * @param {?(WebGLRenderer|object)} options.renderer - {@link WebGLRenderer} instance to use, otherwise
+     * @param {MainLoop} [options.mainLoop] - {@link MainLoop} instance to use, otherwise a default one will be constructed
+     * @param {WebGLRenderer|Object} [options.renderer] - {@link WebGLRenderer} instance to use, otherwise
      * a default one will be constructed. In this case, if options.renderer is an object, it will be used to
      * configure the renderer (see {@link c3DEngine}.  If not present, a new &lt;canvas> will be created and
      * added to viewerDiv (mutually exclusive with mainLoop)
-     * @param {boolean|Object} [options.webXR=false] - enable webxr button to switch on VR visualization.
+     * @param {Object} [options.webXR] - enable webxr button to switch on VR visualization.
      * @param {number} [options.webXR.scale=1.0] - apply webxr scale tranformation.
-     * @param {?Scene} [options.scene3D] - [THREE.Scene](https://threejs.org/docs/#api/en/scenes/Scene) instance to use, otherwise a default one will be constructed
-     * @param {?Color} options.diffuse - [THREE.Color](https://threejs.org/docs/?q=color#api/en/math/Color) Diffuse color terrain material.
+     * @param {Scene} [options.scene3D] - [THREE.Scene](https://threejs.org/docs/#api/en/scenes/Scene) instance to use, otherwise a default one will be constructed
+     * @param {Color} [options.diffuse] - [THREE.Color](https://threejs.org/docs/?q=color#api/en/math/Color) Diffuse color terrain material.
      * This color is applied to terrain if there isn't color layer on terrain extent (by example on pole).
      * @param {boolean} [options.enableFocusOnStart=true] - enable focus on dom element on start.
-     *
-     * @constructor
      */
     constructor(crs, viewerDiv, options = {}) {
         if (!viewerDiv) {

--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -58,7 +58,6 @@ class C3DTilesLayer extends GeometryLayer {
     #fillColorMaterialsBuffer;
     /**
      * @deprecated Deprecated 3D Tiles layer. Use {@link OGC3DTilesLayer} instead.
-     * @constructor
      * @extends GeometryLayer
      *
      * @example
@@ -95,11 +94,11 @@ class C3DTilesLayer extends GeometryLayer {
      * @param {Number} [config.cleanupDelay=1000] The time (in ms) after which a tile content (and its children) are
      * removed from the scene.
      * @param {C3DTExtensions} [config.registeredExtensions] 3D Tiles extensions managers registered for this tileset.
-     * @param {String} [config.pntsMode= PNTS_MODE.COLOR] {@link PointsMaterials} Point cloud coloring mode.
+     * @param {String} [config.pntsMode= PNTS_MODE.COLOR] {@link PointsMaterial} Point cloud coloring mode.
      *      Only 'COLOR' or 'CLASSIFICATION' are possible. COLOR uses RGB colors of the points,
      *      CLASSIFICATION uses a classification property of the batch table to color points.
      * @param {String} [config.pntsShape= PNTS_SHAPE.CIRCLE] Point cloud point shape. Only 'CIRCLE' or 'SQUARE' are possible.
-     * @param {String} [config.pntsSizeMode= PNTS_SIZE_MODE.VALUE] {@link PointsMaterials} Point cloud size mode. Only 'VALUE' or 'ATTENUATED' are possible. VALUE use constant size, ATTENUATED compute size depending on distance from point to camera.
+     * @param {String} [config.pntsSizeMode= PNTS_SIZE_MODE.VALUE] {@link PointsMaterial} Point cloud size mode. Only 'VALUE' or 'ATTENUATED' are possible. VALUE use constant size, ATTENUATED compute size depending on distance from point to camera.
      * @param {Number} [config.pntsMinAttenuatedSize=3] Minimum scale used by 'ATTENUATED' size mode
      * @param {Number} [config.pntsMaxAttenuatedSize=10] Maximum scale used by 'ATTENUATED' size mode
      * @param {Style} [config.style=null] - style used for this layer
@@ -264,7 +263,7 @@ class C3DTilesLayer extends GeometryLayer {
     }
 
     /**
-     * Call by {@link 3dTilesProcessing} which handle load and unload of 3DTiles
+     * Called when a tile content is loaded
      * @param {THREE.Object3D} tileContent - tile as THREE.Object3D
      */
     onTileContentLoaded(tileContent) {

--- a/src/Layer/ColorLayer.js
+++ b/src/Layer/ColorLayer.js
@@ -51,7 +51,6 @@ class ColorLayer extends RasterLayer {
      * it can be an aerial view of the ground or a simple transparent layer with the
      * roads displayed.
      *
-     * @constructor
      * @extends Layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
@@ -65,13 +64,13 @@ class ColorLayer extends RasterLayer {
      * @param {Source} [config.source] - Description and options of the source.
      * @param {number} [config.magFilter] - How the texture is sampled when a texel covers more than one pixel. [see](https://threejs.org/docs/?q=texture#api/en/textures/Texture.magFilter)
      * @param {number} [config.minFilter] - How the texture is sampled when a texel covers less than one pixel. [see](https://threejs.org/docs/?q=texture#api/en/textures/Texture.minFilter)
-     * @param {number} [effect_type=0] - type effect to apply on raster color.
+     * @param {number} [config.effect_type=0] - type effect to apply on raster color.
      * if `effect_type` equals:
      * * `0`: no special effect.
      * * `1`: light color to invisible effect.
      * * `2`: white color to invisible effect.
      * * `3`: custom shader effect (defined `ShaderChunk.customBodyColorLayer` and `ShaderChunk.customHeaderColorLayer`).
-     * @param {number} [effect_parameter=1.0] - amount value used with effect applied on raster color.
+     * @param {number} [config.effect_parameter=1.0] - amount value used with effect applied on raster color.
      *
      * @example
      * // Create a ColorLayer

--- a/src/Layer/CopcLayer.js
+++ b/src/Layer/CopcLayer.js
@@ -3,7 +3,6 @@ import CopcNode from 'Core/CopcNode';
 import PointCloudLayer from 'Layer/PointCloudLayer';
 
 /**
- * @classdesc
  * A layer for [Cloud Optimised Point Cloud](https://copc.io) (COPC) datasets.
  * See {@link PointCloudLayer} class for documentation on base properties.
  *

--- a/src/Layer/ElevationLayer.js
+++ b/src/Layer/ElevationLayer.js
@@ -28,7 +28,6 @@ class ElevationLayer extends RasterLayer {
      * A simple layer, managing an elevation texture to add some reliefs on the
      * plane or globe view for example.
      *
-     * @constructor
      * @extends Layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Layer/EntwinePointTileLayer.js
+++ b/src/Layer/EntwinePointTileLayer.js
@@ -16,7 +16,6 @@ class EntwinePointTileLayer extends PointCloudLayer {
     /**
      * Constructs a new instance of Entwine Point Tile layer.
      *
-     * @constructor
      * @extends PointCloudLayer
      *
      * @example

--- a/src/Layer/FeatureGeometryLayer.js
+++ b/src/Layer/FeatureGeometryLayer.js
@@ -16,7 +16,6 @@ import Feature2Mesh from 'Converter/Feature2Mesh';
  */
 class FeatureGeometryLayer extends GeometryLayer {
     /**
-     * @constructor
      * @extends GeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Layer/GeometryLayer.js
+++ b/src/Layer/GeometryLayer.js
@@ -14,16 +14,15 @@ import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
  * internally for optimisation.
  * @property {number} [zoom.max=Infinity] - this is the maximum zoom beyond which it'll be hidden.
  * The `max` is constant and the value is `Infinity` because there's no maximum display level after which it is hidden.
- * This property is used only if the layer is attached to [TiledGeometryLayer]{@link TiledGeometryLayer}.
+ * This property is used only if the layer is attached to {@link TiledGeometryLayer}.
  * @property {number} [zoom.min=0] - this is the minimum zoom from which it'll be visible.
- * This property is used only if the layer is attached to [TiledGeometryLayer]{@link TiledGeometryLayer}.
+ * This property is used only if the layer is attached to {@link TiledGeometryLayer}.
  */
 class GeometryLayer extends Layer {
     /**
      * A layer usually managing a geometry to display on a view. For example, it
      * can be a layer of buildings extruded from a a WFS stream.
      *
-     * @constructor
      * @extends Layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is
@@ -187,8 +186,7 @@ class GeometryLayer extends Layer {
     }
 
     /**
-     * Picking method for this layer. It uses the {@link Picking#pickObjectsAt}
-     * method.
+     * Picking method for this layer.
      *
      * @param {View} view - The view instance.
      * @param {Object} coordinates - The coordinates to pick in the view. It

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -150,7 +150,6 @@ class LabelsNode extends THREE.Group {
 class LabelLayer extends GeometryLayer {
     #filterGrid = new ScreenGrid();
     /**
-     * @constructor
      * @extends Layer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Layer/Layer.js
+++ b/src/Layer/Layer.js
@@ -19,7 +19,8 @@ import Style from 'Core/Style';
  * @property {Promise} whenReady - this promise is resolved when the layer is added and all initializations are done.
  * This promise is resolved with this layer.
  * This promise is returned by [View#addLayer]{@link View}.
- * @property {object} [zoom] - This property is used only the layer is attached to [TiledGeometryLayer]{@link TiledGeometryLayer}.
+ * @property {object} [zoom] - This property is used only the layer is attached
+ * to {@link TiledGeometryLayer}.
  * By example,
  * The layer checks the tile zoom level to determine if the layer is visible in this tile.
  *
@@ -38,7 +39,6 @@ class Layer extends THREE.EventDispatcher {
      * another available type of Layer, implement a new one inheriting from this
      * one or use [View#addLayer]{@link View}.
      *
-     * @constructor
      * @protected
      *
      * @param {string} id - The id of the layer, that should be unique. It is
@@ -52,17 +52,17 @@ class Layer extends THREE.EventDispatcher {
      * @param {Source|boolean} config.source - instantiated Source specifies data source to display.
      * if config.source is a boolean, it can only be false. if config.source is false,
      * the layer doesn't need Source (like debug Layer or procedural layer).
-     * @param {StyleOptions|Style} [config.style] - an object that contain any properties
+     * @param {StyleOptions} [config.style] - an object that contain any properties
      * (order, zoom, fill, stroke, point, text or/and icon)
      * and sub properties of a Style (@see {@link StyleOptions}). Or directly a {@link Style} .<br/>
      * When entering a StyleOptions the missing style properties will be look for in the data (if any)
      * what won't be done when you use a Style.
      * @param {number} [config.cacheLifeTime=Infinity] - set life time value in cache.
-     * This value is used for [Cache]{@link Cache} expiration mechanism.
-     * @param {(boolean|Object)} [config.addLabelLayer=false] - Used to tell if this layer has
+     * This value is used for cache expiration mechanism.
+     * @param {(boolean|Object)} [config.addLabelLayer] - Used to tell if this layer has
      * labels to display from its data. For example, it needs to be set to `true`
      * for a layer with vector tiles. If it's `true` a new `LabelLayer` is added and attached to this `Layer`.
-     * You can also configure it with [LabelLayer]{@link LabelLayer} options described below such as: `addLabelLayer: { performance: true }`.
+     * You can also configure it with {@link LabelLayer} options described below such as: `addLabelLayer: { performance: true }`.
      * @param {boolean} [config.addLabelLayer.performance=false] - In case label layer adding, so remove labels that have no chance of being visible.
      * Indeed, even in the best case, labels will never be displayed. By example, if there's many labels.
      * @param {boolean} [config.addLabelLayer.forceClampToTerrain=false] - use elevation layer to clamp label on terrain.

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -114,8 +114,6 @@ class OGC3DTilesLayer extends GeometryLayer {
      * Layer for [3D Tiles](https://www.ogc.org/standard/3dtiles/) datasets.
      * @extends Layer
      *
-     * @constructor
-     *
      * @param {String} id - unique layer id.
      * @param {Object} config - layer specific configuration
      * @param {OGC3DTilesSource} config.source - data source configuration

--- a/src/Layer/OrientedImageLayer.js
+++ b/src/Layer/OrientedImageLayer.js
@@ -77,7 +77,7 @@ function createBackground(radius) {
 }
 
 /**
- * @classdesc OrientedImageLayer loads oriented images, and project these textures on the scene.
+ * OrientedImageLayer loads oriented images, and project these textures on the scene.
  * It is design to create an immersive view. </br>
  * It loads a set of panoramic position and orientation,
  * a set of camera calibration file (it's the same set of camera for each panoramic),
@@ -87,7 +87,6 @@ function createBackground(radius) {
  */
 class OrientedImageLayer extends GeometryLayer {
     /**
-     * @constructor
      * @param { string } id - The id of the layer, a unique name.
      * @param { Object } config - configuration of the layer
      * @param { number } config.backgroundDistance - Radius in meter of the sphere used as a background
@@ -95,7 +94,8 @@ class OrientedImageLayer extends GeometryLayer {
      * @param { string } config.crs - crs projection of the view
      * @param { string } config.orientation - Json object, using GeoJSon format to represent points,
      * it's a set of panoramic position and orientation.
-     * @param { string } config.calibrations - Json object, representing a set of camera. see [CameraCalibrationParser]{@link module:CameraCalibrationParser}
+     * @param { string } config.calibrations - Json object, representing a set of camera.
+     * see {@link CameraCalibrationParser}
      * @param { OrientedImageSource } config.source - Source used to build url of texture for each oriented image,
      * a tecture is need for each camera, for each panoramic.
      */

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -134,7 +134,6 @@ class PointCloudLayer extends GeometryLayer {
      * Constructs a new instance of a Point Cloud Layer. This should not be used
      * directly, but rather implemented using `extends`.
      *
-     * @constructor
      * @extends GeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Layer/Potree2Layer.js
+++ b/src/Layer/Potree2Layer.js
@@ -118,7 +118,6 @@ class Potree2Layer extends PointCloudLayer {
     /**
      * Constructs a new instance of Potree2 layer.
      *
-     * @constructor
      * @extends PointCloudLayer
      *
      * @example

--- a/src/Layer/PotreeLayer.js
+++ b/src/Layer/PotreeLayer.js
@@ -16,7 +16,6 @@ class PotreeLayer extends PointCloudLayer {
     /**
      * Constructs a new instance of Potree layer.
      *
-     * @constructor
      * @extends PointCloudLayer
      *
      * @example

--- a/src/Layer/TiledGeometryLayer.js
+++ b/src/Layer/TiledGeometryLayer.js
@@ -39,7 +39,6 @@ class TiledGeometryLayer extends GeometryLayer {
      * It corresponds at meters by pixel. If the projection tile exceeds a certain pixel size (on screen)
      * then it is subdivided into 4 tiles with a zoom greater than 1.
      *
-     * @constructor
      * @extends GeometryLayer
      *
      * @param {string} id - The id of the layer, that should be unique. It is

--- a/src/Parser/GDFParser.js
+++ b/src/Parser/GDFParser.js
@@ -20,7 +20,7 @@ export function getHeaderAttribute(header, attributeName) {
  */
 export default {
     /**
-     * Parses a GDF file content and returns a corresponding `{@link GeoidGrid}`.
+     * Parses a GDF file content and returns a corresponding {@link GeoidGrid}.
      *
      * @param   {string}    gdf                             The content of the GDF file to parse.
      * @param   {Object}    options                         An object gathering the optional parameters to pass to
@@ -30,7 +30,7 @@ export default {
                                                             * It must be a geographic CRS, and must be given as an EPSG
                                                             * code.
      *
-     * @returns {Promise<GeoidGrid>}    A promise resolving with a `{@link GeoidGrid}`, which contains all the necessary
+     * @returns {Promise<GeoidGrid>}    A promise resolving with a {@link GeoidGrid}, which contains all the necessary
                                         * attributes and methods to access GDF file data.
      */
     parse(gdf, options = { in: {} }) {

--- a/src/Parser/GTXParser.js
+++ b/src/Parser/GTXParser.js
@@ -9,14 +9,14 @@ export const BYTES_PER_FLOAT = 4;
 
 /**
  * The `GTXParser` module provides a `[parse]{@link module:GTXParser.parse}` method. This method takes the content of a
- * GTX file in, and returns a `{@link GeoidGrid}`. The `{@link GeoidGrid}` contains all the necessary attributes and
+ * GTX file in, and returns a {@link GeoidGrid}. The {@link GeoidGrid} contains all the necessary attributes and
  * methods to access the GTX data in iTowns.
  *
  * @module GTXParser
  */
 export default {
     /**
-     * Parses a GTX file content and returns a corresponding `{@link GeoidGrid}`.
+     * Parses a GTX file content and returns a corresponding {@link GeoidGrid}.
      *
      * @param   {ArrayBuffer}   gtx                             The content of the GTX file to parse.
      * @param   {Object}        options                         An object gathering the optional parameters to pass to
@@ -28,7 +28,7 @@ export default {
      * @param   {string}        [options.in.dataType='float']   The encoding of geoid height data within the GTX file.
                                                                 * Must be `'float'` or `'double'`.
      *
-     * @returns {Promise<GeoidGrid>}    A promise resolving with a `{@link GeoidGrid}`, which contains all the necessary
+     * @returns {Promise<GeoidGrid>}    A promise resolving with a {@link GeoidGrid}, which contains all the necessary
                                         * attributes and methods to access GTX file data.
      */
     parse(gtx, options = { in: {} }) {

--- a/src/Parser/GeoJsonParser.js
+++ b/src/Parser/GeoJsonParser.js
@@ -195,12 +195,12 @@ function jsonFeaturesToFeatures(crsIn, jsonFeatures, options) {
  */
 export default {
     /**
-     * Parse a GeoJSON file content and return a [FeatureCollection]{@link FeatureCollection}.
+     * Parse a GeoJSON file content and return a {@link FeatureCollection}.
      *
      * @param {string} json - The GeoJSON file content to parse.
      * @param {ParsingOptions} options - Options controlling the parsing.
 
-     * @return {Promise} A promise resolving with a [FeatureCollection]{@link FeatureCollection}.
+     * @return {Promise} A promise resolving with a {@link FeatureCollection}.
      */
     parse(json, options = {}) {
         options = deprecatedParsingOptionsToNewOne(options);

--- a/src/Parser/GpxParser.js
+++ b/src/Parser/GpxParser.js
@@ -11,14 +11,12 @@ import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
  */
 export default {
     /**
-     * Parse a GPX file content and return a [FeatureCollection]{@link
-     * module:GeoJsonParser~FeatureCollection}.
+     * Parse a GPX file content and return a {@link FeatureCollection}.
      *
      * @param {XMLDocument} gpxFile - The GPX file content to parse.
      * @param {ParsingOptions} options - Options controlling the parsing.
      *
-     * @return {Promise} A promise resolving with a [FeatureCollection]{@link
-     * module:GeoJsonParser~FeatureCollection}.
+     * @return {Promise} A promise resolving with a {@link FeatureCollection}.
      */
     parse(gpxFile, options) {
         options = deprecatedParsingOptionsToNewOne(options);

--- a/src/Parser/ISGParser.js
+++ b/src/Parser/ISGParser.js
@@ -14,7 +14,7 @@ import { BYTES_PER_DOUBLE } from 'Parser/GTXParser';
  */
 export default {
     /**
-     * Parses an ISG file content and returns a corresponding `{@link GeoidGrid}`.
+     * Parses an ISG file content and returns a corresponding {@link GeoidGrid}.
      *
      * @param   {string}    isg                             The content of the ISG file to parse.
      * @param   {Object}    options                         An object gathering the optional parameters to pass to
@@ -24,7 +24,7 @@ export default {
                                                             * It must be a geographic CRS, and must be given as an EPSG
                                                             * code.
      *
-     * @returns {Promise<GeoidGrid>}    A promise resolving with a `{@link GeoidGrid}`, which contains all the necessary
+     * @returns {Promise<GeoidGrid>}    A promise resolving with a {@link GeoidGrid}, which contains all the necessary
                                         * attributes and methods to access ISG file data.
      */
     parse(isg, options = { in: {} }) {

--- a/src/Parser/KMLParser.js
+++ b/src/Parser/KMLParser.js
@@ -11,14 +11,12 @@ import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
  */
 export default {
     /**
-     * Parse a KML file content and return a [FeatureCollection]{@link
-     * module:GeoJsonParser~FeatureCollection}.
+     * Parse a KML file content and return a {@link FeatureCollection}.
      *
      * @param {XMLDocument} kmlFile - The KML file content to parse.
      * @param {ParsingOptions} options - Options controlling the parsing.
      *
-     * @return {Promise} A promise resolving with a [FeatureCollection]{@link
-     * module:GeoJsonParser~FeatureCollection}.
+     * @return {Promise} A promise resolving with a {@link FeatureCollection}.
      */
     parse(kmlFile, options) {
         options = deprecatedParsingOptionsToNewOne(options);

--- a/src/Parser/ShapefileParser.js
+++ b/src/Parser/ShapefileParser.js
@@ -9,7 +9,7 @@ import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
  * a shapefile in and gives an object formateted for iTowns, containing all
  * necessary informations to display this shapefile.
  *
- * It uses the [shpjs]{@link https://www.npmjs.com/package/shpjs} library to
+ * It uses the [shpjs](https://www.npmjs.com/package/shpjs) library to
  * parse all the files.
  *
  * @example
@@ -45,8 +45,7 @@ import { deprecatedParsingOptionsToNewOne } from 'Core/Deprecated/Undeprecator';
  */
 export default {
     /**
-     * Parse a bunch of Shapefile files and return a [FeatureCollection]{@link
-     * module:GeoJsonParser~FeatureCollection}.
+     * Parse a bunch of Shapefile files and return a {@link FeatureCollection}.
      *
      * @param {Object} data - All the data that can be specified in a shapefile.
      * @param {ArrayBuffer} data.shp - Data from the shapefile itself,
@@ -54,7 +53,7 @@ export default {
      * @param {ArrayBuffer} data.shx - A positional index of the feature
      * geometry.
      * @param {ArrayBuffer} data.dbf - Columnar attributes for each shape, in
-     * [dBase]{@link https://en.wikipedia.org/wiki/DBase} IV format.
+     * [dBase](https://en.wikipedia.org/wiki/DBase) IV format.
      * @param {string} [data.prj] - The coordinate system and crs projection
      * information.
      * @param {ParsingOptions} [options]

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -187,13 +187,13 @@ export default {
      * Parse a vector tile file and return a [Feature]{@link module:GeoJsonParser.Feature}
      * or an array of Features. While multiple formats of vector tile are
      * available, the only one supported for the moment is the
-     * [Mapbox Vector Tile]{@link https://www.mapbox.com/vector-tiles/specification/}.
+     * [Mapbox Vector Tile](https://www.mapbox.com/vector-tiles/specification/).
      *
      * @param {ArrayBuffer} file - The vector tile file to parse.
      *
-     * @param {ParsingOptions} options - Options controlling the parsing {@link ParsingOptions}.
+     * @param {Object} options - Options controlling the parsing {@link ParsingOptions}.
      *
-     * @param {InformationsData} options.in - Object containing all styles,
+     * @param {Object} options.in - Object containing all styles,
      * layers and informations data, see {@link InformationsData}.
      *
      * @param {Object} options.in.styles - Object containing subobject with

--- a/src/Parser/iGLTFLoader.js
+++ b/src/Parser/iGLTFLoader.js
@@ -13,7 +13,6 @@ class iGLTFLoader extends THREE.Loader {
      * loaded model to transform from y-up to z-up. Note that you can also use Coordinates.geodesicNormal to get the normal
      * to a position on the globe (i.e. in GlobeView) to correctly orient a model on a GlobeView.
      *
-     * @constructor
      * @param {THREE.LoadingManager} [manager] - The loadingManager for the loader to use. Default is THREE.DefaultLoadingManager.
      */
     constructor(manager) {

--- a/src/Provider/Fetcher.js
+++ b/src/Provider/Fetcher.js
@@ -23,8 +23,8 @@ function getTextureFloat(buffer) {
 }
 
 /**
- * Utilitary to fetch resources from a server using the [fetch API]{@link
- * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch}.
+ * Utilitary to fetch resources from a server using the [fetch API](
+ * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch).
  *
  * @module Fetcher
  */
@@ -34,8 +34,8 @@ export default {
      *
      * @param {string} url - The URL of the resources to fetch.
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      *
      * @return {Promise<string>} Promise containing the text.
      */
@@ -51,8 +51,8 @@ export default {
      *
      * @param {string} url - The URL of the resources to fetch.
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      *
      * @return {Promise<Object>} Promise containing the JSON object.
      */
@@ -68,8 +68,8 @@ export default {
      *
      * @param {string} url - The URL of the resources to fetch.
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      *
      * @return {Promise<Document>} Promise containing the XML Document.
      */
@@ -81,17 +81,17 @@ export default {
     },
 
     /**
-     * Wrapper around {@link THREE.TextureLoader}.
+     * Wrapper around [THREE.TextureLoader](https://threejs.org/docs/#api/en/loaders/TextureLoader).
      *
      * @param {string} url - The URL of the resources to fetch.
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      * Note that THREE.js docs mentions `withCredentials`, but it is not
-     * actually used in {@link THREE.TextureLoader}.
+     * actually used in [THREE.TextureLoader](https://threejs.org/docs/#api/en/loaders/TextureLoader).
      *
-     * @return {Promise<THREE.Texture>} Promise containing the {@link
-     * THREE.Texture}.
+     * @return {Promise<THREE.Texture>} Promise containing the
+     * [THREE.Texture](https://threejs.org/docs/api/en/textures/Texture.html).
      */
     texture(url, options = {}) {
         let res;
@@ -113,20 +113,21 @@ export default {
      *
      * @param {string} url - The URL of the resources to fetch.
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      *
      * @return {Promise<ArrayBuffer>} Promise containing the ArrayBuffer.
      */
     arrayBuffer,
 
     /**
-     * Wrapper over fetch to get some {@link THREE.DataTexture}.
+     * Wrapper over fetch to get some
+     * [THREE.DataTexture](https://threejs.org/docs/#api/en/textures/DataTexture).
      *
      * @param {string} url - The URL of the resources to fetch.
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      *
      * @return {Promise<THREE.DataTexture>} Promise containing the DataTexture.
      */
@@ -148,8 +149,8 @@ export default {
      * even `arrayBuffer`. The arrays contains the extensions to append after
      * the `baseUrl` (see example below).
      * @param {Object} options - Fetch options (passed directly to `fetch()`),
-     * see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      *
      * @return {Promise[]} An array of promises, containing all the files,
      * organized by their extensions (see the example below).

--- a/src/Renderer/OBB.js
+++ b/src/Renderer/OBB.js
@@ -13,11 +13,12 @@ const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 let obb;
 
 // it could be considered to remove THREE.Object3D extend.
+/**
+ * Oriented bounding box
+ * @extends THREE.Object3D
+ */
 class OBB extends THREE.Object3D {
     /**
-     * Oriented bounding box
-     * @constructor
-     * @extends THREE.Object3D
      * @param {THREE.Vector3}  min representing the lower (x, y, z) boundary of the box. Default is ( + Infinity, + Infinity, + Infinity ).
      * @param {THREE.Vector3}  max representing the lower upper (x, y, z) boundary of the box. Default is ( - Infinity, - Infinity, - Infinity ).
      */

--- a/src/Renderer/OrientedImageCamera.js
+++ b/src/Renderer/OrientedImageCamera.js
@@ -31,12 +31,11 @@ class Distortion {
 const zoom = new THREE.Vector3();
 
 /**
- * @classdesc OrientedImageCamera is a ThreeJs camera adapted to photogrammetric description.
+ * OrientedImageCamera is a ThreeJs camera adapted to photogrammetric description.
  * So we can build a ThreeJs perspective camera from size and focal information.
  */
 class OrientedImageCamera extends THREE.PerspectiveCamera {
     /**
-     * @constructor
      * @param {number|Vector2} size - image size in pixels (default: x=1024, y=x)
      * @param {number|Vector2} focal - focal length in pixels (default: x=1024, y=x)
      * @param {Vector2} center - principal point in pixels (default: size/2)

--- a/src/Renderer/OrientedImageMaterial.js
+++ b/src/Renderer/OrientedImageMaterial.js
@@ -16,7 +16,7 @@ const noTexture = new THREE.Texture();
 
 const shaderMaterial = new THREE.ShaderMaterial();
 /**
- * @classdesc OrientedImageMaterial is a custom shader material used to do projective texture mapping.<br/>
+ * OrientedImageMaterial is a custom shader material used to do projective texture mapping.<br/>
  *
  * This Material is designed to project many textures simultaneously.
  * Each projected texture setting is stored as an {@link OrientedImageCamera}.<br/>
@@ -27,15 +27,14 @@ const shaderMaterial = new THREE.ShaderMaterial();
  * <br/>
  * The current implementation supports the following distortion models : <br/>
  *  - no distortion (polynom==vec3(0),l1l2==vec2(0))<br/>
- *  - radial distortion (polynom!=vec3(0),l1l2==vec2(0)) (see <b>15.2.2 Radial Model</b> in [MicMac doc]{@link https://github.com/micmacIGN/Documentation/blob/master/DocMicMac.pdf}) </br>
- *  - equilinear fish eye distortion (polynom!=vec3(0),l1l2 != vec2(0)) (see <b>15.3.4 Fish eye models</b> in [MicMac doc]{@link https://github.com/micmacIGN/Documentation/blob/master/DocMicMac.pdf}) </br>
+ *  - radial distortion (polynom!=vec3(0),l1l2==vec2(0)) (see <b>15.2.2 Radial Model</b> in [MicMac doc](https://github.com/micmacIGN/Documentation/blob/master/DocMicMac.pdf)) </br>
+ *  - equilinear fish eye distortion (polynom!=vec3(0),l1l2 != vec2(0)) (see <b>15.3.4 Fish eye models</b> in [MicMac doc](https://github.com/micmacIGN/Documentation/blob/master/DocMicMac.pdf)) </br>
  * (Note: radial decentric parameters P1 are P2 not supported and assumed to be 0).<br/>
  * <br/>
  * To get a more comprehensive support of camera Micmac models, you can consider using [three-photogrammetric-camera]{@link https://github.com/mbredif/three-photogrammetric-camera} instead.
  */
 class OrientedImageMaterial extends THREE.ShaderMaterial {
     /**
-     * @constructor
      * @param { OrientedImageCamera[]} cameras - Array of {@link OrientedImageCamera}. Each camera will project a texture.
      * [CameraCalibrationParser]{@link module:CameraCalibrationParser.parse} can used to create this array of camera from a configuration file.
      * @param {Object} [options={}] - Object with one or more properties defining the material's appearance.
@@ -128,9 +127,9 @@ class OrientedImageMaterial extends THREE.ShaderMaterial {
      * Set new textures and new position/orientation of the camera set.
      * @param {THREE.Texture} textures - Array of [THREE.Texture]{@link https://threejs.org/docs/#api/en/textures/Texture}.
      * @param {Object} feature - New position / orientation of the set of cameras
-     * @param {Array} camerasNames - camera names of panoramic feature
      * @param {THREE.Vector3} feature.position - New position.
      * @param {THREE.Quaternion} feature.quaternion - New orientation.
+     * @param {Array} camerasNames - camera names of panoramic feature
      */
     setTextures(textures, feature, camerasNames) {
         if (!textures) { return; }

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -37,11 +37,10 @@ const white = new THREE.Color(1.0,  1.0,  1.0);
  * integer codes in the files.
  *
  * @typedef {Object} Classification
- * @property {object} category - category classification,
- * @property {boolean} category.visible - category visibility,
- * @property {string} category.name - category name,
- * @property {THREE.Color} category.color - category color,
- * @property {number} category.opacity - category opacity,
+ * @property {boolean} visible - category visibility,
+ * @property {string} name - category name,
+ * @property {THREE.Color} color - category color,
+ * @property {number} opacity - category opacity,
  */
 
 export const ClassificationScheme = {

--- a/src/Renderer/PointsMaterial.js
+++ b/src/Renderer/PointsMaterial.js
@@ -36,14 +36,13 @@ const white = new THREE.Color(1.0,  1.0,  1.0);
  * top of canopy, and water. The different classes are defined using numeric
  * integer codes in the files.
  *
+ * @typedef {Object} Classification
  * @property {object} category - category classification,
  * @property {boolean} category.visible - category visibility,
  * @property {string} category.name - category name,
  * @property {THREE.Color} category.color - category color,
  * @property {number} category.opacity - category opacity,
  */
-// eslint-disable-next-line
-class /* istanbul ignore next */ Classification {}
 
 export const ClassificationScheme = {
     DEFAULT: {

--- a/src/Renderer/RasterTile.js
+++ b/src/Renderer/RasterTile.js
@@ -18,7 +18,7 @@ function getIndiceWithPitch(i, pitch, w) {
 }
 
 /**
- * A `RasterTile` is part of raster [`Layer`]{@link Layer} data.
+ * A `RasterTile` is part of raster {@link Layer} data.
  * This part is a spatial subdivision of the extent of a layer.
  * In the `RasterTile`, The data are converted on three.js textures.
  * This `RasterTile` textures are assigned to a `LayeredMaterial`.

--- a/src/Source/C3DTilesGoogleSource.js
+++ b/src/Source/C3DTilesGoogleSource.js
@@ -20,7 +20,6 @@ function findSessionId(tile) {
 }
 
 /**
- * @classdesc
  * An object defining the source connection to a 3DTiles asset from a [Google api](https://tile.googleapis.com).
  *
  * @extends C3DTilesSource
@@ -34,7 +33,6 @@ class C3DTilesGoogleSource extends C3DTilesSource {
     /**
      * Create a new Source for 3D Tiles data from Google api (experimental).
      *
-     * @constructor
      * @extends C3DTilesSource
      *
      * @property {boolean} isC3DTilesGoogleSource - Used to checkout whether this source is a C3DTilesGoogleSource. Default is

--- a/src/Source/C3DTilesIonSource.js
+++ b/src/Source/C3DTilesIonSource.js
@@ -2,7 +2,6 @@ import Fetcher from 'Provider/Fetcher';
 import C3DTilesSource from './C3DTilesSource';
 
 /**
- * @classdesc
  * An object defining the source connection to a 3DTiles asset of a [Cesium ion server](https://cesium.com/learn/ion/).
  *
  * @extends Source
@@ -18,7 +17,6 @@ class C3DTilesIonSource extends C3DTilesSource {
     /**
      * Create a new Source for 3D Tiles data from Cesium ion.
      *
-     * @constructor
      * @extends Source
      *
      * @param {Object} source An object that can contain all properties of a C3DTilesIonSource and {@link Source}.

--- a/src/Source/C3DTilesSource.js
+++ b/src/Source/C3DTilesSource.js
@@ -2,7 +2,6 @@ import Source from 'Source/Source';
 import Fetcher from 'Provider/Fetcher';
 
 /**
- * @classdesc
  * An object defining the source connection to a 3DTiles dataset from a web server.
  *
  * @extends Source
@@ -16,7 +15,6 @@ class C3DTilesSource extends Source {
     /**
      * Create a new Source for 3D Tiles data from a web server.
      *
-     * @constructor
      * @extends Source
      *
      * @param {Object} source An object that can contain all properties of {@link Source}.

--- a/src/Source/CopcSource.js
+++ b/src/Source/CopcSource.js
@@ -33,7 +33,6 @@ async function getHeaders(fetcher) {
 }
 
 /**
- * @classdesc
  * A source for [Cloud Optimised Point Cloud](https://copc.io/) (COPC) data.
  * Such data consists of a [LAZ 1.4](https://www.ogc.org/standard/las/) file
  * that stores compressed points data organized in a clustered octree.
@@ -77,11 +76,9 @@ class CopcSource extends Source {
      * @param {string} [config.crs='EPSG:4326'] - Native CRS of the COPC
      * ressource. Note that this is not for now inferred from the COPC header.
      * @param {RequestInit} [config.networkOptions] - Fetch options (passed
-     * directly to `fetch()`), see [the syntax for more information]{@link
-     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+     * directly to `fetch()`), see [the syntax for more information](
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
      * @param {Object} [config.attribution] - Attribution of the data.
-     *
-     * @constructor
      */
     constructor(config) {
         super(config);

--- a/src/Source/EntwinePointTileSource.js
+++ b/src/Source/EntwinePointTileSource.js
@@ -5,7 +5,6 @@ import Fetcher from 'Provider/Fetcher';
 import Source from 'Source/Source';
 
 /**
- * @classdesc
  * An object defining the source of Entwine Point Tile data. It fetches and
  * parses the main configuration file of Entwine Point Tile format,
  * [`ept.json`](https://entwine.io/entwine-point-tile.html#ept-json).
@@ -20,8 +19,6 @@ import Source from 'Source/Source';
  */
 class EntwinePointTileSource extends Source {
     /**
-     * @constructor
-     *
      * @param {Object} config - The configuration, see {@link Source} for
      * available values.
      * @param {number|string} [config.colorDepth='auto'] - Does the color

--- a/src/Source/FileSource.js
+++ b/src/Source/FileSource.js
@@ -3,7 +3,6 @@ import Cache from 'Core/Scheduler/Cache';
 import CRS from 'Core/Geographic/Crs';
 
 /**
- * @classdesc
  * An object defining the source of a single resource to get from a direct
  * access. It inherits from {@link Source}. There is multiple ways of adding a
  * resource here:
@@ -103,8 +102,6 @@ class FileSource extends Source {
      * @param {Object} source - An object that can contain all properties of a
      * FileSource and {@link Source}. Only `crs` is mandatory, but if it
      * presents in `features` under the property `crs`, it is fine.
-     *
-     * @constructor
      */
     constructor(source) {
         /* istanbul ignore next */

--- a/src/Source/OGC3DTilesGoogleSource.js
+++ b/src/Source/OGC3DTilesGoogleSource.js
@@ -2,7 +2,6 @@ import OGC3DTilesSource from './OGC3DTilesSource';
 
 class OGC3DTilesGoogleSource extends OGC3DTilesSource {
     /**
-     * @classdesc
      * An object defining the source connection to a 3D Tiles asset from [Google Tiles API](https://tile.googleapis.com).
      *
      * @extends OGC3DTilesSource
@@ -11,8 +10,6 @@ class OGC3DTilesGoogleSource extends OGC3DTilesSource {
      * You should not change this, as it is used internally for optimisation.
      * @property {string} url - The URL to the tileset json.
      * @property {string} baseUrl - The base URL to access tiles.
-     *
-     * @constructor
      *
      * @property {boolean} isOGC3DTilesGoogleSource - Used to check if this source is an OGC3DTilesGoogleSource. Set to
      * true. You should not change this, as it is used internally for optimisation.

--- a/src/Source/OGC3DTilesIonSource.js
+++ b/src/Source/OGC3DTilesIonSource.js
@@ -2,7 +2,6 @@ import OGC3DTilesSource from './OGC3DTilesSource';
 
 class OGC3DTilesIonSource extends OGC3DTilesSource {
     /**
-     * @classdesc
      * An object defining the source connection to a 3DTiles asset of a [Cesium ion server](https://cesium.com/learn/ion/).
      *
      * @extends Source
@@ -11,8 +10,6 @@ class OGC3DTilesIonSource extends OGC3DTilesSource {
      * You should not change this, as it is used internally for optimisation.
      * @property {string} accessToken - The Cesium ion access token used to retrieve the resource.
      * @property {string} assetId - The id of the asset on Cesium ion.
-     *
-     * @constructor
      *
      * @param {Object} source An object that can contain all properties of an OGC3DTilesIonSource and {@link Source}.
      * Only `accessToken` and `assetId` are mandatory.

--- a/src/Source/OGC3DTilesSource.js
+++ b/src/Source/OGC3DTilesSource.js
@@ -2,7 +2,6 @@ import Source from 'Source/Source';
 
 class OGC3DTilesSource extends Source {
     /**
-     * @classdesc
      * An object defining the source connection to a 3DTiles dataset from a web server.
      *
      * @extends Source
@@ -10,8 +9,6 @@ class OGC3DTilesSource extends Source {
      * @property {boolean} isOGC3DTilesSource - Used to check if this source is an isOGC3DTilesSource. Set to true.
      * You should not change this, as it is used internally for optimisation.
      * @property {string} url - The URL of the tileset json.
-     *
-     * @constructor
      *
      * @param {Object} source An object that can contain all properties of OGC3DTilesSource and of {@link Source}.
      * Only `url` is mandatory.

--- a/src/Source/OrientedImageSource.js
+++ b/src/Source/OrientedImageSource.js
@@ -2,17 +2,17 @@ import Source from 'Source/Source';
 import Fetcher from 'Provider/Fetcher';
 
 /**
- * @classdesc OrientedImageSource is a specific source used to load oriented images.
+ * OrientedImageSource is a specific source used to load oriented images.
  * @extends Source
  */
 class OrientedImageSource extends Source {
     /**
-     * @constructor
      * @param { Object } source - Configuration object
      * @param { string } source.url - Url for all the textures.
      * @param { string } source.orientationsUrl - Json Url, using GeoJSon format to represent points,
      * it's a set of panoramic position and orientation.
-     * @param { string } source.calibrationUrl - Json url, representing a set of camera. see [CameraCalibrationParser]{@link module:CameraCalibrationParser}
+     * @param { string } source.calibrationUrl - Json url, representing a set of camera.
+     * see {@link CameraCalibrationParser}
      * This Url must contains {sensorId} and {cameraId}, and these pattern will be replaced to build the Url,
      * to find the good texture for each camera for each panoramic.
      */

--- a/src/Source/Potree2Source.js
+++ b/src/Source/Potree2Source.js
@@ -3,10 +3,7 @@ import Fetcher from 'Provider/Fetcher';
 import Potree2BinParser from 'Parser/Potree2BinParser';
 
 /**
- * @classdesc
  * Potree2Source are object containing informations on how to fetch potree 2.0 points cloud resources.
- *
- *
  */
 
 class Potree2Source extends Source {
@@ -149,8 +146,6 @@ class Potree2Source extends Source {
      * ```
      *
      * @extends Source
-     *
-     * @constructor
      */
     constructor(source) {
         if (!source.file) {

--- a/src/Source/PotreeSource.js
+++ b/src/Source/PotreeSource.js
@@ -4,10 +4,7 @@ import PotreeBinParser from 'Parser/PotreeBinParser';
 import PotreeCinParser from 'Parser/PotreeCinParser';
 
 /**
- * @classdesc
  * PotreeSource are object containing informations on how to fetch points cloud resources.
- *
- *
  */
 
 class PotreeSource extends Source {
@@ -61,8 +58,6 @@ class PotreeSource extends Source {
      * ```
      *
      * @extends Source
-     *
-     * @constructor
      */
     constructor(source) {
         if (!source.file) {

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -10,6 +10,7 @@ import Fetcher from 'Provider/Fetcher';
 import Cache from 'Core/Scheduler/Cache';
 import CRS from 'Core/Geographic/Crs';
 
+/** @private */
 export const supportedParsers = new Map([
     ['application/geo+json', GeoJsonParser.parse],
     ['application/json', GeoJsonParser.parse],
@@ -28,8 +29,8 @@ const noCache = { getByArray: () => {}, setByArray: a => a, clear: () => {} };
  * @property {boolean} isInverted - This option is to be set to the
  * correct value, true or false (default being false), if the computation of
  * the coordinates needs to be inverted to same scheme as OSM, Google Maps
- * or other system. See [this link]{@link
- * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates}
+ * or other system. See [this link](
+ * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates)
  * for more informations.
  *
  */
@@ -49,14 +50,13 @@ class InformationsData {
 /**
  * This interface describes parsing options.
  * @typedef {Object} ParsingOptions
- * @property {InformationsData|Source} in - data informations contained in the file.
+ * @property {Source} in - data informations contained in the file.
  * @property {FeatureBuildingOptions|Layer} out - options indicates how the features should be built.
  */
 
 let uid = 0;
 
 /**
- * @classdesc
  * Sources are object containing informations on how to fetch resources, from a
  * set source.
  *
@@ -78,8 +78,8 @@ let uid = 0;
  * fetched resource. If this property is set, it overrides the chosen fetcher
  * method with `format`.
  * @property {Object} networkOptions - Fetch options (passed directly to
- * `fetch()`), see [the syntax for more information]{@link
- * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax}.
+ * `fetch()`), see [the syntax for more information](
+ * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax).
  * By default, set to `{ crossOrigin: 'anonymous' }`.
  * @property {string} crs - The crs projection of the resources.
  * @property {string} attribution - The intellectual property rights for the
@@ -104,8 +104,6 @@ class Source extends InformationsData {
     /**
      * @param {Object} source - An object that can contain all properties of a
      * Source. Only the `url` property is mandatory.
-     *
-     * @constructor
      */
     constructor(source) {
         super(source);

--- a/src/Source/Source.js
+++ b/src/Source/Source.js
@@ -47,12 +47,11 @@ class InformationsData {
     }
 }
 /**
- * This class describes parsing options.
+ * This interface describes parsing options.
+ * @typedef {Object} ParsingOptions
  * @property {InformationsData|Source} in - data informations contained in the file.
  * @property {FeatureBuildingOptions|Layer} out - options indicates how the features should be built.
  */
-// eslint-disable-next-line
-class /* istanbul ignore next */ ParsingOptions {}
 
 let uid = 0;
 

--- a/src/Source/TMSSource.js
+++ b/src/Source/TMSSource.js
@@ -6,10 +6,9 @@ import CRS from 'Core/Geographic/Crs';
 const extent = new Extent(CRS.tms_4326, 0, 0, 0);
 
 /**
- * @classdesc
- * An object defining the source of resources to get from a [TMS]{@link
- * https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification} server. It
- * inherits from {@link Source}.
+ * An object defining the source of resources to get from a
+ * [TMS](https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification) server.
+ * It inherits from {@link Source}.
  *
  * @extends Source
  *
@@ -19,8 +18,8 @@ const extent = new Extent(CRS.tms_4326, 0, 0, 0);
  * @property {boolean} isInverted - The isInverted property is to be set to the
  * correct value, true or false (default being false) if the computation of the
  * coordinates needs to be inverted to match the same scheme as OSM, Google Maps
- * or other system. See [this link]{@link
- * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/}
+ * or other system. See [this link](
+ * https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/)
  * for more information.
  * @property {Object} tileMatrixSetLimits - it describes the available tile for this layer
  * @property {Object} extentSetlimits - these are the extents of the set of identical zoom tiles.
@@ -74,8 +73,6 @@ class TMSSource extends Source {
     /**
      * @param {Object} source - An object that can contain all properties of a
      * TMSSource and {@link Source}. Only `url` is mandatory.
-     *
-     * @constructor
      */
     constructor(source) {
         source.format = source.format || 'image/png';

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -21,7 +21,6 @@ function mergeCollections(collections) {
 }
 
 /**
- * @classdesc
  * VectorTilesSource are object containing informations on how to fetch vector
  * tiles resources.
  *
@@ -56,7 +55,6 @@ class VectorTilesSource extends TMSSource {
      * Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/)
      * for more informations.
      * @param {string} [source.accessToken] - Mapbox access token
-     * @constructor
      */
     constructor(source) {
         source.format = 'application/x-protobuf;type=mapbox-vector';

--- a/src/Source/WFSSource.js
+++ b/src/Source/WFSSource.js
@@ -3,9 +3,8 @@ import URLBuilder from 'Provider/URLBuilder';
 import CRS from 'Core/Geographic/Crs';
 
 /**
- * @classdesc
  * An object defining the source of resources to get from a
- * [WFS]{@link http://www.opengeospatial.org/standards/wfs} server. It inherits
+ * [WFS](http://www.opengeospatial.org/standards/wfs) server. It inherits
  * from {@link Source}.
  *
  * @extends Source
@@ -101,8 +100,6 @@ class WFSSource extends Source {
      * @param {Object} source - An object that can contain all properties of a
      * WFSSource and {@link Source}. `url`, `typeName` and `crs` are
      * mandatory.
-     *
-     * @constructor
      */
     constructor(source) {
         if (source.projection) {

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -2,9 +2,8 @@ import Source from 'Source/Source';
 import URLBuilder from 'Provider/URLBuilder';
 
 /**
- * @classdesc
  * An object defining the source of images to get from a
- * [WMS]{@link http://www.opengeospatial.org/standards/wms} server. It inherits
+ * [WMS](http://www.opengeospatial.org/standards/wms) server. It inherits
  * from {@link Source}.
  *
  * @extends Source
@@ -35,8 +34,8 @@ import URLBuilder from 'Provider/URLBuilder';
  * is 21.
  * @property {string} bboxDigits - The bbox digits precision used in URL
  * @property {Object} vendorSpecific - An object containing vendor specific
- * parameters. See for example a [list of these parameters for GeoServer]{@link
- * https://docs.geoserver.org/latest/en/user/services/wms/vendor.html}. This
+ * parameters. See for example a [list of these parameters for GeoServer](
+ * https://docs.geoserver.org/latest/en/user/services/wms/vendor.html). This
  * object is read simply with the `key` being the name of the parameter and
  * `value` being the value of the parameter. If used, this property should be
  * set in the constructor parameters.
@@ -71,8 +70,6 @@ class WMSSource extends Source {
      * @param {Object} source - An object that can contain all properties of
      * WMSSource and {@link Source}. `url`, `name`, `extent` and `crs`
      * are mandatory.
-     *
-     * @constructor
      */
     constructor(source) {
         if (!source.name) {

--- a/src/Source/WMTSSource.js
+++ b/src/Source/WMTSSource.js
@@ -1,9 +1,8 @@
 import TMSSource from 'Source/TMSSource';
 
 /**
- * @classdesc
  * An object defining the source of resources to get from a
- * [WMTS]{@link http://www.opengeospatial.org/standards/wmts} server. It inherits
+ * [WMTS](http://www.opengeospatial.org/standards/wmts) server. It inherits
  * from {@link TMSSource}.
  *
  * @extends TMSSource
@@ -63,8 +62,6 @@ class WMTSSource extends TMSSource {
     /**
      * @param {Object} source - An object that can contain all properties of a
      * WMTSSource and {@link Source}. Only `url`, `name` and `crs` are mandatory.
-     *
-     * @constructor
      */
     constructor(source) {
         if (!source.name) {

--- a/src/Utils/OrientationUtils.js
+++ b/src/Utils/OrientationUtils.js
@@ -118,17 +118,16 @@ export default {
     },
 
     /**
-     * FunctionOrQuaternion is either a THREE.Quaternion or a function that accepts
-     * arguments `(coordinates, target)` and returns the quaternion that models a rotation
-     * around the point of origin. If target is not provided, a new quaternion is
-     * created and returned instead.
-     *
-     * @typedef {function|THREE.Quaternion} FunctionOrQuaternion
+     * @typedef {Function|THREE.Quaternion} FunctionOrQuaternion - Either a
+     * THREE.Quaternion or a function that accepts arguments `(coordinates,
+     * target)` and returns the quaternion that models a rotation around the
+     * point of origin. If target is not provided, a new quaternion is created
+     * and returned instead.
      *
      * @property {Coordinates} coordinates the origin of the local East North Up
      * (ENU) frame
      * @property {THREE.Quaternion} [target=new THREE.Quaternion()] output Quaternion.
-    */
+     */
 
     /**
      * A Projection object models a Coordinate Reference System (CRS).
@@ -190,7 +189,7 @@ export default {
      * between the ENU and LCC frames.
      * This is a generally small rotation around Z.
      *
-     * @param {Projection} proj the lcc projection (may be parsed using proj4)
+     * @param {Object} proj the lcc projection (may be parsed using proj4)
      * @param {number} proj.lat0 - the latitude of origin
      * @param {number} proj.long0 - the longitude of the central meridian
      * @param {Coordinates} [coordinates]  coordinates the origin of the local East North Up
@@ -214,7 +213,7 @@ export default {
      * between the ENU and LCC frames.
      * This is a generally small rotation around Z.
      *
-     * @param {Projection} proj the lcc projection (may be parsed using proj4)
+     * @param {Object} proj the lcc projection (may be parsed using proj4)
      * @param {number} proj.lat0 - the latitude of origin
      * @param {number} proj.long0 - the longitude of the central meridian
      * @param {Coordinates} [coordinates]  coordinates the origin of the local East North Up
@@ -235,7 +234,7 @@ export default {
      * between the ENU and TMerc frames.
      * This is a generally small rotation around Z.
      *
-     * @param {Projection} proj the tmerc projection (may be parsed using proj4)
+     * @param {Object} proj the tmerc projection (may be parsed using proj4)
      * @param {number} proj.e - the excentricity of the ellipsoid (supersedes {proj.a} and {proj.b})
      * @param {number} proj.a - the semimajor radius of the ellipsoid axis
      * @param {number} proj.b - the semiminor radius of the ellipsoid axis
@@ -275,7 +274,7 @@ export default {
      * between the ENU and TMerc frames.
      * This is a generally small rotation around Z.
      *
-     * @param {Projection} proj the tmerc projection (may be parsed using proj4)
+     * @param {Object} proj the tmerc projection (may be parsed using proj4)
      * @param {number} proj.e - the excentricity of the ellipsoid (supersedes
      * {proj.a} and {proj.b})
      * @param {number} proj.a - the semimajor radius of the ellipsoid axis


### PR DESCRIPTION
## Description

When testing migration from jsdoc to tsdoc, I found that a number of jsdoc comments are actually not valid (and jsdoc silently ignore them...).

This PR includes:
- [x] Support of `typedef` in the jsdoc template
- [x] Removal of empty class used for `typedef` documentation and used as a sort of "fix" of the point above.
- [x] Removal of `@constructor`, `@class` and `@classdec` which are leftovers of pre-class javascript and not valid in post-ES5.
- [x] Various typecheck issues. 
