### PR TITLE
fix(i3dm): use instanceId to get info

### DIFF
--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -356,14 +356,14 @@ class OGC3DTilesLayer extends GeometryLayer {
     getC3DTileFeatureFromIntersectsArray(intersects) {
         if (!intersects.length) { return null; }
 
-        const { face, index, object } = intersects[0];
+        const { face, index, object, instanceId } = intersects[0];
 
         /** @type{number|null} */
         let batchId;
         if (object.isPoints && index) {
             batchId = object.geometry.getAttribute('_BATCHID')?.getX(index) ?? index;
         } else if (object.isMesh && face) {
-            batchId = object.geometry.getAttribute('_BATCHID')?.getX(face.a);
+            batchId = object.geometry.getAttribute('_BATCHID')?.getX(face.a) ?? instanceId;
         }
 
         if (batchId === undefined) {


### PR DESCRIPTION
## Description
Fix https://github.com/iTowns/itowns/issues/2434

Use the instanceId returned by the three.js [raycaster](https://threejs.org/docs/#api/en/core/Raycaster.intersectObject) to retrieve info


## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/1c22d9e4-0331-420e-83b6-0b2ba6ba3877)
