### PR TITLE
fix(Zoom): use zoom state

### DIFF
--- a/src/Controls/StateControl.js
+++ b/src/Controls/StateControl.js
@@ -265,7 +265,7 @@ class StateControl extends THREE.EventDispatcher {
     touchToState(finger) {
         for (const key of Object.keys(DEFAULT_STATES)) {
             const state = this[key];
-            if (state.enable && finger == state.finger) {
+            if (state.enable && finger === state.finger) {
                 return state;
             }
         }
@@ -396,7 +396,7 @@ class StateControl extends THREE.EventDispatcher {
 
         if (this.enabled && this.ZOOM.enable) {
             viewCoords.copy(this._view.eventToViewCoords(event));
-            this.currentState = this.NONE;
+            this.currentState = this.ZOOM;
             this.dispatchEvent({ type: this.ZOOM._event, delta: event.deltaY, viewCoords });
         }
     }


### PR DESCRIPTION
## Description
Switch state to `ZOOM` when zoom by mouse wheel is triggered.


## Motivation and Context
In a use case of mine, I'm using a similar function than `zoomToTile` of  OGC3DTilesHelper.js but instead of `view.controls.lookAtCoordinate`, I'm calling `CameraUtils.transformCameraToLookAtTarget(view, view.camera3D, cameraTransform);`

By doing this, zooming after calling this method was translating me in random direction (cf video)

[Screencast from 15-10-2024 16:10:24.webm](https://github.com/user-attachments/assets/83e4fbc3-4fbb-453e-8eb7-4a50451ebc2e)

(I'm using 3dtiles_loader.html to try it out)

By replacing the `currentState` by `ZOOM`, I don't encounter this issue anymore, because I need this to be called:



https://github.com/iTowns/itowns/blob/cfb9d0f5184f6d569a3f81101778dd767df9a875/src/Controls/GlobeControls.js#L584



We could also see if this part is really necessary:

https://github.com/iTowns/itowns/blob/cfb9d0f5184f6d569a3f81101778dd767df9a875/src/Controls/GlobeControls.js#L568-L570