### PR TITLE
feat(3d-tiles): support picking of metadata

### DIFF
--- a/examples/jsm/OGC3DTilesHelper.js
+++ b/examples/jsm/OGC3DTilesHelper.js
@@ -33,6 +33,11 @@ export function fillHTMLWithPickingInfo(event, pickingArg) {
         // eslint-disable-next-line
         htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature));
     }
+
+    layer.getMetadataFromIntersections(intersects).then((metadata) => {
+        // eslint-disable-next-line
+        metadata?.forEach(m => htmlDiv.appendChild(createHTMLListFromObject(m)));
+    });
 }
 
 function zoomToSphere(view, tile, sphere) {


### PR DESCRIPTION
## Description
This PR add support for picking metadata from the `EXT_mesh_structural_metadata` GLTF extension (optionally using the `EXT_mesh_features` for getting the feature).

## Motivation and Context
We are testing the production of complex 3D buildings datasets at IGN from [BD Topo/Uni](https://espacecollaboratif.ign.fr/data/about). The pipeline is currently BD Topo -> CityJSON -> 3D Tiles. We are using [tyler](https://github.com/3DGI/tyler) to output 3D Tiles from CityJSON which uses both extensions to store feature data.

When the pipeline will be completed , I will publish some datasets in our test base (in another PR).
