### PR TITLE
PointCloudLayer: geographic reprojection for point clouds on load

### DIFF
--- a/examples/copc_3d_loader.html
+++ b/examples/copc_3d_loader.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Itowns - Entwine 3D loader</title>
+        <title>Itowns - COPC 3D loader</title>
 
         <script type="importmap">
         {
@@ -30,19 +30,23 @@
         </style>
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <!-- <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19"></script> -->
     </head>
     <body>
-        <div id="description">Specify the URL of a Entwine Point Tree to load:
+        <div id="description">Specify the URL of a COPC file to load:
             <input type="text" id="loadUrl" />
-            <button id='loadUrlBtn'>Load</button>
-            <button id="loadLyonBtn">Load "Grand Lyon" dataset</button>
+            <button id="loadUrlBtn">Load</button>
+            <button id='loadLidarHDBtn'>Load LiDAR HD dataset</button>
             <div id="share"></div>
         </div>
         <div id="viewerDiv"></div>
 
+        <!-- <script src="../dist/itowns.js"></script>
+        <script src="js/GUI/LoadingScreen.js"></script>
+        <script src="../dist/debug.js"></script> -->
+        <!-- <script type="text/javascript"> -->
         <script type="module">
 
-            // TODO rempa click
             import lil from 'lil';
             import GuiTools from 'GuiTools';
             import setupLoadingScreen from 'LoadingScreen';
@@ -64,7 +68,6 @@
                 var layer = new itowns.ColorLayer('Ortho', config);
                 view.addLayer(layer);
             });
