### PR TITLE
feat(controls): add state controls at view init

### DIFF
--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -180,6 +180,8 @@ let previous;
  * @property      {boolean} enableDamping Enable damping or not (simulates the lag that a real camera
  * operator introduces while operating a heavy physical camera). Default is true.
  * @property      {boolean} dampingMoveFactor the damping move factor. Default is 0.25.
+ * @property      {StateControl~State} stateControl redefining which controls state is triggered by the keyboard/mouse
+ * event (For example, rewrite the PAN movement to be triggered with the 'left' mouseButton instead of 'right').
  */
 class GlobeControls extends THREE.EventDispatcher {
     constructor(view, placement, options = {}) {
@@ -189,7 +191,7 @@ class GlobeControls extends THREE.EventDispatcher {
         this.camera = view.camera3D;
 
         // State control
-        this.states = new StateControl(this.view);
+        this.states = new StateControl(this.view, options.stateControl);
 
         // this.enabled property has moved to StateControl
         Object.defineProperty(this, 'enabled', {


### PR DESCRIPTION
## Description
Add possibility to define the controls at the view initialization

## Motivation and Context
The controls can be redefined afterwards already but I wondered why it couldn't be at the init
