### PR TITLE
MapBox VectorTile: bug fixes using an official MapBox stream

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -31,6 +31,7 @@
     "Vector tiles": {
         "vector_tile_raster_3d": "Raster on 3D map",
         "vector_tile_raster_2d": "Raster on 2D map",
+        "vector_tile_mapbox_raster": "Mapbox Vector Tiles to raster",
         "vector_tile_3d_mesh": "Vector tile to 3d objects",
         "vector_tile_3d_mesh_mapbox": "Mapbox Vector tile to 3d objects",
         "vector_tile_dragndrop": "Drag and drop a style"

--- a/examples/source_file_kml_raster_usgs.html
+++ b/examples/source_file_kml_raster_usgs.html
@@ -69,7 +69,6 @@
             }
 
             var kmlStyle = {
-                zoom: { min: 10, max: 20 },
                 text: {
                     field: '{name}',
                     haloColor: 'black',

--- a/examples/vector_tile_mapbox_raster.html
+++ b/examples/vector_tile_mapbox_raster.html
@@ -1,0 +1,91 @@
+<html>
+  <head>
+    <title>Itowns - vector-tiles 2d </title>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="css/example.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="css/LoadingScreen.css"
+    />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+  </head>
+  <body>
+    <div id="viewerDiv"></div>
+
+    <!-- Import iTowns source code -->
+    <script src="../dist/itowns.js"></script>
+    <script src="../dist/debug.js"></script>
+    <!-- Import iTowns LoadingScreen and GuiTools plugins -->
+    <script src="js/GUI/GuiTools.js"></script>
+    <script src="js/GUI/LoadingScreen.js"></script>
+
+    <script>
+      const typeView = 'Planar';
+      // const typeView = 'Globe';
+
+      // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
+      var viewerDiv = document.getElementById('viewerDiv');
+      let view;
+
+      if (typeView === 'Globe') {
+        const coord = new itowns.Coordinates('EPSG:4326', 2.351323, 48.856712); // Paris
+        // const coord = new itowns.Coordinates("EPSG:4326", 60.599525, 56.834341); // Yekaterinburg
+        const placement = {
+          coord,
+          range: 950000,
+        };
+        view = new itowns.GlobeView(viewerDiv, placement);
+      } else if (typeView === 'Planar') {
+        // Define geographic extent: CRS, min/max X, min/max Y
+        var extent = new itowns.Extent(
+            'EPSG:3857',
+            -20037508.342789244, 20037508.342789244,
+            -20037508.342789255, 20037508.342789244);
+
+        // Instanciate PlanarView
+        view = new itowns.PlanarView(viewerDiv, extent, {
+            maxSubdivisionLevel: 20,
+            controls: {
+                // We do not want the user to zoom out too much
+                maxAltitude: 40000000,
+                // We want to keep the rotation disabled, to only have a view from the top
+                enableRotation: false,
+                // Don't zoom too much on smart zoom
+                smartTravelHeightMax: 100000,
+            },
+        });
+      }
+ 
+      const debugMenu = new GuiTools("menuDiv", view);
+      setupLoadingScreen(viewerDiv, view);
+
+      const source = new itowns.VectorTilesSource({
+        style: "mapbox://styles/mapbox/streets-v8",
+        accessToken:
+          "pk.eyJ1IjoiZnRvcm9tYW5vZmYiLCJhIjoiY2xrc2Zpa2o3MDQxNTNxcG5sczJyaTlncyJ9.5KFKdMLIiy-b_fAjSVhjCQ",
+      });
+
+      const layer = new itowns.ColorLayer("vector-map", {
+        source,
+        noTextureParentOutsideLimit: true,
+        addLabelLayer: true,
+      });
+
+      view.addLayer(layer).then(() => {
+        debugMenu.addLayerGUI.bind(debugMenu);
+        itowns.ColorLayersOrdering.moveLayerToIndex(view, "vector-map", 15);
+      });
+
+      debug.createTileDebugUI(debugMenu.gui, view);
+    </script>
+  </body>
+</html>

--- a/src/Converter/Feature2Texture.js
+++ b/src/Converter/Feature2Texture.js
@@ -70,6 +70,9 @@ function drawFeature(ctx, feature, extent, invCtxScale) {
     for (const geometry of feature.geometries) {
         if (Extent.intersectsExtent(geometry.extent, extent)) {
             context.setGeometry(geometry);
+            if (style.zoom.min > style.context.zoom || style.zoom.max <= style.context.zoom) {
+                return;
+            }
 
             if (
                 feature.type === FEATURE_TYPES.POINT && style.point

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -941,17 +941,16 @@ class Style {
      * @param {Boolean} canBeFilled - true if feature.type == FEATURE_TYPES.POLYGON.
      */
     applyToCanvasPolygon(txtrCtx, polygon, invCtxScale, canBeFilled) {
-        const context = this.context;
         // draw line or edge of polygon
         if (this.stroke) {
             // TO DO add possibility of using a pattern (https://github.com/iTowns/itowns/issues/2210)
-            this._applyStrokeToPolygon(txtrCtx, invCtxScale, polygon, context);
+            this._applyStrokeToPolygon(txtrCtx, invCtxScale, polygon);
         }
 
         // fill inside of polygon
-        if (canBeFilled && this.fill) {
+        if (canBeFilled && (this.fill.pattern || this.fill.color)) {
             // canBeFilled can be move to StyleContext in the later PR
-            this._applyFillToPolygon(txtrCtx, invCtxScale, polygon, context);
+            this._applyFillToPolygon(txtrCtx, invCtxScale, polygon);
         }
     }
 

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -162,7 +162,7 @@ function defineStyleProperty(style, category, parameter, userValue, defaultValue
                 const dataValue = style.context.featureStyle?.[category]?.[parameter];
                 if (dataValue != undefined) { return readExpression(dataValue, style.context); }
                 if (defaultValue instanceof Function) {
-                    return defaultValue(style.context.properties, style.context);
+                    return defaultValue(style.context.properties, style.context) ?? defaultValue;
                 }
                 return defaultValue;
             },
@@ -808,7 +808,8 @@ class Style {
                 style.stroke.color = color;
                 style.stroke.opacity = opacity;
                 style.stroke.width = 1.0;
-                style.stroke.dasharray = [];
+            } else {
+                style.stroke.width  = 0.0;
             }
         } else if (layer.type === 'line') {
             const prepare = readVectorProperty(layer.paint['line-color'], { type: 'color' });
@@ -942,7 +943,7 @@ class Style {
      */
     applyToCanvasPolygon(txtrCtx, polygon, invCtxScale, canBeFilled) {
         // draw line or edge of polygon
-        if (this.stroke) {
+        if (this.stroke.width > 0) {
             // TO DO add possibility of using a pattern (https://github.com/iTowns/itowns/issues/2210)
             this._applyStrokeToPolygon(txtrCtx, invCtxScale, polygon);
         }
@@ -958,11 +959,11 @@ class Style {
         if (txtrCtx.strokeStyle !== this.stroke.color) {
             txtrCtx.strokeStyle = this.stroke.color;
         }
-        const width = (this.stroke.width || 2.0) * invCtxScale;
+        const width = this.stroke.width * invCtxScale;
         if (txtrCtx.lineWidth !== width) {
             txtrCtx.lineWidth = width;
         }
-        const alpha = this.stroke.opacity == undefined ? 1.0 : this.stroke.opacity;
+        const alpha = this.stroke.opacity;
         if (alpha !== txtrCtx.globalAlpha && typeof alpha == 'number') {
             txtrCtx.globalAlpha = alpha;
         }

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -905,13 +905,13 @@ class Style {
                         }
                     }
                     style.icon.source = sprites.source;
-                    style.icon.size = readVectorProperty(layer.layout['icon-size']) || 1;
+                    style.icon.size = readVectorProperty(layer.layout['icon-size']) ?? 1;
                     const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['icon-color'], { type: 'color' }));
                     // https://docs.mapbox.com/style-spec/reference/layers/#paint-symbol-icon-color
                     if (iconImg.sdf) {
                         style.icon.color = color;
                     }
-                    style.icon.opacity = readVectorProperty(layer.paint['icon-opacity']) || (opacity !== undefined && opacity);
+                    style.icon.opacity = readVectorProperty(layer.paint['icon-opacity']) ?? (opacity !== undefined && opacity);
                 } catch (err) {
                     err.message = `VTlayer '${layer.id}': argument sprites must not be null when using layer.layout['icon-image']`;
                     throw err;

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -302,14 +302,11 @@ function _addIcon(icon, domElement, opt) {
 }
 
 /**
- * An object that can contain any properties (order, zoom, fill, stroke, point,
+ * An object that can contain any properties (zoom, fill, stroke, point,
  * text or/and icon) and sub properties of a Style.<br/>
  * Used for the instanciation of a {@link Style}.
  *
  * @typedef {Object} StyleOptions
- *
- * @property {Number} [order] - Order of the features that will be associated to
- * the style. It can helps sorting and prioritizing features if needed.
  *
  * @property {Object} [zoom] - Level on which to display the feature
  * @property {Number} [zoom.max] - max level
@@ -468,8 +465,6 @@ function _addIcon(icon, domElement, opt) {
  * The first parameter of functions used to set `Style` properties is always an object containing
  * the properties of the features displayed with the current `Style` instance.
  *
- * @property {Number} order - Order of the features that will be associated to
- * the style. It can helps sorting and prioritizing features if needed.
  * @property {Object} fill - Polygons and fillings style.
  * @property {String|Function|THREE.Color} fill.color - Defines the main color of the filling. Can be
  * any [valid color
@@ -619,14 +614,12 @@ function _addIcon(icon, domElement, opt) {
 class Style {
     /**
      * @param {StyleOptions} [params={}] An object that contain any properties
-     * (order, zoom, fill, stroke, point, text or/and icon)
+     * (zoom, fill, stroke, point, text or/and icon)
      * and sub properties of a Style ({@link StyleOptions}).
      */
     constructor(params = {}) {
         this.isStyle = true;
         this.context = new StyleContext();
-
-        this.order = params.order || 0;
 
         params.zoom = params.zoom || {};
         params.fill = params.fill || {};
@@ -767,12 +760,11 @@ class Style {
      * set Style from vector tile layer properties.
      * @param {Object} layer vector tile layer.
      * @param {Object} sprites vector tile layer.
-     * @param {Number} [order=0]
      * @param {Boolean} [symbolToCircle=false]
      *
      * @returns {StyleOptions} containing all properties for itowns.Style
      */
-    static setFromVectorTileLayer(layer, sprites, order = 0, symbolToCircle = false) {
+    static setFromVectorTileLayer(layer, sprites, symbolToCircle = false) {
         const style = {
             fill: {},
             stroke: {},
@@ -783,8 +775,6 @@ class Style {
 
         layer.layout = layer.layout || {};
         layer.paint = layer.paint || {};
-
-        style.order = order;
 
         if (layer.type === 'fill') {
             const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['fill-color'] || layer.paint['fill-pattern'], { type: 'color' }));
@@ -847,7 +837,7 @@ class Style {
 
             // content
             style.text.field = readVectorProperty(layer.layout['text-field']);
-            style.text.wrap = readVectorProperty(layer.layout['text-max-width']);
+            style.text.wrap = readVectorProperty(layer.layout['text-max-width']);// Units ems
             style.text.spacing = readVectorProperty(layer.layout['text-letter-spacing']);
             style.text.transform = readVectorProperty(layer.layout['text-transform']);
             style.text.justify = readVectorProperty(layer.layout['text-justify']);

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -825,6 +825,8 @@ class Style {
             style.point.opacity = opacity;
             style.point.radius = readVectorProperty(layer.paint['circle-radius']);
         } else if (layer.type === 'symbol') {
+            // if symbol we shouldn't draw stroke but defaut value is 1.
+            style.stroke.width = 0.0;
             // overlapping order
             style.text.zOrder = readVectorProperty(layer.layout['symbol-z-order']);
             if (style.text.zOrder == 'auto') {

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -871,7 +871,6 @@ class Style {
                                 if (stop[1].includes('{')) {
                                     cropValues = function _(p) {
                                         const id = stop[1].replace(/\{(.+?)\}/g, (a, b) => (p[b] || '')).trim();
-                                        cropValues = sprites[id];
                                         return sprites[id];
                                     };
                                 }
@@ -884,7 +883,6 @@ class Style {
                         if (iconImg[0].includes('{')) {
                             style.icon.cropValues = function _(p) {
                                 const id = iconImg.replace(/\{(.+?)\}/g, (a, b) => (p[b] || '')).trim();
-                                style.icon.cropValues = sprites[id];
                                 return sprites[id];
                             };
                         }

--- a/src/Core/Style.js
+++ b/src/Core/Style.js
@@ -917,7 +917,10 @@ class Style {
                     style.icon.source = sprites.source;
                     style.icon.size = readVectorProperty(layer.layout['icon-size']) || 1;
                     const { color, opacity } = rgba2rgb(readVectorProperty(layer.paint['icon-color'], { type: 'color' }));
-                    style.icon.color = color;
+                    // https://docs.mapbox.com/style-spec/reference/layers/#paint-symbol-icon-color
+                    if (iconImg.sdf) {
+                        style.icon.color = color;
+                    }
                     style.icon.opacity = readVectorProperty(layer.paint['icon-opacity']) || (opacity !== undefined && opacity);
                 } catch (err) {
                     err.message = `VTlayer '${layer.id}': argument sprites must not be null when using layer.layout['icon-image']`;

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -304,6 +304,7 @@ class LabelLayer extends GeometryLayer {
                     const label = new Label(content, coord.clone(), this.style);
 
                     label.layerId = this.id;
+                    label.order = f.order;
                     label.padding = this.margin || label.padding;
 
                     labels.push(label);

--- a/src/Layer/LabelLayer.js
+++ b/src/Layer/LabelLayer.js
@@ -294,6 +294,10 @@ class LabelLayer extends GeometryLayer {
                     }
                 }
 
+                if (this.style.zoom.min > this.style.context.zoom || this.style.zoom.max <= this.style.context.zoom) {
+                    return;
+                }
+
                 const label = new Label(content, coord.clone(), this.style);
 
                 label.layerId = this.id;

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -152,8 +152,19 @@ function readPBF(file, options) {
             const layers = options.in.layers[vtLayerName]
                 .filter(l => l.filterExpression.filter({ zoom: z }, vtFeature));
 
-            let feature;
+            for (const layer of layers) {
+                const feature = collection.requestFeatureById(layer.id, vtFeature.type - 1);
+                feature.id = layer.id;
+                feature.order = layer.order;
+                feature.style = options.in.styles[feature.id];
+                vtFeatureToFeatureGeometry(vtFeature, feature);
+            }
 
+
+            /*
+            // This optimization is not fully working and need to be reassessed
+            // (see https://github.com/iTowns/itowns/pull/2469/files#r1861802136)
+            let feature;
             for (const layer of layers) {
                 if (!feature) {
                     feature = collection.requestFeatureById(layer.id, vtFeature.type - 1);
@@ -168,6 +179,7 @@ function readPBF(file, options) {
                     feature.style = options.in.styles[feature.id];
                 }
             }
+            */
         }
     });
 

--- a/src/Parser/VectorTileParser.js
+++ b/src/Parser/VectorTileParser.js
@@ -148,8 +148,10 @@ function readPBF(file, options) {
         for (let i = vectorTileLayer.length - 1; i >= 0; i--) {
             const vtFeature = vectorTileLayer.feature(i);
             vtFeature.tileNumbers = { x, y: options.extent.row, z };
+            // Find layers where this vtFeature is used
             const layers = options.in.layers[vtLayerName]
-                .filter(l => l.filterExpression.filter({ zoom: z }, vtFeature) && z >= l.zoom.min && z < l.zoom.max);
+                .filter(l => l.filterExpression.filter({ zoom: z }, vtFeature));
+
             let feature;
 
             for (const layer of layers) {

--- a/src/Renderer/Label2DRenderer.js
+++ b/src/Renderer/Label2DRenderer.js
@@ -186,13 +186,15 @@ class Label2DRenderer {
         if (!frustum.containsPoint(worldPosition.applyMatrix4(camera.matrixWorldInverse)) ||
         // Check if globe horizon culls the label
         // Do some horizon culling (if possible) if the tiles level is small enough.
-            label.horizonCullingPoint && GlobeLayer.horizonCulling(label.horizonCullingPoint) ||
-        // Check if content isn't present in visible labels
-            this.grid.visible.some((l) => {
-                // TODO for icon without text filter by position
-                const textContent = label.content.textContent;
-                return textContent !== '' && l.content.textContent.toLowerCase() == textContent.toLowerCase();
-            })) {
+            label.horizonCullingPoint && GlobeLayer.horizonCulling(label.horizonCullingPoint)
+            // Why do we might need this part ?
+            // || // Check if content isn't present in visible labels
+            // this.grid.visible.some((l) => {
+            //     // TODO for icon without text filter by position
+            //     const textContent = label.content.textContent;
+            //     return textContent !== '' && l.content.textContent.toLowerCase() == textContent.toLowerCase();
+            // })
+        ) {
             label.visible = false;
         } else {
             // projecting world position label

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -140,7 +140,7 @@ class VectorTilesSource extends TMSSource {
                 });
                 return Promise.all(TMSUrlList);
             }
-            return (Promise.resolve([this.url]));
+            return (Promise.resolve([toTMSUrl(this.url)]));
         }).then((TMSUrlList) => {
             this.urls = Array.from(new Set(TMSUrlList));
         });

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -71,9 +71,10 @@ class VectorTilesSource extends TMSSource {
 
         this.accessToken = source.accessToken;
 
+        let styleUrl;
         if (source.style) {
             if (typeof source.style == 'string') {
-                const styleUrl = urlParser.normalizeStyleURL(source.style, this.accessToken);
+                styleUrl = urlParser.normalizeStyleURL(source.style, this.accessToken);
                 promise = Fetcher.json(styleUrl, this.networkOptions);
             } else {
                 promise = Promise.resolve(source.style);
@@ -84,8 +85,9 @@ class VectorTilesSource extends TMSSource {
 
         this.whenReady = promise.then((style) => {
             this.jsonStyle = style;
-            const baseurl = source.sprite || style.sprite;
+            let baseurl = source.sprite || style.sprite;
             if (baseurl) {
+                baseurl = new URL(baseurl, styleUrl).toString();
                 const spriteUrl = urlParser.normalizeSpriteURL(baseurl, '', '.json', this.accessToken);
                 return Fetcher.json(spriteUrl, this.networkOptions).then((sprites) => {
                     this.sprites = sprites;
@@ -123,9 +125,11 @@ class VectorTilesSource extends TMSSource {
             if (this.url == '.') {
                 const TMSUrlList = Object.values(style.sources).map((sourceVT) => {
                     if (sourceVT.url) {
+                        sourceVT.url = new URL(sourceVT.url, styleUrl).toString();
                         const urlSource = urlParser.normalizeSourceURL(sourceVT.url, this.accessToken);
                         return Fetcher.json(urlSource, this.networkOptions).then((tileJSON) => {
                             if (tileJSON.tiles[0]) {
+                                tileJSON.tiles[0] = decodeURIComponent(new URL(tileJSON.tiles[0], urlSource).toString());
                                 return toTMSUrl(tileJSON.tiles[0]);
                             }
                         });

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -117,7 +117,7 @@ class VectorTilesSource extends TMSSource {
                     if (layer['source-layer'] === undefined) {
                         getPropertiesFromRefLayer(mvtStyle.layers, layer);
                     }
-                    const style = Style.setFromVectorTileLayer(layer, this.sprites, order, this.symbolToCircle);
+                    const style = Style.setFromVectorTileLayer(layer, this.sprites, this.symbolToCircle);
                     this.styles[layer.id] = style;
 
                     if (!this.layers[layer['source-layer']]) {

--- a/src/Source/VectorTilesSource.js
+++ b/src/Source/VectorTilesSource.js
@@ -127,10 +127,6 @@ class VectorTilesSource extends TMSSource {
                         id: layer.id,
                         order,
                         filterExpression: featureFilter(layer.filter),
-                        zoom: {
-                            min: layer.minzoom || 0,
-                            max: layer.maxzoom || 24,
-                        },
                     });
                 }
             });

--- a/test/data/vectortiles/style.json
+++ b/test/data/vectortiles/style.json
@@ -19,7 +19,8 @@
             "maxzoom": 13,
             "paint": {
                 "fill-color": "rgb(255, 0, 0)"
-            }
+            },
+            "source-layer": "source_layer"
         }
     ]
 }

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -67,15 +67,17 @@ describe('Vector tiles', function () {
         }).catch(done);
     });
 
-    it('returns nothing', (done) => {
+    it('returns an empty collection', (done) => {
         parse(null).then((collection) => {
-            assert.equal(collection, undefined);
+            assert.ok(collection.isFeatureCollection);
+            assert.equal(collection.features.length, 0);
             done();
         }).catch(done);
     });
 
     it('filters all features out', (done) => {
         parse(multipolygon, {}).then((collection) => {
+            assert.ok(collection.isFeatureCollection);
             assert.equal(collection.features.length, 0);
             done();
         }).catch(done);

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -13,7 +13,7 @@ import sprite from '../data/vectortiles/sprite.json';
 import mapboxStyle from '../data/mapboxMulti.json';
 
 const resources = {
-    'test/data/vectortiles/style.json': style,
+    'https://test/data/vectortiles/style.json': style,
     'https://test/tilejson.json': tilejson,
     'https://test/sprite.json': sprite,
     'https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7.json': mapboxStyle,
@@ -187,7 +187,7 @@ describe('VectorTilesSource', function () {
 
     it('loads the style from a file', function _it(done) {
         const source = new VectorTilesSource({
-            style: 'test/data/vectortiles/style.json',
+            style: 'https://test/data/vectortiles/style.json',
         });
         source.whenReady
             .then(() => {

--- a/test/unit/vectortiles.js
+++ b/test/unit/vectortiles.js
@@ -176,6 +176,7 @@ describe('VectorTilesSource', function () {
                     paint: {
                         'fill-color': 'rgb(255, 0, 0)',
                     },
+                    'source-layer': 'source_layer',
                 }],
             },
         });
@@ -201,6 +202,40 @@ describe('VectorTilesSource', function () {
             }).catch(done);
     });
 
+    it('loads the style from a file with ref layer', function _it(done) {
+        const source = new VectorTilesSource({
+            url: 'fakeurl',
+            style: {
+                sources: { tilejson: {} },
+                layers: [
+                    {
+                        id: 'land',
+                        type: 'fill',
+                        paint: {
+                            'fill-color': 'rgb(255, 0, 0)',
+                        },
+                        'source-layer': 'source_layer',
+                    },
+                    {
+                        id: 'land-secondary',
+                        paint: {
+                            'fill-color': 'rgb(0, 255, 0)',
+                        },
+                        ref: 'land',
+                    },
+                ],
+            },
+        });
+        source.whenReady.then(() => {
+            assert.ok(source.styles.land);
+            assert.equal(source.styles.land.fill.color, 'rgb(255,0,0)');
+            assert.ok(source.styles['land-secondary']);
+            assert.equal(source.styles['land-secondary'].fill.color, 'rgb(0,255,0)');
+            done();
+        })
+            .catch(done);
+    });
+
     it('sets the correct Style#zoom.min', (done) => {
         const source = new VectorTilesSource({
             url: 'fakeurl',
@@ -213,6 +248,7 @@ describe('VectorTilesSource', function () {
                     paint: {
                         'fill-color': 'rgb(255, 0, 0)',
                     },
+                    'source-layer': 'source_layer',
                 }, {
                     // minzoom is 5 (specified)
                     id: 'second',
@@ -221,6 +257,7 @@ describe('VectorTilesSource', function () {
                         'fill-color': 'rgb(255, 0, 0)',
                     },
                     minzoom: 5,
+                    'source-layer': 'source_layer',
                 }, {
                     // minzoom is 4 (first stop)
                     // If a style have `stops` expression, should it be used to determine the min zoom?
@@ -230,6 +267,7 @@ describe('VectorTilesSource', function () {
                         'fill-color': 'rgb(255, 0, 0)',
                         'fill-opacity': { stops: [[4, 1], [7, 0.5]] },
                     },
+                    'source-layer': 'source_layer',
                 }, {
                     // minzoom is 1 (first stop and no specified minzoom)
                     id: 'fourth',
@@ -238,6 +276,7 @@ describe('VectorTilesSource', function () {
                         'fill-color': 'rgb(255, 0, 0)',
                         'fill-opacity': { stops: [[1, 1], [7, 0.5]] },
                     },
+                    'source-layer': 'source_layer',
                 }, {
                     // minzoom is 4 (first stop is higher than specified)
                     id: 'fifth',
@@ -247,6 +286,7 @@ describe('VectorTilesSource', function () {
                         'fill-opacity': { stops: [[4, 1], [7, 0.5]] },
                     },
                     minzoom: 3,
+                    'source-layer': 'source_layer',
                 }],
             },
         });


### PR DESCRIPTION
Using the mapbox style file "mapbox://styles/mapbox/streets-v8" on mapLib and on itowns, I noticed the result as not at all comparable.
![image](https://github.com/user-attachments/assets/b4131f87-5634-4c5f-b7e8-6068a86c04f7)
![image](https://github.com/user-attachments/assets/d30b4487-8e41-4556-be55-9fe68048a548)

Thus I looked layers by layers to understand what were we doing wrong in itowns and tried to correct a maximum of bugs. The example using the mapbox stream has been added. (examples/vector_tile_2d_mapbox.html)


What this PR does:
- new feature:
   - support relative urls in style file (ArcGIS style file)
   - add a warn properties in source to add warnings and send them only ones 
- itowns bug fix:
   - Mapbox stream
      - enter url in {z}/{y}/{x} instead of ${z}/${y}/${x}
      - wrong selection of metadata when "{id}" in sprite
      - gestion of MVT layer using the 'ref' properties
      - gestion of line and polygon Label (simplified -> we use the first point of the geometry and sending a warning)
      - good gestion of the layer.order properties
   - Style
      - take into account the zoom in style when displaying layer
      - no display of polygon when fill.color is undefined
      - no display of line when stroke.width is 0
      - no recoloring of icon when icon.color is white (to avoid a lightning of the icon)
      - allow multiple label with same text (for contour lines)
      - no display of icon if size is 0
   