-
             // Add two elevation layers.
             // These will deform iTowns globe geometry to represent terrain elevation.
             function addElevationLayerFromConfig(config) {
@@ -75,70 +78,82 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
 
+            var layer;
+
             // Check if an url had been given as an argument
             // and parse to get url and options.
-            const urlParams = new URL(location).searchParams;
-            let url = urlParams.get('ept');
-            urlParams.delete('ept');
+            const urlParams = new URL(location.href).searchParams
+            let url = urlParams.get('copc');
+            urlParams.delete('copc');
 
             const options = {};
             for (const [k, v] of urlParams) {
                 options[k] = isNaN(parseFloat(v, 10)) ? v : parseFloat(v, 10);
             }
 
-            loadEPT(url);
+            loadCopc(url, options);
 
-            var eptLayer;
             function onLayerReady() {
-                var lookAt = eptLayer.root.origin;
+                var lookAt = layer.root.clampOBB.position;
+                var coordLookAt = new itowns.Coordinates(view.referenceCrs).setFromVector3(lookAt);
 
                 var size = new THREE.Vector3();
-                eptLayer.root.voxelOBB.box3D.getSize(size);
+                layer.root.voxelOBB.box3D.getSize(size);
 
                 view.controls.lookAtCoordinate({
-                    coord: lookAt,
+                    coord: coordLookAt,
                     range: 2 * size.length(),
                 }, false);
             }
 
-            function loadEPT(url) {
+            function loadCopc(url, options) {
                 if(!url) return;
+
+                // Share the view
                 document.getElementById('share').innerHTML = '<a href="' +
-                    location.href.replace(location.search, '?ept=' + url) +
+                    location.href.replace(location.search, '?copc=' + url) +
                     '" target="_blank">Link to share this view</a>';
 
-                const eptSource = new itowns.EntwinePointTileSource({ url });
+                const source = new itowns.CopcSource({ url });
 
-                if (eptLayer) {
-                    eptLayer.debugUI.destroy();
-                    view.removeLayer('Entwine Point Tile');
+                if (layer) {
+                    layer.debugUI.destroy();
+                    view.removeLayer('COPC');
                     view.notifyChange();
-                    eptLayer.delete();
+                    layer.delete();
                 }
 
-                eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', {
-                    source: eptSource,
+                const config = {
+                    source,
                     crs: view.referenceCrs,
-                });
+                    sseThreshold: 2,
+                    pointBudget: 3000000,
+                    ...options,
+                }
 
-                itowns.View.prototype.addLayer.call(view, eptLayer).then(onLayerReady);
+                layer = new itowns.CopcLayer('COPC', config);
 
-                eptLayer.whenReady
-                    .then(() => debug.PointCloudDebug.initTools(view, eptLayer, debugGui));
+                itowns.View.prototype.addLayer.call(view, layer).then(onLayerReady);
+
+                layer.whenReady
+                    .then(() => debug.PointCloudDebug.initTools(view, layer, debugGui));
             }
 
             const loadUrlBtn = document.getElementById('loadUrlBtn');
             loadUrlBtn.addEventListener('click', () => {
-                url = document.getElementById('loadUrl').value;
-                loadEPT(url);
+                const url = document.getElementById('loadUrl').value;
+                if (url) { loadCopc(url); }
             });
 
-            const loadLyonBtn = document.getElementById('loadLyonBtn');
-            loadLyonBtn.addEventListener('click', () => {
-                url = 'https://download.data.grandlyon.com/files/grandlyon/imagerie/mnt2018/lidar/ept/';
-                loadEPT(url);
+            const loadLidarHDBtn = document.getElementById('loadLidarHDBtn');
+            loadLidarHDBtn.addEventListener('click', () => {
+                const url ="https://dl-lidar.ign.fr/ppk-lidar/ML/LHD_FXX_0746_6509_PTS_C_LAMB93_IGN69.copc.laz" // fixed with proxy
+                const options = {
+                    mode: 2,
+                    opacity: 0.5,
+                }
+                loadCopc(url, options);
             });
-
         </script>
     </body>
 </html>

--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="UTF-8">
 
-        <title>Itowns - COPC loader</title>
+        <title>Itowns - COPC simple loader</title>
 
         <script type="importmap">
         {
@@ -32,12 +32,12 @@
     </head>
     <body>
         <div id="description">Specify the URL of a COPC file to load:
-            <input type="text" id="copc_url" />
-            <button onclick="readURL()">Load</button>
+            <input type="text" id="loadUrl" />
+            <button id="loadUrlBtn">Load</button>
             <div>
-                <button id="loadAutzenButton">Load Autzen Stadium (80mb)</button>
-                <button id="loadSofiButton">Load SoFI Stadium (2.3gb)</button>
-                <button id="loadMillsiteButton">Load Millsite (1.9gb)</button>
+                <button id="loadAutzenBtn">Load Autzen Stadium (80mb)</button>
+                <button id="loadSofiBtn">Load SoFI Stadium (2.3gb)</button>
+                <button id="loadMillsiteBtn">Load Millsite (1.9gb)</button>
             <div id="share"></div>
             </div>
         </div>
@@ -53,32 +53,45 @@
 
             let layer; // COPCLayer
 
-            const uri = new URL(location);
-
+            const viewerDiv = document.getElementById('viewerDiv');
             const gui = new lil();
 
-            const viewerDiv = document.getElementById('viewerDiv');
             const view = new itowns.View('EPSG:4326', viewerDiv);
             const controls = new itowns.PlanarControls(view);
             view.mainLoop.gfxEngine.renderer.setClearColor(0xdddddd);
 
-            setUrl(uri.searchParams.get('copc'));
+            // Check if an url had been given as an argument
+            // and parse to get url and options.
+            const urlParams = new URL(location).searchParams;
+            let url = urlParams.get('copc');
+            urlParams.delete('copc');
+
+            const options = {};
+            for (const [k, v] of urlParams) {
+                options[k] = isNaN(parseFloat(v, 10)) ? v : parseFloat(v, 10);
+            }
+
+            loadCopc(url, options)
+
+            function changeViewCrs(crs) {
+                view.referenceCrs = crs;
+                view.camera.crs = crs;
+            }
 
             function onLayerReady() {
-                const camera = view.camera.camera3D;
+                var lookAt = layer.root.origin.toVector3();
 
-                const lookAt = new THREE.Vector3();
                 const size = new THREE.Vector3();
-                layer.root.bbox.getSize(size);
-                layer.root.bbox.getCenter(lookAt);
+                layer.root.voxelOBB.box3D.getSize(size);
 
-                camera.far = 2.0 * size.length();
-
-                controls.groundLevel = layer.root.bbox.min.z;
-                const position = layer.root.bbox.min.clone().add(
-                    size.multiply({ x: 1, y: 1, z: size.x / size.z }),
+                controls.groundLevel = layer.minElevationRange;
+                var corner = new THREE.Vector3(...layer.source.header.min);
+                var position = corner.clone().add(
+                    size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
                 );
 
+                const camera = view.camera.camera3D;
+                camera.far = 10.0 * size.length();
                 camera.position.copy(position);
                 camera.lookAt(lookAt);
                 camera.updateProjectionMatrix();
@@ -86,83 +99,67 @@
                 view.notifyChange(camera);
             }
 
+            function loadCopc(url, options) {
+                if(!url) return;
 
-            function readURL() {
-                const url = document.getElementById('copc_url').value;
+                // Share the view
+                document.getElementById('share').innerHTML = '<a href="' +
+                    location.href.replace(location.search, '') +
+                    '?copc=' + url
+                    + '" target="_blank">Link to share this view</a>';
 
-                if (url) {
-                    setUrl(url);
-                }
-            }
-
-            function setUrl(url) {
-                if (!url) return;
-
-                const input_url = document.getElementById('copc_url');
-                if (!input_url) return;
-
-                uri.searchParams.set('copc', url);
-                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
-
-                input_url.value = url;
-                load(url);
-            }
-
-
-            function load(url) {
-                const options = {};
-                const urlParams = uri.searchParams
-                urlParams.keys().forEach(key => {
-                    if (key !== 'copc') {
-                        options[key] = parseInt(urlParams.get(key), 10);
-                    }
-                });
                 const source = new itowns.CopcSource({ url });
-
-                if (layer) {
-                    layer.debugUI.destroy()
-                    view.removeLayer('COPC');
-                    view.notifyChange();
-                    layer.delete();
-                }
 
                 const config = {
                     source,
-                    crs: view.referenceCrs,
                     sseThreshold: 2,
                     pointBudget: 3000000,
                     ...options,
                 };
 
-                layer = new itowns.CopcLayer('COPC', config);
-                view.addLayer(layer).then(onLayerReady);
-                layer.whenReady
-                    .then(() => debug.PointCloudDebug.initTools(view, layer, gui));
+                source.whenReady.then(() => {
+                    changeViewCrs(source.crs);
+                    if (layer) {
+                        layer.debugUI.destroy();
+                        view.removeLayer('COPC', true);
+                    }
+                    layer = new itowns.CopcLayer('COPC', config);
+                    view.addLayer(layer).then(onLayerReady);
+                    layer.whenReady
+                        .then(() => debug.PointCloudDebug.initTools(view, layer, gui));
+                })
             }
 
             function loadAutzen() {
-                setUrl("https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz");
+                loadCopc("https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz");
             }
 
             function loadSofi() {
-                setUrl("https://s3.amazonaws.com/hobu-lidar/sofi.copc.laz");
+                loadCopc("https://s3.amazonaws.com/hobu-lidar/sofi.copc.laz");
             }
 
             function loadMillsite() {
-                setUrl("https://s3.amazonaws.com/data.entwine.io/millsite.copc.laz");
+                loadCopc("https://s3.amazonaws.com/data.entwine.io/millsite.copc.laz");
             }
 
-            const loadAutzenButton = document.getElementById('loadAutzenButton');
-            const loadSofiButton = document.getElementById('loadSofiButton');
-            const loadMillsiteButton = document.getElementById('loadMillsiteButton');
+            const loadAutzenBtn = document.getElementById('loadAutzenBtn');
+            const loadSofiBtn = document.getElementById('loadSofiBtn');
+            const loadMillsiteBtn = document.getElementById('loadMillsiteBtn');
 
-            loadAutzenButton.addEventListener('click', loadAutzen);
-            loadSofiButton.addEventListener('click', loadSofi);
-            loadMillsiteButton.addEventListener('click', loadMillsite);
+            loadAutzenBtn.addEventListener('click', loadAutzen);
+            loadSofiBtn.addEventListener('click', loadSofi);
+            loadMillsiteBtn.addEventListener('click', loadMillsite);
 
-            window.view = view;
+            // window.view = view;
             window.itowns = itowns;
             window.THREE = THREE;
+
+            function load() {
+                const url = document.getElementById('loadUrl').value;
+                if (url) { loadCopc(url); }
+            }
+            const loadUrlBtn = document.getElementById('loadUrlBtn');
+            loadUrlBtn.addEventListener('click', load);
 
         </script>
     </body>

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -27,17 +27,15 @@
         </style>
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19"></script>
     </head>
     <body>
         <div id="description">Specify the URL of a Entwine Point Tree to load:
-            <input type="text" id="ept_url" />
-            <button id="readUrlButton">Load</button>
-            <button id="loadLyonButton">Load the Grand Lyon dataset</button>
+            <input type="text" id="loadUrl" />
+            <button id="loadUrlBtn">Load</button>
+            <button id="loadLyonBtn">Load the Grand Lyon dataset</button>
             <div id="share"></div>
         </div>
-        <div id="viewerDiv">
-        </div>
+        <div id="viewerDiv"></div>
 
         <script type="module">
 
@@ -53,24 +51,57 @@
             var debugGui = new lil();
             var viewerDiv = document.getElementById('viewerDiv');
             viewerDiv.style.display = 'block';
-            var view = new itowns.View('EPSG:3946', viewerDiv);
-            view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
 
+            var eptLayer;
+
+            const view = new itowns.View('EPSG:4326', viewerDiv);
             const controls = new itowns.PlanarControls(view);
+            view.mainLoop.gfxEngine.renderer.setClearColor(0xdddddd);
 
-            var eptLayer, eptSource;
+            view.domElement.addEventListener('dblclick', dblClickHandler);
+
+            // Check if an url had been given as an argument
+            // and parse to get url and options.
+            const uri = new URL(location.href);
+            const urlParams = uri.searchParams;
+            let url = urlParams.get('ept');
+            urlParams.delete('ept');
+
+            const options = {};
+            for (const [k, v] of urlParams) {
+                options[k] = isNaN(parseFloat(v, 10)) ? v : parseFloat(v, 10);
+            }
+
+            loadEPT(url, options);
+
+            function dblClickHandler(event) {
+                var pick = view.pickObjectsAt(event, 5, eptLayer);
+
+                for (const p of pick) {
+                    console.info('Selected point #' + p.index + ' in position (' +
+                        p.object.position.x + ', ' +
+                        p.object.position.y + ', ' +
+                        p.object.position.z +
+                        ') - node ' + p.object.userData.node.id);
+                }
+            }
+
+            function changeViewCrs(crs) {
+                view.referenceCrs = crs;
+                view.camera.crs = crs;
+            }
 
             function onLayerReady() {
-                var lookAt = new THREE.Vector3();
-                var size = new THREE.Vector3();
-                eptLayer.root.bbox.getSize(size);
-                eptLayer.root.bbox.getCenter(lookAt);
+                var lookAt = eptLayer.root.origin.toVector3();
 
+                var size = new THREE.Vector3();
+                eptLayer.root.voxelOBB.box3D.getSize(size);
                 view.camera3D.far = 2.0 * size.length();
 
-                controls.groundLevel = eptLayer.root.bbox.min.z;
-                var position = eptLayer.root.bbox.min.clone().add(
-                    size.multiply({ x: 0, y: 0, z: size.x / size.z })
+                controls.groundLevel = eptLayer.minElevationRange;
+                var corner = new THREE.Vector3(...eptLayer.source.boundsConforming.slice(0, 3));
+                var position = corner.clone().add(
+                    size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
                 );
 
                 view.camera3D.position.copy(position);
@@ -78,85 +109,60 @@
                 view.camera3D.updateProjectionMatrix();
 
                 view.notifyChange(view.camera3D);
+
+                // add GUI
+                debug.PointCloudDebug.initTools(view, eptLayer, debugGui)
             }
 
-            function readEPTURL() {
-                const urlParams = new URL(location.href).searchParams
-                var url = document.getElementById('ept_url').value || urlParams.get('ept');
+            let eptName
+            function loadEPT(url, options) {
+                if(!url) return;
 
-                if (url) {
-                    const options = {};
-                    urlParams.keys().forEach(key => {
-                        if (key !== 'ept') {
-                            options[key] = parseInt(urlParams.get(key), 10);
-                        }
-                    });
-                    loadEPT(url, options);
-
-                    document.getElementById('share').innerHTML = '<a href="' +
+                // Share the view
+                document.getElementById('share').innerHTML = '<a href="' +
                         location.href.replace(location.search, '') +
                         '?ept=' + url
                         + '" target="_blank">Link to share this view</a>';
-                    document.getElementById('ept_url').value = url;
-                }
-            }
 
-            let eptName;
-            function loadEPT(url, options) {
-                eptSource = new itowns.EntwinePointTileSource({ url });
-
-                if (eptLayer) {
-                    eptLayer.debugUI.destroy();
-                    view.removeLayer(eptName);
-                    view.notifyChange();
-                    eptLayer.delete();
-                }
+                const eptSource = new itowns.EntwinePointTileSource({ url });
 
                 const config = {
                     source: eptSource,
-                    crs: view.referenceCrs,
                     ...options,
-                }
+                };
 
-                eptName = url.split('/').pop()
-                eptName = eptName[0].toUpperCase() + eptName.slice(1);
-                eptLayer = new itowns.EntwinePointTileLayer(eptName, config);
-
-                view.addLayer(eptLayer).then(onLayerReady);
-
-                eptLayer.whenReady
-                    .then(() => debug.PointCloudDebug.initTools(view, eptLayer, debugGui));
-
-                function dblClickHandler(event) {
-                    var pick = view.pickObjectsAt(event, 5, eptLayer);
-
-                    for (const p of pick) {
-                        console.info('Selected point #' + p.index + ' in position (' +
-                            p.object.position.x + ', ' +
-                            p.object.position.y + ', ' +
-                            p.object.position.z +
-                         ') - node ' + p.object.userData.node.id);
+                eptSource.whenReady.then(() => {
+                    changeViewCrs(eptSource.crs);
+                    if (eptLayer) {
+                        eptLayer.debugUI.destroy();
+                        console.log(eptName)
+                        view.removeLayer(eptName, true);
                     }
-                }
-                view.domElement.addEventListener('dblclick', dblClickHandler);
+
+                    if(url.slice(-1) === '/') url = url.slice(0, -1);
+
+                    eptName = url.split('/').pop()
+                    eptName = eptName[0].toUpperCase() + eptName.slice(1);
+                    eptLayer = new itowns.EntwinePointTileLayer(eptName, config);
+                    view.addLayer(eptLayer).then(onLayerReady);
+
+                })
             }
 
-            function onloadGrandLyon() {
-                document.getElementById('ept_url').value = 'https://download.data.grandlyon.com/files/grandlyon/imagerie/mnt2018/lidar/ept';
-                readEPTURL();
-            }
+            const loadUrlBtn = document.getElementById('loadUrlBtn');
+            loadUrlBtn.addEventListener('click', () => {
+                url = document.getElementById('loadUrl').value;
+                if (url) { loadEPT(url); }
+            });
 
-            const loadLyonButton = document.getElementById('loadLyonButton');
-            const readUrlButton = document.getElementById('readUrlButton');
+            const loadLyonBtn = document.getElementById('loadLyonBtn');
+            loadLyonBtn.addEventListener('click', () => {
+                url = 'https://download.data.grandlyon.com/files/grandlyon/imagerie/mnt2018/lidar/ept/';
+                loadEPT(url);
+            });
 
-            loadLyonButton.addEventListener('click', onloadGrandLyon);
-            readUrlButton.addEventListener('click', readEPTURL);
-
-            readEPTURL();
-            window.view = view;
             window.itowns = itowns;
             window.THREE = THREE;
-
         </script>
     </body>
 </html>

--- a/examples/potree2_25d_map.html
+++ b/examples/potree2_25d_map.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!-- <!DOCTYPE html> -->
 <html>
     <head>
         <title>Point Cloud Viewer</title>
@@ -47,99 +47,101 @@
             <div id="info"></div>
         </div>
 
-        <div>
         <script type="module">
 
-                import lil from 'lil';
-                import setupLoadingScreen from 'LoadingScreen';
-                import * as THREE from 'three';
-                import * as itowns from 'itowns';
-                import * as debug from 'debug';
-                import * as itowns_widgets from 'itowns_widgets';
+            import lil from 'lil';
+            import setupLoadingScreen from 'LoadingScreen';
+            import * as THREE from 'three';
+            import * as itowns from 'itowns';
+            import * as debug from 'debug';
+            import * as itowns_widgets from 'itowns_widgets';
 
-                var potreeLayer;
-                var oldPostUpdate;
-                var viewerDiv;
-                var debugGui;
-                var view;
-                var controls;
+            var potreeLayer;
+            var oldPostUpdate;
+            var viewerDiv;
+            var debugGui;
+            var view;
+            var controls;
 
-                // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
-                itowns.CRS.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+            // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
+            itowns.CRS.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
-                viewerDiv = document.getElementById('viewerDiv');
-                viewerDiv.style.display = 'block';
+            viewerDiv = document.getElementById('viewerDiv');
+            viewerDiv.style.display = 'block';
 
-                debugGui = new lil();
+            debugGui = new lil();
 
-                // TODO: do we really need to disable logarithmicDepthBuffer ?
-                view = new itowns.View('EPSG:3946', viewerDiv);
-                setupLoadingScreen(viewerDiv, view);
-                view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
+            const crs = 'EPSG:4326';
+            view = new itowns.View(crs, viewerDiv);
+            setupLoadingScreen(viewerDiv, view);
+            view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
 
-                // Configure Point Cloud layer
-                potreeLayer = new itowns.Potree2Layer('Lion', {
-                    source: new itowns.Potree2Source({
-                        file: 'metadata.json',
-                        url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
-                        crs: view.referenceCrs,
-                    }),
+            // Configure Point Cloud layer
+            const source = new itowns.Potree2Source({
+                file: 'metadata.json',
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
+                crs,
+            });
+
+            potreeLayer = new itowns.Potree2Layer('Lion', {
+                source,
+            });
+
+            // point selection on double-click
+            function dblClickHandler(event) {
+                var pick = view.pickObjectsAt(event, 5, potreeLayer);
+
+                for (const p of pick) {
+                    console.info('Selected point #' + p.index + ' in position (' +
+                        p.object.position.x + ', ' +
+                        p.object.position.y + ', ' +
+                        p.object.position.z +
+                        ') in Points ' + p.object.layer.id);
+                }
+            }
+            view.domElement.addEventListener('dblclick', dblClickHandler);
+
+            function placeCamera(position, lookAt) {
+                view.camera.camera3D.position.copy(position);
+                view.camera.camera3D.lookAt(lookAt);
+                // create controls
+                controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
+                debugGui.add(controls.options, 'moveSpeed', 1, 100).name('Movement speed');
+
+                view.notifyChange(view.camera.camera3D);
+            }
+
+            // add potreeLayer to scene
+            function onLayerReady() {
+                var position;
+                var lookAt = new THREE.Vector3();
+                var size = new THREE.Vector3();
+
+                potreeLayer.root.voxelOBB.box3D.getSize(size);
+                potreeLayer.root.voxelOBB.box3D.getCenter(lookAt);
+                lookAt.z = potreeLayer.root.voxelOBB.box3D.min.z;
+
+                debug.PointCloudDebug.initTools(view, potreeLayer, debugGui);
+
+                view.camera.camera3D.far = 2.0 * size.length();
+
+                var corner = new THREE.Vector3(...potreeLayer.source.metadata.boundingBox.min);
+                var position = corner.clone().add(
+                    size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
+                );
+
+                placeCamera(position, lookAt);
+                controls.moveSpeed = size.length() / 3;
+
+                // update stats window
+                var info = document.getElementById('info');
+                view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, () => {
+                    info.textContent = potreeLayer.displayedCount.toLocaleString() + ' points';
                 });
-
-                // point selection on double-click
-                function dblClickHandler(event) {
-                    var pick = view.pickObjectsAt(event, 5, potreeLayer);
-
-                    for (const p of pick) {
-                        console.info('Selected point #' + p.index + ' in position (' +
-                            p.object.position.x + ', ' +
-                            p.object.position.y + ', ' +
-                            p.object.position.z +
-                         ') in Points ' + p.object.layer.id);
-                    }
-                }
-                view.domElement.addEventListener('dblclick', dblClickHandler);
-
-                function placeCamera(position, lookAt) {
-                    view.camera.camera3D.position.copy(position);
-                    view.camera.camera3D.lookAt(lookAt);
-                    // create controls
-                    controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
-                    debugGui.add(controls.options, 'moveSpeed', 1, 100).name('Movement speed');
-
-                    view.notifyChange(view.camera.camera3D);
-                }
-
-                // add potreeLayer to scene
-                function onLayerReady() {
-                    var ratio;
-                    var position;
-                    var lookAt = new THREE.Vector3();
-                    var size = new THREE.Vector3();
-
-                    potreeLayer.root.bbox.getSize(size);
-                    potreeLayer.root.bbox.getCenter(lookAt);
-
-                    debug.PointCloudDebug.initTools(view, potreeLayer, debugGui);
-
-                    view.camera.camera3D.far = 2.0 * size.length();
-
-                    ratio = size.x / size.z;
-                    position = potreeLayer.root.bbox.min.clone().add(
-                        size.multiply({ x: 0, y: 0, z: ratio * 0.5 }));
-                    lookAt.z = potreeLayer.root.bbox.min.z;
-                    placeCamera(position, lookAt);
-                    controls.moveSpeed = size.length() / 3;
-
-                    // update stats window
-                    var info = document.getElementById('info');
-                    view.addFrameRequester(itowns.MAIN_LOOP_EVENTS.AFTER_RENDER, () => {
-                        info.textContent = potreeLayer.displayedCount.toLocaleString() + ' points';
-                    });
-                }
-                window.view = view;
-                view.addLayer(potreeLayer).then(onLayerReady);
-                window.view = view;
+            }
+            window.view = view;
+            view.addLayer(potreeLayer).then(onLayerReady);
+            window.view = view;
             window.itowns = itowns;
             window.THREE = THREE;
 

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -65,8 +65,24 @@
                 var view;
                 var controls;
 
-                // Define crs projection that we will use (taken from https://epsg.io/3946, Proj4js section)
-                itowns.CRS.defs('EPSG:3946', '+proj=lcc +lat_1=45.25 +lat_2=46.75 +lat_0=46 +lon_0=3 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+                /* OTHER available dataset
+                const name = 'eglise_saint_blaise_arles';
+                const url = 'https://raw.githubusercontent.com/gmaillet/dataset/master/';
+                const file = 'eglise_saint_blaise_arles.js';
+                const crs = 'EPSG:4978';
+                => Geocentric
+
+                Probleme de CORS if 'Allow CORS' plugin off
+                const url = 'https://cors-anywhere.herokuapp.com/https://viz.lib.vt.edu/thessaloniki/resources/pointclouds/thessaloniki';
+                const file = 'cloud.js';
+                const crs = 'EPSG:3857';
+                => crs unknown. Most probaly a projection centered on the center of acquisition... 
+                */
+
+                itowns.CRS.defs("EPSG:25831","+proj=utm +zone=31 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs");
+                const url = 'https://betaserver.icgc.cat/potree12/resources/pointclouds/templesagradafamilia';
+                const file = 'cloud.js';
+                const crs = 'EPSG:25831';
 
                 viewerDiv = document.getElementById('viewerDiv');
                 viewerDiv.style.display = 'block';
@@ -74,17 +90,19 @@
                 debugGui = new lil();
 
                 // TODO: do we really need to disable logarithmicDepthBuffer ?
-                view = new itowns.View('EPSG:3946', viewerDiv);
+                view = new itowns.View(crs, viewerDiv);
                 setupLoadingScreen(viewerDiv, view);
                 view.mainLoop.gfxEngine.renderer.setClearColor(0xcccccc);
 
                 // Configure Point Cloud layer
+                const potreeSource = new itowns.PotreeSource({
+                    file,
+                    url,
+                    crs,
+                });
+
                 potreeLayer = new itowns.PotreeLayer('eglise_saint_blaise_arles', {
-                    source: new itowns.PotreeSource({
-                        file: 'eglise_saint_blaise_arles.js',
-                        url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/eglise_saint_blaise_arles',
-                        crs: view.referenceCrs,
-                    }),
+                    source: potreeSource,
                 });
 
                 // point selection on double-click
@@ -104,33 +122,33 @@
                 function placeCamera(position, lookAt) {
                     view.camera3D.position.copy(position);
                     view.camera3D.lookAt(lookAt);
-                    // create controls
-                    controls = new itowns.FirstPersonControls(view, { focusOnClick: true });
-                    debugGui.add(controls.options, 'moveSpeed', 1, 100).name('Movement speed');
+                    view.camera3D.updateProjectionMatrix();
 
                     view.notifyChange(view.camera3D);
                 }
 
                 // add potreeLayer to scene
                 function onLayerReady() {
-                    var ratio;
-                    var position;
-                    var lookAt = new THREE.Vector3();
-                    var size = new THREE.Vector3();
+                    var lookAt = potreeLayer.root.origin.toVector3();
 
-                    potreeLayer.root.bbox.getSize(size);
-                    potreeLayer.root.bbox.getCenter(lookAt);
+                    var size = new THREE.Vector3();
+                    potreeLayer.root.voxelOBB.box3D.getSize(size);
+
+                    lookAt.z = potreeLayer.root.voxelOBB.box3D.min.z;
+
+                    view.camera3D.far = 5.0 * size.length();
+
+                    var corner = new THREE.Vector3(...potreeLayer.source.boundsConforming.slice(0, 3));
+                    var position = corner.clone().add(
+                        size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
+                    );
+
+                    placeCamera(position, lookAt);
 
                     debug.PointCloudDebug.initTools(view, potreeLayer, debugGui);
 
-                    view.camera3D.far = 2.0 * size.length();
-
-                    ratio = size.x / size.z;
-                    position = potreeLayer.root.bbox.min.clone().add(
-                        size.multiply({ x: 0, y: 0, z: ratio * 0.5 }));
-                    lookAt.z = potreeLayer.root.bbox.min.z;
-                    placeCamera(position, lookAt);
-                    controls.moveSpeed = size.length() / 3;
+                    controls = new itowns.PlanarControls(view);
+                    controls.groundLevel = potreeLayer.minElevationRange;
 
                     // update stats window
                     var info = document.getElementById('info');

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
     <head>
         <title>Point Cloud on globe</title>
@@ -45,6 +44,7 @@
     <body>
         <div id="viewerDiv"></div>
         <div id="info"></div>
+
         <script type="module">
 
             import lil from 'lil';
@@ -65,29 +65,64 @@
 
             debugGui = new lil();
 
-            var placement = {
-                coord: new itowns.Coordinates('EPSG:4326',  4.631512, 43.675626),
-                range: 100,
-                tilt: 45,
-                heading: -60
-            }
-
-            view = new itowns.GlobeView(viewerDiv, placement, { handleCollision: false });
+            var view = new itowns.GlobeView(viewerDiv);
             setupLoadingScreen(viewerDiv, view);
 
             view.controls.minDistance = 50;
 
+            itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(function _(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ElevationLayer(config.id, config);
+                view.addLayer(layer);
+            });
+            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var layer = new itowns.ColorLayer(config.id, config);
+                view.addLayer(layer);
+            });
+
+            /* OTHER dataset
+            Donnees geocentrique -> probleme pour le placement camera
+            name = 'eglise_saint_blaise_arles';
+            const url = 'https://raw.githubusercontent.com/gmaillet/dataset/master/';
+            const file = 'eglise_saint_blaise_arles.js';
+            const crs = 'EPSG:4978';
+            */
+
+            itowns.CRS.defs("EPSG:25831","+proj=utm +zone=31 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs");
+            name = 'TempleSagradaFamilia';
+            const url = 'https://betaserver.icgc.cat/potree12/resources/pointclouds/templesagradafamilia';
+            const file = 'cloud.js';
+            const crs = 'EPSG:25831';
+
             // Configure Point Cloud layer
-            potreeLayer = new itowns.PotreeLayer('eglise_saint_blaise_arles', {
-                source: new itowns.PotreeSource({
-                    file: 'eglise_saint_blaise_arles.js',
-                    url: 'https://raw.githubusercontent.com/gmaillet/dataset/master',
-                    crs: view.referenceCrs,
-                }),
+            const potreeSource = new itowns.PotreeSource({
+                    file,
+                    url,
+                    crs,
+                });
+
+            potreeLayer = new itowns.PotreeLayer(name, {
+                source: potreeSource,
             });
 
             // add potreeLayer to scene
             function onLayerReady() {
+                var lookAt = potreeLayer.root.clampOBB.position;
+
+                var coordLookAt = new itowns.Coordinates(view.referenceCrs).setFromVector3(lookAt);
+
+                var size = new THREE.Vector3();
+                potreeLayer.root.voxelOBB.box3D.getSize(size);
+
+                console.log(coordLookAt);
+
+                view.controls.lookAtCoordinate({
+                    coord: coordLookAt,
+                    range: 2 * size.length(),
+                }, false);
+
+                // add GUI
                 debug.PointCloudDebug.initTools(view, potreeLayer, debugGui);
 
                 // update stats window
@@ -100,16 +135,7 @@
 
             itowns.View.prototype.addLayer.call(view, potreeLayer).then(onLayerReady);
 
-            itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(function _(config) {
-                config.source = new itowns.WMTSSource(config.source);
-                var layer = new itowns.ElevationLayer(config.id, config);
-                view.addLayer(layer);
-            });
-            itowns.Fetcher.json('./layers/JSONLayers/Ortho.json').then(function _(config) {
-                config.source = new itowns.WMTSSource(config.source);
-                var layer = new itowns.ColorLayer(config.id, config);
-                view.addLayer(layer);
-            });
+
             window.view = view;
             window.itowns = itowns;
             window.THREE = THREE;

--- a/examples/vpc_simple_loader.html
+++ b/examples/vpc_simple_loader.html
@@ -81,18 +81,16 @@
             var vpcLayer, vpcSource;
 
             function onLayerReady() {
-                var lookAt = new THREE.Vector3();
+                var lookAt = vpcLayer.root.origin.toVector3();
+
                 var size = new THREE.Vector3();
+                vpcLayer.root.voxelOBB.box3D.getSize(size);
+                view.camera3D.far = 10.0 * size.length();
 
-                const rootBbox = vpcLayer.root.children[0].bbox;
-                rootBbox.getSize(size);
-                rootBbox.getCenter(lookAt);
-
-                view.camera3D.far = 20.0 * size.length();
-
-                controls.groundLevel = rootBbox.min.z;
-                var position = rootBbox.min.clone().add(
-                    size.multiply({ x: 0, y: 0, z: size.x / size.z })
+                controls.groundLevel = vpcLayer.minElevationRange;
+                var corner = new THREE.Vector3(...vpcLayer.source.sources[0].boundsConforming.slice(0, 3));
+                var position = corner.clone().add(
+                    size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
                 );
 
                 view.camera3D.position.copy(position);
@@ -131,7 +129,7 @@
 
             function loadAmiens() {
                 const options = {
-                    material: {mode: 2},
+                    mode: 2,
                     opacity: 0.9,
                 }
                 loadVPC('https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/amiens.vpc', options);
@@ -139,7 +137,7 @@
 
             function loadRouen() {
                 const options = {
-                    material: {mode: 2},
+                    mode: 2,
                     opacity: 0.9,
                 }
                 loadVPC('https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/rouen.vpc', options);
@@ -147,7 +145,7 @@
 
             function loadOrleans() {
                 const options = {
-                    material: {mode: 2},
+                    mode: 2,
                     opacity: 0.9,
                 }
                 loadVPC('https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/vpc/index.vpc', options);

--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -1,4 +1,6 @@
-import { PNTS_MODE, PNTS_SHAPE, PNTS_SIZE_MODE } from 'itowns';
+import { View, PNTS_MODE, PNTS_SHAPE, PNTS_SIZE_MODE, GeometryLayer } from 'itowns';
+import * as THREE from 'three';
+import OBBHelper from './OBBHelper';
 
 const folderName = 'Styling';
 
@@ -44,6 +46,122 @@ function setupControllerVisibily(gui, displayMode, sizeMode) {
     } else {
         getController(gui, 'minAttenuatedSize').show();
         getController(gui, 'maxAttenuatedSize').show();
+    }
+}
+
+/**
+ * Generate the position array of the bbox corner form the bbox
+ * Adapted from THREE.BoxHelper.js
+ * https://github.com/mrdoob/three.js/blob/master/src/helpers/BoxHelper.js
+ *
+ * @param {THREE.box3} bbox - Box3 of the node
+ * @returns {array}
+ */
+function getCornerPosition(bbox) {
+    const array =  new Float32Array(8 * 3);
+
+    const min = bbox.min;
+    const max = bbox.max;
+
+    /*
+      5____4
+    1/___0/|
+    | 6__|_7
+    2/___3/
+
+    0: max.x, max.y, max.z
+    1: min.x, max.y, max.z
+    2: min.x, min.y, max.z
+    3: max.x, min.y, max.z
+    4: max.x, max.y, min.z
+    5: min.x, max.y, min.z
+    6: min.x, min.y, min.z
+    7: max.x, min.y, min.z
+    */
+    array[0] = max.x; array[1] = max.y; array[2] = max.z;
+    array[3] = min.x; array[4] = max.y; array[5] = max.z;
+    array[6] = min.x; array[7] = min.y; array[8] = max.z;
+    array[9] = max.x; array[10] = min.y; array[11] = max.z;
+    array[12] = max.x; array[13] = max.y; array[14] = min.z;
+    array[15] = min.x; array[16] = max.y; array[17] = min.z;
+    array[18] = min.x; array[19] = min.y; array[20] = min.z;
+    array[21] = max.x; array[22] = min.y; array[23] = min.z;
+    return array;
+}
+
+const red =  new THREE.Color(0xff0000);
+function debugIdUpdate(context, layer, node) {
+    // filtering helper attached to node with the current debug layer
+    if (!node.link) {
+        node.link = {};
+    }
+    let helper = node.link[layer.id];
+    if (node.visible) {
+        if (!helper) {
+            helper = new THREE.Group();
+
+            // node obbes
+            const obbHelper = new OBBHelper(node.clampOBB, node.voxelKey, red);
+            obbHelper.layer = layer;
+            helper.add(obbHelper);
+
+            // point data boxes (in local ref)
+            const tightboxHelper = new THREE.BoxHelper(undefined, 0x0000ff);
+            if (node.obj) {
+                tightboxHelper.geometry.attributes.position.array = getCornerPosition(node.obj.geometry.boundingBox);
+                tightboxHelper.applyMatrix4(node.obj.matrixWorld);
+                node.obj.tightboxHelper = tightboxHelper;
+                helper.add(tightboxHelper);
+                tightboxHelper.updateMatrixWorld(true);
+            } else if (node.promise) {
+                // TODO rethink architecture of node.obj/node.promise ?
+                node.promise.then(() => {
+                    if (node.obj) {
+                        tightboxHelper.geometry.attributes.position.array = getCornerPosition(node.obj.geometry.boundingBox);
+                        tightboxHelper.applyMatrix4(node.obj.matrixWorld);
+                        node.obj.tightboxHelper = tightboxHelper;
+                        helper.add(tightboxHelper);
+                        tightboxHelper.updateMatrixWorld(true);
+                    }
+                });
+            }
+
+            node.link[layer.id] = helper;
+        } else {
+            node.link[layer.id].visible = true;
+        }
+
+        layer.object3d.add(helper);
+
+        if (node.children && node.children.length) {
+            if (node.sse >= 1) {
+                return node.children;
+            } else {
+                for (const child of node.children) {
+                    if (child.link?.[layer.id]) {
+                        child.link[layer.id].visible = false;
+                    }
+                }
+            }
+        }
+    } else if (helper) {
+        layer.object3d.remove(helper);
+    }
+}
+
+class DebugLayer extends GeometryLayer {
+    constructor(id, options = {}) {
+        super(id, options.object3d || new THREE.Group(), options);
+        this.update = debugIdUpdate;
+        this.isDebugLayer = true;
+        this.layer = options.layer;
+    }
+
+    preUpdate(context, sources) {
+        if (sources.has(this.parent)) {
+            this.object3d.clear();
+        }
+        return this.layer.preUpdate(context, sources);
     }
 }
 
@@ -184,7 +302,25 @@ export default {
 
         // UI
         const debugUI = layer.debugUI.addFolder('Debug').close();
-        debugUI.add(layer.bboxes, 'visible').name('Display Bounding Boxes').onChange(update);
+
+        const obb_layer_id = `${layer.id}_obb_debug`;
+        const obbLayer = new DebugLayer(obb_layer_id, {
+            visible: false,
+            cacheLifeTime: Infinity,
+            source: false,
+            layer,
+        });
+
+        if (view.getLayerById(obbLayer.id)) {
+            view.removeLayer(obbLayer.id);
+        }
+        View.prototype.addLayer.call(view, obbLayer);
+
+        debugUI.add(obbLayer, 'visible').name('Display Bounding Boxes')
+            .onChange(() => {
+                view.notifyChange(obbLayer);
+            });
+
         debugUI.add(layer, 'dbgStickyNode').name('Sticky node name').onChange(update);
         debugUI.add(layer, 'dbgDisplaySticky').name('Display sticky node').onChange(update);
         debugUI.add(layer, 'dbgDisplayChildren').name('Display children of sticky node').onChange(update);

--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -61,7 +61,7 @@ export default {
         layer.debugUI.add(layer, 'sseThreshold').name('SSE threshold').onChange(update);
         layer.debugUI.add(layer, 'octreeDepthLimit', -1, 20).name('Depth limit').onChange(update);
         layer.debugUI.add(layer, 'pointBudget', 1, 15000000).name('Max point count').onChange(update);
-        layer.debugUI.add(layer.object3d.position, 'z', -50, 50).name('Z translation').onChange(() => {
+        layer.debugUI.add(layer.object3d.position, 'z', -5000, 5000).name('Z translation').onChange(() => {
             layer.object3d.updateMatrixWorld();
             view.notifyChange(layer);
         });

--- a/packages/Geographic/src/Crs.ts
+++ b/packages/Geographic/src/Crs.ts
@@ -69,7 +69,7 @@ function unitFromProj4Unit(proj: ProjectionDefinition) {
         return UNIT.DEGREE;
     } else if (proj.units === 'm' || proj.units === 'meter') {
         return UNIT.METER;
-    } else if (proj.units === 'foot') {
+    } else if (proj.units === 'foot' || proj.units === 'ft') {
         return UNIT.FOOT;
     } else if (proj.units === undefined && proj.to_meter === undefined) {
         // See https://proj.org/en/9.4/usage/projections.html [17/10/2024]

--- a/packages/Geographic/src/OrientationUtils.ts
+++ b/packages/Geographic/src/OrientationUtils.ts
@@ -416,6 +416,7 @@ export function quaternionFromEnuToCRS(
         case 'Geocentric': return quaternionFromEnuToGeocent();
         case 'Lambert Tangential Conformal Conic Projection':
             return quaternionFromEnuToLCC(proj as LCCProjection);
+        case 'Universal Transverse Mercator System':
         case 'Fast_Transverse_Mercator': return quaternionFromEnuToTMerc(proj as TMercProjection);
         case 'longlat': return quaternionFromEnuToLongLat();
         default: return quaternionUnimplemented(proj);
@@ -453,6 +454,7 @@ export function quaternionFromCRSToEnu(
         case 'Geocentric': return quaternionFromGeocentToEnu();
         case 'Lambert Tangential Conformal Conic Projection':
             return quaternionFromLCCToEnu(proj as LCCProjection);
+        case 'Universal Transverse Mercator System':
         case 'Fast_Transverse_Mercator': return quaternionFromTMercToEnu(proj as TMercProjection);
         case 'longlat': return quaternionFromLongLatToEnu();
         default: return quaternionUnimplemented(proj);

--- a/packages/Main/src/Core/CopcNode.js
+++ b/packages/Main/src/Core/CopcNode.js
@@ -34,8 +34,9 @@ class CopcNode extends PointCloudNode {
      * @param {number} entryLength - Size of the node entry.
      * @param {CopcSource} source - Data source (COPC) of the node.
      * @param {number} [numPoints=0] - Number of points given by this entry.
+     * @param {string} crs - The crs of the node.
      */
-    constructor(depth, x, y, z, entryOffset, entryLength, source, numPoints = 0) {
+    constructor(depth, x, y, z, entryOffset, entryLength, source, numPoints = 0, crs) {
         super(numPoints, source);
         this.isCopcNode = true;
 
@@ -48,6 +49,8 @@ class CopcNode extends PointCloudNode {
         this.z = z;
 
         this.voxelKey = buildVoxelKey(depth, x, y, z);
+
+        this.crs = crs;
     }
 
     get octreeIsLoaded() {
@@ -146,6 +149,7 @@ class CopcNode extends PointCloudNode {
             byteSize,
             this.source,
             pointCount,
+            this.crs,
         );
         this.add(child);
         stack.push(child);
@@ -162,10 +166,7 @@ class CopcNode extends PointCloudNode {
 
         const buffer = await this._fetch(this.entryOffset, this.entryLength);
         const geometry = await this.source.parser(buffer, {
-            in: {
-                ...this.source,
-                pointCount: this.numPoints,
-            },
+            in: this,
         });
 
         return geometry;

--- a/packages/Main/src/Core/EntwinePointTileNode.js
+++ b/packages/Main/src/Core/EntwinePointTileNode.js
@@ -48,8 +48,9 @@ class EntwinePointTileNode extends PointCloudNode {
      * @param {number} [numPoints=0] - The number of points in this node. If
      * `-1`, it means that the octree hierarchy associated to this node needs to
      * be loaded.
+     * @param {string} crs - The crs of the node.
      */
-    constructor(depth, x, y, z, source, numPoints = 0) {
+    constructor(depth, x, y, z, source, numPoints = 0, crs) {
         super(numPoints, source);
         this.isEntwinePointTileNode = true;
 
@@ -61,6 +62,8 @@ class EntwinePointTileNode extends PointCloudNode {
         this.voxelKey = buildVoxelKey(depth, x, y, z);
 
         this.url = `${this.source.url}/ept-data/${this.voxelKey}.${this.source.extension}`;
+
+        this.crs = crs;
     }
 
     get octreeIsLoaded() {
@@ -103,7 +106,7 @@ class EntwinePointTileNode extends PointCloudNode {
         const numPoints = hierarchy[voxelKey];
 
         if (typeof numPoints == 'number') {
-            const child = new EntwinePointTileNode(depth, x, y, z, this.source, numPoints);
+            const child = new EntwinePointTileNode(depth, x, y, z, this.source, numPoints, this.crs);
             this.add(child);
             stack.push(child);
         }

--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -1,4 +1,7 @@
 import * as THREE from 'three';
+import OBB from 'Renderer/OBB';
+import proj4 from 'proj4';
+import { OrientationUtils, Coordinates } from '@itowns/geographic';
 
 const size = new THREE.Vector3();
 const position = new THREE.Vector3();
@@ -7,8 +10,11 @@ const translation = new THREE.Vector3();
 /**
  * @property {number} numPoints - The number of points in this node.
  * @property {PointCloudSource} source - Data source of the node.
+ * @property {string} crs - The crs of the node.
  * @property {PointCloudNode[]} children - The children nodes of this node.
- * @property {THREE.Box3} bbox - The bounding box of the node.
+ * @property {OBB} voxelOBB - The node cubique obb.
+ * @property {OBB} clampOBB - The cubique obb clamped to zmin and zmax.
+ * @property {number} sse - The sse of the node set at an nitial value of -1.
  */
 class PointCloudNode extends THREE.EventDispatcher {
     constructor(numPoints = 0, source) {
@@ -19,7 +25,8 @@ class PointCloudNode extends THREE.EventDispatcher {
         this.source = source;
 
         this.children = [];
-        this.bbox = new THREE.Box3();
+        this.voxelOBB = new OBB();
+        this.clampOBB = new OBB();
         this.sse = -1;
     }
 
@@ -31,42 +38,170 @@ class PointCloudNode extends THREE.EventDispatcher {
         throw new Error('In extended PointCloudNode, you have to implement the getter id!');
     }
 
+    // get the center of the node i.e. the center of the bounding box.
+    get center() {
+        if (this._center != undefined) { return this._center; }
+        const centerBbox = new THREE.Vector3();
+        this.voxelOBB.box3D.getCenter(centerBbox);
+        this._center =  new Coordinates(this.crs).setFromVector3(centerBbox.applyMatrix4(this.clampOBB.matrixWorld));
+        return this._center;
+    }
+
+    // the origin is the center of the bounding box projected on the z=O local plan, in the world referential.
+    get origin() {
+        if (this._origin != undefined) { return this._origin; }
+        const centerCrsIn = proj4(this.crs, this.source.crs).forward(this.center);
+        this._origin =  new Coordinates(this.crs).setFromArray(proj4(this.source.crs, this.crs).forward([centerCrsIn.x, centerCrsIn.y, 0]));
+        return this._origin;
+    }
+
+    /**
+     * get the rotation between the local referentiel and the geocentrique one (if appliable).
+     *
+     * @returns {THREE.Quaternion}
+     */
+    get rotation() {
+        if (this._rotation != undefined) { return this._rotation; }
+        this._rotation = new THREE.Quaternion();
+        if (proj4.defs(this.crs).projName === 'geocent') {
+            this._rotation = OrientationUtils.quaternionFromCRSToCRS(this.crs, this.source.crs)(this.origin);
+        }
+        return this._rotation;
+    }
+
+    setOBBes(min, max) {
+        const root = this;
+        const crs = {
+            in: root.source.crs,
+            out: this.crs,
+        };
+        const zmin = root.source.zmin;
+        const zmax = root.source.zmax;
+
+        let forward = (x => x);
+        if (crs.in !== crs.out) {
+            try {
+                forward = proj4(crs.in, crs.out).forward;
+            } catch (err) {
+                throw new Error(`${err} is not defined in proj4`);
+            }
+        }
+
+        const corners = [
+            ...forward([max[0], max[1], max[2]]),
+            ...forward([min[0], max[1], max[2]]),
+            ...forward([min[0], min[1], max[2]]),
+            ...forward([max[0], min[1], max[2]]),
+            ...forward([max[0], max[1], min[2]]),
+            ...forward([min[0], max[1], min[2]]),
+            ...forward([min[0], min[1], min[2]]),
+            ...forward([max[0], min[1], min[2]]),
+        ];
+
+        // get center of box at altitude Z=0 and project it in view crs;
+        const origin = forward([(min[0] + max[0]) * 0.5, (min[1] + max[1]) * 0.5, 0]);
+
+        // get LocalRotation
+        const isGeocentric = proj4.defs(crs.out).projName === 'geocent';
+        let rotation = new THREE.Quaternion();
+        if (isGeocentric) {
+            const coordOrigin = new Coordinates(crs.out).setFromArray(origin);
+            rotation = OrientationUtils.quaternionFromCRSToCRS(crs.out, crs.in)(coordOrigin);
+        }
+
+        // project corners in local referentiel
+        const cornersLocal = [];
+        for (let i = 0; i < 24; i += 3) {
+            const cornerLocal = new THREE.Vector3(
+                corners[i] - origin[0],
+                corners[i + 1] - origin[1],
+                corners[i + 2] - origin[2],
+            );
+            cornerLocal.applyQuaternion(rotation);
+            cornersLocal.push(...cornerLocal.toArray());
+        }
+
+        // get the bbox containing all cornersLocal => the bboxLocal
+        root.voxelOBB.box3D.setFromArray(cornersLocal);
+        root.voxelOBB.position.set(...origin);
+        root.voxelOBB.quaternion.copy(rotation).invert();
+
+        root.voxelOBB.updateMatrix();
+        root.voxelOBB.updateMatrixWorld(true);
+
+        root.voxelOBB.matrixWorldInverse = root.voxelOBB.matrixWorld.clone().invert();
+
+        root.clampOBB.copy(root.voxelOBB);
+
+        const clampBBox = root.clampOBB.box3D;
+        if (clampBBox.min.z < zmax) {
+            clampBBox.max.z = Math.min(clampBBox.max.z, zmax);
+        }
+        if (clampBBox.max.z > zmin) {
+            clampBBox.min.z = Math.max(clampBBox.min.z, zmin);
+        }
+
+        root.clampOBB.matrixWorldInverse = root.voxelOBB.matrixWorldInverse;
+    }
+
     add(node, indexChild) {
         this.children.push(node);
         node.parent = this;
         this.createChildAABB(node, indexChild);
     }
 
-    createChildAABB(node) {
+    /**
+     * Create an (A)xis (A)ligned (B)ounding (B)ox for the given node given
+     * `this` is its parent.
+     * @param {CopcNode} childNode - The child node
+     */
+    createChildAABB(childNode) {
+        // initialize the child node obb
+        childNode.voxelOBB.copy(this.voxelOBB);
+        const voxelBBox = this.voxelOBB.box3D;
+        const childVoxelBBox = childNode.voxelOBB.box3D;
+
         // factor to apply, based on the depth difference (can be > 1)
-        const f = 2 ** (node.depth - this.depth);
+        const f = 2 ** (childNode.depth - this.depth);
 
         // size of the child node bbox (Vector3), based on the size of the
         // parent node, and divided by the factor
-        this.bbox.getSize(size).divideScalar(f);
+        voxelBBox.getSize(size).divideScalar(f);
 
-        // initialize the child node bbox at the location of the parent node bbox
-        node.bbox.min.copy(this.bbox.min);
-
-        // position of the parent node, if it was at the same depth than the
+        // position of the parent node, if it was at the same depth as the
         // child, found by multiplying the tree position by the factor
         position.copy(this).multiplyScalar(f);
 
         // difference in position between the two nodes, at child depth, and
         // scale it using the size
-        translation.subVectors(node, position).multiply(size);
+        translation.subVectors(childNode, position).multiply(size);
 
         // apply the translation to the child node bbox
-        node.bbox.min.add(translation);
+        childVoxelBBox.min.add(translation);
 
         // use the size computed above to set the max
-        node.bbox.max.copy(node.bbox.min).add(size);
+        childVoxelBBox.max.copy(childVoxelBBox.min).add(size);
+
+        // get a clamped bbox from the voxel bbox
+        childNode.clampOBB.copy(childNode.voxelOBB);
+
+        const childClampBBox = childNode.clampOBB.box3D;
+
+        if (childClampBBox.min.z < this.source.zmax) {
+            childClampBBox.max.z = Math.min(childClampBBox.max.z, this.source.zmax);
+        }
+        if (childClampBBox.max.z > this.source.zmin) {
+            childClampBBox.min.z = Math.max(childClampBBox.min.z, this.source.zmin);
+        }
+
+        childNode.voxelOBB.matrixWorldInverse = this.voxelOBB.matrixWorldInverse;
+        childNode.clampOBB.matrixWorldInverse = this.clampOBB.matrixWorldInverse;
     }
 
-    load() {
-        return this.source.fetcher(this.url, this.source.networkOptions)
-            .then(file => this.source.parse(file, {
-                in: this.source,
+    load(networkOptions = this.source.networkOptions) {
+        return this.source.fetcher(this.url, networkOptions)
+            .then(file => this.source.parser(file, {
+                in: this,
             }));
     }
 

--- a/packages/Main/src/Core/PotreeNode.js
+++ b/packages/Main/src/Core/PotreeNode.js
@@ -6,8 +6,48 @@ import PointCloudNode from 'Core/PointCloudNode';
 // subdivision algo recursively)
 const dHalfLength = new THREE.Vector3();
 
+function computeChildBBox(voxelBBox, childIndex) {
+    // Code inspired from potree
+    const childVoxelBBox = voxelBBox.clone();
+    voxelBBox.getCenter(childVoxelBBox.max);
+    dHalfLength.copy(childVoxelBBox.max).sub(voxelBBox.min);
+
+    if (childIndex === 1) {
+        childVoxelBBox.min.z += dHalfLength.z;
+        childVoxelBBox.max.z += dHalfLength.z;
+    } else if (childIndex === 3) {
+        childVoxelBBox.min.z += dHalfLength.z;
+        childVoxelBBox.max.z += dHalfLength.z;
+        childVoxelBBox.min.y += dHalfLength.y;
+        childVoxelBBox.max.y += dHalfLength.y;
+    } else if (childIndex === 0) {
+        //
+    } else if (childIndex === 2) {
+        childVoxelBBox.min.y += dHalfLength.y;
+        childVoxelBBox.max.y += dHalfLength.y;
+    } else if (childIndex === 5) {
+        childVoxelBBox.min.z += dHalfLength.z;
+        childVoxelBBox.max.z += dHalfLength.z;
+        childVoxelBBox.min.x += dHalfLength.x;
+        childVoxelBBox.max.x += dHalfLength.x;
+    } else if (childIndex === 7) {
+        childVoxelBBox.min.add(dHalfLength);
+        childVoxelBBox.max.add(dHalfLength);
+    } else if (childIndex === 4) {
+        childVoxelBBox.min.x += dHalfLength.x;
+        childVoxelBBox.max.x += dHalfLength.x;
+    } else if (childIndex === 6) {
+        childVoxelBBox.min.y += dHalfLength.y;
+        childVoxelBBox.max.y += dHalfLength.y;
+        childVoxelBBox.min.x += dHalfLength.x;
+        childVoxelBBox.max.x += dHalfLength.x;
+    }
+
+    return childVoxelBBox;
+}
+
 class PotreeNode extends PointCloudNode {
-    constructor(numPoints = 0, childrenBitField = 0, source) {
+    constructor(numPoints = 0, childrenBitField = 0, source, crs) {
         super(numPoints, source);
         this.childrenBitField = childrenBitField;
 
@@ -16,6 +56,8 @@ class PotreeNode extends PointCloudNode {
         this.hierarchyKey = 'r';
 
         this.baseurl = source.baseurl;
+
+        this.crs = crs;
     }
 
     get octreeIsLoaded() {
@@ -36,84 +78,71 @@ class PotreeNode extends PointCloudNode {
         super.add(node, indexChild);
     }
 
-    createChildAABB(node, childIndex) {
-        // Code inspired from potree
-        node.bbox.copy(this.bbox);
-        this.bbox.getCenter(node.bbox.max);
-        dHalfLength.copy(node.bbox.max).sub(this.bbox.min);
+    createChildAABB(childNode, childIndex) {
+        childNode.voxelOBB.copy(this.voxelOBB);
+        childNode.voxelOBB.box3D = computeChildBBox(this.voxelOBB.box3D, childIndex);
 
-        if (childIndex === 1) {
-            node.bbox.min.z += dHalfLength.z;
-            node.bbox.max.z += dHalfLength.z;
-        } else if (childIndex === 3) {
-            node.bbox.min.z += dHalfLength.z;
-            node.bbox.max.z += dHalfLength.z;
-            node.bbox.min.y += dHalfLength.y;
-            node.bbox.max.y += dHalfLength.y;
-        } else if (childIndex === 0) {
-            //
-        } else if (childIndex === 2) {
-            node.bbox.min.y += dHalfLength.y;
-            node.bbox.max.y += dHalfLength.y;
-        } else if (childIndex === 5) {
-            node.bbox.min.z += dHalfLength.z;
-            node.bbox.max.z += dHalfLength.z;
-            node.bbox.min.x += dHalfLength.x;
-            node.bbox.max.x += dHalfLength.x;
-        } else if (childIndex === 7) {
-            node.bbox.min.add(dHalfLength);
-            node.bbox.max.add(dHalfLength);
-        } else if (childIndex === 4) {
-            node.bbox.min.x += dHalfLength.x;
-            node.bbox.max.x += dHalfLength.x;
-        } else if (childIndex === 6) {
-            node.bbox.min.y += dHalfLength.y;
-            node.bbox.max.y += dHalfLength.y;
-            node.bbox.min.x += dHalfLength.x;
-            node.bbox.max.x += dHalfLength.x;
+        childNode.clampOBB.copy(childNode.voxelOBB);
+        const childClampBBox = childNode.clampOBB.box3D;
+
+        if (childClampBBox.min.z < this.source.zmax) {
+            childClampBBox.max.z = Math.min(childClampBBox.max.z, this.source.zmax);
         }
+        if (childClampBBox.max.z > this.source.zmin) {
+            childClampBBox.min.z = Math.max(childClampBBox.min.z, this.source.zmin);
+        }
+
+        childNode.voxelOBB.matrixWorldInverse = this.voxelOBB.matrixWorldInverse;
+        childNode.clampOBB.matrixWorldInverse = this.clampOBB.matrixWorldInverse;
     }
 
-    load() {
+    networkOptions() {
+    }
+
+    async load() {
         // Query octree/HRC if we don't have children potreeNode yet.
         if (!this.octreeIsLoaded) {
-            this.loadOctree();
+            await this.loadOctree();
         }
-        return super.load();
+        return super.load(this.networkOptions());
     }
 
     loadOctree() {
+        this.offsetBBox = new THREE.Box3().setFromArray(this.source.boundsConforming);// Only for Potree1
         const octreeUrl = `${this.baseurl}/${this.hierarchyKey}.${this.source.extensionOctree}`;
-        return this.source.fetcher(octreeUrl, this.source.networkOptions).then((blob) => {
-            const view = new DataView(blob);
-            const stack = [];
-            let offset = 0;
+        return this.source.fetcher(octreeUrl, this.source.networkOptions)
+            .then((blob) => {
+                const view = new DataView(blob);
+                const stack = [];
+                let offset = 0;
 
-            this.childrenBitField = view.getUint8(0); offset += 1;
-            this.numPoints = view.getUint32(1, true); offset += 4;
+                this.childrenBitField = view.getUint8(0); offset += 1;
+                this.numPoints = view.getUint32(1, true); offset += 4;
 
-            stack.push(this);
+                stack.push(this);
 
-            while (stack.length && offset < blob.byteLength) {
-                const snode = stack.shift();
-                // look up 8 children
-                for (let indexChild = 0; indexChild < 8; indexChild++) {
-                    // does snode have a #indexChild child ?
-                    if (snode.childrenBitField & (1 << indexChild) && (offset + 5) <= blob.byteLength) {
-                        const childrenBitField = view.getUint8(offset); offset += 1;
-                        const numPoints = view.getUint32(offset, true) || this.numPoints; offset += 4;
-                        const child = new PotreeNode(numPoints, childrenBitField, this.source);
-                        snode.add(child, indexChild);
-                        if ((child.depth % this.source.hierarchyStepSize) == 0) {
-                            child.baseurl = `${this.baseurl}/${child.hierarchyKey.substring(1)}`;
-                        } else {
-                            child.baseurl = this.baseurl;
+                while (stack.length && offset < blob.byteLength) {
+                    const snode = stack.shift();
+                    // look up 8 children
+                    for (let indexChild = 0; indexChild < 8; indexChild++) {
+                        // does snode have a #indexChild child ?
+                        if (snode.childrenBitField & (1 << indexChild) && (offset + 5) <= blob.byteLength) {
+                            const childrenBitField = view.getUint8(offset); offset += 1;
+                            const numPoints = view.getUint32(offset, true) || this.numPoints; offset += 4;
+                            const child = new PotreeNode(numPoints, childrenBitField, this.source, this.crs);
+
+                            snode.add(child, indexChild);
+                            child.offsetBBox = computeChildBBox(child.parent.offsetBBox, indexChild);// For Potree1 Parser
+                            if ((child.depth % this.source.hierarchyStepSize) == 0) {
+                                child.baseurl = `${this.baseurl}/${child.hierarchyKey.substring(1)}`;
+                            } else {
+                                child.baseurl = this.baseurl;
+                            }
+                            stack.push(child);
                         }
-                        stack.push(child);
                     }
                 }
-            }
-        });
+            });
     }
 }
 

--- a/packages/Main/src/Layer/CopcLayer.js
+++ b/packages/Main/src/Layer/CopcLayer.js
@@ -1,4 +1,3 @@
-import * as THREE from 'three';
 import CopcNode from 'Core/CopcNode';
 import PointCloudLayer from 'Layer/PointCloudLayer';
 
@@ -39,22 +38,14 @@ class CopcLayer extends PointCloudLayer {
 
         const resolve = super.addInitializationStep();
         this.whenReady = this.source.whenReady.then((/** @type {CopcSource} */ source) => {
-            const { cube } = source.info;
+            this.setElevationRange();
+
             const { pageOffset, pageLength } = source.info.rootHierarchyPage;
+            this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1, this.crs);
+            const { cube } = source.info;
+            this.root.setOBBes(cube.slice(0, 3), cube.slice(3, 6));
 
-            const root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this.source, -1);
-            root.bbox.min.fromArray(cube, 0);
-            root.bbox.max.fromArray(cube, 3);
-
-            this.minElevationRange = this.minElevationRange ?? source.header.min[2];
-            this.maxElevationRange = this.maxElevationRange ?? source.header.max[2];
-
-            this.scale = new THREE.Vector3(1.0, 1.0, 1.0);
-            this.offset = new THREE.Vector3(0.0, 0.0, 0.0);
-
-            this.root = root;
-
-            return root.loadOctree().then(resolve);
+            return this.root.loadOctree().then(resolve);
         });
     }
 }

--- a/packages/Main/src/Layer/PointCloudLayer.js
+++ b/packages/Main/src/Layer/PointCloudLayer.js
@@ -220,8 +220,7 @@ class PointCloudLayer extends GeometryLayer {
             this.material = new PointsMaterial(this.material);
         }
 
-        this.mode = mode || PNTS_MODE.COLOR;
-
+        this.material.mode = mode || PNTS_MODE.COLOR;
         /**
          * @type {PointCloudNode | undefined}
          */

--- a/packages/Main/src/Layer/PointCloudLayer.js
+++ b/packages/Main/src/Layer/PointCloudLayer.js
@@ -2,72 +2,11 @@ import * as THREE from 'three';
 import GeometryLayer from 'Layer/GeometryLayer';
 import PointsMaterial, { PNTS_MODE } from 'Renderer/PointsMaterial';
 import Picking from 'Core/Picking';
-import { OBBHelper } from '@itowns/debug';
 
 const point = new THREE.Vector3();
 const bboxMesh = new THREE.Mesh();
 const box3 = new THREE.Box3();
 bboxMesh.geometry.boundingBox = box3;
-
-
-/**
- * Generate the position array of the bbox corner form the bbox
- * Adapted from THREE.BoxHelper.js
- * https://github.com/mrdoob/three.js/blob/master/src/helpers/BoxHelper.js
- *
- * @param {THREE.box3} bbox - Box3 of the node
- * @returns {array}
- */
-function getCornerPosition(bbox) {
-    const array =  new Float32Array(8 * 3);
-
-    const min = bbox.min;
-    const max = bbox.max;
-
-    /*
-      5____4
-    1/___0/|
-    | 6__|_7
-    2/___3/
-
-    0: max.x, max.y, max.z
-    1: min.x, max.y, max.z
-    2: min.x, min.y, max.z
-    3: max.x, min.y, max.z
-    4: max.x, max.y, min.z
-    5: min.x, max.y, min.z
-    6: min.x, min.y, min.z
-    7: max.x, min.y, min.z
-    */
-    array[0] = max.x; array[1] = max.y; array[2] = max.z;
-    array[3] = min.x; array[4] = max.y; array[5] = max.z;
-    array[6] = min.x; array[7] = min.y; array[8] = max.z;
-    array[9] = max.x; array[10] = min.y; array[11] = max.z;
-    array[12] = max.x; array[13] = max.y; array[14] = min.z;
-    array[15] = min.x; array[16] = max.y; array[17] = min.z;
-    array[18] = min.x; array[19] = min.y; array[20] = min.z;
-    array[21] = max.x; array[22] = min.y; array[23] = min.z;
-    return array;
-}
-
-const red =  new THREE.Color(0xff0000);
-function initBoundingBox(elt, layer) {
-    // bbox in local ref -> cyan
-
-    // elt.obj.boxHelper = new THREE.Group();
-    const clampOBB = new OBBHelper(elt.clampOBB, elt.voxelKey, red);
-    elt.obj.boxHelper = clampOBB;
-    // elt.obj.boxHelper.add(clampOBB);
-    layer.bboxes.add(elt.obj.boxHelper);
-
-    // tightbbox in local ref -> blue
-    const tightboxHelper = new THREE.BoxHelper(undefined, 0x0000ff);
-    tightboxHelper.geometry.attributes.position.array = getCornerPosition(elt.obj.geometry.boundingBox);
-    tightboxHelper.applyMatrix4(elt.obj.matrixWorld);
-    elt.obj.tightboxHelper = tightboxHelper;
-    layer.bboxes.add(tightboxHelper);
-    tightboxHelper.updateMatrixWorld(true);
-}
 
 function computeSSEPerspective(context, pointSize, pointSpacing, distance) {
     if (distance <= 0) {
@@ -107,12 +46,6 @@ function computeScreenSpaceError(context, pointSize, pointSpacing, distance) {
 function markForDeletion(elt) {
     if (elt.obj) {
         elt.obj.visible = false;
-        if (__DEBUG__) {
-            if (elt.obj.boxHelper) {
-                elt.obj.boxHelper.visible = false;
-                elt.obj.tightboxHelper.visible = false;
-            }
-        }
     }
 
     if (!elt.notVisibleSince) {
@@ -354,19 +287,6 @@ class PointCloudLayer extends GeometryLayer {
         if (elt.numPoints !== 0) {
             if (elt.obj) {
                 elt.obj.visible = true;
-
-                if (__DEBUG__) {
-                    if (this.bboxes.visible) {
-                        if (!elt.obj.boxHelper) {
-                            initBoundingBox(elt, layer);
-                        }
-                        elt.obj.boxHelper.visible = true;
-                        elt.obj.boxHelper.material.color.r = 1 - elt.sse;
-                        elt.obj.boxHelper.material.color.g = elt.sse;
-
-                        elt.obj.tightboxHelper.visible = true;
-                    }
-                }
             } else if (!elt.promise) {
                 const distance = Math.max(0.001, distanceToCamera);
                 // Increase priority of nearest node
@@ -510,36 +430,7 @@ class PointCloudLayer extends GeometryLayer {
                 obj.material = null;
                 obj.geometry = null;
                 obj.userData.node.obj = null;
-
-                if (__DEBUG__) {
-                    if (obj.boxHelper) {
-                        obj.boxHelper.removeMe = true;
-                        if (Array.isArray(obj.boxHelper.material)) {
-                            for (const material of obj.boxHelper.material) {
-                                material.dispose();
-                            }
-                        } else {
-                            obj.boxHelper.material.dispose();
-                        }
-                        obj.boxHelper.geometry.dispose();
-                    }
-                    if (obj.tightboxHelper) {
-                        obj.tightboxHelper.removeMe = true;
-                        if (Array.isArray(obj.tightboxHelper.material)) {
-                            for (const material of obj.tightboxHelper.material) {
-                                material.dispose();
-                            }
-                        } else {
-                            obj.tightboxHelper.material.dispose();
-                        }
-                        obj.tightboxHelper.geometry.dispose();
-                    }
-                }
             }
-        }
-
-        if (__DEBUG__) {
-            this.bboxes.children = this.bboxes.children.filter(b => !b.removeMe);
         }
     }
 

--- a/packages/Main/src/Layer/VpcLayer.js
+++ b/packages/Main/src/Layer/VpcLayer.js
@@ -3,19 +3,18 @@ import PointCloudNode from 'Core/PointCloudNode';
 import CopcNode from 'Core/CopcNode';
 import EntwinePointTileNode from 'Core/EntwinePointTileNode';
 import PointCloudLayer from 'Layer/PointCloudLayer';
+import OBB from 'Renderer/OBB';
 
-function _instantiateRootNode(source) {
+function _instantiateRootNode(source, crs) {
     let root;
     if (source.isCopcSource) {
         const { info } = source;
         const { pageOffset, pageLength } = info.rootHierarchyPage;
-        root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1);
-        root.bbox.min.fromArray(info.cube, 0);
-        root.bbox.max.fromArray(info.cube, 3);
+        root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1, crs);
+        root.setOBBes(info.cube.slice(0, 3), info.cube.slice(3, 6));
     } else if (source.isEntwinePointTileSource) {
-        root = new EntwinePointTileNode(0, 0, 0, 0, source, -1);
-        root.bbox.min.fromArray(source.boundsConforming, 0);
-        root.bbox.max.fromArray(source.boundsConforming, 3);
+        root = new EntwinePointTileNode(0, 0, 0, 0, source, -1, crs);
+        root.setOBBes(source.boundsConforming.slice(0, 3), source.boundsConforming.slice(3, 6));
     } else {
         const msg = '[VPCLayer]: stack point cloud format not supporter';
         console.warn(msg);
@@ -70,31 +69,32 @@ class VpcLayer extends PointCloudLayer {
 
         // a Vpc layer should be ready when all the child sources are
         this.whenReady = this.source.whenReady.then((/** @type {VpcSource} */ sources) => {
-            this.minElevationRange = this.minElevationRange ?? this.source.minElevation;
-            this.maxElevationRange = this.maxElevationRange ?? this.source.maxElevation;
+            this.setElevationRange();
 
             const boundsConforming = this.source.boundsConforming;
             this.root = new PointCloudNode(0, this.source);
-            this.root.bbox.min.fromArray(boundsConforming, 0);
-            this.root.bbox.max.fromArray(boundsConforming, 3);
+            this.root.crs = this.crs;
+            this.root.setOBBes(boundsConforming.slice(0, 3), boundsConforming.slice(3, 6));
             this.root.depth = 0;
 
             sources.forEach((source, i) => {
                 const boundsConforming = source.boundsConforming;
-                const bbox = new THREE.Box3().setFromArray(boundsConforming);
                 const mockRoot = {
-                    bbox,
+                    voxelOBB: new OBB(),
+                    clampOBB: new OBB(),
                     children: [],
                     waitingForSource: true,
                     source,
+                    crs: this.crs,
                 };
+                PointCloudNode.prototype.setOBBes.call(mockRoot, boundsConforming.slice(0, 3), boundsConforming.slice(3, 6));
 
                 // As we delayed the intanciation of the source to the moment we need to render a particular node,
                 // we need to wait for the source to be instantiate to be able
                 // to instantiate a node and load the Octree associated.
                 const promise =
                     source.whenReady.then((src) => {
-                        const root = _instantiateRootNode(src);
+                        const root = _instantiateRootNode(src, this.crs);
                         this.root.children[i] = root;
                         return root.loadOctree().then(resolve)
                             .then(() => root);

--- a/packages/Main/src/Loader/Potree2Loader.js
+++ b/packages/Main/src/Loader/Potree2Loader.js
@@ -89,7 +89,7 @@ export default function load(buffer, options) {
 
                 const x = (view.getInt32(pointOffset + attributeOffset + 0, true) * scale[0]) + offset[0] - min.x;
                 const y = (view.getInt32(pointOffset + attributeOffset + 4, true) * scale[1]) + offset[1] - min.y;
-                const z = (view.getInt32(pointOffset + attributeOffset + 8, true) * scale[2]) + offset[2] - min.z;
+                const z = (view.getInt32(pointOffset + attributeOffset + 8, true) * scale[2]) + offset[2];
 
                 const index = toIndex(x, y, z);
                 const count = grid[index]++;

--- a/packages/Main/src/Loader/Potree2Loader.js
+++ b/packages/Main/src/Loader/Potree2Loader.js
@@ -33,6 +33,7 @@ of the authors and should not be interpreted as representing official policies,
     either expressed or implied, of the FreeBSD Project.
  */
 
+import proj4 from 'proj4';
 import { PointAttribute, PointAttributeTypes } from 'Core/Potree2PointAttributes';
 
 const typedArrayMapping = {
@@ -48,10 +49,50 @@ const typedArrayMapping = {
     double: Float64Array,
 };
 
+/**
+ * Applies the given Quaternion to this vector.
+ * @param {Array} v - The array depicting the position [x, y, z].
+ * @param {Array} q - The Array depicting the Quaternion. [x, y, z, w]
+ *
+ * @return {Vector3} A reference to this vector.
+ */
+function _applyQuaternion(v, q) {
+    // quaternion q is assumed to have unit length
+    const vx = v[0];
+    const vy = v[1];
+    const vz = v[2];
+    const qx = q[0];
+    const qy = q[1];
+    const qz = q[2];
+    const qw = q[3];
+
+    // t = 2 * cross( q.xyz, v );
+    const tx = 2 * (qy * vz - qz * vy);
+    const ty = 2 * (qz * vx - qx * vz);
+    const tz = 2 * (qx * vy - qy * vx);
+
+    const res = [];
+    // v + q.w * t + cross( q.xyz, t );
+    res[0] = vx + qw * tx + qy * tz - qz * ty;
+    res[1] = vy + qw * ty + qz * tx - qx * tz;
+    res[2] = vz + qw * tz + qx * ty - qy * tx;
+
+    return res;
+}
+
 export default function load(buffer, options) {
-    const { pointAttributes, scale, min, size, offset, numPoints } = options;
+    const { pointAttributes, scale, size, offset, numPoints } = options;
 
     const view = new DataView(buffer);
+
+    const forward = (options.in.crs !== options.out.crs) ?
+        proj4(options.in.projDefs, options.out.projDefs).forward :
+        (x => x);
+    const applyQuaternion = (options.in.crs !== options.out.crs) ?
+        _applyQuaternion : (x => x);
+
+    const origin = options.out.origin;
+    const quaternion = options.out.rotation;
 
     const attributeBuffers = {};
     let attributeOffset = 0;
@@ -87,19 +128,31 @@ export default function load(buffer, options) {
             for (let j = 0; j < numPoints; j++) {
                 const pointOffset = j * bytesPerPoint;
 
-                const x = (view.getInt32(pointOffset + attributeOffset + 0, true) * scale[0]) + offset[0] - min.x;
-                const y = (view.getInt32(pointOffset + attributeOffset + 4, true) * scale[1]) + offset[1] - min.y;
-                const z = (view.getInt32(pointOffset + attributeOffset + 8, true) * scale[2]) + offset[2];
+                const point = [
+                    (view.getInt32(pointOffset + attributeOffset + 0, true) * scale[0]) + offset[0],
+                    (view.getInt32(pointOffset + attributeOffset + 4, true) * scale[1]) + offset[1],
+                    (view.getInt32(pointOffset + attributeOffset + 8, true) * scale[2]) + offset[2],
+                ];
 
-                const index = toIndex(x, y, z);
+                const [x, y, z] = forward(point);
+
+                const position = applyQuaternion([
+                    x - origin[0],
+                    y - origin[1],
+                    z - origin[2],
+                ], quaternion);
+
+                // Ask what is it doign exactly ?
+                // const index = toIndex(x, y, z);
+                const index = toIndex(position.x, position.y, position.z);
                 const count = grid[index]++;
                 if (count === 0) {
                     numOccupiedCells++;
                 }
 
-                positions[3 * j + 0] = x;
-                positions[3 * j + 1] = y;
-                positions[3 * j + 2] = z;
+                positions[3 * j + 0] = position[0];
+                positions[3 * j + 1] = position[1];
+                positions[3 * j + 2] = position[2];
             }
 
             attributeBuffers[pointAttribute.name] = { buffer: buff, attribute: pointAttribute };

--- a/packages/Main/src/Parser/LASParser.js
+++ b/packages/Main/src/Parser/LASParser.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 import { spawn, Thread, Transfer } from 'threads';
+import proj4 from 'proj4';
+import { OrientationUtils, Coordinates } from '@itowns/geographic';
 
 let _lazPerf;
 let _thread;
@@ -17,6 +19,22 @@ async function loader() {
     _thread = await spawn(workerInstance());
     if (_lazPerf) { _thread.lazPerf(_lazPerf); }
     return _thread;
+}
+
+function getOrigin(options) {
+    const center = options.out.origin;
+    const centerCrsIn = proj4(options.out.crs, options.in.crs).forward(center);
+    return proj4(options.in.crs, options.out.crs).forward([centerCrsIn.x, centerCrsIn.y, 0]);
+}
+
+function getLocalRotation(options, origin) {
+    const isGeocentric = proj4.defs(options.out.crs).projName === 'geocent';
+    let rotation = new THREE.Quaternion();
+    if (isGeocentric) {
+        const coordOrigin = new Coordinates(options.out.crs).setFromArray(origin);
+        rotation = OrientationUtils.quaternionFromCRSToCRS(options.out.crs, options.in.crs)(coordOrigin);
+    }
+    return rotation;
 }
 
 function buildBufferGeometry(attributes) {
@@ -46,8 +64,6 @@ function buildBufferGeometry(attributes) {
     }
     const scanAngle = new THREE.BufferAttribute(attributes.scanAngle, 1);
     geometry.setAttribute('scanAngle', scanAngle);
-
-    geometry.userData.origin = new THREE.Vector3().fromArray(attributes.origin);
 
     return geometry;
 }
@@ -106,15 +122,29 @@ export default {
      */
     async parseChunk(data, options = {}) {
         const lasLoader = await loader();
+        const origin = getOrigin(options);
+        const quaternion = getLocalRotation(options, origin);
         const parsedData = await lasLoader.parseChunk(Transfer(data), {
             pointCount: options.in.pointCount,
             header: options.in.header,
-            eb: options.eb,
+            eb: options.in.eb,
             colorDepth: options.in.colorDepth,
+            in: {
+                crs: options.in.crs,
+                projDefs: proj4.defs(options.in.crs),
+            },
+            out: {
+                crs: options.out.crs,
+                projDefs: proj4.defs(options.out.crs),
+                origin,
+                rotation: quaternion.toArray(),
+            },
         });
 
         const geometry = buildBufferGeometry(parsedData.attributes);
-        geometry.computeBoundingBox();
+        geometry.boundingBox = new THREE.Box3().setFromArray(parsedData.attributes.bbox);
+        geometry.userData.origin = new THREE.Vector3().fromArray(origin);
+        geometry.userData.rotation = quaternion;
         return geometry;
     },
 
@@ -125,9 +155,12 @@ export default {
      * @param {ArrayBuffer} data - The file content to parse.
      * @param {Object} [options]
      * @param {Object} [options.in] - Options to give to the parser.
+     * @param {String} options.in.crs - Crs of the source.
+     * @param {String} options.out.crs - Crs of the view.
      * @param { 8 | 16 } [options.in.colorDepth] - Color depth (in bits).
      * Defaults to 8 bits for LAS 1.2 and 16 bits for later versions
      * (as mandatory by the specification)
+
      *
      * @return {Promise} A promise resolving with a `THREE.BufferGeometry`. The
      * header of the file is contained in `userData`.
@@ -137,16 +170,29 @@ export default {
             console.warn("Warning: options 'skip' not supported anymore");
         }
 
-        const input = options.in;
-
         const lasLoader = await loader();
+        const origin = getOrigin(options);
+        const quaternion = getLocalRotation(options, origin);
         const parsedData = await lasLoader.parseFile(Transfer(data), {
-            colorDepth: input?.colorDepth,
+            colorDepth: options.in.colorDepth,
+            in: {
+                crs: options.in.crs,
+                projDefs: proj4.defs(options.in.crs),
+            },
+            out: {
+                crs: options.out.crs,
+                projDefs: proj4.defs(options.out.crs),
+                origin,
+                rotation: quaternion.toArray(),
+            },
         });
 
         const geometry = buildBufferGeometry(parsedData.attributes);
+        geometry.boundingBox = new THREE.Box3().setFromArray(parsedData.attributes.bbox);
+        geometry.userData.origin = new THREE.Vector3().fromArray(origin);
+        geometry.userData.rotation = quaternion;
         geometry.userData.header = parsedData.header;
-        geometry.computeBoundingBox();
+
         return geometry;
     },
 };

--- a/packages/Main/src/Parser/PotreeBinParser.js
+++ b/packages/Main/src/Parser/PotreeBinParser.js
@@ -1,3 +1,4 @@
+import proj4 from 'proj4';
 import * as THREE from 'three';
 
 // See the different constants holding ordinal, name, numElements, byteSize in PointAttributes.cpp in PotreeConverter
@@ -49,6 +50,31 @@ const POINT_ATTRIBUTES = {
     },
 };
 
+// Find a way to factor this methode between the different PointCloud Parser
+function _applyQuaternion(v, q) {
+    // quaternion q is assumed to have unit length
+    const vx = v[0];
+    const vy = v[1];
+    const vz = v[2];
+    const qx = q[0];
+    const qy = q[1];
+    const qz = q[2];
+    const qw = q[3];
+
+    // t = 2 * cross( q.xyz, v );
+    const tx = 2 * (qy * vz - qz * vy);
+    const ty = 2 * (qz * vx - qx * vz);
+    const tz = 2 * (qx * vy - qy * vx);
+
+    const res = [];
+    // v + q.w * t + cross( q.xyz, t );
+    res[0] = vx + qw * tx + qy * tz - qz * ty;
+    res[1] = vy + qw * ty + qz * tx - qx * tz;
+    res[2] = vz + qw * tz + qx * ty - qy * tx;
+
+    return res;
+}
+
 for (const potreeName of Object.keys(POINT_ATTRIBUTES)) {
     const attr = POINT_ATTRIBUTES[potreeName];
     attr.potreeName = potreeName;
@@ -69,6 +95,7 @@ export default {
      * @param {ArrayBuffer} buffer - the bin buffer.
      * @param {Object} options
      * @param {string[]} options.in.pointAttributes - the point attributes information contained in cloud.js
+     * @param {THREE.Vector3} options.out.origin - the origin position of the data
      * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      *
      */
@@ -79,8 +106,24 @@ export default {
 
         const view = new DataView(buffer);
         // Format: X1,Y1,Z1,R1,G1,B1,A1,[...],XN,YN,ZN,RN,GN,BN,AN
+        const source = options.in.source;
+        const scale = source.scale;
+        const pointAttributes = source.pointAttributes;
+
+        // find a methode by recursion to get offset from the node id ?
+        const offset = options.in.offsetBBox.min.toArray();
+
+        const forward = (source.crs !== options.in.crs) ?
+            proj4(source.crs, options.in.crs).forward :
+            (x => x);
+        const applyQuaternion = (source.crs !== options.in.crs) ?
+            _applyQuaternion : (x => x);
+
+        const origin = options.in.origin.toArray();
+        const quaternion = options.in.rotation.toArray();
+
         let pointByteSize = 0;
-        for (const potreeName of options.in.pointAttributes) {
+        for (const potreeName of pointAttributes) {
             pointByteSize += POINT_ATTRIBUTES[potreeName].byteSize;
         }
         const numPoints = Math.floor(buffer.byteLength / pointByteSize);
@@ -88,20 +131,46 @@ export default {
         const geometry = new THREE.BufferGeometry();
         let elemOffset = 0;
         let attrOffset = 0;
-        for (const potreeName of options.in.pointAttributes) {
+
+        for (const potreeName of pointAttributes) {
             const attr = POINT_ATTRIBUTES[potreeName];
             const arrayLength = attr.numElements * numPoints;
             const array = new attr.arrayType(arrayLength);
             for (let arrayOffset = 0; arrayOffset < arrayLength; arrayOffset += attr.numElements) {
+                const position = [];
                 for (let elemIdx = 0; elemIdx < attr.numElements; elemIdx++) {
-                    array[arrayOffset + elemIdx] = attr.getValue(view, attrOffset + elemIdx * attr.numByte);
+                    if (attr.attributeName === 'position') {
+                        position.push(attr.getValue(view, attrOffset + elemIdx * attr.numByte)
+                        * scale
+                        + offset[elemIdx]);
+                    } else {
+                        array[arrayOffset + elemIdx] = attr.getValue(view, attrOffset + elemIdx * attr.numByte);
+                    }
                 }
+                if (attr.attributeName === 'position') {
+                    const [x, y, z] = forward(position);
+
+                    const position2 = applyQuaternion([
+                        x - origin[0],
+                        y - origin[1],
+                        z - origin[2],
+                    ], quaternion);
+
+                    array[arrayOffset + 0] = position2[0];
+                    array[arrayOffset + 1] = position2[1];
+                    array[arrayOffset + 2] = position2[2];
+                }
+
                 attrOffset += pointByteSize;
             }
             elemOffset += attr.byteSize;
             attrOffset = elemOffset;
+
             geometry.setAttribute(attr.attributeName, new THREE.BufferAttribute(array, attr.numElements, attr.normalized));
         }
+
+        geometry.userData.origin = options.in.origin;
+        geometry.userData.rotation = options.in.rotation;
 
         geometry.computeBoundingBox();
 

--- a/packages/Main/src/Parser/PotreeCinParser.js
+++ b/packages/Main/src/Parser/PotreeCinParser.js
@@ -5,10 +5,12 @@ export default {
     /** Parse .cin PotreeConverter format (see {@link https://github.com/peppsac/PotreeConverter/tree/custom_bin}) and convert to a THREE.BufferGeometry
      * @function parse
      * @param {ArrayBuffer} buffer - the cin buffer.
-     * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
+     * @param {Object} options
+     * @param {THREE.Vector3} options.out.origin - the origin position of the data
      *
+     * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      */
-    parse: function parse(buffer) {
+    parse: function parse(buffer, options) {
         if (!buffer) {
             throw new Error('No array buffer provided.');
         }
@@ -28,6 +30,9 @@ export default {
         geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         geometry.setAttribute('color', new THREE.BufferAttribute(colors, 4, true));
         geometry.boundingBox = box;
+
+        geometry.userData.origin = options.out.origin;
+        geometry.userData.rotation = new THREE.Quaternion();
 
         return Promise.resolve(geometry);
     },

--- a/packages/Main/src/Provider/PointCloudProvider.js
+++ b/packages/Main/src/Provider/PointCloudProvider.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { Extent } from '@itowns/geographic';
 
 let nextuuid = 1;
 function addPickingAttribute(points) {
@@ -36,12 +35,16 @@ export default {
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            points.position.copy(geometry.userData.origin || node.bbox.min);
-            points.scale.copy(layer.scale);
+            points.position.copy(geometry.userData.origin);
+
+            const quaternion = geometry.userData.rotation.clone().invert();
+            points.quaternion.copy(quaternion);
             points.updateMatrix();
-            points.tightbbox = geometry.boundingBox.applyMatrix4(points.matrix);
+            points.updateMatrixWorld(true);
+
+            points.matrixWorldInverse = points.matrixWorld.clone().invert();
+
             points.layer = layer;
-            points.extent = Extent.fromBox3(command.view.referenceCrs, node.bbox);
             points.userData.node = node;
             return points;
         });

--- a/packages/Main/src/Renderer/Shader/PointsVS.glsl
+++ b/packages/Main/src/Renderer/Shader/PointsVS.glsl
@@ -98,7 +98,7 @@ void main() {
             vec2 uv = vec2(i, (1. - i));
             vColor = texture2D(gradientTexture, uv);
         } else if (mode == PNTS_MODE_ELEVATION) {
-            float z = (modelMatrix * vec4(position, 1.0)).z;
+            float z = vec4(position, 1.0).z;
             float i = (z - elevationRange.x) / (elevationRange.y - elevationRange.x);
             vec2 uv = vec2(i, (1. - i));
             vColor = texture2D(gradientTexture, uv);

--- a/packages/Main/src/Source/CopcSource.js
+++ b/packages/Main/src/Source/CopcSource.js
@@ -1,9 +1,8 @@
 import { Binary, Info, Las } from 'copc';
-import { CRS, Extent } from '@itowns/geographic';
+import { CRS } from '@itowns/geographic';
 import Fetcher from 'Provider/Fetcher';
 import LASParser from 'Parser/LASParser';
 import Source from 'Source/Source';
-import * as THREE from 'three';
 
 /**
  * @param {function(number, number):Promise<Uint8Array>} fetcher
@@ -98,19 +97,18 @@ class CopcSource extends Source {
                     range: `bytes=${begin}-${end - 1}`,
                 },
             }).then(buffer => new Uint8Array(buffer));
+
         this.whenReady = getHeaders(get).then((metadata) => {
             this.header = metadata.header;
             this.info = metadata.info;
             this.eb = metadata.eb;
 
+            this.zmin = this.header.min[2];
+            this.zmax = this.header.max[2];
+
             this.spacing = this.info.spacing;
 
             this.crs = CRS.defsFromWkt(metadata.wkt);
-
-            const bbox = new THREE.Box3();
-            bbox.min.fromArray(this.info.cube, 0);
-            bbox.max.fromArray(this.info.cube, 3);
-            this.extent = Extent.fromBox3(this.crs, bbox);
 
             return this;
         });

--- a/packages/Main/src/Source/EntwinePointTileSource.js
+++ b/packages/Main/src/Source/EntwinePointTileSource.js
@@ -31,13 +31,28 @@ class EntwinePointTileSource extends Source {
         this.isEntwinePointTileSource = true;
         this.colorDepth = config.colorDepth;
 
+        this.fetcher = Fetcher.arrayBuffer;
+
         // Necessary because we use the url without the ept.json part as a base
         this.url = this.url.replace('/ept.json', '');
 
         // https://entwine.io/entwine-point-tile.html#ept-json
         this.whenReady = Fetcher.json(`${this.url}/ept.json`, this.networkOptions).then((metadata) => {
+            this.boundsConforming = metadata.boundsConforming;
+            this.bounds = metadata.bounds;// xMin, yMin, zMin, xMax, yMax, zMax
+            this.span = metadata.span;
+
+            this.zmin = this.boundsConforming[2];
+            this.zmax = this.boundsConforming[5];
+
+            // NOTE: this spacing is kinda arbitrary here, we take the width and
+            // length (height can be ignored), and we divide by the specified
+            // span in ept.json. This needs improvements.
+            this.spacing = (Math.abs(this.bounds[3] - this.bounds[0])
+                + Math.abs(this.bounds[4] - this.bounds[1])) / (2 * this.span);
+
             // Set parser and its configuration from schema
-            this.parse = metadata.dataType === 'laszip' ? LASParser.parse : PotreeBinParser.parse;
+            this.parser = metadata.dataType === 'laszip' ? LASParser.parse : PotreeBinParser.parse;
             this.extension = metadata.dataType === 'laszip' ? 'laz' : 'bin';
 
             if (metadata.srs) {
@@ -54,20 +69,8 @@ class EntwinePointTileSource extends Source {
                 }
             }
 
-            this.boundsConforming = metadata.boundsConforming;
-            this.bounds = metadata.bounds; // xMin, yMin, zMin, xMax, yMax, zMax
-            this.span = metadata.span;
-
-            // NOTE: this spacing is kinda arbitrary here, we take the width and
-            // length (height can be ignored), and we divide by the specified
-            // span in ept.json. This needs improvements.
-            this.spacing = (Math.abs(this.bounds[3] - this.bounds[0])
-                + Math.abs(this.bounds[4] - this.bounds[1])) / (2 * this.span);
-
             return this;
         });
-
-        this.fetcher = Fetcher.arrayBuffer;
     }
 }
 

--- a/packages/Main/src/Source/Potree2Source.js
+++ b/packages/Main/src/Source/Potree2Source.js
@@ -217,6 +217,10 @@ class Potree2Source extends Source {
         if (!source.file) {
             throw new Error('New Potree2Source: file is required');
         }
+        if (!source.crs) {
+            // with better data and the spec this might be removed
+            throw new Error('New PotreeSource: crs is required');
+        }
 
         super(source);
         this.file = source.file;
@@ -229,6 +233,9 @@ class Potree2Source extends Source {
                 this.baseurl = `${this.url}`;
                 this.extension = 'bin';
                 this.parser = Potree2BinParser.parse;
+
+                this.zmin = metadata.attributes.filter(attributes => attributes.name === 'position')[0].min[2];
+                this.zmax = metadata.attributes.filter(attributes => attributes.name === 'position')[0].max[2];
 
                 this.spacing = metadata.spacing;
 

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -39,6 +39,19 @@ describe('COPC', function () {
                     }).catch(done);
             }).timeout(5000);
         });
+
+        describe('Copc Layer', function () {
+            it('instanciates a layer', (done) => {
+                const layer = new CopcLayer('copc', { source, crs: 'EPSG:4978' });
+                layer.whenReady
+                    .then(() => {
+                        assert.equal(layer.zmin, source.header.min[2]);
+                        assert.ok(layer.root.isCopcNode);
+                        assert.ok(layer.root.children.length > 0);
+                        done();
+                    }).catch(done);
+            });
+        });
     });
 
     describe('Layer', function () {

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -120,7 +120,7 @@ describe('Entwine Point Tile', function () {
             const coord = new Coordinates(view.referenceCrs).setFromVector3(layer.root.voxelOBB.box3D.getCenter(lookAt));
             view.controls.lookAtCoordinate({
                 coord,
-                range: 250,
+                range: -250,
             }, false)
                 .then(() => {
                     layer.update(context, layer, layer.root);
@@ -139,25 +139,25 @@ describe('Entwine Point Tile', function () {
     describe('Entwine Point Tile Node', function () {
         let root;
         before(function () {
-            const layer = { source: { url: 'http://server.geo', extension: 'laz' } };
-            root = new EntwinePointTileNode(0, 0, 0, 0, layer, 4000);
+            const source = { url: 'http://server.geo', extension: 'laz' };
+            root = new EntwinePointTileNode(0, 0, 0, 0, source, 4000);
             root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
-            root.add(new EntwinePointTileNode(1, 0, 0, 0, layer, 3000));
-            root.add(new EntwinePointTileNode(1, 0, 0, 1, layer, 3000));
-            root.add(new EntwinePointTileNode(1, 0, 1, 1, layer, 3000));
+            root.add(new EntwinePointTileNode(1, 0, 0, 0, source, 3000));
+            root.add(new EntwinePointTileNode(1, 0, 0, 1, source, 3000));
+            root.add(new EntwinePointTileNode(1, 0, 1, 1, source, 3000));
 
-            root.children[0].add(new EntwinePointTileNode(2, 0, 0, 0, layer, 2000));
-            root.children[0].add(new EntwinePointTileNode(2, 0, 1, 0, layer, 2000));
-            root.children[1].add(new EntwinePointTileNode(2, 0, 1, 3, layer, 2000));
-            root.children[2].add(new EntwinePointTileNode(2, 0, 2, 2, layer, 2000));
-            root.children[2].add(new EntwinePointTileNode(2, 0, 3, 3, layer, 2000));
+            root.children[0].add(new EntwinePointTileNode(2, 0, 0, 0, source, 2000));
+            root.children[0].add(new EntwinePointTileNode(2, 0, 1, 0, source, 2000));
+            root.children[1].add(new EntwinePointTileNode(2, 0, 1, 3, source, 2000));
+            root.children[2].add(new EntwinePointTileNode(2, 0, 2, 2, source, 2000));
+            root.children[2].add(new EntwinePointTileNode(2, 0, 3, 3, source, 2000));
 
-            root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 0, 0, layer, 1000));
-            root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 1, 0, layer, 1000));
-            root.children[1].children[0].add(new EntwinePointTileNode(3, 0, 2, 7, layer, 1000));
-            root.children[2].children[0].add(new EntwinePointTileNode(3, 0, 5, 4, layer, 1000));
-            root.children[2].children[1].add(new EntwinePointTileNode(3, 1, 6, 7, layer));
+            root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 0, 0, source, 1000));
+            root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 1, 0, source, 1000));
+            root.children[1].children[0].add(new EntwinePointTileNode(3, 0, 2, 7, source, 1000));
+            root.children[2].children[0].add(new EntwinePointTileNode(3, 0, 5, 4, source, 1000));
+            root.children[2].children[1].add(new EntwinePointTileNode(3, 1, 6, 7, source));
         });
 
         describe('finds the common ancestor of two nodes', () => {

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -1,13 +1,14 @@
 import assert from 'assert';
+import { Vector3 } from 'three';
 import View from 'Core/View';
 import GlobeView from 'Core/Prefab/GlobeView';
 import { Coordinates } from '@itowns/geographic';
 import EntwinePointTileSource from 'Source/EntwinePointTileSource';
 import EntwinePointTileLayer from 'Layer/EntwinePointTileLayer';
 import EntwinePointTileNode from 'Core/EntwinePointTileNode';
-import LASParser from 'Parser/LASParser';
 import sinon from 'sinon';
 import Fetcher from 'Provider/Fetcher';
+import LASParser from 'Parser/LASParser';
 import Renderer from './bootstrap';
 
 import eptFile from '../data/entwine/ept.json';
@@ -78,17 +79,15 @@ describe('Entwine Point Tile', function () {
         });
     });
 
-    describe('Layer', function () {
+    describe('Entwine Point Tile Layer', function () {
         let renderer;
-        let placement;
         let view;
         let layer;
         let context;
 
         before(function (done) {
             renderer = new Renderer();
-            placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
-            view = new GlobeView(renderer.domElement, placement, { renderer });
+            view = new GlobeView(renderer.domElement, {}, { renderer });
             layer = new EntwinePointTileLayer('testEptLayer', { source });
 
             context = {
@@ -117,8 +116,11 @@ describe('Entwine Point Tile', function () {
         });
 
         it('tries to update on the root and succeeds', function (done) {
+            const lookAt = new Vector3();
+            const coord = new Coordinates(view.referenceCrs).setFromVector3(layer.root.voxelOBB.box3D.getCenter(lookAt));
             view.controls.lookAtCoordinate({
-                range: -250,
+                coord,
+                range: 250,
             }, false)
                 .then(() => {
                     layer.update(context, layer, layer.root);
@@ -134,12 +136,12 @@ describe('Entwine Point Tile', function () {
         });
     });
 
-    describe('Node', function () {
+    describe('Entwine Point Tile Node', function () {
         let root;
         before(function () {
             const layer = { source: { url: 'http://server.geo', extension: 'laz' } };
             root = new EntwinePointTileNode(0, 0, 0, 0, layer, 4000);
-            root.bbox.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+            root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
             root.add(new EntwinePointTileNode(1, 0, 0, 0, layer, 3000));
             root.add(new EntwinePointTileNode(1, 0, 0, 1, layer, 3000));

--- a/packages/Main/test/unit/lasparser.js
+++ b/packages/Main/test/unit/lasparser.js
@@ -2,8 +2,11 @@ import assert from 'assert';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import LASParser from 'Parser/LASParser';
 import Fetcher from 'Provider/Fetcher';
+import * as THREE from 'three';
 import proj4 from 'proj4';
+import { OrientationUtils, Coordinates } from '@itowns/geographic';
 import { compareWithEpsilon } from './utils';
+
 
 const baseurl = 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds';
 const lasUrl = `${baseurl}/data_test.las`;
@@ -34,16 +37,26 @@ describe('LASParser', function () {
         const epsilon = 0.1;
         LASParser.enableLazPerf('../../examples/libs/laz-perf');
 
+        const rotation = new THREE.Quaternion();
+
+        afterEach(async function () {
+            await LASParser.terminate();
+        });
+
         it('parses a las file to a THREE.BufferGeometry (with reprojection)', async function () {
             if (!lasData) { this.skip(); }
             proj4.defs('EPSG:2994', '+proj=lcc +lat_0=41.75 +lon_0=-120.5 +lat_1=43 +lat_2=45.5 +x_0=399999.9999984 +y_0=0 +ellps=GRS80 +towgs84=-0.991,1.9072,0.5129,-1.25033e-07,-4.6785e-08,-5.6529e-08,0 +units=ft +no_defs +type=crs');
+            const coordinates = new Coordinates('EPSG:2994', -2505146.7021798044, -3847441.7959745415, 4412576.847879505);
+            const rotation = OrientationUtils.quaternionFromCRSToCRS('EPSG:2994', 'EPSG:4978')(coordinates);
+
             const options = {
                 in: {
-                    crs: 'EPSG:2994',
-                },
-                out: {
+                    source: {
+                        crs: 'EPSG:2994',
+                    },
                     crs: 'EPSG:4978',
-                    origin: { x: -2505146.7021798044, y: -3847441.7959745415, z: 4412576.847879505 },
+                    origin: coordinates,
+                    rotation,
                 },
             };
             const bufferGeometry = await LASParser.parse(lasData, options);
@@ -52,22 +65,23 @@ describe('LASParser', function () {
             assert.strictEqual(bufferGeometry.attributes.position.count, header.pointCount);
             assert.strictEqual(bufferGeometry.attributes.intensity.count, header.pointCount);
             assert.strictEqual(bufferGeometry.attributes.classification.count, header.pointCount);
-            assert.strictEqual(bufferGeometry.attributes.color, undefined);
+            assert.strictEqual(bufferGeometry.attributes.color, undefined, 'bufferGeometry.attributes.color');
 
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z, header.min[2], epsilon));
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z, header.max[2], epsilon));
-            await LASParser.terminate();
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z, -176.9, epsilon), 'bufferGeometry.boundingBox.min.z');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z, 780.2, epsilon), 'bufferGeometry.boundingBox.max.z');
         });
 
         it('parses a laz file to a THREE.BufferGeometry', async function () {
             if (!lazV14Data) { this.skip(); }
+            const coordinates = new Coordinates('EPSG:3857', 746000, 6508000, 1000);
             const options = {
                 in: {
+                    source: {
+                        crs: 'EPSG:3857',
+                    },
                     crs: 'EPSG:3857',
-                },
-                out: {
-                    crs: 'EPSG:3857',
-                    origin: { x: 746000, y: 6508000, z: 1000 },
+                    origin: coordinates,
+                    rotation,
                 },
             };
             const bufferGeometry = await LASParser.parse(lazV14Data, options);
@@ -85,7 +99,6 @@ describe('LASParser', function () {
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + origin.x, header.max[0], epsilon));
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + origin.y, header.max[1], epsilon));
             assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + origin.z, header.max[2], epsilon));
-            await LASParser.terminate();
         });
 
         it('parses a copc chunk to a THREE.BufferGeometry', async function _it() {
@@ -121,16 +134,18 @@ describe('LASParser', function () {
                 evlrOffset: 630520,
                 evlrCount: 1,
             };
+            const coordinates = new Coordinates('EPSG:3857', 746000, 6508000, 1000);
             const options = {
                 in: {
-                    pointCount: header.pointCount,
-                    header,
+                    source: {
+                        crs: 'EPSG:3857',
+                        header,
+                    },
+                    numPoints: header.pointCount,
                     // eb,
                     crs: 'EPSG:3857',
-                },
-                out: {
-                    crs: 'EPSG:3857',
-                    origin: { x: 746000, y: 6508000, z: 1000 },
+                    origin: coordinates,
+                    rotation,
                 },
             };
             const bufferGeometry = await LASParser.parseChunk(copcData, options);
@@ -139,7 +154,6 @@ describe('LASParser', function () {
             assert.strictEqual(bufferGeometry.attributes.intensity.count, header.pointCount);
             assert.strictEqual(bufferGeometry.attributes.classification.count, header.pointCount);
             assert.strictEqual(bufferGeometry.attributes.color.count, header.pointCount);
-            await LASParser.terminate();
         });
     });
 });

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -61,6 +61,7 @@ describe('Potree', function () {
             potreeSource = new PotreeSource({
                 file: fileName,
                 url: baseurl,
+                crs: 'EPSG:4978',
             });
 
             // Configure Point Cloud layer
@@ -86,10 +87,10 @@ describe('Potree', function () {
         describe('potree Layer', function () {
             it('Add point potree layer', function (done) {
                 View.prototype.addLayer.call(viewer, potreeLayer)
-                    .then((layer) => {
+                    .then(() => {
                         context.camera.camera3D.updateMatrixWorld();
-                        assert.equal(layer.root.children.length, 6);
-                        layer.bboxes.visible = true;
+                        assert.equal(potreeLayer.root.children.length, 6);
+                        potreeLayer.bboxes.visible = true;
                         done();
                     }).catch(done);
             });

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -85,6 +85,18 @@ describe('Potree', function () {
         });
 
         describe('potree Layer', function () {
+            it('no crs -> should fail', function () {
+                try {
+                    // eslint-disable-next-line no-unused-vars
+                    const source = new PotreeSource({
+                        file: fileName,
+                        url: baseurl,
+                    });
+                } catch (err) {
+                    assert.ok(err instanceof Error);
+                    assert.equal(err.message, 'New PotreeSource: crs is required');
+                }
+            });
             it('Add point potree layer', function (done) {
                 View.prototype.addLayer.call(viewer, potreeLayer)
                     .then(() => {
@@ -148,7 +160,7 @@ describe('Potree', function () {
             });
 
             it('load child node', function (done) {
-                const root = new PotreeNode(numPoints, childrenBitField, potreeSource);
+                const root = new PotreeNode(numPoints, childrenBitField, potreeSource, 'EPSG:4978');
                 root.loadOctree()
                     .then(() => root.children[0].load()
                         .then(() => {

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -18,7 +18,7 @@ describe('Potree2', function () {
 
     before(function () {
         renderer = new Renderer();
-        viewer = new View('EPSG:3946', renderer.domElement, { renderer });
+        viewer = new View('EPSG:4978', renderer.domElement, { renderer });
         viewer.camera.camera3D.position.copy(new Vector3(0, 0, 10));
 
         // Configure Point Cloud layer
@@ -43,10 +43,10 @@ describe('Potree2', function () {
 
     it('Add point potree2 layer', function (done) {
         View.prototype.addLayer.call(viewer, potree2Layer)
-            .then((layer) => {
+            .then(() => {
                 context.camera.camera3D.updateMatrixWorld();
-                assert.equal(layer.root.children.length, 6);
-                layer.bboxes.visible = true;
+                assert.equal(potree2Layer.root.children.length, 6);
+                potree2Layer.bboxes.visible = true;
                 done();
             }).catch(done);
     });
@@ -64,7 +64,7 @@ describe('Potree2', function () {
                 assert.equal(potree2Layer.group.children.length, 1);
                 done();
             }).catch(done);
-    }).timeout(5000);
+    }).timeout(10000);
 
     it('postUpdate potree2 layer', function () {
         potree2Layer.postUpdate(context, potree2Layer);

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -26,10 +26,10 @@ describe('Potree2', function () {
             file: 'metadata.json',
             url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
             networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            crs: viewer.referenceCrs,
         });
         potree2Layer = new Potree2Layer('lion', {
             source: potree2Source,
-            crs: viewer.referenceCrs,
         });
 
         context = {
@@ -39,6 +39,20 @@ describe('Potree2', function () {
             geometryLayer: potree2Layer,
             view: viewer,
         };
+    });
+
+    it('no crs -> should fail', function () {
+        try {
+            // eslint-disable-next-line no-unused-vars
+            const source = new Potree2Source({
+                file: 'metadata.json',
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
+                networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            });
+        } catch (err) {
+            assert.ok(err instanceof Error);
+            assert.equal(err.message, 'New PotreeSource: crs is required');
+        }
     });
 
     it('Add point potree2 layer', function (done) {
@@ -95,7 +109,7 @@ describe('Potree2', function () {
         });
 
         it('load child node', function (done) {
-            const root = new Potree2Node(numPoints, childrenBitField, potree2Source);
+            const root = new Potree2Node(numPoints, childrenBitField, potree2Source, 'EPSG:4978');
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;
             root.hierarchyByteSize = 12650n;

--- a/packages/Main/test/unit/potree2BinParser.js
+++ b/packages/Main/test/unit/potree2BinParser.js
@@ -1,3 +1,4 @@
+import { Coordinates } from '@itowns/geographic';
 import assert from 'assert';
 import Potree2BinParser from 'Parser/Potree2BinParser';
 import * as THREE from 'three';
@@ -34,9 +35,15 @@ describe('Potree2BinParser', function () {
                         }],
                         vectors: [],
                     },
+                    crs: 'EPSG:4978',
                 },
-                bbox: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
+                voxelOBB: {
+                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
+                },
                 numPoints: nbPoints,
+                crs: 'EPSG:4978',
+                origin: new Coordinates('EPSG:4978', 0, 0, 0),
+                rotation: new THREE.Quaternion(),
             },
         };
 
@@ -130,9 +137,15 @@ describe('Potree2BinParser', function () {
                         }],
                         vectors: [],
                     },
+                    crs: 'EPSG:4978',
                 },
-                bbox: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
+                voxelOBB: {
+                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
+                },
                 numPoints,
+                crs: 'EPSG:4978',
+                origin: new Coordinates('EPSG:4978', 0, 0, 0),
+                rotation: new THREE.Quaternion(),
             },
         };
 

--- a/packages/Main/test/unit/potree2layerparsing.js
+++ b/packages/Main/test/unit/potree2layerparsing.js
@@ -50,13 +50,16 @@ describe('Potree2 Provider', function () {
             file: 'metadata.json',
             url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
             networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            crs: 'EPSG:4978',
             metadata,
         });
 
         const layer1 = new Potree2Layer('pointsCloud1', { source, crs: view.referenceCrs });
         layers.push(layer1);
-        const p1 = layer1.whenReady.then((l) => {
-            const normalDefined = l.material.defines.NORMAL || l.material.defines.NORMAL_SPHEREMAPPED || l.material.defines.NORMAL_OCT16;
+        const p1 = layer1.whenReady.then(() => {
+            const normalDefined = layer1.material.defines.NORMAL
+                || layer1.material.defines.NORMAL_SPHEREMAPPED
+                || layer1.material.defines.NORMAL_OCT16;
             assert.ok(!normalDefined);
         });
 
@@ -65,6 +68,7 @@ describe('Potree2 Provider', function () {
             file: 'metadata.json',
             url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
             networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            crs: 'EPSG:4978',
             metadata: {
                 version: '2.0',
                 name: 'lion',
@@ -121,10 +125,10 @@ describe('Potree2 Provider', function () {
 
         const layer2 = new Potree2Layer('pointsCloud2', { source, crs: view.referenceCrs });
         layers.push(layer2);
-        const p2 = layer2.whenReady.then((l) => {
-            assert.ok(l.material.defines.NORMAL);
-            assert.ok(!l.material.defines.NORMAL_SPHEREMAPPED);
-            assert.ok(!l.material.defines.NORMAL_OCT16);
+        const p2 = layer2.whenReady.then(() => {
+            assert.ok(layer2.material.defines.NORMAL);
+            assert.ok(!layer2.material.defines.NORMAL_SPHEREMAPPED);
+            assert.ok(!layer2.material.defines.NORMAL_OCT16);
         });
 
         // // spheremapped normals
@@ -132,6 +136,7 @@ describe('Potree2 Provider', function () {
             file: 'metadata.json',
             url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
             networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            crs: 'EPSG:4978',
             metadata: {
                 version: '2.0',
                 name: 'lion',
@@ -188,10 +193,10 @@ describe('Potree2 Provider', function () {
         const layer3 = new Potree2Layer('pointsCloud3', { source, crs: view.referenceCrs });
 
         layers.push(layer3);
-        const p3 = layer3.whenReady.then((l) => {
-            assert.ok(!l.material.defines.NORMAL);
-            assert.ok(l.material.defines.NORMAL_SPHEREMAPPED);
-            assert.ok(!l.material.defines.NORMAL_OCT16);
+        const p3 = layer3.whenReady.then(() => {
+            assert.ok(!layer3.material.defines.NORMAL);
+            assert.ok(layer3.material.defines.NORMAL_SPHEREMAPPED);
+            assert.ok(!layer3.material.defines.NORMAL_OCT16);
         });
 
         // // oct16 normals
@@ -199,6 +204,7 @@ describe('Potree2 Provider', function () {
             file: 'metadata.json',
             url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
             networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+            crs: 'EPSG:4978',
             metadata: {
                 version: '2.0',
                 name: 'lion',
@@ -256,10 +262,10 @@ describe('Potree2 Provider', function () {
 
         layers.push(layer4);
         const p4 = layer4.whenReady
-            .then((l) => {
-                assert.ok(!l.material.defines.NORMAL);
-                assert.ok(!l.material.defines.NORMAL_SPHEREMAPPED);
-                assert.ok(l.material.defines.NORMAL_OCT16);
+            .then(() => {
+                assert.ok(!layer4.material.defines.NORMAL);
+                assert.ok(!layer4.material.defines.NORMAL_SPHEREMAPPED);
+                assert.ok(layer4.material.defines.NORMAL_OCT16);
             });
 
         layers.forEach(p => View.prototype.addLayer.call(view, p));

--- a/packages/Main/test/unit/potree2layerprocessing.js
+++ b/packages/Main/test/unit/potree2layerprocessing.js
@@ -10,7 +10,7 @@ describe('preUpdate Potree2Layer', function () {
         hierarchyStepSize: 1,
     };
     layer.root = new Potree2Node(4000, 0, layer);
-    layer.root.bbox.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+    layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
     layer.root.add(new Potree2Node(3000, 0, layer), 1, layer.root);
     layer.root.children[0].obj = { layer, isPoints: true };

--- a/packages/Main/test/unit/potreeBinParser.js
+++ b/packages/Main/test/unit/potreeBinParser.js
@@ -1,7 +1,13 @@
 import assert from 'assert';
 import PotreeBinParser from 'Parser/PotreeBinParser';
+import { Coordinates } from '@itowns/geographic';
+import * as THREE from 'three';
 
 describe('PotreeBinParser', function () {
+    const bBox = new THREE.Box3();
+    bBox.min.set(0, 0, 0);
+    bBox.max.set(10, 10, 10);
+
     it('should correctly parse position buffer', function (done) {
         const buffer = new ArrayBuffer(12 * 4);
         const dv = new DataView(buffer);
@@ -11,7 +17,15 @@ describe('PotreeBinParser', function () {
 
         const options = {
             in: {
-                pointAttributes: ['POSITION_CARTESIAN'],
+                source: {
+                    pointAttributes: ['POSITION_CARTESIAN'],
+                    scale: 1,
+                    crs: 'EPSG:4978',
+                },
+                crs: 'EPSG:4978',
+                origin: new Coordinates('EPSG:4978', 0, 0, 0),
+                rotation: new THREE.Quaternion(),
+                offsetBBox: bBox,
             },
         };
 
@@ -53,7 +67,15 @@ describe('PotreeBinParser', function () {
 
         const options = {
             in: {
-                pointAttributes: ['POSITION_CARTESIAN', 'INTENSITY', 'COLOR_PACKED', 'CLASSIFICATION'],
+                source: {
+                    pointAttributes: ['POSITION_CARTESIAN', 'INTENSITY', 'COLOR_PACKED', 'CLASSIFICATION'],
+                    scale: 1,
+                    crs: 'EPSG:4978',
+                },
+                crs: 'EPSG:4978',
+                origin: new Coordinates('EPSG:4978', 0, 0, 0),
+                rotation: new THREE.Quaternion(),
+                offsetBBox: bBox,
             },
         };
 

--- a/packages/Main/test/unit/potreelayerparsing.js
+++ b/packages/Main/test/unit/potreelayerparsing.js
@@ -42,7 +42,8 @@ describe('Potree Provider', function () {
             it('cloud with no normal information', function _it(done) {
             // No normals
                 const cloud = {
-                    boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                    boundingBox: { lx: 10, ly: 20, ux: 30, uy: 40 },
+                    tightBoundingBox: { lx: 1, ly: 2, ux: 3, uy: 4 },
                     scale: 1.0,
                     pointAttributes: ['POSITION', 'RGB'],
                     octreeDir: 'data',
@@ -51,13 +52,16 @@ describe('Potree Provider', function () {
                 const source = new PotreeSource({
                     file: fileName,
                     url: baseurl,
+                    crs: 'EPSG:4978',
                     cloud,
                 });
 
                 const layer = new PotreeLayer('pointsCloudNoNormal', { source, crs: view.referenceCrs });
                 View.prototype.addLayer.call(view, layer);
-                layer.whenReady.then((l) => {
-                    const normalDefined = l.material.defines.NORMAL || l.material.defines.NORMAL_SPHEREMAPPED || l.material.defines.NORMAL_OCT16;
+                layer.whenReady.then(() => {
+                    const normalDefined = layer.material.defines.NORMAL
+                        || layer.material.defines.NORMAL_SPHEREMAPPED
+                        || layer.material.defines.NORMAL_OCT16;
                     assert.ok(!normalDefined);
                     done();
                 }).catch(done);
@@ -66,7 +70,8 @@ describe('Potree Provider', function () {
             it('cloud with normals as vector', function _it(done) {
             // // // // normals as vector
                 const cloud = {
-                    boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                    boundingBox: { lx: 10, ly: 20, ux: 30, uy: 40 },
+                    tightBoundingBox: { lx: 1, ly: 2, ux: 3, uy: 4 },
                     scale: 1.0,
                     pointAttributes: ['POSITION', 'NORMAL', 'CLASSIFICATION'],
                     octreeDir: 'data',
@@ -75,15 +80,16 @@ describe('Potree Provider', function () {
                 const source = new PotreeSource({
                     file: fileName,
                     url: baseurl,
+                    crs: 'EPSG:4978',
                     cloud,
                 });
 
                 const layer = new PotreeLayer('pointsCloud2', { source, crs: view.referenceCrs });
                 View.prototype.addLayer.call(view, layer);
-                layer.whenReady.then((l) => {
-                    assert.ok(l.material.defines.NORMAL);
-                    assert.ok(!l.material.defines.NORMAL_SPHEREMAPPED);
-                    assert.ok(!l.material.defines.NORMAL_OCT16);
+                layer.whenReady.then(() => {
+                    assert.ok(layer.material.defines.NORMAL);
+                    assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
+                    assert.ok(!layer.material.defines.NORMAL_OCT16);
                     done();
                 }).catch(done);
             });
@@ -91,7 +97,8 @@ describe('Potree Provider', function () {
             it('cloud with spheremapped normals', function _it(done) {
             // // spheremapped normals
                 const cloud = {
-                    boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                    boundingBox: { lx: 10, ly: 20, ux: 30, uy: 40 },
+                    tightBoundingBox: { lx: 1, ly: 2, ux: 3, uy: 4 },
                     scale: 1.0,
                     pointAttributes: ['POSITION', 'COLOR_PACKED', 'NORMAL_SPHEREMAPPED'],
                     octreeDir: 'data',
@@ -99,15 +106,16 @@ describe('Potree Provider', function () {
                 const source = new PotreeSource({
                     file: fileName,
                     url: baseurl,
+                    crs: 'EPSG:4978',
                     cloud,
                 });
                 const layer = new PotreeLayer('pointsCloud3', { source, crs: view.referenceCrs });
                 View.prototype.addLayer.call(view, layer);
 
-                layer.whenReady.then((l) => {
-                    assert.ok(!l.material.defines.NORMAL);
-                    assert.ok(l.material.defines.NORMAL_SPHEREMAPPED);
-                    assert.ok(!l.material.defines.NORMAL_OCT16);
+                layer.whenReady.then(() => {
+                    assert.ok(!layer.material.defines.NORMAL);
+                    assert.ok(layer.material.defines.NORMAL_SPHEREMAPPED);
+                    assert.ok(!layer.material.defines.NORMAL_OCT16);
                     done();
                 }).catch(done);
             });
@@ -115,7 +123,8 @@ describe('Potree Provider', function () {
             it('cloud with oct16 normals', function _it(done) {
             // // // oct16 normals
                 const cloud = {
-                    boundingBox: { lx: 0, ly: 1, ux: 2, uy: 3 },
+                    boundingBox: { lx: 10, ly: 20, ux: 30, uy: 40 },
+                    tightBoundingBox: { lx: 1, ly: 2, ux: 3, uy: 4 },
                     scale: 1.0,
                     pointAttributes: ['POSITION', 'COLOR_PACKED', 'CLASSIFICATION', 'NORMAL_OCT16'],
                     octreeDir: 'data',
@@ -124,15 +133,16 @@ describe('Potree Provider', function () {
                     file: fileName,
                     url: baseurl,
                     cloud,
+                    crs: 'EPSG:4978',
                 });
                 const layer = new PotreeLayer('pointsCloud4', { source, crs: view.referenceCrs });
                 View.prototype.addLayer.call(view, layer);
 
                 layer.whenReady
-                    .then((l) => {
-                        assert.ok(!l.material.defines.NORMAL);
-                        assert.ok(!l.material.defines.NORMAL_SPHEREMAPPED);
-                        assert.ok(l.material.defines.NORMAL_OCT16);
+                    .then(() => {
+                        assert.ok(!layer.material.defines.NORMAL);
+                        assert.ok(!layer.material.defines.NORMAL_SPHEREMAPPED);
+                        assert.ok(layer.material.defines.NORMAL_OCT16);
                         done();
                     }).catch(done);
             });

--- a/packages/Main/test/unit/potreelayerprocessing.js
+++ b/packages/Main/test/unit/potreelayerprocessing.js
@@ -10,7 +10,7 @@ describe('preUpdate PotreeLayer', function () {
         hierarchyStepSize: 1,
     };
     layer.root = new PotreeNode(4000, 0, layer);
-    layer.root.bbox.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+    layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
     layer.root.add(new PotreeNode(3000, 0, layer), 1, layer.root);
     layer.root.children[0].obj = { layer, isPoints: true };

--- a/packages/Main/test/unit/vpc.js
+++ b/packages/Main/test/unit/vpc.js
@@ -1,13 +1,14 @@
 import assert from 'assert';
 import View from 'Core/View';
 import GlobeView from 'Core/Prefab/GlobeView';
-import { Coordinates } from '@itowns/geographic';
+import { Coordinates, CRS } from '@itowns/geographic';
 import VpcSource from 'Source/VpcSource';
 import VpcLayer from 'Layer/VpcLayer';
 import Renderer from './bootstrap';
 
 const vpcEptUrl = 'https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/vpc/index.vpc';
 const vpcCopcUrl = 'https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/amiens.vpc';
+CRS.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 describe('VPC', function () {
     let vpcEptSource;
@@ -24,8 +25,8 @@ describe('VPC', function () {
             it('whenReady', function (done) {
                 vpcEptSource.whenReady
                     .then(() => {
-                        assert.ok(vpcEptSource.minElevation);
-                        assert.ok(vpcEptSource.maxElevation);
+                        assert.ok(vpcEptSource.zmin);
+                        assert.ok(vpcEptSource.zmax);
                         assert.ok(vpcEptSource.sources.length > 0);
                         done();
                     }).catch(done);
@@ -42,8 +43,8 @@ describe('VPC', function () {
             it('whenReady', function (done) {
                 vpcCopcSource.whenReady
                     .then(() => {
-                        assert.ok(vpcCopcSource.minElevation);
-                        assert.ok(vpcCopcSource.maxElevation);
+                        assert.ok(vpcCopcSource.zmin);
+                        assert.ok(vpcCopcSource.zmax);
                         assert.ok(vpcCopcSource.sources.length > 0);
                         done();
                     }).catch(done);
@@ -75,19 +76,17 @@ describe('VPC', function () {
     });
 
     describe('Layer', function () {
-        let renderer;
-        let placement;
         let view;
         let vpcLayer;
 
         before(function () {
-            renderer = new Renderer();
-            placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
+            const renderer = new Renderer();
+            const placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
             view = new GlobeView(renderer.domElement, placement, { renderer });
         });
 
         it('instantiate', () => {
-            vpcLayer = new VpcLayer('testVpcLayer', { source: vpcEptSource });
+            vpcLayer = new VpcLayer('testVpcLayer', { source: vpcEptSource, crs: view.referenceCrs });
             assert.ok(vpcLayer.isVpcLayer);
         });
 

--- a/test/hooks_functional.js
+++ b/test/hooks_functional.js
@@ -148,11 +148,16 @@ const loadExample = async (url, screenshotName) => {
         await initializeLayers();
     } catch (e) {
         if (e instanceof Error && e.name === 'TimeoutError') {
-            console.warn('     *** Warning: initializeLayers timed out -> Camera motion had been stopped ***');
+            console.warn('     *** Warning: initializeLayers timed out ***');
             await page.evaluate(() => {
                 itowns.CameraUtils.stop(view, view.camera3D);
             });
-            await initializeLayers();
+            console.warn('         -> Camera motion had been stopped');
+            try {
+                await initializeLayers();
+            } catch (e) {
+                console.warn('     *** Warning: initializeLayers timed out again ***');
+            }
         } else {
             console.warn(e);
             throw e;


### PR DESCRIPTION
The aim of the PR is to allow projection of dataPointCloud in a view crs different than the source crs.
For the projection we use proj4.

There is two main parts in this PR:
- the projection of the bounding box read from metadonne in the layer.
- the projection of the data during the parsing.

Instead of doing pure projection we add after the projection, an transformation of data in a local system orienté in the direction of the data and z orthogonal.

Other minor change:
- ~~the 'spacing' is move from source to the layer.~~
- ~~A 'elevation' propertie was also added to replace the z data (that is not an elevation)~~
- update examples

