### PR TITLE
Supporting Relative url in VectorTile Style file

### DIFF
--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -872,8 +872,13 @@ class Style {
                                     cropValues = function _(p) {
                                         const id = stop[1].replace(/\{(.+?)\}/g, (a, b) => (p[b] || '')).trim();
                                         cropValues = sprites[id];
+                                        if (cropValues === undefined) {
+                                            console.warn(`WARNING: "${id}" not found in sprite file`);
+                                        }
                                         return sprites[id];
                                     };
+                                } else if (cropValues === undefined) {
+                                    console.warn(`WARNING: "${stop[1]}" not found in sprite file`);
                                 }
                                 return [stop[0], cropValues];
                             }),

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -140,7 +140,7 @@ class VectorTilesSource extends TMSSource {
                 });
                 return Promise.all(TMSUrlList);
             }
-            return (Promise.resolve([this.url]));
+            return (Promise.resolve([toTMSUrl(this.url)]));
         }).then((TMSUrlList) => {
             this.urls = Array.from(new Set(TMSUrlList));
         });

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -71,9 +71,10 @@ class VectorTilesSource extends TMSSource {
 
         this.accessToken = source.accessToken;
 
+        let styleUrl;
         if (source.style) {
             if (typeof source.style == 'string') {
-                const styleUrl = urlParser.normalizeStyleURL(source.style, this.accessToken);
+                styleUrl = urlParser.normalizeStyleURL(source.style, this.accessToken);
                 promise = Fetcher.json(styleUrl, this.networkOptions);
             } else {
                 promise = Promise.resolve(source.style);
@@ -84,8 +85,9 @@ class VectorTilesSource extends TMSSource {
 
         this.whenReady = promise.then((style) => {
             this.jsonStyle = style;
-            const baseurl = source.sprite || style.sprite;
+            let baseurl = source.sprite || style.sprite;
             if (baseurl) {
+                baseurl = new URL(baseurl, styleUrl).toString();
                 const spriteUrl = urlParser.normalizeSpriteURL(baseurl, '', '.json', this.accessToken);
                 return Fetcher.json(spriteUrl, this.networkOptions).then((sprites) => {
                     this.sprites = sprites;
@@ -123,9 +125,11 @@ class VectorTilesSource extends TMSSource {
             if (this.url == '.') {
                 const TMSUrlList = Object.values(style.sources).map((sourceVT) => {
                     if (sourceVT.url) {
+                        sourceVT.url = new URL(sourceVT.url, styleUrl).toString();
                         const urlSource = urlParser.normalizeSourceURL(sourceVT.url, this.accessToken);
                         return Fetcher.json(urlSource, this.networkOptions).then((tileJSON) => {
                             if (tileJSON.tiles[0]) {
+                                tileJSON.tiles[0] = decodeURIComponent(new URL(tileJSON.tiles[0], urlSource).toString());
                                 return toTMSUrl(tileJSON.tiles[0]);
                             }
                         });

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -67,15 +67,17 @@ describe('Vector tiles', function () {
         }).catch(done);
     });
 
-    it('returns nothing', (done) => {
+    it('returns an empty collection', (done) => {
         parse(null).then((collection) => {
-            assert.equal(collection, undefined);
+            assert.ok(collection.isFeatureCollection);
+            assert.equal(collection.features.length, 0);
             done();
         }).catch(done);
     });
 
     it('filters all features out', (done) => {
         parse(multipolygon, {}).then((collection) => {
+            assert.ok(collection.isFeatureCollection);
             assert.equal(collection.features.length, 0);
             done();
         }).catch(done);

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -13,7 +13,7 @@ import sprite from '../data/vectortiles/sprite.json';
 import mapboxStyle from '../data/mapboxMulti.json';
 
 const resources = {
-    'test/data/vectortiles/style.json': style,
+    'https://test/data/vectortiles/style.json': style,
     'https://test/tilejson.json': tilejson,
     'https://test/sprite.json': sprite,
     'https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7.json': mapboxStyle,
@@ -187,7 +187,7 @@ describe('VectorTilesSource', function () {
 
     it('loads the style from a file', function _it(done) {
         const source = new VectorTilesSource({
-            style: 'test/data/vectortiles/style.json',
+            style: 'https://test/data/vectortiles/style.json',
         });
         source.whenReady
             .then(() => {


### PR DESCRIPTION
UPDATE: The modification done here were reused in the PR global about VT #2469. 


Linked to issue #2454 .
ArcGis VectorTile server uses relative url to point the localisation of sprite and tile in the style.json file.

This PR aims at fixing that issue.

A second bug where the url given should already be writing with the $ has been fixed as well as adding a warning when some icons where not found in the sprite sheet giving in the style file.