### PR TITLE
Fix elevation values clamping blocking terrain subdivision

### DIFF
--- a/src/Parser/XbilParser.js
+++ b/src/Parser/XbilParser.js
@@ -64,8 +64,16 @@ export function computeMinMaxElevation(texture, pitch, options) {
                 }
             }
         }
-        if (options.zmin > min) { min = options.zmin; }
-        if (options.zmax < max) { max = options.zmax; }
+        // Clamp values to zmin and zmax values configured in ElevationLayer
+        if (options.zmin != null) {
+            if (min < options.zmin) { min = options.zmin; }
+            if (max < options.zmin) { max = options.zmin; }
+        }
+
+        if (options.zmax != null) {
+            if (min > options.zmax) { min = options.zmax; }
+            if (max > options.zmax) { max = options.zmax; }
+        }
     }
 
     if (max === -Infinity || min === Infinity) {


### PR DESCRIPTION
Fix elevation values clamping: also clamp the `max` elevation value of  a tile to `options.zmin` and the `min` value to `options.zmax`. 

In some cases an elevation texture tile only has values below `options.zmin`. In this case, only `min` was clamped to `options.zmin` which could for instance result in `min` being superior to `max` (e.g. `min=0` and `max=-943566`). This was causing the bounding sphere of the node to be wrong and then the [subdivision](https://github.com/iTowns/itowns/blob/master/src/Layer/TiledGeometryLayer.js#L413) check to fail. Resulting in rendering like thtis:

![image-2024-03-11-17-10-16-562](https://github.com/user-attachments/assets/3b1e8f56-cc10-4b0d-b35e-5a914a0d15ff)