### PR TITLE
Make globe sun light optional

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -100,7 +100,7 @@
             itowns.enableKtx2Loader('./lib/basis/', view.renderer);
 
             // Add ambient light to globally illuminates all objects
-            const light = new AmbientLight(0x404040, 15);
+            const light = new AmbientLight(0x404040, 40);
             view.scene.add(light);
 
             // Setup loading screen

--- a/src/Core/Prefab/GlobeView.js
+++ b/src/Core/Prefab/GlobeView.js
@@ -96,11 +96,6 @@ class GlobeView extends View {
         const tileLayer = new GlobeLayer('globe', options.object3d, options);
         this.mainLoop.gfxEngine.label2dRenderer.infoTileLayer = tileLayer.info;
 
-        const sun = new THREE.DirectionalLight();
-        sun.position.set(-0.5, 0, 1);
-        sun.updateMatrixWorld(true);
-        this.scene.add(sun);
-
         this.addLayer(tileLayer);
         this.tileLayer = tileLayer;
 

--- a/test/functional/source_file_gpx_3d.js
+++ b/test/functional/source_file_gpx_3d.js
@@ -11,6 +11,6 @@ describe('source_file_gpx_3d', function _() {
     });
 
     it('should wait for the mesh to be added to the scene', async function _it() {
-        await page.waitForFunction(() => view.scene.children.length === 5, { timeout: 10000 });
+        await page.waitForFunction(() => view.scene.children.length === 4, { timeout: 10000 });
     });
 });


### PR DESCRIPTION
## Description
* Add a configuration option to the `GlobeView` to make sun lightning simulation optional
* Update 3D tiles loader example lightning

## Motivation and Context
This light can cause weird lightning like the folllowing:
 
![sunlight-opt](https://github.com/user-attachments/assets/30a6fcf1-8270-4042-ad36-6840df13ffca)

And shadows are not casted on the terrain anyway
