### PR TITLE
chore(deps): bump 3d-tiles-renderer from 0.3.37 to 0.3.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/vector-tile": "^2.0.3",
         "@tmcw/togeojson": "^5.8.1",
         "@tweenjs/tween.js": "^25.0.0",
-        "3d-tiles-renderer": "^0.3.37",
+        "3d-tiles-renderer": "^0.3.38",
         "brotli-compress": "^1.3.3",
         "copc": "^0.0.6",
         "earcut": "^3.0.0",
@@ -3289,9 +3289,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/3d-tiles-renderer": {
-      "version": "0.3.37",
-      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.3.37.tgz",
-      "integrity": "sha512-xgoBhAEpLnrs0NKEklx67RyCdWH4EeW6zh46upsrvWonC7xTiGE48/w2ZG63slosaNb8KlRWmQ46WtUtSfNJbg==",
+      "version": "0.3.38",
+      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.3.38.tgz",
+      "integrity": "sha512-gpfigbT1OeFDmXl8j5ZKdTR9x4wQ/9ZjYGoixEiSrsfW7+w7dwkzGfWORxMsCw+Y8Q9c2HURiz5uyMfpUy43vg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "three": ">=0.123.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@mapbox/vector-tile": "^2.0.3",
     "@tmcw/togeojson": "^5.8.1",
     "@tweenjs/tween.js": "^25.0.0",
-    "3d-tiles-renderer": "^0.3.37",
+    "3d-tiles-renderer": "^0.3.38",
     "brotli-compress": "^1.3.3",
     "copc": "^0.0.6",
     "earcut": "^3.0.0",

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -292,7 +292,7 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         // Setup classification bufferAttribute
         if (model.isPoints) {
-            const classificationData = batchTable?.getData('Classification');
+            const classificationData = batchTable?.getPropertyArray('Classification');
             if (classificationData) {
                 geometry.setAttribute('classification',
                     new THREE.BufferAttribute(classificationData, 1),

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -140,10 +140,12 @@ class OGC3DTilesLayer extends GeometryLayer {
             this.tilesRenderer.registerPlugin(new CesiumIonAuthPlugin({
                 apiToken: config.source.accessToken,
                 assetId: config.source.assetId,
+                autoRefreshToken: true,
             }));
         } else if (config.source.isOGC3DTilesGoogleSource) {
             this.tilesRenderer.registerPlugin(new GoogleCloudAuthPlugin({
                 apiToken: config.source.key,
+                autoRefreshToken: true,
             }));
         }
         this.tilesRenderer.registerPlugin(new ImplicitTilingPlugin());


### PR DESCRIPTION
## Motivation and Context
We got some 3D tiles data with ImplicitTiling fixed in version 0.3.38 of 3d-tiles-renderer package.
Issue fixed: https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/728