### PR TITLE
fix(OGC3DTilesLayer): handle multiple views

### DIFF
--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -32,6 +32,7 @@ export const VIEW_EVENTS = {
     INITIALIZED: 'initialized',
     COLOR_LAYERS_ORDER_CHANGED,
     CAMERA_MOVED: 'camera-moved',
+    REMOVED: 'removed',
 };
 
 /**
@@ -297,6 +298,7 @@ class View extends THREE.EventDispatcher {
         }
 
         window.removeEventListener('resize', this._resizeListener);
+        this.dispatchEvent({ type: VIEW_EVENTS.REMOVED });
 
         // controls dispose
         if (this.controls) {

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -122,7 +122,8 @@ let screenMeters;
 let id = 0;
 
 /**
- * @property {HTMLElement} domElement - Thhe domElement holding the canvas where the view is displayed
+ * @property {number} id - The id of the view. It's incremented at each new view instance, starting at 0.
+ * @property {HTMLElement} domElement - The domElement holding the canvas where the view is displayed
  * @property {String} referenceCrs - The coordinate reference system of the view
  * @property {MainLoop} mainLoop - itowns mainloop scheduling the operations
  * @property {THREE.Scene} scene - threejs scene of the view
@@ -147,10 +148,10 @@ class View extends THREE.EventDispatcher {
      * var view = itowns.View('EPSG:4326', viewerDiv, { camera: { type: itowns.CAMERA_TYPE.ORTHOGRAPHIC } });
      * var customControls = itowns.THREE.OrbitControls(view.camera3D, viewerDiv);
      *
-     * @param {string} crs - The default CRS of Three.js coordinates. Should be a cartesian CRS.
+     * @param {String} crs - The default CRS of Three.js coordinates. Should be a cartesian CRS.
      * @param {HTMLElement} viewerDiv - Where to instanciate the Three.js scene in the DOM
      * @param {Object} [options] - Optional properties.
-     * @param {object} [options.camera] - Options for the camera associated to the view. See {@link Camera} options.
+     * @param {Object} [options.camera] - Options for the camera associated to the view. See {@link Camera} options.
      * @param {MainLoop} [options.mainLoop] - {@link MainLoop} instance to use, otherwise a default one will be constructed
      * @param {WebGLRenderer|Object} [options.renderer] - {@link WebGLRenderer} instance to use, otherwise
      * a default one will be constructed. In this case, if options.renderer is an object, it will be used to

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -119,6 +119,8 @@ const viewers = [];
 // Size of the camera frustrum, in meters
 let screenMeters;
 
+let id = 0;
+
 /**
  * @property {HTMLElement} domElement - Thhe domElement holding the canvas where the view is displayed
  * @property {String} referenceCrs - The coordinate reference system of the view
@@ -169,6 +171,7 @@ class View extends THREE.EventDispatcher {
         super();
 
         this.domElement = viewerDiv;
+        this.id = id++;
 
         this.referenceCrs = crs;
 

--- a/src/Core/View.js
+++ b/src/Core/View.js
@@ -32,7 +32,7 @@ export const VIEW_EVENTS = {
     INITIALIZED: 'initialized',
     COLOR_LAYERS_ORDER_CHANGED,
     CAMERA_MOVED: 'camera-moved',
-    REMOVED: 'removed',
+    DISPOSED: 'disposed',
 };
 
 /**
@@ -298,7 +298,6 @@ class View extends THREE.EventDispatcher {
         }
 
         window.removeEventListener('resize', this._resizeListener);
-        this.dispatchEvent({ type: VIEW_EVENTS.REMOVED });
 
         // controls dispose
         if (this.controls) {
@@ -309,8 +308,6 @@ class View extends THREE.EventDispatcher {
         }
         // remove alls frameRequester
         this.removeAllFrameRequesters();
-        // remove alls events
-        this.removeAllEvents();
         // remove all layers
         const layers = this.getLayers(l => !l.isTiledGeometryLayer && !l.isAtmosphere);
         for (const layer of layers) {
@@ -327,6 +324,9 @@ class View extends THREE.EventDispatcher {
         viewers.splice(id, 1);
         // Remove remaining objects in the scene (e.g. helpers, debug, etc.)
         this.scene.traverse(ObjectRemovalHelper.cleanup);
+        this.dispatchEvent({ type: VIEW_EVENTS.DISPOSED });
+        // remove alls events
+        this.removeAllEvents();
     }
 
     /**

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -22,7 +22,12 @@ import PointsMaterial, {
 } from 'Renderer/PointsMaterial';
 
 const _raycaster = new THREE.Raycaster();
-const viewers = [];
+
+// Stores lruCache, downloadQueue and parseQueue for each id of view {@link View}
+// every time a tileset has been added
+// https://github.com/iTowns/itowns/issues/2426
+const viewers = {};
+
 // Internal instance of GLTFLoader, passed to 3d-tiles-renderer-js to support GLTF 1.0 and 2.0
 // Temporary exported to be used in deprecated B3dmParser
 export const itownsGLTFLoader = new iGLTFLoader();
@@ -184,10 +189,11 @@ class OGC3DTilesLayer extends GeometryLayer {
 
 
     /**
-     * Sets the lruCache and download and parse queues so they are shared amongst all tilesets.
-    * @param {String} id - viewer id.
-    * @private
-    */
+     * Sets the lruCache and download and parse queues so they are shared amongst
+     * all tilesets from a same {@link View} view.
+     * @param {String} id - viewer id.
+     * @private
+     */
     _setupCacheAndQueues(id) {
         if (viewers[id]) {
             this.tilesRenderer.lruCache = viewers[id].lruCache;

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -20,6 +20,7 @@ import PointsMaterial, {
     PNTS_SIZE_MODE,
     ClassificationScheme,
 } from 'Renderer/PointsMaterial';
+import { VIEW_EVENTS } from 'Core/View';
 
 const _raycaster = new THREE.Raycaster();
 
@@ -191,10 +192,11 @@ class OGC3DTilesLayer extends GeometryLayer {
     /**
      * Sets the lruCache and download and parse queues so they are shared amongst
      * all tilesets from a same {@link View} view.
-     * @param {String} id - viewer id.
+     * @param {View} view - view associated to this layer.
      * @private
      */
-    _setupCacheAndQueues(id) {
+    _setupCacheAndQueues(view) {
+        const id = view.id;
         if (viewers[id]) {
             this.tilesRenderer.lruCache = viewers[id].lruCache;
             this.tilesRenderer.downloadQueue = viewers[id].downloadQueue;
@@ -205,6 +207,9 @@ class OGC3DTilesLayer extends GeometryLayer {
                 downloadQueue: this.tilesRenderer.downloadQueue,
                 parseQueue: this.tilesRenderer.parseQueue,
             };
+            view.addEventListener(VIEW_EVENTS.REMOVED, (evt) => {
+                delete viewers[evt.target.id];
+            });
         }
     }
 
@@ -247,7 +252,7 @@ class OGC3DTilesLayer extends GeometryLayer {
         });
 
 
-        this._setupCacheAndQueues(view.id);
+        this._setupCacheAndQueues(view);
         this._setupEvents();
 
 

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -207,7 +207,7 @@ class OGC3DTilesLayer extends GeometryLayer {
                 downloadQueue: this.tilesRenderer.downloadQueue,
                 parseQueue: this.tilesRenderer.parseQueue,
             };
-            view.addEventListener(VIEW_EVENTS.REMOVED, (evt) => {
+            view.addEventListener(VIEW_EVENTS.DISPOSED, (evt) => {
                 delete viewers[evt.target.id];
             });
         }


### PR DESCRIPTION
## Description
Handle the 3dtiles cache in each view when multiple views are created

## Motivation and Context
https://github.com/iTowns/itowns/issues/2426

## Modifications
Adding an id to the view. Incremented at each new view.
Adding a list of cache and queues in OGC3DTilesLayer.js, to share them if in in the same view

## Improvements
@jailln @Desplandis 

How to handle a View disposing ?
Also, a "viewers" constant already exist in View.js, maybe this one could be used ?

https://github.com/iTowns/itowns/blob/a4f0d2284fabbe4a5ecf0cb512c9c35d6b684ee3/src/Core/View.js#L118
