### PR TITLE
fix(RasterTile): partial loading for raster tiles

### DIFF
--- a/packages/Main/src/Provider/DataSourceProvider.js
+++ b/packages/Main/src/Provider/DataSourceProvider.js
@@ -3,7 +3,23 @@ export default {
         const layer = command.layer;
         const src = command.extentsSource;
         const dst = command.extentsDestination || src;
+        const promises = src.map((from, i) => (layer.getData(from, dst[i])));
 
-        return Promise.all(src.map((from, i) => (layer.getData(from, dst[i]))));
+        // partialLoading sets the return promise as fulfilled if at least one sub-promise is fulfilled
+        // It waits until all promises are resolved
+        if (command.partialLoading) {
+            return Promise.allSettled(promises)
+                .then((results) => {
+                    const anyFulfilledPromise = results.find(promise => promise.status === 'fulfilled');
+                    if (!anyFulfilledPromise) {
+                        // All promises failed -> reject
+                        return Promise.reject(new Error('Failed to load any data'));
+                    }
+                    return results.map(prom => (prom.value ? prom.value : null));
+                });
+        }
+
+        // Without partialLoading, the return promise is rejected as soon as any sub-promise is rejected
+        return Promise.all(promises);
     },
 };

--- a/packages/Main/src/Renderer/RasterTile.js
+++ b/packages/Main/src/Renderer/RasterTile.js
@@ -120,7 +120,7 @@ class RasterTile extends THREE.EventDispatcher {
         this.level = EMPTY_TEXTURE_ZOOM;
     }
 
