### PR TITLE
chore(eslint): Add no-use-before-define and change max-len rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -136,7 +136,14 @@ module.exports = {
                 'plugin:@typescript-eslint/recommended',
             ],
             rules: {
-                '@stylistic/max-len': ['warn', 80],
+                '@stylistic/max-len': ['warn', {
+                    code: 100,
+                    comments: 80,
+                    ignoreUrls: true,
+                }],
+                // see https://typescript-eslint.io/rules/no-use-before-define/
+                'no-use-before-define': 'off',
+                '@typescript-eslint/no-use-before-define': 'error',
                 'valid-jsdoc': 'off',
                 'tsdoc/syntax': 'warn',
             },


### PR DESCRIPTION
## Motivation and Context

This PR relax some rules introduced by #2413 (100 characters per line of code, still 80 chars per line of comment except line including URLs). It also replace the `no-use-before-define` by `@typescript-estlint/no-use-before-define` as per [typescript eslint documentation](https://typescript-eslint.io/rules/no-use-before-define/) since the former was also throwing errors on types used before definition.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

## Screenshots (if appropriate)
