### PR TITLE
Preparation for PR reprojection 'a la volee'

### DIFF
--- a/examples/entwine_3d_loader.html
+++ b/examples/entwine_3d_loader.html
@@ -87,8 +87,10 @@
                 eptSource = new itowns.EntwinePointTileSource({ url });
 
                 if (eptLayer) {
-                    view.removeLayer('ept');
+                    debugGui.removeFolder(eptLayer.debugUI);
+                    view.removeLayer('Entwine Point Tile');
                     view.notifyChange();
+                    eptLayer.delete();
                 }
 
                 eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', {

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -88,7 +88,7 @@
                 eptSource = new itowns.EntwinePointTileSource({ url });
 
                 if (eptLayer) {
-                    debugGUI.removeFolder(eptLayer.debugUI);
+                    debugGui.removeFolder(eptLayer.debugUI);
                     view.removeLayer('Entwine Point Tile');
                     view.notifyChange();
                     eptLayer.delete();

--- a/src/Core/Geographic/Crs.ts
+++ b/src/Core/Geographic/Crs.ts
@@ -35,6 +35,10 @@ export const UNIT = {
      * Distance unit in meter.
      */
     METER: 2,
+    /**
+     * Distance unit in foot.
+     */
+    FOOT: 3,
 } as const;
 
 /**
@@ -50,8 +54,10 @@ export function is4326(crs: ProjectionLike) {
 function unitFromProj4Unit(proj: ProjectionDefinition) {
     if (proj.units === 'degrees') {
         return UNIT.DEGREE;
-    } else if (proj.units === 'm') {
+    } else if (proj.units === 'm' || proj.units === 'meter') {
         return UNIT.METER;
+    } else if (proj.units === 'foot') {
+        return UNIT.FOOT;
     } else if (proj.units === undefined && proj.to_meter === undefined) {
         // See https://proj.org/en/9.4/usage/projections.html [17/10/2024]
         // > The default unit for projected coordinates is the meter.
@@ -65,7 +71,7 @@ function unitFromProj4Unit(proj: ProjectionDefinition) {
  * Returns the horizontal coordinates system units associated with this CRS.
  *
  * @param crs - The CRS to extract the unit from.
- * @returns Either `UNIT.METER`, `UNIT.DEGREE` or `undefined`.
+ * @returns Either `UNIT.METER`, `UNIT.DEGREE`, `UNIT.FOOT` or `undefined`.
  */
 export function getUnit(crs: ProjectionLike) {
     mustBeString(crs);

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -340,12 +340,12 @@ class PointCloudLayer extends GeometryLayer {
                     // be added nor cleaned
                     this.group.add(elt.obj);
                     elt.obj.updateMatrixWorld(true);
-
-                    elt.promise = null;
-                }, (err) => {
-                    if (err.isCancelledCommandException) {
-                        elt.promise = null;
+                }).catch((err) => {
+                    if (!err.isCancelledCommandException) {
+                        return err;
                     }
+                }).finally(() => {
+                    elt.promise = null;
                 });
             }
         }

