### PR TITLE
fix(C3DTilesLayer): updateStyle works with new style API

### DIFF
--- a/src/Layer/C3DTilesLayer.js
+++ b/src/Layer/C3DTilesLayer.js
@@ -143,7 +143,7 @@ class C3DTilesLayer extends GeometryLayer {
         }
 
         /** @type {Style} */
-        this._style = config.style || null;
+        this.style = config.style || null;
 
         /** @type {Map<string, THREE.MeshStandardMaterial>} */
         this.#fillColorMaterialsBuffer = new Map();
@@ -386,21 +386,16 @@ class C3DTilesLayer extends GeometryLayer {
                     if (c3DTileFeature.object3d != object3d) {
                         continue;// this feature do not belong to object3d
                     }
+
+                    this._style.context.setGeometry({
+                        properties: c3DTileFeature,
+                    });
+
                     /** @type {THREE.Color} */
-                    let color = null;
-                    if (typeof this._style.fill.color === 'function') {
-                        color = new THREE.Color(this._style.fill.color(c3DTileFeature));
-                    } else {
-                        color = new THREE.Color(this._style.fill.color);
-                    }
+                    const color = new THREE.Color(this._style.fill.color);
 
                     /** @type {number} */
-                    let opacity = null;
-                    if (typeof this._style.fill.opacity === 'function') {
-                        opacity = this._style.fill.opacity(c3DTileFeature);
-                    } else {
-                        opacity = this._style.fill.opacity;
-                    }
+                    const opacity = this._style.fill.opacity;
 
                     const materialId = color.getHexString() + opacity;
 
@@ -464,7 +459,13 @@ class C3DTilesLayer extends GeometryLayer {
     }
 
     set style(value) {
-        this._style = value;
+        if (value instanceof Style) {
+            this._style = value;
+        } else if (!value) {
+            this._style = null;
+        } else {
+            this._style = new Style(value);
+        }
         this.updateStyle();
     }
 

--- a/src/Utils/gui/C3DTilesStyle.js
+++ b/src/Utils/gui/C3DTilesStyle.js
@@ -1,4 +1,3 @@
-import Style from 'Core/Style';
 import { C3DTILES_LAYER_EVENTS } from 'Layer/C3DTilesLayer';
 import Widget from './Widget';
 
@@ -221,12 +220,12 @@ class C3DTilesStyle extends Widget {
                 }
 
                 // set style
-                c3DTilesLayer.style = new Style({
+                c3DTilesLayer.style = {
                     fill: {
                         color: fillColorFunction,
                         opacity: fillOpacityFunction,
                     },
-                });
+                };
             });
         });
 


### PR DESCRIPTION
What is wrong:

[widgets_3dtiles_style]( https://www.itowns-project.org/itowns/examples/#widgets_3dtiles_style) is not working, after a look I realised that ````style.[category].property```` is now checking what is the type of the property when getting it.

https://github.com/iTowns/itowns/blob/1d9ffe9946d109d21e7ec2cf586616bb4c6670cb/src/Core/Style.js#L157
https://github.com/iTowns/itowns/blob/1d9ffe9946d109d21e7ec2cf586616bb4c6670cb/src/Core/Style.js#L22

In this case style.fill.color (resp. style.fill.opacity) are functions and that's the layer checking the type

https://github.com/iTowns/itowns/blob/1d9ffe9946d109d21e7ec2cf586616bb4c6670cb/src/Layer/C3DTilesLayer.js#L391

So the problem is C3DTilesLayer should not handling if fill.color is a function or something else but just calling fill.color and get what this is supposed to return.

Solution :

Since the layer is not handling the call of the style function (it's Style now) and that's the layer knowing what feature is being updated, the layer is now setting feature in parameters binded by Style and more precisely in the stylecontext parameter (which looks appropiate since style context has a feature property)

https://github.com/valentinMachado/itowns/blob/45203e1295d952c4a86bf89f6680711a9f865ca6/src/Layer/C3DTilesLayer.js#L390
https://github.com/iTowns/itowns/blob/1d9ffe9946d109d21e7ec2cf586616bb4c6670cb/src/Core/Style.js#L45

so style function can access to what feature is being updated (note that I had to create a getter of feature property to make this possible)

The example is now working with that solution but the style api change had break the C3DTilesLayer style api and this breaking change should be notify to itowns users.

I hope this post is clear and the solution proposed is appropriate