-    disposeAtIndexes(indexes = null) {
+    disposeAtIndexes(indexes) {
         for (const index of indexes) {
             const texture = this.textures[index];
             if (texture && texture.isTexture) {
@@ -263,7 +263,7 @@ export class RasterElevationTile extends RasterTile {
         const parentDataElevation = parentTexture && parentTexture.image && parentTexture.image.data;
         const dataElevation = texture.image && texture.image.data;
 
-        if (parentDataElevation && dataElevation && !checkNodeElevationTextureValidity(dataElevation, nodatavalue)) {
+        if (dataElevation && !checkNodeElevationTextureValidity(dataElevation, nodatavalue)) {
             insertSignificantValuesFromParent(dataElevation, parentDataElevation && dataParent(texture, parentTexture, parentDataElevation, pitch), nodatavalue);
         }
     }

--- a/packages/Main/src/Renderer/RasterTile.js
+++ b/packages/Main/src/Renderer/RasterTile.js
@@ -61,12 +61,13 @@ class RasterTile extends THREE.EventDispatcher {
     initFromParent(parent, extents) {
         if (parent && parent.level > this.level) {
             let index = 0;
-            for (const c of extents) {
-                for (const texture of parent.textures) {
-                    if (c.isInside(texture.extent)) {
-                        this.setTexture(index++, texture, c.offsetToParent(texture.extent));
-                        break;
-                    }
+            const sortedParentTextures = this.sortBestParentTextures(parent.textures);
+            for (const childExtent of extents) {
+                const matchingParentTexture = sortedParentTextures
+                    .find(parentTexture => parentTexture && childExtent.isInside(parentTexture.extent));
+                if (matchingParentTexture) {
+                    this.setTexture(index++, matchingParentTexture,
+                        childExtent.offsetToParent(matchingParentTexture.extent));
                 }
             }
 
@@ -78,6 +79,32 @@ class RasterTile extends THREE.EventDispatcher {
         }
     }
 
+    sortBestParentTextures(textures) {
+        const sortByValidity = (a, b) => {
+            if (a.isTexture === b.isTexture) {
+                return 0;
+            } else {
+                return a.isTexture ? -1 : 1;
+            }
+        };
+        const sortByZoom = (a, b) => b.extent.zoom - a.extent.zoom;
+
+        return textures.toSorted((a, b) => sortByValidity(a, b) || sortByZoom(a, b));
+    }
+
+    disposeRedrawnTextures(newTextures) {
+        const validTextureIndexes = newTextures
+            .map((texture, index) => (this.shouldWriteTextureAtIndex(index, texture) ? index : -1))
+            .filter(index => index !== -1);
+
+        if (validTextureIndexes.length === newTextures.length) {
+            // Dispose the whole tile when all textures are overwritten
+            this.dispose(false);
+        } else {
+            this.disposeAtIndexes(validTextureIndexes);
+        }
+    }
+
     dispose(removeEvent = true) {
         if (removeEvent) {
             this.layer.removeEventListener('visible-property-changed', this._handlerCBEvent);
@@ -86,29 +113,42 @@ class RasterTile extends THREE.EventDispatcher {
             this._listeners = {};
         }
         // TODO: WARNING  verify if textures to dispose aren't attached with ancestor
-        for (const texture of this.textures) {
-            if (texture.isTexture) {
+        // Dispose all textures
+        this.disposeAtIndexes(this.textures.keys());
+        this.textures = [];
+        this.offsetScales = [];
+        this.level = EMPTY_TEXTURE_ZOOM;
+    }
+
+    disposeAtIndexes(indexes = null) {
+        for (const index of indexes) {
+            const texture = this.textures[index];
+            if (texture && texture.isTexture) {
                 texture.dispose();
             }
         }
-        this.level = EMPTY_TEXTURE_ZOOM;
-        this.textures = [];
-        this.offsetScales = [];
         this.material.layersNeedUpdate = true;
     }
 
     setTexture(index, texture, offsetScale) {
-        this.level = (texture && texture.extent && (index == 0)) ? texture.extent.zoom : this.level;
-        this.textures[index] = texture || null;
-        this.offsetScales[index] = offsetScale;
-        this.material.layersNeedUpdate = true;
+        if (this.shouldWriteTextureAtIndex(index, texture)) {
+            this.level = (texture && texture.extent) ? texture.extent.zoom : this.level;
+            this.textures[index] = texture || null;
+            this.offsetScales[index] = offsetScale;
+            this.material.layersNeedUpdate = true;
+        }
     }
 
     setTextures(textures, pitchs) {
-        this.dispose(false);
+        this.disposeRedrawnTextures(textures);
         for (let i = 0, il = textures.length; i < il; ++i) {
             this.setTexture(i, textures[i], pitchs[i]);
         }
+    }
+
+    shouldWriteTextureAtIndex(index, texture) {
+        // Do not apply noData texture if current texture is valid
+        return !this.textures[index] || texture && texture.isTexture;
     }
 }
 
@@ -182,8 +222,12 @@ export class RasterElevationTile extends RasterTile {
     }
 
     setTextures(textures, offsetScales) {
+        const anyValidTexture = textures.find(texture => texture != null);
+        if (!anyValidTexture) {
+            return;
+        }
         const currentLevel = this.level;
-        this.replaceNoDataValueFromTexture(textures[0]);
+        this.replaceNoDataValueFromTexture(anyValidTexture);
         super.setTextures(textures, offsetScales);
         this.updateMinMaxElevation();
         if (currentLevel !== this.level) {
@@ -192,10 +236,11 @@ export class RasterElevationTile extends RasterTile {
     }
 
     updateMinMaxElevation() {
-        if (this.textures[0] && !this.layer.useColorTextureElevation) {
+        const firstValidIndex = this.textures.findIndex(texture => texture.isTexture);
+        if (firstValidIndex !== -1 && !this.layer.useColorTextureElevation) {
             const { min, max } = computeMinMaxElevation(
-                this.textures[0],
-                this.offsetScales[0],
+                this.textures[firstValidIndex],
+                this.offsetScales[firstValidIndex],
                 {
                     noDataValue: this.layer.noDataValue,
                     zmin: this.layer.zmin,
@@ -214,11 +259,11 @@ export class RasterElevationTile extends RasterTile {
             return;
         }
         // replace no data value with parent texture value or 0 (if no significant value found).
-        const parentTexture = this.textures[0];
+        const parentTexture = this.textures.find(texture => texture != null);
         const parentDataElevation = parentTexture && parentTexture.image && parentTexture.image.data;
         const dataElevation = texture.image && texture.image.data;
 
-        if (dataElevation && !checkNodeElevationTextureValidity(dataElevation, nodatavalue)) {
+        if (parentDataElevation && dataElevation && !checkNodeElevationTextureValidity(dataElevation, nodatavalue)) {
             insertSignificantValuesFromParent(dataElevation, parentDataElevation && dataParent(texture, parentTexture, parentDataElevation, pitch), nodatavalue);
         }
     }


### PR DESCRIPTION
## Description
Sets a new way to request data from DataSource provider : partial loading. If it is enabled, the command execution is considered successful as soon as one of the data loading promise is successful. It returns the same results array than before but includes null for failed requests. The caller takes responsibility for handling those null values.

## Motivation and Context
See issue [2311](https://github.com/iTowns/itowns/issues/2311). It more broadly fixes glitches whitnessed when rendering reprojected raster (or ratserized) data sources . It especially occurres from far away or on data source boundaries, when projecting (epsg:3857) data on the globe (epsg:4326). This seems to correspond to issue [2395](https://github.com/iTowns/itowns/issues/2395)

## Screenshots
See before / after comparison for this layer : 
```
            var wmtsSource = new itowns.WMTSSource({
                url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities',
                crs: 'EPSG:3857',
                name: 'GEOGRAPHICALGRIDSYSTEMS.EDUGEO.LYON1947',
                tileMatrixSet: 'PM_6_16',
                version: '1.0.0',
                style: 'normal',
                format: 'image/png',
            });
```
### Before fix

https://github.com/user-attachments/assets/fb7303e5-c6a5-4033-8467-2be2ccc505e2

### After fix

https://github.com/user-attachments/assets/a2bb023d-f4e7-456f-9a7c-2147fed8a68d