--- a/src/Layer/PointCloudLayer.js
+++ b/src/Layer/PointCloudLayer.js
@@ -328,10 +328,6 @@ class PointCloudLayer extends GeometryLayer {
                     redraw: true,
                     earlyDropFunction: cmd => !cmd.requester.visible || !this.visible,
                 }).then((pts) => {
-                    if (this.onPointsCreated) {
-                        this.onPointsCreated(layer, pts);
-                    }
-
                     elt.obj = pts;
                     // store tightbbox to avoid ping-pong (bbox = larger => visible, tight => invisible)
                     elt.tightbbox = pts.tightbbox;

--- a/test/unit/copc.js
+++ b/test/unit/copc.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import CopcSource from 'Source/CopcSource';
+
+const copcUrl = 'https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz';
+
+describe('COPC', function () {
+    let source;
+
+    describe('Copc Source', function () {
+        describe('retrieving crs from wkt information', function () {
+            it('wkt.srs.type is COMPD_CS', function (done) {
+                const networkOptions = process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {};
+                source = new CopcSource({
+                    url: copcUrl,
+                    networkOptions,
+                });
+                source.whenReady
+                    .then((headers) => {
+                        assert.ok(headers.header.pointCount);
+                        assert.ok(headers.info.spacing);
+                        assert.ok(Array.isArray(headers.eb));
+                        assert.equal(source.crs, 'NAD83 / Oregon GIC Lambert (ft)');
+                        // when the proj4 PR will be merged we should change to :
+                        // assert.equal(source.crs, 'EPSG:2992');
+                        done();
+                    }).catch(done);
+            }).timeout(5000);
+        });
+    });
+});

--- a/test/unit/fetcher.js
+++ b/test/unit/fetcher.js
@@ -70,7 +70,8 @@ describe('Fetcher', function () {
     describe('texture', function () {
         // Fetcher.texture always send a texture even with a false url...
         const url = 'https://data.geopf.fr/wmts?' +
-        'LAYER=ORTHOIMAGERY.ORTHOPHOTOS&FORMAT=image/jpeg&SERVICE=WMTS&VERSION=1.0.0&' +
+        'LAYER=ORTHOIMAGERY.ORTHOPHOTOS&FORMAT=image/jpeg' +
+        '&SERVICE=WMTS&VERSION=1.0.0&' +
         'REQUEST=GetTile&STYLE=normal&' +
         'TILEMATRIXSET=PM&TILEMATRIX=2&TILEROW=1&TILECOL=1';
         it('should load a texture', (done) => {

--- a/test/unit/lasparser.js
+++ b/test/unit/lasparser.js
@@ -10,16 +10,26 @@ const lasUrl = `${baseurl}/data_test.las`;
 const url = 'https://github.com/connormanning/copc.js/raw/master/src/test/data';
 const lazV14Url = `${url}/ellipsoid-1.4.laz`;
 
+const copcUrl = `${url}/ellipsoid.copc.laz`;
+
 describe('LASParser', function () {
     let lasData;
     let lazV14Data;
-    it('fetch binaries', async function () {
+    let copcData;
+    describe('fetch binaries', function () {
         const networkOptions = process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {};
-        lasData = await Fetcher.arrayBuffer(lasUrl, networkOptions);
-        lazV14Data = await Fetcher.arrayBuffer(lazV14Url, networkOptions);
-    }).timeout(4000);
+        it('fetch las data', async function () {
+            lasData = await Fetcher.arrayBuffer(lasUrl, networkOptions);
+        });
+        it('fetch laz data', async function () {
+            lazV14Data = await Fetcher.arrayBuffer(lazV14Url, networkOptions);
+        });
+        it('fetch copc data', async function _it() {
+            copcData = await Fetcher.arrayBuffer(copcUrl, networkOptions);
+        });
+    });
 
-    describe('unit tests', function () {
+    describe('unit tests', function _describe() {
         const epsilon = 0.1;
         LASParser.enableLazPerf('./examples/libs/laz-perf');
 
@@ -40,6 +50,7 @@ describe('LASParser', function () {
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + origin.x, header.max[0], epsilon));
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + origin.y, header.max[1], epsilon));
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + origin.z, header.max[2], epsilon));
+            await LASParser.terminate();
         });
 
         it('parses a laz file to a THREE.BufferGeometry', async function () {
@@ -59,9 +70,55 @@ describe('LASParser', function () {
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + origin.x, header.max[0], epsilon));
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + origin.y, header.max[1], epsilon));
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + origin.z, header.max[2], epsilon));
+            await LASParser.terminate();
         });
 
-        afterEach(async function () {
+        it('parses a copc chunk to a THREE.BufferGeometry', async function _it() {
+            if (!copcData) { this.skip(); }
+            const header = {
+                fileSignature: 'LASF',
+                fileSourceId: 0,
+                globalEncoding: 16,
+                projectId: '00000000-0000-0000-0000000000000000',
+                majorVersion: 1,
+                minorVersion: 4,
+                systemIdentifier: '',
+                generatingSoftware: '',
+                fileCreationDayOfYear: 1,
+                fileCreationYear: 1,
+                headerLength: 375,
+                pointDataOffset: 1424,
+                vlrCount: 3,
+                pointDataRecordFormat: 7,
+                pointDataRecordLength: 36,
+                pointCount: 100000,
+                pointCountByReturn: [
+                    50002, 49998, 0, 0,
+                    0,     0, 0, 0,
+                    0,     0, 0, 0,
+                    0,     0, 0,
+                ],
+                scale: [0.01, 0.01, 0.01],
+                offset: [-8242596, 4966606, 0],
+                min: [-8242746, 4966506, -50],
+                max: [-8242446, 4966706, 50],
+                waveformDataOffset: 0,
+                evlrOffset: 630520,
+                evlrCount: 1,
+            };
+            const options = {
+                in: {
+                    pointCount: header.pointCount,
+                    header,
+                },
+                // eb,
+            };
+            const bufferGeometry = await LASParser.parseChunk(copcData, options);
+
+            assert.strictEqual(bufferGeometry.attributes.position.count, header.pointCount);
+            assert.strictEqual(bufferGeometry.attributes.intensity.count, header.pointCount);
+            assert.strictEqual(bufferGeometry.attributes.classification.count, header.pointCount);
+            assert.strictEqual(bufferGeometry.attributes.color.count, header.pointCount);
             await LASParser.terminate();
         });
     });

--- a/test/unit/potree.js
+++ b/test/unit/potree.js
@@ -65,7 +65,6 @@ describe('Potree', function () {
             // Configure Point Cloud layer
             potreeLayer = new PotreeLayer('lion_takanawa', {
                 source,
-                onPointsCreated: () => {},
                 crs: viewer.referenceCrs,
             });
 

--- a/test/unit/potree2.js
+++ b/test/unit/potree2.js
@@ -27,7 +27,6 @@ describe('Potree2', function () {
                 url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
                 networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
             }),
-            onPointsCreated: () => {},
             crs: viewer.referenceCrs,
         });
 

--- a/test/unit/potree2.js
+++ b/test/unit/potree2.js
@@ -62,7 +62,7 @@ describe('Potree2', function () {
                 assert.equal(potreeLayer.group.children.length, 1);
                 done();
             }).catch(done);
-    });
+    }).timeout(5000);
 
     it('postUpdate potree2 layer', function () {
         potreeLayer.postUpdate(context, potreeLayer);


### PR DESCRIPTION
Following PR #2272 that became a big PR. I extracted commits that are needed for the reprojection but are also independants :
- support of meter and foot units in crs
- parsing crs from metadata (for entwnie and copc data)
- few simplification or deletion of useless code
