### PR TITLE
feat: add `enableMeshoptDecoder` function for GLTFs

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -54,10 +54,11 @@
                     "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
                 }
             }
-		</script>
+        </script>
 
         <script type="module">
             import { AmbientLight } from 'three';
+            import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
             import {
                 zoomToLayer,
                 fillHTMLWithPickingInfo,
@@ -95,9 +96,11 @@
 
             // Enable various compression support for 3D Tiles tileset:
             // - `KHR_draco_mesh_compression` mesh compression extension
-            // - `KHR_texture_basisu` texture compresion extension
+            // - `KHR_texture_basisu` texture compression extension
+            // - `EXT_meshopt_compression` data compression extension
             itowns.enableDracoLoader('./libs/draco/');
             itowns.enableKtx2Loader('./lib/basis/', view.renderer);
+            itowns.enableMeshoptDecoder(MeshoptDecoder);
 
             // Add ambient light to globally illuminates all objects
             const light = new AmbientLight(0x404040, 40);

--- a/src/Layer/OGC3DTilesLayer.js
+++ b/src/Layer/OGC3DTilesLayer.js
@@ -122,6 +122,27 @@ export function enableKtx2Loader(path, renderer) {
     itownsGLTFLoader.setKTX2Loader(ktx2Loader);
 }
 
+/**
+ * Enable loading 3D Tiles and GLTF with
+ * [meshopt](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md) compression extension.
+ *
+ * @param {MeshOptDecoder.constructor} MeshOptDecoder - The Meshopt decoder
+ * module.
+ *
+ * @example
+ * import * as itowns from 'itowns';
+ * import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+ *
+ * // Enable support of EXT_meshopt_compression
+ * itowns.enableMeshoptDecoder(MeshoptDecoder);
+ */
+export function enableMeshoptDecoder(MeshOptDecoder) {
+    if (!MeshOptDecoder) {
+        throw new Error('MeshOptDecoder module is mandatory');
+    }
+    itownsGLTFLoader.setMeshoptDecoder(MeshOptDecoder);
+}
+
 class OGC3DTilesLayer extends GeometryLayer {
     /**
      * Layer for [3D Tiles](https://www.ogc.org/standard/3dtiles/) datasets.

--- a/src/Main.js
+++ b/src/Main.js
@@ -54,7 +54,13 @@ export { default as PointCloudLayer } from 'Layer/PointCloudLayer';
 export { default as PotreeLayer } from 'Layer/PotreeLayer';
 export { default as Potree2Layer } from 'Layer/Potree2Layer';
 export { default as C3DTilesLayer, C3DTILES_LAYER_EVENTS } from 'Layer/C3DTilesLayer';
-export { default as OGC3DTilesLayer, OGC3DTILES_LAYER_EVENTS, enableDracoLoader, enableKtx2Loader } from 'Layer/OGC3DTilesLayer';
+export {
+    default as OGC3DTilesLayer,
+    OGC3DTILES_LAYER_EVENTS,
+    enableDracoLoader,
+    enableKtx2Loader,
+    enableMeshoptDecoder,
+} from 'Layer/OGC3DTilesLayer';
 export { default as TiledGeometryLayer } from 'Layer/TiledGeometryLayer';
 export { default as OrientedImageLayer } from 'Layer/OrientedImageLayer';
 export { STRATEGY_MIN_NETWORK_TRAFFIC, STRATEGY_GROUP, STRATEGY_PROGRESSIVE, STRATEGY_DICHOTOMY } from 'Layer/LayerUpdateStrategy';


### PR DESCRIPTION
## Description

This PR adds a function to enable decoding meshopt-compressed GLTF files, similar to the ones for draco and KTX2.
This was tested from [this sample dataset](https://data.3dgi.xyz/3dtiles-test-data/download/3D-basisvoorziening-2021-30dz1_01.zip) produced by [3DGI/tyler](https://github.com/3DGI/tyler) from a CityJSON dataset.