### PR TITLE
fix(tests): re set --no-sandbox

### DIFF
--- a/test/hooks_functional.js
+++ b/test/hooks_functional.js
@@ -218,7 +218,7 @@ export const mochaHooks = {
         // for more information on developing with the SUID sandbox.
         // If you want to live dangerously and need an immediate workaround, you can try
         // using --no-sandbox.
-        const args = [];
+        const args = ['--no-sandbox'];
 
         if (process.env.HTTPS_PROXY) {
             args.push(`--proxy-server=${process.env.HTTPS_PROXY}`);


### PR DESCRIPTION
On the date of the 01/15/2025 the functionnal tests are never lasting:

Error: Failed to launch the browser process!
[2007:2007:0115/150816.726224:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.

Warning that was already found in the hooks_functional.js file.

I put it back and the CI seems to work fine once again.