### PR TITLE
refactor: migrate Coordinates and Ellipsoid to typescript

### DIFF
--- a/examples/jsm/OGC3DTilesHelper.js
+++ b/examples/jsm/OGC3DTilesHelper.js
@@ -47,7 +47,7 @@ function zoomToSphere(view, tile, sphere) {
     const distance = radius * Math.tan(fov * 2);
 
     return {
-        coord: new Coordinates('EPSG:4978', center),
+        coord: new Coordinates('EPSG:4978').setFromVector3(center),
         range: distance + radius,
     };
 }

--- a/src/Controls/GlobeControls.js
+++ b/src/Controls/GlobeControls.js
@@ -755,7 +755,7 @@ class GlobeControls extends THREE.EventDispatcher {
         const range = this.getRange(point);
         if (point && range > this.minDistance) {
             return this.lookAtCoordinate({
-                coord: new Coordinates('EPSG:4978', point),
+                coord: new Coordinates('EPSG:4978').setFromVector3(point),
                 range: range * (event.direction === 'out' ? 1 / 0.6 : 0.6),
                 time: 1500,
             });
@@ -1028,7 +1028,9 @@ class GlobeControls extends THREE.EventDispatcher {
      */
 
     getCameraCoordinate() {
-        return new Coordinates('EPSG:4978', this.camera.position).as('EPSG:4326');
+        return new Coordinates('EPSG:4978')
+            .setFromVector3(this.camera.position)
+            .as('EPSG:4326');
     }
 
     /**
@@ -1216,7 +1218,9 @@ class GlobeControls extends THREE.EventDispatcher {
             return;
         }
 
-        return new Coordinates('EPSG:4978', pickedPosition).as('EPSG:4326');
+        return new Coordinates('EPSG:4978')
+            .setFromVector3(pickedPosition)
+            .as('EPSG:4326');
     }
 }
 

--- a/src/Core/Geographic/Coordinates.js
+++ b/src/Core/Geographic/Coordinates.js
@@ -86,8 +86,16 @@ class Coordinates {
         this._normal = new THREE.Vector3();
 
         if (v0.length > 0) {
+            console.warn(
+                'Deprecated Coordinates#constructor(string, number[]),',
+                'use new Coordinates(string).setFromArray(number[]) instead.',
+            );
             this.setFromArray(v0);
         } else if (v0.isVector3 || v0.isCoordinates) {
+            console.warn(
+                'Deprecated Coordinates#constructor(string, Vector3),',
+                'use new Coordinates(string).setFromVector3(Vector3) instead.',
+            );
             this.setFromVector3(v0);
         } else {
             this.setFromValues(v0, v1, v2);
@@ -103,6 +111,7 @@ class Coordinates {
     setCrs(crs) {
         CRS.isValid(crs);
         this.crs = crs;
+        return this;
     }
 
     /**

--- a/src/Core/Geographic/Coordinates.ts
+++ b/src/Core/Geographic/Coordinates.ts
@@ -3,18 +3,25 @@ import proj4 from 'proj4';
 import * as CRS from 'Core/Geographic/Crs';
 import Ellipsoid from 'Core/Math/Ellipsoid';
 
-proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
+import type { ProjectionLike } from './Crs';
 
 const ellipsoid = new Ellipsoid();
-const projectionCache = {};
+const projectionCache: Record<string, Record<string, proj4.Converter>> = {};
 
 const v0 = new THREE.Vector3();
 const v1 = new THREE.Vector3();
 
-let coord0;
-let coord1;
+let coord0: Coordinates;
+let coord1: Coordinates;
 
-function proj4cache(crsIn, crsOut) {
+export interface CoordinatesLike {
+    readonly crs: string;
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+}
+
+function proj4cache(crsIn: string, crsOut: string): proj4.Converter {
     if (!projectionCache[crsIn]) {
         projectionCache[crsIn] = {};
     }
@@ -43,34 +50,39 @@ function proj4cache(crsIn, crsOut) {
  * @example
  * // Declare EPSG:3946 with proj4
  * itowns.proj4.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
- *
- * @property {boolean} isCoordinates - Used to checkout whether this coordinates
- * is a Coordinates. Default is true. You should not change this, as it is used
- * internally for optimisation.
- * @property {string} crs - A supported crs by default in
- * [`proj4js`](https://github.com/proj4js/proj4js#named-projections), or an
- * added crs to `proj4js` (using `proj4.defs`). Note that `EPSG:4978` is also
- * supported by default in itowns.
- * @property {number} x - The first value of the coordinate.
- * @property {number} y - The second value of the coordinate.
- * @property {number} z - The third value of the coordinate.
- * @property {number} latitude - The first value of the coordinate.
- * @property {number} longitude - The second value of the coordinate.
- * @property {number} altitude - The third value of the coordinate.
- * @property {THREE.Vector3} geodesicNormal - The geodesic normal of the
- * coordinate.
  */
 class Coordinates {
     /**
-     * @param {string} crs - A supported Coordinate Reference System.
-     * @param {number|Array<number>|Coordinates|THREE.Vector3} [v0=0] -
-     * x or longitude value, or a more complex one: it can be an array of three
-     * numbers, being x/lon, y/lat, z/alt, or it can be `THREE.Vector3`. It can
-     * also simply be a Coordinates.
-     * @param {number} [v1=0] - y or latitude value.
-     * @param {number} [v2=0] - z or altitude value.
+     * Used to checkout whether this coordinates is a Coordinates. Default is
+     * true. You should not change this, as it is used internally for
+     * optimisation.
      */
-    constructor(crs, v0 = 0, v1 = 0, v2 = 0) {
+    readonly isCoordinates: boolean;
+    /**
+     * A supported crs by default in
+     * [`proj4js`](https://github.com/proj4js/proj4js#named-projections), or an
+     * added crs to `proj4js` (using `proj4.defs`). Note that `EPSG:4978` is
+     * also supported by default in itowns.
+     */
+    crs: ProjectionLike;
+
+    /** The first value of the coordinate. */
+    x: number;
+    /** The second value of the coordinate. */
+    y: number;
+    /** The third value of the coordinate. */
+    z: number;
+
+    private _normal: THREE.Vector3;
+    private _normalNeedsUpdate: boolean;
+
+    /**
+     * @param crs - A supported Coordinate Reference System.
+     * @param x - x or longitude value.
+     * @param y - y or latitude value.
+     * @param z - z or altitude value.
+     */
+    constructor(crs: ProjectionLike, x: number = 0, y: number = 0, z: number = 0) {
         this.isCoordinates = true;
 
         CRS.isValid(crs);
@@ -85,20 +97,24 @@ class Coordinates {
         // Normal
         this._normal = new THREE.Vector3();
 
-        if (v0.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((x as any).length > 0) { // deepscan-disable-line
             console.warn(
                 'Deprecated Coordinates#constructor(string, number[]),',
-                'use new Coordinates(string).setFromArray(number[]) instead.',
+                'use `new Coordinates(string).setFromArray(number[])` instead.',
             );
-            this.setFromArray(v0);
-        } else if (v0.isVector3 || v0.isCoordinates) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            this.setFromArray(x as any);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } else if ((x as any).isVector3 || (x as any).isCoordinates) {
             console.warn(
                 'Deprecated Coordinates#constructor(string, Vector3),',
-                'use new Coordinates(string).setFromVector3(Vector3) instead.',
+                'use `new Coordinates(string).setFromVector3(Vector3)` instead.',
             );
-            this.setFromVector3(v0);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            this.setFromVector3(x as any);
         } else {
-            this.setFromValues(v0, v1, v2);
+            this.setFromValues(x, y, z);
         }
 
         this._normalNeedsUpdate = true;
@@ -106,9 +122,9 @@ class Coordinates {
 
     /**
      * Sets the Coordinate Reference System.
-     * @param {String} crs Coordinate Reference System (e.g. 'EPSG:4978')
+     * @param crs - Coordinate Reference System (e.g. 'EPSG:4978')
      */
-    setCrs(crs) {
+    setCrs(crs: ProjectionLike): this {
         CRS.isValid(crs);
         this.crs = crs;
         return this;
@@ -117,16 +133,16 @@ class Coordinates {
     /**
      * Set the values of this Coordinates.
      *
-     * @param {number} [v0=0] - x or longitude value.
-     * @param {number} [v1=0] - y or latitude value.
-     * @param {number} [v2=0] - z or altitude value.
+     * @param x - x or longitude value.
+     * @param y - y or latitude value.
+     * @param z - z or altitude value.
      *
-     * @return {Coordinates} This Coordinates.
+     * @returns This Coordinates.
      */
-    setFromValues(v0 = 0, v1 = 0, v2 = 0) {
-        this.x = v0 == undefined ? 0 : v0;
-        this.y = v1 == undefined ? 0 : v1;
-        this.z = v2 == undefined ? 0 : v2;
+    setFromValues(x: number = 0, y: number = 0, z: number = 0): this {
+        this.x = x;
+        this.y = y;
+        this.z = z;
 
         this._normalNeedsUpdate = true;
         return this;
@@ -135,48 +151,50 @@ class Coordinates {
     /**
      * Set the values of this Coordinates from an array.
      *
-     * @param {Array<number>} array - An array of number to assign to the
-     * Coordinates.
-     * @param {number} [offset] - Optional offset into the array.
+     * @param array - An array of number to assign to the Coordinates.
+     * @param offset - Optional offset into the array.
      *
-     * @return {Coordinates} This Coordinates.
+     * @returns This Coordinates.
      */
-    setFromArray(array, offset = 0) {
-        return this.setFromValues(array[offset], array[offset + 1], array[offset + 2]);
+    setFromArray(array: number[], offset: number = 0): this {
+        return this.setFromValues(
+            array[offset],
+            array[offset + 1],
+            array[offset + 2],
+        );
     }
 
     /**
      * Set the values of this Coordinates from a `THREE.Vector3` or an `Object`
      * having `x/y/z` properties, like a `Coordinates`.
      *
-     * @param {THREE.Vector3|Coordinates} v0 - The object to read the values
-     * from.
+     * @param v - The object to read the values from.
      *
-     * @return {Coordinates} This Coordinates.
+     * @returns This Coordinates.
      */
-    setFromVector3(v0) {
-        return this.setFromValues(v0.x, v0.y, v0.z);
+    setFromVector3(v: THREE.Vector3Like): this {
+        return this.setFromValues(v.x, v.y, v.z);
     }
 
     /**
      * Returns a new Coordinates with the same values as this one. It will
      * instantiate a new Coordinates with the same CRS as this one.
      *
-     * @return {Coordinates} The target with its new coordinates.
+     * @returns The target with its new coordinates.
      */
-    clone() {
-        return new Coordinates(this.crs, this);
+    clone(): Coordinates {
+        return new Coordinates(this.crs, this.x, this.y, this.z);
     }
 
     /**
      * Copies the values of the passed Coordinates to this one. The CRS is
      * however not copied.
      *
-     * @param {Coordinates} src - The source to copy from.
+     * @param src - The source to copy from.
      *
-     * @return {Coordinates} This Coordinates.
+     * @returns This Coordinates.
      */
-    copy(src) {
+    copy(src: CoordinatesLike): this {
         this.crs = src.crs;
         return this.setFromVector3(src);
     }
@@ -197,6 +215,9 @@ class Coordinates {
         this.z = value;
     }
 
+    /**
+     * The geodesic normal of the coordinate.
+     */
     get geodesicNormal() {
         if (this._normalNeedsUpdate) {
             this._normalNeedsUpdate = false;
@@ -216,38 +237,36 @@ class Coordinates {
     /**
      * Return this Coordinates values into a `THREE.Vector3`.
      *
-     * @param {THREE.Vector3} [target] - The target to put the values in. If not
-     * specified, a new vector will be created.
-     *
-     * @return {THREE.Vector3}
+     * @param target - The target to put the values in. If not specified, a new
+     * vector will be created.
      */
-    toVector3(target = new THREE.Vector3()) {
+    toVector3(target: THREE.Vector3 = new THREE.Vector3()): THREE.Vector3 {
         return target.copy(this);
     }
 
     /**
      * Copy values coordinates to array
      *
-     * @param  {number[]} array - array to store this vector to. If this is not
+     * @param array - array to store this vector to. If this is not
      * provided a new array will be created.
-     * @param  {number} [offset=0] - optional offset into the array.
+     * @param offset - optional offset into the array.
      *
-     * @return {number[]} Returns an array [x, y, z], or copies x, y and z into
-     * the provided array.
+     * @returns An array [x, y, z], or copies x, y and z into the provided
+     * array.
      */
-    toArray(array = [], offset = 0) {
+    toArray(array: number[] = [], offset: number = 0): ArrayLike<number> {
         return THREE.Vector3.prototype.toArray.call(this, array, offset);
     }
 
     /**
      * Calculate planar distance between this coordinates and `coord`.
-     * Planar distance is the straight-line euclidean distance calculated in a 2D cartesian coordinate system.
+     * Planar distance is the straight-line euclidean distance calculated in a
+     * 2D cartesian coordinate system.
      *
-     * @param  {Coordinates}  coord  The coordinate
-     * @return {number} planar distance
-     *
+     * @param coord - The coordinate
+     * @returns planar distance
      */
-    planarDistanceTo(coord) {
+    planarDistanceTo(coord: Coordinates): number {
         this.toVector3(v0).setZ(0);
         coord.toVector3(v1).setZ(0);
         return v0.distanceTo(v1);
@@ -255,16 +274,13 @@ class Coordinates {
 
     /**
      * Calculate geodetic distance between this coordinates and `coord`.
-     * **Geodetic distance** is calculated in an ellispoid space as the shortest distance
-     * across the curved surface of the world.
+     * **Geodetic distance** is calculated in an ellispoid space as the shortest
+     * distance across the curved surface of the world.
      *
-     * => As the crow flies/ Orthodromy
-     *
-     * @param  {Coordinates}  coord  The coordinate
-     * @return {number} geodetic distance
-     *
+     * @param coord - The coordinate
+     * @returns geodetic distance
      */
-    geodeticDistanceTo(coord) {
+    geodeticDistanceTo(coord: Coordinates): number {
         this.as('EPSG:4326', coord0);
         coord.as('EPSG:4326', coord1);
         return ellipsoid.geodesicDistance(coord0, coord1);
@@ -273,34 +289,36 @@ class Coordinates {
     /**
      * Calculate earth euclidean distance between this coordinates and `coord`.
      *
-     * @param  {Coordinates}  coord  The coordinate
-     * @return {number} earth euclidean distance
-     *
+     * @param coord - The coordinate
+     * @returns earth euclidean distance
      */
-    spatialEuclideanDistanceTo(coord) {
+    spatialEuclideanDistanceTo(coord: Coordinates): number {
         this.as('EPSG:4978', coord0).toVector3(v0);
         coord.as('EPSG:4978', coord1).toVector3(v1);
         return v0.distanceTo(v1);
     }
 
     /**
-     * Multiplies this `coordinates` (with an implicit 1 in the 4th dimension) and `mat`.
+     * Multiplies this `coordinates` (with an implicit 1 in the 4th dimension)
+     * and `mat`.
      *
-     * @param      {THREE.Matrix4}  mat The matrix.
-     * @return     {Coordinates}  return this object.
+     * @param mat - The matrix.
+     * @returns return this object.
      */
-    applyMatrix4(mat) {
-        return THREE.Vector3.prototype.applyMatrix4.call(this, mat);
+    applyMatrix4(mat: THREE.Matrix4): this {
+        THREE.Vector3.prototype.applyMatrix4.call(this, mat);
+        return this;
     }
 
     /**
-     * Returns coordinates in the wanted [CRS](http://inspire.ec.europa.eu/theme/rs).
+     * Returns coordinates in the wanted
+     * [CRS](http://inspire.ec.europa.eu/theme/rs).
      *
-     * @param {string} crs - The CRS to convert the Coordinates into.
-     * @param {Coordinates} [target] - The target to put the converted
+     * @param crs - The CRS to convert the Coordinates into.
+     * @param target - The target to put the converted
      * Coordinates into. If not specified a new one will be created.
      *
-     * @return {Coordinates} - The resulting Coordinates after the conversion.
+     * @returns The resulting Coordinates after the conversion.
      *
      * @example
      * const position = { longitude: 2.33, latitude: 48.24, altitude: 24999549 };
@@ -318,7 +336,7 @@ class Coordinates {
      * @example
      * new Coordinates('EPSG:4978', x: 20885167, y: 849862, z: 23385912).as('EPSG:4326'); // Geographic system
      */
-    as(crs, target = new Coordinates(crs)) {
+    as(crs: ProjectionLike, target = new Coordinates(crs)): Coordinates {
         if (this.crs == crs) {
             target.copy(this);
         } else {
@@ -326,7 +344,8 @@ class Coordinates {
                 this.y = THREE.MathUtils.clamp(this.y, -89.999999, 89.999999);
             }
 
-            target.setFromArray(proj4cache(this.crs, crs).forward([this.x, this.y, this.z]));
+            target.setFromArray(proj4cache(this.crs, crs)
+                .forward([this.x, this.y, this.z]));
         }
 
         target.crs = crs;

--- a/src/Core/Math/Ellipsoid.ts
+++ b/src/Core/Math/Ellipsoid.ts
@@ -47,7 +47,10 @@ class Ellipsoid {
      * @param target - An object to store this vector to. If this is not
      * specified, a new vector will be created.
      */
-    geodeticSurfaceNormal(cartesian: Coordinates, target = new THREE.Vector3()) {
+    geodeticSurfaceNormal(
+        cartesian: Coordinates,
+        target = new THREE.Vector3(),
+    ): THREE.Vector3 {
         return cartesian.toVector3(target).multiply(this._invRadiiSquared).normalize();
     }
 
@@ -59,7 +62,10 @@ class Ellipsoid {
      * @param target - An object to store this vector to. If this is not
      * specified, a new vector will be created.
      */
-    geodeticSurfaceNormalCartographic(coordCarto: Coordinates, target = new THREE.Vector3()) {
+    geodeticSurfaceNormalCartographic(
+        coordCarto: Coordinates,
+        target = new THREE.Vector3(),
+    ): THREE.Vector3 {
         const longitude = THREE.MathUtils.degToRad(coordCarto.longitude);
         const latitude = THREE.MathUtils.degToRad(coordCarto.latitude);
         const cosLatitude = Math.cos(latitude);
@@ -90,7 +96,10 @@ class Ellipsoid {
         return this;
     }
 
-    cartographicToCartesian(coordCarto: Coordinates, target = new THREE.Vector3()) {
+    cartographicToCartesian(
+        coordCarto: Coordinates,
+        target = new THREE.Vector3(),
+    ): THREE.Vector3 {
         normal.copy(coordCarto.geodesicNormal);
 
         target.multiplyVectors(this._radiiSquared, normal);
@@ -115,7 +124,7 @@ class Ellipsoid {
     cartesianToCartographic(
         position: THREE.Vector3Like,
         target = new Coordinates('EPSG:4326', 0, 0, 0),
-    ) {
+    ): Coordinates {
         // for details, see for example http://www.linz.govt.nz/data/geodetic-system/coordinate-conversion/geodetic-datum-conversions/equations-used-datum
         // TODO the following is only valable for oblate ellipsoid of
         // revolution. do we want to support triaxial ellipsoid?
@@ -149,7 +158,7 @@ class Ellipsoid {
         );
     }
 
-    cartographicToCartesianArray(coordCartoArray: Coordinates[]) {
+    cartographicToCartesianArray(coordCartoArray: Coordinates[]): THREE.Vector3[] {
         const cartesianArray = [];
         for (let i = 0; i < coordCartoArray.length; i++) {
             cartesianArray.push(this.cartographicToCartesian(coordCartoArray[i]));
@@ -158,7 +167,7 @@ class Ellipsoid {
         return cartesianArray;
     }
 
-    intersection(ray: THREE.Ray) {
+    intersection(ray: THREE.Ray): THREE.Vector3 | false {
         const EPSILON = 0.0001;
         const O_C = ray.origin;
         const dir = ray.direction;
@@ -215,7 +224,7 @@ class Ellipsoid {
      * @param coordCarto2 - The coordinate carto 2
      * @returns The orthodromic distance between the two given coordinates.
      */
-    geodesicDistance(coordCarto1: Coordinates, coordCarto2: Coordinates) {
+    geodesicDistance(coordCarto1: Coordinates, coordCarto2: Coordinates): number {
         // The formula uses the distance on approximated sphere,
         // with the nearest local radius of curvature of the ellipsoid
         // https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf

--- a/src/Core/Math/Ellipsoid.ts
+++ b/src/Core/Math/Ellipsoid.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import proj4 from 'proj4';
-import Coordinates from 'Core/Geographic/Coordinates';
+import Coordinates from '../Geographic/Coordinates';
 
 export const ellipsoidSizes = new THREE.Vector3(
     proj4.WGS84.a,
@@ -10,7 +10,13 @@ export const ellipsoidSizes = new THREE.Vector3(
 const normal = new THREE.Vector3();
 
 class Ellipsoid {
-    constructor(size = ellipsoidSizes) {
+    size: THREE.Vector3;
+    eccentricity: number;
+
+    private _radiiSquared: THREE.Vector3;
+    private _invRadiiSquared: THREE.Vector3;
+
+    constructor(size: THREE.Vector3 = ellipsoidSizes) {
         this.size = new THREE.Vector3();
         this._radiiSquared = new THREE.Vector3();
         this._invRadiiSquared = new THREE.Vector3();
@@ -19,11 +25,11 @@ class Ellipsoid {
         this.setSize(size);
     }
 
-    geodeticSurfaceNormal(cartesian, target = new THREE.Vector3()) {
+    geodeticSurfaceNormal(cartesian: Coordinates, target = new THREE.Vector3()) {
         return cartesian.toVector3(target).multiply(this._invRadiiSquared).normalize();
     }
 
-    geodeticSurfaceNormalCartographic(coordCarto, target = new THREE.Vector3()) {
+    geodeticSurfaceNormalCartographic(coordCarto: Coordinates, target = new THREE.Vector3()) {
         const longitude = THREE.MathUtils.degToRad(coordCarto.longitude);
         const latitude = THREE.MathUtils.degToRad(coordCarto.latitude);
         const cosLatitude = Math.cos(latitude);
@@ -33,19 +39,19 @@ class Ellipsoid {
             Math.sin(latitude));
     }
 
-    setSize(size) {
+    setSize(size: THREE.Vector3Like) {
         this.size.set(size.x, size.y, size.z);
 
         this._radiiSquared.multiplyVectors(size, size);
 
-        this._invRadiiSquared.x = (size.x == 0) ? 0 : 1 / this._radiiSquared.x;
-        this._invRadiiSquared.y = (size.y == 0) ? 0 : 1 / this._radiiSquared.y;
-        this._invRadiiSquared.z = (size.z == 0) ? 0 : 1 / this._radiiSquared.z;
+        this._invRadiiSquared.x = (size.x === 0) ? 0 : 1 / this._radiiSquared.x;
+        this._invRadiiSquared.y = (size.y === 0) ? 0 : 1 / this._radiiSquared.y;
+        this._invRadiiSquared.z = (size.z === 0) ? 0 : 1 / this._radiiSquared.z;
 
         this.eccentricity = Math.sqrt(this._radiiSquared.x - this._radiiSquared.z) / this.size.x;
     }
 
-    cartographicToCartesian(coordCarto, target = new THREE.Vector3()) {
+    cartographicToCartesian(coordCarto: Coordinates, target = new THREE.Vector3()) {
         normal.copy(coordCarto.geodesicNormal);
 
         target.multiplyVectors(this._radiiSquared, normal);
@@ -60,18 +66,23 @@ class Ellipsoid {
     }
 
     /**
-     * Convert cartesian coordinates to geographic according to the current ellipsoid of revolution.
-     * @param {Object} position - The coordinate to convert
-     * @param {number} position.x
-     * @param {number} position.y
-     * @param {number} position.z
-     * @param {Coordinate} [target] coordinate to copy result
-     * @returns {Coordinate} an object describing the coordinates on the reference ellipsoid, angles are in degree
+     * Convert cartesian coordinates to geographic according to the current
+     * ellipsoid of revolution.
+     * @param position - The coordinate to convert
+     * @param target - coordinate to copy result
+     * @returns an object describing the coordinates on the reference ellipsoid,
+     * angles are in degree
      */
-    cartesianToCartographic(position, target = new Coordinates('EPSG:4326', 0, 0, 0)) {
+    cartesianToCartographic(
+        position: THREE.Vector3Like,
+        target = new Coordinates('EPSG:4326', 0, 0, 0),
+    ) {
         // for details, see for example http://www.linz.govt.nz/data/geodetic-system/coordinate-conversion/geodetic-datum-conversions/equations-used-datum
-        // TODO the following is only valable for oblate ellipsoid of revolution. do we want to support triaxial ellipsoid?
-        const R = Math.sqrt(position.x * position.x + position.y * position.y + position.z * position.z);
+        // TODO the following is only valable for oblate ellipsoid of
+        // revolution. do we want to support triaxial ellipsoid?
+        const R = Math.sqrt(position.x * position.x +
+            position.y * position.y +
+            position.z * position.z);
         const a = this.size.x; // x
         const b = this.size.z; // z
         const e = Math.abs((a * a - b * b) / (a * a));
@@ -84,14 +95,22 @@ class Ellipsoid {
         const sinu = Math.sin(nu);
         const cosu = Math.cos(nu);
 
-        const phi = Math.atan((position.z * (1 - f) + e * a * sinu * sinu * sinu) / ((1 - f) * (rsqXY - e * a * cosu * cosu * cosu)));
+        const phi = Math.atan(
+            (position.z * (1 - f) + e * a * sinu * sinu * sinu) /
+                ((1 - f) * (rsqXY - e * a * cosu * cosu * cosu)));
 
-        const h = (rsqXY * Math.cos(phi)) + position.z * Math.sin(phi) - a * Math.sqrt(1 - e * Math.sin(phi) * Math.sin(phi));
+        const h = (rsqXY * Math.cos(phi)) +
+            position.z * Math.sin(phi) -
+            a * Math.sqrt(1 - e * Math.sin(phi) * Math.sin(phi));
 
-        return target.setFromValues(THREE.MathUtils.radToDeg(theta), THREE.MathUtils.radToDeg(phi), h);
+        return target.setFromValues(
+            THREE.MathUtils.radToDeg(theta),
+            THREE.MathUtils.radToDeg(phi),
+            h,
+        );
     }
 
-    cartographicToCartesianArray(coordCartoArray) {
+    cartographicToCartesianArray(coordCartoArray: Coordinates[]) {
         const cartesianArray = [];
         for (let i = 0; i < coordCartoArray.length; i++) {
             cartesianArray.push(this.cartographicToCartesian(coordCartoArray[i]));
@@ -100,19 +119,26 @@ class Ellipsoid {
         return cartesianArray;
     }
 
-    intersection(ray) {
+    intersection(ray: THREE.Ray) {
         const EPSILON = 0.0001;
         const O_C = ray.origin;
         const dir = ray.direction;
         // normalizeVector( dir );
 
         const a =
-            ((dir.x * dir.x) * this._invRadiiSquared.x) + ((dir.y * dir.y) * this._invRadiiSquared.y) + ((dir.z * dir.z) * this._invRadiiSquared.z);
+            ((dir.x * dir.x) * this._invRadiiSquared.x) +
+            ((dir.y * dir.y) * this._invRadiiSquared.y) +
+            ((dir.z * dir.z) * this._invRadiiSquared.z);
 
         const b =
-            ((2 * O_C.x * dir.x) * this._invRadiiSquared.x) + ((2 * O_C.y * dir.y) * this._invRadiiSquared.y) + ((2 * O_C.z * dir.z) * this._invRadiiSquared.z);
+            ((2 * O_C.x * dir.x) * this._invRadiiSquared.x) +
+            ((2 * O_C.y * dir.y) * this._invRadiiSquared.y) +
+            ((2 * O_C.z * dir.z) * this._invRadiiSquared.z);
+
         const c =
-            ((O_C.x * O_C.x) * this._invRadiiSquared.x) + ((O_C.y * O_C.y) * this._invRadiiSquared.y) + ((O_C.z * O_C.z) * this._invRadiiSquared.z) - 1;
+            ((O_C.x * O_C.x) * this._invRadiiSquared.x) +
+            ((O_C.y * O_C.y) * this._invRadiiSquared.y) +
+            ((O_C.z * O_C.z) * this._invRadiiSquared.z) - 1;
 
         let d = ((b * b) - (4 * a * c));
         if (d < 0 || a === 0 || b === 0 || c === 0) { return false; }
@@ -122,8 +148,11 @@ class Ellipsoid {
         const t1 = (-b + d) / (2 * a);
         const t2 = (-b - d) / (2 * a);
 
-        if (t1 <= EPSILON && t2 <= EPSILON) { return false; } // both intersections are behind the ray origin
-        // var back = (t1 <= EPSILON || t2 <= EPSILON); // If only one intersection (t>0) then we are inside the ellipsoid and the intersection is at the back of the ellipsoid
+        if (t1 <= EPSILON && t2 <= EPSILON) {
+            // both intersections are behind the ray origin
+            return false;
+        }
+
         let t = 0;
         if (t1 <= EPSILON) { t = t2; } else
             if (t2 <= EPSILON) { t = t1; } else { t = (t1 < t2) ? t1 : t2; }
@@ -137,21 +166,17 @@ class Ellipsoid {
         return inter;
     }
 
-    computeDistance(coordCarto1, coordCarto2) {
-        console.warn('computeDistance is renamed to geodesicDistance');
-        this.geodesicDistance(coordCarto1, coordCarto2);
-    }
-
     /**
      * Calculate the geodesic distance, between coordCarto1 and coordCarto2.
-     * It's most short distance on ellipsoid surface between coordCarto1 and coordCarto2.
+     * It's most short distance on ellipsoid surface between coordCarto1 and
+     * coordCarto2.
      * It's called orthodromy.
      *
-     * @param      {Coordinates}  coordCarto1  The coordinate carto 1
-     * @param      {Coordinates}  coordCarto2  The coordinate carto 2
-     * @return     {number}  The orthodromic distance between the two given coordinates.
+     * @param coordCarto1 - The coordinate carto 1
+     * @param coordCarto2 - The coordinate carto 2
+     * @returns The orthodromic distance between the two given coordinates.
      */
-    geodesicDistance(coordCarto1, coordCarto2) {
+    geodesicDistance(coordCarto1: Coordinates, coordCarto2: Coordinates) {
         // The formula uses the distance on approximated sphere,
         // with the nearest local radius of curvature of the ellipsoid
         // https://geodesie.ign.fr/contenu/fichiers/Distance_longitude_latitude.pdf
@@ -160,7 +185,9 @@ class Ellipsoid {
         const longitude2 = THREE.MathUtils.degToRad(coordCarto2.longitude);
         const latitude2 = THREE.MathUtils.degToRad(coordCarto2.latitude);
 
-        const distRad = Math.acos(Math.sin(latitude1) * Math.sin(latitude2) + Math.cos(latitude1) * Math.cos(latitude2) * Math.cos(longitude2 - longitude1));
+        const distRad = Math.acos(
+            Math.sin(latitude1) * Math.sin(latitude2) +
+                Math.cos(latitude1) * Math.cos(latitude2) * Math.cos(longitude2 - longitude1));
 
         const e = this.eccentricity;
         const latMoy = (latitude1 + latitude2) * 0.5;

--- a/src/Renderer/Camera.js
+++ b/src/Renderer/Camera.js
@@ -188,7 +188,9 @@ class Camera {
      * @return  {Coordinates}   Coordinates object holding camera's position.
      */
     position(crs) {
-        return new Coordinates(this.crs, this.camera3D.position).as(crs || this.crs);
+        return new Coordinates(this.crs)
+            .setFromVector3(this.camera3D.position)
+            .as(crs || this.crs);
     }
 
     /**

--- a/src/Utils/CameraUtils.js
+++ b/src/Utils/CameraUtils.js
@@ -154,7 +154,10 @@ class CameraRig extends THREE.Object3D {
 
     // set rig's objects transformation from camera's position and target's position
     setFromPositions(view, cameraPosition) {
-        this.setTargetFromCoordinate(view, new Coordinates(view.referenceCrs, targetPosition));
+        this.setTargetFromCoordinate(
+            view,
+            new Coordinates(view.referenceCrs).setFromVector3(targetPosition),
+        );
         this.target.rotation.set(0, 0, 0);
         this.updateMatrixWorld(true);
         this.camera.position.copy(cameraPosition);

--- a/test/unit/ellipsoid.js
+++ b/test/unit/ellipsoid.js
@@ -5,7 +5,20 @@ import Ellipsoid from 'Core/Math/Ellipsoid';
 describe('Ellipsoid', function () {
     const c1 = new Coordinates('EPSG:4326', 0, 0, 0);
     const ellipsoid = new Ellipsoid();
-    it('geodeticSurfaceNormalCartographic', () => {
+
+    it('geodeticSurfaceNormal', function () {
+        c1.setFromValues(6378137, 0, 0);
+        const v = ellipsoid.geodeticSurfaceNormal(c1);
+        assert.equal(v.x, 1);
+        assert.equal(v.y, 0);
+        assert.equal(v.z, 0);
+        c1.x = -6378137;
+        ellipsoid.geodeticSurfaceNormal(c1, v);
+        assert.equal(v.x, -1);
+    });
+
+    it('geodeticSurfaceNormalCartographic', function () {
+        c1.setFromValues(0, 0, 0);
         const v = ellipsoid.geodeticSurfaceNormalCartographic(c1);
         assert.equal(v.x, 1);
         assert.equal(v.y, 0);
@@ -15,13 +28,14 @@ describe('Ellipsoid', function () {
         assert.equal(v.x, -1);
     });
 
-    it('cartographicToCartesian', () => {
-        c1.x = 0;
+    it('cartographicToCartesian', function () {
+        c1.setFromValues(0, 0, 0);
         const v = ellipsoid.cartographicToCartesian(c1);
         assert.equal(v.x, ellipsoid.size.x);
     });
 
-    it('cartesianToCartographic', () => {
+    it('cartesianToCartographic', function () {
+        c1.setFromValues(0, 0, 0);
         const altitude = 2000;
         const v = ellipsoid.cartographicToCartesian(c1);
         v.x += altitude;
@@ -29,14 +43,15 @@ describe('Ellipsoid', function () {
         assert.equal(c1.z, altitude);
     });
 
-    it('cartographicToCartesianArray', () => {
-        c1.z = 0;
+    it('cartographicToCartesianArray', function () {
+        c1.setFromValues(0, 0, 0);
         const a = ellipsoid.cartographicToCartesianArray([c1]);
         assert.equal(a.length, 1);
         assert.equal(a[0].x, ellipsoid.size.x);
     });
 
-    it('geodesic distance', () => {
+    it('geodesic distance', function () {
+        c1.setFromValues(0, 0, 0);
         const a = ellipsoid.geodesicDistance(c1, c1);
         assert.equal(a, 0);
         const c2 = new Coordinates('EPSG:4326', 180, 0, 0);

--- a/utils/debug/Debug.js
+++ b/utils/debug/Debug.js
@@ -177,7 +177,9 @@ function Debug(view, datDebugTool, chartDivContainer) {
             const size = { x: g.width * ratio, y: g.height * ratio };
             debugCamera.aspect = size.x / size.y;
             const camera = view.camera3D;
-            const coord = new Coordinates(view.referenceCrs, camera.position).as(tileLayer.extent.crs);
+            const coord = new Coordinates(view.referenceCrs)
+                .setFromVector3(camera.position)
+                .as(tileLayer.extent.crs);
             const extent = view.tileLayer.info.displayed.extent;
             displayedTilesObb.setFromExtent(extent);
             displayedTilesObbHelper.visible = true;


### PR DESCRIPTION
## Description

This PR includes:
- Migration of `Coordinates` from javascript to typescript
- Migration of `Ellipsoid` from javascript to typescript
- Add missing types
- Code formatting
- TSDoc compliant documentation

Proposed breaking type changes:
- For simplification and alignment with `Three.Vector3`, I propose that the constructor of `Coordinates` only accepts numbers as parameters. We could set from array, coordinates-like objects from corresponding methods `setFromArray()` or `setFromVector3`. Note that for js users, we would not for now break compatibility (maybe add a depreciation notice).

## Motivation and Context

As described in proposal #2396, we aim to gradually migrate our entire codebase (with the exception of deprecated modules) from javascript to typescript. We choose to start with modules with no-dependency and move up in the dependency tree.

This PR is the second step of **Migrate geographic modules**, migrating the both co-dependent modules `Coordinates` and `Ellipsoid`. This PR is a follow-up of #2436.