### PR TITLE
fix(examples): add envmap for PBR materials in 3d tiles loader example

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -57,8 +57,12 @@
         </script>
 
         <script type="module">
-            import { AmbientLight } from 'three';
+            import {
+                AmbientLight,
+                PMREMGenerator,
+            } from 'three';
             import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+            import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
             import {
                 zoomToLayer,
                 fillHTMLWithPickingInfo,
@@ -105,6 +109,13 @@
             // Add ambient light to globally illuminates all objects
             const light = new AmbientLight(0x404040, 40);
             view.scene.add(light);
+
+            // Set the environment map for all physical materials in the scene.
+            // Otherwise, mesh with only diffuse colors will appear black.
+            const environment = new RoomEnvironment();
+            const pmremGenerator = new PMREMGenerator(view.renderer);
+            view.scene.environment = pmremGenerator.fromScene(environment).texture;
+            pmremGenerator.dispose();
 
             // Setup loading screen
             setupLoadingScreen(viewerDiv, view);


### PR DESCRIPTION
## Description

This PR add a global environment map on the scene for all PBR materials in the `3d-tiles-loader` example. The absence of such map caused meshes with only diffuse colors to render totally black.
![before](https://github.com/user-attachments/assets/c50c2996-1c1b-4bff-83f6-93e9e5d01b98)

I decided to use the `RoomEnvironment` in conjonction with the `PMREMGenerator` to generate the env map. This is the technique used in a lot of three examples. The end-result:
![after](https://github.com/user-attachments/assets/26cfc489-10d7-4568-9678-0b1f257615bd)

I used the following datasets generated from `tyler` to test this change:

[3dtiles-terrain.zip](https://github.com/user-attachments/files/18707770/3dtiles-terrain.zip)
