### PR TITLE
feat(eslint): remove preference for default export

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,6 +60,7 @@ module.exports = {
       devDependencies: ['test/**', 'tests/**', 'examples/**'],
     }], */
         'import/no-extraneous-dependencies': 'off',
+        'import/prefer-default-export': 'off',
 
         // TODO reactivate all the following rules
 
@@ -95,9 +96,9 @@ module.exports = {
             'error',
             'ignorePackages',
             {
-                'js': 'never',
-                'ts': 'never',
-                'tsx': 'never',
+                js: 'never',
+                ts: 'never',
+                tsx: 'never',
             },
         ],
         camelcase: 'off',


### PR DESCRIPTION
## Description
Change ESlint config to remove the preference for default exports.
Also clear a warning caused by unnecessarily quoted object fields in the config.

## Motivation and Context
Default exports mess with tree shaking and are generally better avoided.
