### PR TITLE
fix(wms): take wms 1.1.1 version into account for axis order

### DIFF
--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -106,8 +106,8 @@ class WMSSource extends Source {
         // 4326 (lat/long) axis order depends on the WMS version used
             if (this.crs == 'EPSG:4326') {
             // EPSG 4326 x = lat, long = y
-            // version 1.1.0 long/lat while version 1.3.0 mandates xy (so lat,long)
-                this.axisOrder = (this.version === '1.1.0' ? 'wsen' : 'swne');
+            // version 1.X.X long/lat while version 1.3.0 mandates xy (so lat,long)
+                this.axisOrder = (this.version === '1.3.0' ? 'swne' : 'wsen');
             } else {
             // xy,xy order
                 this.axisOrder = 'wsen';


### PR DESCRIPTION
## Description
Axis order in WMS in EPSG:4326 is long/lat in version 1.X.X while it is lat/long for 1.3.0. Versions 1.0.0, 1.1.0 and 1.1.1 do exist. We were previously testing the version against '1.1.0' value to determine the order, ignoring versions 1.0.0 and 1.1.1. Now testing on version 1.3.0 to enable native compatibility with those versions as well.