### PR TITLE
fix(COG): Fix extent in COG parser

### DIFF
--- a/examples/js/plugins/COGParser.js
+++ b/examples/js/plugins/COGParser.js
@@ -235,7 +235,7 @@ const COGParser = (function _() {
          */
         parse: async function _(data, options) {
             const source = options.in;
-            const tileExtent = options.extent.as(source.crs);
+            const tileExtent = options.extent.isExtent ? options.extent.as(source.crs) : options.extent.toExtent(source.crs);
 
             const level = selectLevel(source, tileExtent, source.tileWidth, source.tileHeight);
             const viewport = makeWindowFromExtent(source, tileExtent, level.resolution);


### PR DESCRIPTION
We see some error with Cloud Optimized Geotiff Parser (`extent.as` is not a function).

I think it's an oversight of https://github.com/iTowns/itowns/commit/4b57498d3f7a8744002347031822c4bee8eaf56a.
