### PR TITLE
feat(ci): bump node to next LTS (v22)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,10 +20,10 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       # Install packages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -159,7 +159,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/
 
       - run: npm ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
 
       # Use specific Node.js version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: 'npm'
@@ -84,11 +84,11 @@ jobs:
     steps:
 
       # Use specific Node.js version
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       # Install packages
@@ -114,11 +114,11 @@ jobs:
     steps:
 
       # Use specific Node.js version
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       # Install packages
@@ -149,7 +149,7 @@ jobs:
         contents: write
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch all branches
           fetch-depth: 0
@@ -157,7 +157,7 @@ jobs:
       # Configure git user for later command induced commits
       - uses: fregante/setup-git-user@v1
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
@@ -261,12 +261,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
 
       - name: Message commit
         run: echo "is RELEASE => ${{ github.event.head_commit.message }} !!"


### PR DESCRIPTION
## Description
Update the CI's node version to the next LTS version 22.

## Motivation and Context
Node version 18 will soon (6 months from now) stop being supported, and some
packages require a higher version.
