### PR TITLE
fix(fetcher): improve image loading error log

### DIFF
--- a/src/Provider/Fetcher.js
+++ b/src/Provider/Fetcher.js
@@ -104,7 +104,11 @@ export default {
             rej = reject;
         });
 
-        textureLoader.load(url, res, () => {}, rej);
+        textureLoader.load(url, res, () => {}, (event) => {
+            const error = new Error(`Failed to load texture from URL: \`${url}\``);
+            error.originalEvent = event;
+            rej(error);
+        });
         return promise;
     },
 


### PR DESCRIPTION
Small modification to improve image texture fetching error. 

Before:

![image](https://github.com/user-attachments/assets/f2d4cede-097a-4918-afaa-2857e5a9a6a0)

After:

![image](https://github.com/user-attachments/assets/0f0909e6-8412-456a-9fac-0e74dbdfbacb)
