### PR TITLE
fix(xbilparser): apply zmin / zmax for any texture subsampling size

### DIFF
--- a/src/Parser/XbilParser.js
+++ b/src/Parser/XbilParser.js
@@ -64,16 +64,17 @@ export function computeMinMaxElevation(texture, pitch, options) {
                 }
             }
         }
-        // Clamp values to zmin and zmax values configured in ElevationLayer
-        if (options.zmin != null) {
-            if (min < options.zmin) { min = options.zmin; }
-            if (max < options.zmin) { max = options.zmin; }
-        }
+    }
 
-        if (options.zmax != null) {
-            if (min > options.zmax) { min = options.zmax; }
-            if (max > options.zmax) { max = options.zmax; }
-        }
+    // Clamp values to zmin and zmax values configured in ElevationLayer
+    if (options.zmin != null) {
+        if (min < options.zmin) { min = options.zmin; }
+        if (max < options.zmin) { max = options.zmin; }
+    }
+
+    if (options.zmax != null) {
+        if (min > options.zmax) { min = options.zmax; }
+        if (max > options.zmax) { max = options.zmax; }
     }
 
     if (max === -Infinity || min === Infinity) {


### PR DESCRIPTION
## Description
Min and max clamping elevation parameters were not applied when subsampling parent tile elevation texture with a window smaller that two pixels wide. 

This implies that some tiles are not clamped when applying a strong zoom, like switching from the globe view to a city without animation, using STRATEGY_MIN_NETWORK_TRAFFIC. For a custom terrain, setting the usual -99999 nodata value and clamping minimum altitude to 0 results in unexpected culling removing the terrain. See the screenshot.

After looking at git history, I suppose that this might just be a coding mistake, putting these conditions in the wrong code block. What do you think @gchoqueux ?

## Screenshots (if appropriate)
https://github.com/user-attachments/assets/45da2794-c1c4-43c9-8bc8-9f772345078b


