### PR TITLE
fix(wms) : assign axis order param from source

### DIFF
--- a/src/Core/Geographic/Crs.ts
+++ b/src/Core/Geographic/Crs.ts
@@ -4,6 +4,12 @@ import type { ProjectionDefinition } from 'proj4';
 
 proj4.defs('EPSG:4978', '+proj=geocent +datum=WGS84 +units=m +no_defs');
 
+// Redefining proj4 global projections to match epsg.org database axis order.
+// See https://github.com/iTowns/itowns/pull/2465#issuecomment-2517024859
+proj4.defs('EPSG:4326').axis = 'neu';
+proj4.defs('EPSG:4269').axis = 'neu';
+proj4.defs('WGS84').axis = 'neu';
+
 /**
  * A projection as a CRS identifier string. This identifier references a
  * projection definition previously defined with
@@ -137,6 +143,19 @@ export function reasonableEpsilon(crs: ProjectionLike) {
     } else {
         return 0.001;
     }
+}
+
+/**
+ * Returns the axis parameter defined in proj4 for the provided crs.
+ * Might be undefined depending on crs definition.
+ *
+ * @param crs - The CRS to get axis from.
+ * @returns the matching proj4 axis string, 'enu' for instance (east, north, up)
+ */
+export function axisOrder(crs: ProjectionLike) {
+    mustBeString(crs);
+    const projection = proj4.defs(crs);
+    return !projection ? undefined : projection.axis;
 }
 
 /**

--- a/src/Source/WMSSource.js
+++ b/src/Source/WMSSource.js
@@ -102,16 +102,16 @@ class WMSSource extends Source {
         this.transparent = source.transparent || false;
         this.bboxDigits = source.bboxDigits;
 
-        if (!source.axisOrder) {
-        // 4326 (lat/long) axis order depends on the WMS version used
-            if (this.crs == 'EPSG:4326') {
+        if (source.axisOrder) {
+            this.axisOrder = source.axisOrder;
+        } else if (this.crs == 'EPSG:4326') {
+            // 4326 (lat/long) axis order depends on the WMS version used
             // EPSG 4326 x = lat, long = y
             // version 1.X.X long/lat while version 1.3.0 mandates xy (so lat,long)
-                this.axisOrder = (this.version === '1.3.0' ? 'swne' : 'wsen');
-            } else {
+            this.axisOrder = this.version === '1.3.0' ? 'swne' : 'wsen';
+        } else {
             // xy,xy order
-                this.axisOrder = 'wsen';
-            }
+            this.axisOrder = 'wsen';
         }
 
         const crsPropName = (this.version === '1.3.0') ? 'CRS' : 'SRS';

--- a/test/unit/crs.js
+++ b/test/unit/crs.js
@@ -53,4 +53,10 @@ describe('CRS assertions', function () {
         assert.strictEqual(CRS.reasonableEpsilon('EPSG:4326'), 0.01);
         assert.strictEqual(CRS.reasonableEpsilon('EPSG:3857'), 0.001);
     });
+
+    it('should return neu axis order', function () {
+        assert.equal(CRS.axisOrder('WGS84'), 'neu');
+        assert.equal(CRS.axisOrder('WGS84'), 'neu');
+        assert.equal(CRS.axisOrder('EPSG:4269'), 'neu');
+    });
 });


### PR DESCRIPTION
## Description
WMSSource was'nt taking the axisOrder parameter into account when provided.

## Motivation and Context
Consistency: This parameter was advertised in documentation while not being used afterwards.
