### PR TITLE
Refactor WebXr with support  of vr controllers

### DIFF
--- a/config/threeExamples.mjs
+++ b/config/threeExamples.mjs
@@ -11,5 +11,8 @@ export default {
         './capabilities/WebGL.js',
         './libs/ktx-parse.module.js',
         './libs/zstddec.module.js',
+        //  webXR
+        './libs/motion-controllers.module.js',
+        './webxr/XRControllerModelFactory.js',
     ],
 };

--- a/examples/view_3d_map_webxr.html
+++ b/examples/view_3d_map_webxr.html
@@ -14,6 +14,7 @@
         <script type="importmap">
             {
                 "imports": {
+                    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
                     "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
                 }
             }
@@ -40,11 +41,7 @@
             const viewerDiv = document.getElementById('viewerDiv');
 
             // Create a GlobeView
-            const view = new itowns.GlobeView(viewerDiv, placement, {
-                webXR: { scale: 0.005 },
-            });
-            // Temporary workaround to https://github.com/iTowns/itowns/issues/2473
-            view.scene.matrixWorldAutoUpdate = true;
+            const view = new itowns.GlobeView(viewerDiv, placement, { webXR: { controllers: true } });
 
             // Instantiate three's VR Button
             const vrButton = VRButton.createButton(view.renderer);

--- a/packages/Main/src/Controls/VRControls.js
+++ b/packages/Main/src/Controls/VRControls.js
@@ -1,0 +1,457 @@
+import * as THREE from 'three';
+import { Coordinates } from '@itowns/geographic';
+import DEMUtils from 'Utils/DEMUtils';
+import { XRControllerModelFactory } from 'ThreeExtended/webxr/XRControllerModelFactory';
+
+/**
+ * @property {Array} controllers - WebXR controllers list
+ * */
+class VRControls {
+    static MIN_DELTA_ALTITUDE = 1.8;
+    static MAX_NUMBER_CONTROLLERS = 2;  // For now, we are fully supporting a maximum of 2 controllers.
+    /**
+     * Requires a contextXR variable.
+     * @param {*} _view itowns view object
+     * @param {*} _groupXR XR 3D object group
+     */
+    constructor(_view, _groupXR = {}) {
+    // Store instance references.
+        this.view = _view;
+        this.groupXR = _groupXR;
+        this.webXRManager = _view.mainLoop.gfxEngine.renderer.xr;
+
+        this.rightButtonPressed = false;
+        this.controllers = [];
+        this.initControllers();
+    }
+
+    // Static factory method:
+    static init(view, vrHeadSet) {
+        return new VRControls(view, vrHeadSet);
+    }
+
+
+    initControllers() {
+        //  Add a light for the controllers
+        this.groupXR.add(new THREE.HemisphereLight(0xa5a5a5, 0x898989, 3));
+
+        const controllerModelFactory = new XRControllerModelFactory();
+
+        for (let i = 0; i < VRControls.MAX_NUMBER_CONTROLLERS; i++) {
+            const controller = this.webXRManager.getController(i);
+
+
+            controller.addEventListener('connected', (event) => {
+                controller.name = event.data.handedness;    // Left or right
+                controller.userData.handedness = event.data.handedness;
+                controller.gamepad = event.data.gamepad;
+                this.groupXR.add(controller);
+
+                const gripController = this.webXRManager.getControllerGrip(i);
+                gripController.name = `${controller.name}GripController`;
+                gripController.userData.handedness = event.data.handedness;
+                this.bindGripController(controllerModelFactory, gripController, this.groupXR);
+                this.controllers.push(controller);
+                this.groupXR.add(gripController);
+
+
+                // Event listeners
+                this.setupEventListeners(controller);
+            });
+
+            controller.addEventListener('disconnected', function removeCtrl() {
+                this.remove(this.children[0]);
+            });
+        }
+    }
+
+    bindGripController(controllerModelFactory, gripController, vrHeadSet) {
+        gripController.add(controllerModelFactory.createControllerModel(gripController));
+        vrHeadSet.add(gripController);
+    }
+
+
+
+
+    // Register event listeners for controllers.
+    setupEventListeners(controller) {
+        controller.addEventListener('itowns-xr-axes-changed', e => this.onAxisChanged(e));
+        controller.addEventListener('itowns-xr-axes-stop', e => this.onAxisStop(e));
+        controller.addEventListener('itowns-xr-button-pressed', e => this.onButtonPressed(e));
+        controller.addEventListener('itowns-xr-button-released', e => this.onButtonReleased(e));
+
+        controller.addEventListener('selectstart', e => this.onSelectStart(e));
+        controller.addEventListener('selectend', e => this.onSelectEnd(e));
+    }
+
+
+    /*
+Listening {XRInputSource} and emit changes for convenience user binding,
+There is NO JOYSTICK Events so we need to check it ourselves
+Adding a few internal states for reactivity
+- controller.isStickActive {boolean} true when a controller stick is not on initial state.
+*/
+
+    listenGamepad() {
+        for (const controller of this.controllers) {
+            if (!controller.gamepad) {
+                return;
+            }
+            // gamepad.axes = [0, 0, x, y];
+
+            const gamepad = controller.gamepad;
+            const activeValue = gamepad.axes.some(value => value !== 0);
+
+            // Handle stick activity state
+            if (controller.isStickActive && !activeValue && controller.gamepad.endGamePadtrackEmit) {
+                controller.dispatchEvent({
+                    type: 'itowns-xr-axes-stop',
+                    message: { controller },
+                });
+                controller.isStickActive = false;
+                return;
+            } else if (!controller.isStickActive && activeValue) {
+                controller.gamepad.endGamePadtrackEmit = false;
+                controller.isStickActive = true;
+            } else if (controller.isStickActive && !activeValue) {
+                controller.gamepad.endGamePadtrackEmit = true;
+            }
+
+            if (activeValue) {
+                controller.dispatchEvent({
+                    type: 'itowns-xr-axes-changed',
+                    message: { controller },
+                });
+            }
+
+            for (const [index, button] of gamepad.buttons.entries()) {
+                if (button.pressed) {
+                    // 0 - trigger
+                    // 1 - grip
+                    // 3 - stick pressed
+                    // 4 - bottom button
+                    // 5 - upper button
+                    controller.dispatchEvent({
+                        type: 'itowns-xr-button-pressed',
+                        message: {
+                            controller,
+                            buttonIndex: index,
+                            button,
+                        },
+                    });
+                    controller.lastButtonItem = button;
+                } else if (controller.lastButtonItem && controller.lastButtonItem === button) {
+                    controller.dispatchEvent({
+                        type: 'itowns-xr-button-released',
+                        message: {
+                            controller,
+                            buttonIndex: index,
+                            button,
+                        },
+                    });
+                    controller.lastButtonItem = undefined;
+                }
+
+                if (button.touched) {
+                    // triggered really often
+                }
+            }
+        }
+    }
+
+
+    // Clamp a translation to ground and then apply the transformation.
+    clampAndApplyTransformationToXR(trans, offsetRotation) {
+        const transClamped = this.clampToGround(trans);
+        this.applyTransformationToXR(transClamped, offsetRotation);
+    }
+
+    // Apply a translation and rotation to the XR group.
+    applyTransformationToXR(trans, offsetRotation) {
+        this.groupXR.position.copy(trans);
+        this.groupXR.quaternion.copy(offsetRotation);
+        this.groupXR.updateMatrixWorld(true);
+    }
+
+    /**
+   * Clamp the given translation vector so that the camera remains at or above ground level.
+   * @param {THREE.Vector3} trans - The translation vector.
+   * @returns {THREE.Vector3} The clamped coordinates as a Vector3.
+   */
+    clampToGround(trans) {
+        const transCoordinate = new Coordinates(
+            this.view.referenceCrs,
+            trans.x,
+            trans.y,
+            trans.z,
+        );
+
+        const terrainElevation = DEMUtils.getElevationValueAt(
+            this.view.tileLayer,
+            transCoordinate,
+            DEMUtils.PRECISE_READ_Z,
+        ) || 0;
+
+        if (this.view.controls.getCameraCoordinate) {
+            const coordsProjected = transCoordinate.as(this.view.controls.getCameraCoordinate().crs);
+            if (coordsProjected.altitude - terrainElevation - VRControls.MIN_DELTA_ALTITUDE <= 0) {
+                coordsProjected.altitude = terrainElevation + VRControls.MIN_DELTA_ALTITUDE;
+            }
+            return coordsProjected.as(this.view.referenceCrs).toVector3();
+        } else {
+            return trans;
+        }
+    }
+
+    // Calculate a speed factor based on the camera's altitude.
+    getSpeedFactor() {
+        const altitude = this.view.controls.getCameraCoordinate ? this.view.controls.getCameraCoordinate().altitude : 1;
+        return Math.min(Math.max(altitude / 50, 2), 2000); // TODO: Adjust if needed -> add as a config ?
+    }
+
+    // Calculate a yaw rotation quaternion based on an axis value from the joystick.
+    getRotationYaw(axisValue) {
+        // Clone the current XR group's orientation.
+        const baseOrientation = this.groupXR.quaternion.clone().normalize();
+        let deltaRotation = 0;
+
+        if (axisValue) {
+            deltaRotation = -Math.PI * axisValue / 140; // Adjust sensitivity as needed.
+        }
+        // Get the "up" direction from the camera coordinate. // TODO should we handle other than globe ?
+        const upAxis = this.groupXR.position.clone().normalize();
+        // Create a quaternion representing a yaw rotation about the up axis.
+        const yawQuaternion = new THREE.Quaternion()
+            .setFromAxisAngle(upAxis, deltaRotation)
+            .normalize();
+        // Apply the yaw rotation.
+        baseOrientation.premultiply(yawQuaternion);
+        return baseOrientation;
+    }
+
+    // Calculate a pitch rotation quaternion based on an axis value from the joystick.
+    getRotationPitch(axisValue) {
+    // Clone the current XR group's orientation.
+        const baseOrientation = this.groupXR.quaternion.clone().normalize();
+        let deltaRotation = 0;
+
+        if (axisValue) {
+            deltaRotation = -Math.PI * axisValue / 140; // Adjust sensitivity as needed.
+        }
+
+        // Compute the right axis from the current orientation.
+        // (Assuming (1, 0, 0) is the right direction in local space.)
+        const rightAxis = new THREE.Vector3(1, 0, 0)
+            .applyQuaternion(baseOrientation)
+            .normalize();
+
+        // Create a quaternion representing a pitch rotation about the right axis.
+        const pitchQuaternion = new THREE.Quaternion()
+            .setFromAxisAngle(rightAxis, deltaRotation)
+            .normalize();
+
+        // Apply the pitch rotation.
+        baseOrientation.premultiply(pitchQuaternion);
+        return baseOrientation;
+    }
+
+    // Compute a translation vector for vertical adjustment.
+    getTranslationElevation(axisValue, speedFactor) {
+        const speed = axisValue * speedFactor;
+        const direction = this.view.camera3D.position.clone().normalize();
+
+        direction.multiplyScalar(-speed);
+        return direction;
+    }
+
+    // Handles camera flying based on controller input.
+    cameraOnFly(ctrl) {
+        let directionX = new THREE.Vector3();
+        let directionZ = new THREE.Vector3();
+        const speedFactor = this.getSpeedFactor();
+        if (ctrl.gamepad.axes[3] !== 0) {
+            const speed = ctrl.gamepad.axes[3] * speedFactor;
+            directionZ = new THREE.Vector3(0, 0, 1)
+                .applyQuaternion(this.view.camera3D.quaternion.clone().normalize())
+                .multiplyScalar(speed);
+        }
+        if (ctrl.gamepad.axes[2] !== 0) {
+            const speed = ctrl.gamepad.axes[2] * speedFactor;
+            directionX = new THREE.Vector3(1, 0, 0)
+                .applyQuaternion(this.view.camera3D.quaternion.clone().normalize())
+                .multiplyScalar(speed);
+        }
+        const offsetRotation = this.groupXR.quaternion.clone();
+        const trans = this.groupXR.position.clone().add(directionX.add(directionZ));
+        // this.applyTransformationToXR(trans, offsetRotation);
+        this.clampAndApplyTransformationToXR(trans, offsetRotation);
+    }
+
+    /* =======================
+     Event Handler Methods
+     ======================= */
+
+    // Right select ends.
+    /* c8 ignore next 3 */
+    onSelectRightEnd() {
+    // Uncomment and implement teleportation if needed:
+    }
+
+    // Right select starts.
+    /* c8 ignore next 3 */
+    onSelectRightStart() {
+    // No operation needed yet.
+    }
+
+    // Left select starts.
+    /* c8 ignore next 3 */
+    onSelectLeftStart() {
+    // No operation needed yet.
+    }
+
+    // Left select ends.
+    /* c8 ignore next 3 */
+    onSelectLeftEnd() {
+        // No operation needed yet.
+    }
+    onSelectStart(data) {
+        const ctrl = data.target;
+
+        if (ctrl.userData.handedness === 'left') {
+            this.onSelectLeftStart(ctrl);
+        } else if (ctrl.userData.handedness === 'right') {
+            this.onSelectRightStart(ctrl);
+        }
+    }
+    onSelectEnd(data) {
+        const ctrl = data.target;
+
+        if (ctrl.userData.handedness === 'left') {
+            this.onSelectRightEnd(ctrl);
+        } else if (ctrl.userData.handedness === 'right') {
+            this.onSelectLeftEnd(ctrl);
+        }
+    }
+    onButtonPressed(data) {
+        const ctrl = data.target;
+        if (ctrl.userData.handedness === 'left') {
+            this.onLeftButtonPressed(data);
+        } else if (ctrl.userData.handedness === 'right') {
+            this.onRightButtonPressed(data);
+        }
+    }
+
+    // Right button pressed.
+    onRightButtonPressed(data) {
+        const ctrl = data.target;
+        if (data.message.buttonIndex === 1) {
+            // Activate vertical adjustment.
+            if (ctrl.gamepad.axes[3] === 0) {
+                return;
+            }
+            this.rightButtonPressed = true;
+        }
+    }
+
+    // Left button pressed.
+    /* c8 ignore next 3 */
+    onLeftButtonPressed() {
+    // No operation defined.
+    }
+
+    // Axis changed.
+    onAxisChanged(data) {
+        const ctrl = data.target;
+        if (ctrl.gamepad.axes[2] === 0 && ctrl.gamepad.axes[3] === 0) {
+            return;
+        }
+        if (ctrl.userData.handedness === 'left') {
+            this.onLeftAxisChanged(ctrl);
+        } else if (ctrl.userData.handedness === 'right') {
+            this.onRightAxisChanged(ctrl);
+        }
+    }
+
+    // Right axis changed.
+    onRightAxisChanged(ctrl) {
+        if (ctrl.userData.handedness !== 'right') {
+            return;
+        }
+        //  Check if GRIP is pressed
+        if (this.rightButtonPressed) {
+            const offsetRotation = this.groupXR.quaternion.clone();
+            const speedFactor = this.getSpeedFactor();
+            const deltaTransl = this.getTranslationElevation(ctrl.gamepad.axes[3], speedFactor);
+            const trans = this.groupXR.position.clone().add(deltaTransl);
+            this.clampAndApplyTransformationToXR(trans, offsetRotation);
+        } else {
+            this.cameraOnFly(ctrl);
+        }
+    }
+
+    // Left axis changed.
+    onLeftAxisChanged(ctrl) {
+        if (ctrl.userData.handedness !== 'left') {
+            return;
+        }
+
+        const trans = this.groupXR.position.clone();
+        let offsetRotation;
+
+        //  Only apply rotation on 1 axis at the time
+        if (Math.abs(ctrl.gamepad.axes[2]) > Math.abs(ctrl.gamepad.axes[3])) {
+            offsetRotation = this.getRotationYaw(ctrl.gamepad.axes[2]);
+        } else {
+            offsetRotation = this.getRotationPitch(ctrl.gamepad.axes[3]);
+        }
+
+        this.applyTransformationToXR(trans, offsetRotation);
+    }
+
+    // Right axis stops.
+    onAxisStop(data) {
+        const ctrl = data.target;
+
+        if (ctrl.userData.handedness === 'left') {
+            this.onLeftAxisStop(ctrl);
+        } else if (ctrl.userData.handedness === 'right') {
+            this.onRightAxisStop(ctrl);
+        }
+    }
+
+    // Right axis stops.
+    /* c8 ignore next 3 */
+    onRightAxisStop() {
+        // No operation defined.
+    }
+
+    // Left axis stops.
+    /* c8 ignore next 3 */
+    onLeftAxisStop() {
+        // No operation defined.
+    }
+
+    // Button released.
+    onButtonReleased(data) {
+        const ctrl = data.target;
+
+        if (ctrl.userData.handedness === 'left') {
+            this.onLeftButtonReleased(ctrl);
+        } else if (ctrl.userData.handedness === 'right') {
+            this.onRightButtonReleased(ctrl);
+        }
+    }
+    // Right button released.
+    onRightButtonReleased() {
+        this.rightButtonPressed = false;
+    }
+
+    // Left button released.
+    /* c8 ignore next 3 */
+    onLeftButtonReleased() {
+    // No operation defined.
+    }
+}
+
+export default VRControls;
+

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -6,6 +6,7 @@ import { Coordinates, ellipsoidSizes } from '@itowns/geographic';
 import GlobeLayer from 'Core/Prefab/Globe/GlobeLayer';
 import Atmosphere from 'Core/Prefab/Globe/Atmosphere';
 import CameraUtils from 'Utils/CameraUtils';
+import WebXR from 'Renderer/WebXR';
 
 /**
  * Fires when the view is completely loaded. Controls and view's functions can be called then.
@@ -79,6 +80,10 @@ class GlobeView extends View {
      * @param {CameraTransformOptions|Extent} placement - An object to place view
      * @param {object} [options] - See options of {@link View}.
      * @param {Object} [options.controls] - See options of {@link GlobeControls}
+     * @param {Object} [options.webXR] - WebXR configuration - its presence alone
+     * enable WebXR to switch on VR visualization. (optional).
+     * @param {function} [options.webXR.callback] - WebXR rendering callback (optional).
+     * @param {boolean} [options.webXR.controllers] - Enable the webXR controllers handling (optional).
      */
     constructor(viewerDiv, placement = {}, options = {}) {
         THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
@@ -113,6 +118,11 @@ class GlobeView extends View {
 
         // GlobeView needs this.camera.resize to set perpsective matrix camera
         this.camera.resize(viewerDiv.clientWidth, viewerDiv.clientHeight);
+
+        if (options.webXR) {
+            this.webXR = new WebXR(this, typeof options.webXR === 'boolean' ? {} : options.webXR);
+            this.webXR.initializeWebXR();
+        }
     }
 
     /**

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { CRS, Coordinates } from '@itowns/geographic';
 import Camera from 'Renderer/Camera';
-import initializeWebXR from 'Renderer/WebXR';
 import MainLoop, { MAIN_LOOP_EVENTS, RENDERING_PAUSED } from 'Core/MainLoop';
 import Capabilities from 'Core/System/Capabilities';
 import { COLOR_LAYERS_ORDER_CHANGED } from 'Renderer/ColorLayersOrdering';
@@ -157,8 +156,6 @@ class View extends THREE.EventDispatcher {
      * a default one will be constructed. In this case, if options.renderer is an object, it will be used to
      * configure the renderer (see {@link c3DEngine}.  If not present, a new &lt;canvas> will be created and
      * added to viewerDiv (mutually exclusive with mainLoop)
-     * @param {Object} [options.webXR] - enable webxr button to switch on VR visualization.
-     * @param {number} [options.webXR.scale=1.0] - apply webxr scale tranformation.
      * @param {Scene} [options.scene3D] - [THREE.Scene](https://threejs.org/docs/#api/en/scenes/Scene) instance to use, otherwise a default one will be constructed
      * @param {Color} [options.diffuse] - [THREE.Color](https://threejs.org/docs/?q=color#api/en/math/Color) Diffuse color terrain material.
      * This color is applied to terrain if there isn't color layer on terrain extent (by example on pole).
@@ -257,10 +254,6 @@ class View extends THREE.EventDispatcher {
 
         // push all viewer to keep source.cache
         viewers.push(this);
-
-        if (options.webXR) {
-            initializeWebXR(this, options.webXR);
-        }
     }
 
     /**

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -313,6 +313,17 @@ class OGC3DTilesLayer extends GeometryLayer {
         if (config.sseThreshold) {
             this.sseThreshold = config.sseThreshold;
         }
+        // Used for custom schedule callbacks (VR)
+        this.tasks = [];
+
+        this.tilesSchedulingCB = (func) => {
+            this.tasks.push(func);
+        };
+        // We set our scheduling callback for tiles downloading and parsing -> MANDATORY for VR
+        // (WebXR session has its own requestAnimationFrame method separate from that of the window
+        //  https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/213#issuecomment-947943386)
+        this.tilesRenderer.downloadQueue.schedulingCallback = this.tilesSchedulingCB;
+        this.tilesRenderer.parseQueue.schedulingCallback = this.tilesSchedulingCB;
     }
 
     /**
@@ -436,9 +447,15 @@ class OGC3DTilesLayer extends GeometryLayer {
             }
         }
     }
-
+    handleTasks() {
+        for (let t = 0, l = this.tasks.length; t < l; t++) {
+            this.tasks[t]();
+        }
+        this.tasks.length = 0;
+    }
     preUpdate(context) {
         this.scale = context.camera._preSSE;
+        this.handleTasks();
         this.tilesRenderer.update();
         return null; // don't return any element because 3d-tiles-renderer already updates them
     }

--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -24,6 +24,7 @@ export { default as FlyControls } from 'Controls/FlyControls';
 export { default as FirstPersonControls } from 'Controls/FirstPersonControls';
 export { default as StreetControls } from 'Controls/StreetControls';
 export { default as PlanarControls } from 'Controls/PlanarControls';
+export { default as VRControls } from 'Controls/VRControls';
 export { CONTROL_EVENTS } from 'Controls/GlobeControls';
 export { PLANAR_CONTROL_EVENT } from 'Controls/PlanarControls';
 export { default as Feature2Mesh } from 'Converter/Feature2Mesh';

--- a/packages/Main/src/Renderer/c3DEngine.js
+++ b/packages/Main/src/Renderer/c3DEngine.js
@@ -56,7 +56,11 @@ class c3DEngine {
 
         this.renderView = function _(view) {
             this.renderer.clear();
-            this.renderer.render(view.scene, view.camera3D);
+            if (view._camXR) {
+                this.renderer.render(view.scene, view._camXR);
+            } else {
+                this.renderer.render(view.scene, view.camera3D);
+            }
             if (view.tileLayer) {
                 this.label2dRenderer.render(view.tileLayer.object3d, view.camera3D);
             }

--- a/packages/Main/test/unit/webxr.js
+++ b/packages/Main/test/unit/webxr.js
@@ -1,37 +1,408 @@
 import assert from 'assert';
-import View from 'Core/View';
+import GlobeView from 'Core/Prefab/GlobeView';
+import WebXR from 'Renderer/WebXR';
+import DEMUtils from 'Utils/DEMUtils';
+import VRControls from 'Controls/VRControls';
+
+import { Coordinates } from '@itowns/geographic';
+import * as THREE from 'three';
 import Renderer from './bootstrap';
+
+
 
 describe('WebXR', function () {
     let viewer;
+    const original = DEMUtils.getElevationValueAt;
+    const ELEVATION = 10;
+
     before(async function () {
         const renderer = new Renderer();
+        const p = {
+            coord: new Coordinates('EPSG:4326', -75.61349, 40.044259),
+            range: 200,
+            tilt: 10,
+            heading: -145,
+        };
 
-        viewer = new View('EPSG:4326', renderer.domElement, {
+        viewer = new GlobeView(renderer.domElement, p,  {
             renderer,
-            webXR: { scale: 0.005 },
+            webXR: { controllers: true },
         });
+
+        DEMUtils.getElevationValueAt = () => ELEVATION;
+    });
+
+
+    after(() => {
+        DEMUtils.getElevationValueAt = original;
+    });
+
+    it('should store webXr', function () {
+        // Verify that the viewer instance has a webXR property set up.
+        assert.ok(viewer.webXR);
     });
 
     it('should initialize webXr', function () {
-        const webXRManager = viewer.mainLoop.gfxEngine.renderer.xr;
+        // Access the WebXR manager from the viewer's renderer.
+        const webXRManager = viewer.renderer.xr;
+        // Retrieve the 'sessionstart' event listener from the manager.
         const sessionEvent = webXRManager.events.get('sessionstart');
-
+        // Check that the 'sessionstart' event is a function, indicating proper initialization.
         assert.ok(typeof sessionEvent === 'function');
     });
 
     it('should initialize webXr session', function () {
-        const webXRManager = viewer.mainLoop.gfxEngine.renderer.xr;
+        // Access the WebXR manager from the viewer's renderer.
+        const webXRManager = viewer.renderer.xr;
+        // Before the session starts, ensure that the XR session is not enabled and no camera has been set.
         assert.ok(webXRManager.enabled === undefined);
+        assert.ok(viewer._camXR === undefined);
+        // Simulate a session start event.
         webXRManager.dispatchEvent({ type: 'sessionstart' });
+        // Verify that after the event, the WebXR manager is enabled and the camera (_camXR) is initialized.
         assert.ok(webXRManager.enabled);
+        assert.ok(viewer._camXR);
     });
 
-    it('should close webXr session', function () {
-        const webXRManager = viewer.mainLoop.gfxEngine.renderer.xr;
-        assert.ok(webXRManager.enabled);
-        document.emitEvent('keydown', { key: 'Escape' });
-        assert.ok(webXRManager.enabled === false);
-        assert.ok(viewer);
+    it('should initialize a webXR session without controllers with no option', function (done) {
+        // Create a fake THREE.js scene.
+        const fakeScene = new THREE.Scene();
+        // Create a fake PerspectiveCamera for the 3D camera.
+        const fakeCamera3D = new THREE.PerspectiveCamera();
+        fakeCamera3D.updateProjectionMatrix();
+        // Define a fake main loop with a step function that sets a flag when called.
+        const fakeMainLoop = {
+            step(view, timestamp) {
+                this.called = true;
+            },
+        };
+        let notifyCalled = false;
+        // Create a fake view object containing necessary properties for WebXR initialization.
+        const fakeView = {
+            renderer: new Renderer(),
+            scene: fakeScene,
+            camera3D: fakeCamera3D,
+            mainLoop: fakeMainLoop,
+            // notifyChange will flag that it was invoked.
+            notifyChange(camera, flag) {
+                notifyCalled = true;
+            },
+        };
+
+        // Retrieve the fake XR manager from the fake view's renderer.
+        const fakeXR = fakeView.renderer.xr;
+        // Simulate an active XR session.
+        fakeXR.isPresenting = true;
+        // Define options with controllers disabled.
+        const options = {
+            controllers: false,
+            callback() {},
+        };
+
+        // Create a new WebXR instance with the fake view and options.
+        const webxrInstance = new WebXR(fakeView, options);
+        // Attach the webxrInstance to fakeView for later reference.
+        fakeView.webXR = webxrInstance;
+        // Initialize the WebXR session.
+        webxrInstance.initializeWebXR();
+        // Dispatch the 'sessionstart' event to simulate starting the session.
+        fakeXR.dispatchEvent({ type: 'sessionstart' });
+
+        // Since controllers are disabled, verify that vrControls remains null.
+        assert.strictEqual(fakeView.webXR.vrControls, null, 'vrControls should be null when controllers option is false');
+
+        // Simulate the animation loop callback with a dummy timestamp.
+        fakeXR.animationLoopCallback(54321);
+
+        // Check that camera3D's position was updated from the fake XR camera (expected to be (80, 90, 100)).
+        assert.ok(fakeView.camera3D.position.equals(new THREE.Vector3(80, 90, 100)), 'camera3D position updated from xr camera');
+        // Check that camera3D's quaternion was updated from the fake XR camera (expected to be (0, 0, 0, 1)).
+        assert.ok(fakeView.camera3D.quaternion.equals(new THREE.Quaternion(0, 0, 0, 1)), 'camera3D quaternion updated from xr camera');
+        // Verify that the view was notified of the change.
+        assert.ok(notifyCalled, 'notifyChange should have been called');
+        // Verify that the main loop's step function was executed.
+        assert.ok(fakeMainLoop.called, 'mainLoop.step should have been called');
+        done();
+    });
+
+    describe('vrControls', function () {
+        it('should initialize webXr controllers handler', function () {
+            const vrControls = viewer.webXR.vrControls;
+            assert.ok(vrControls);
+            assert.ok(vrControls.controllers);
+        });
+
+        it('should register controllers on "connected" events', function () {
+            const webXRManager = viewer.renderer.xr;
+
+            const vrControls = viewer.webXR.vrControls;
+            // Reset controllers to ensure a clean state.
+            vrControls.controllers = [];
+
+            // Simulate a "connected" event for the first controller.
+            const controller0 = webXRManager.getController(0);
+            controller0.dispatchEvent({
+                type: 'connected',
+                data: { handedness: 'right', gamepad: { axes: [0, 0, 0, 0], buttons: [] } },
+            });
+            assert.strictEqual(vrControls.controllers.length, 1);
+            assert.strictEqual(vrControls.controllers[0].name, 'right');
+
+            // Simulate a "connected" event for the second controller.
+            const controller1 = webXRManager.getController(1);
+            controller1.dispatchEvent({
+                type: 'connected',
+                data: { handedness: 'left', gamepad: { axes: [0, 0, 0, 0], buttons: [] } },
+            });
+            assert.strictEqual(vrControls.controllers.length, 2);
+            assert.strictEqual(vrControls.controllers[1].name, 'left');
+        });
+
+        it('should bind grip controllers to the XR group', function () {
+            const vrControls = viewer.webXR.vrControls;
+
+            // Verify that the XR group contains a grip controller.
+            const groupChildren = vrControls.groupXR.children;
+            const gripFound = groupChildren.some(child =>
+                child.name && child.name.indexOf('GripController') !== -1);
+            assert.ok(gripFound, 'Grip controller should be present in groupXR');
+        });
+
+        it('should compute a valid yaw rotation quaternion', function () {
+            const vrControls = viewer.webXR.vrControls;
+
+            const currentVal = vrControls.groupXR.quaternion.clone().normalize();
+
+            const yawQuat = vrControls.getRotationYaw(0);
+            assert.ok(yawQuat instanceof THREE.Quaternion, 'getRotationYaw should return a THREE.Quaternion');
+
+            assert.ok(yawQuat.equals(currentVal), 'getRotationYaw(0) should return the current rotation');
+        });
+        it('should compute yaw rotation with non-zero axis', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const originalQuaternion = vrControls.groupXR.quaternion.clone();
+            const yawQuat = vrControls.getRotationYaw(50);
+            assert.notStrictEqual(yawQuat, originalQuaternion, 'Yaw should change with axis input');
+        });
+
+        it('should compute a valid pitch rotation quaternion', function () {
+            const vrControls = viewer.webXR.vrControls;
+
+            const pitchQuat = vrControls.getRotationPitch(10);
+            assert.ok(pitchQuat instanceof THREE.Quaternion, 'getRotationPitch should return a THREE.Quaternion');
+        });
+
+        it('should compute a valid translation elevation vector', function () {
+            const vrControls = viewer.webXR.vrControls;
+            // const currentVal = viewer.camera3D.position.clone().normalize();
+
+            const speedFactor = vrControls.getSpeedFactor();
+            const transVec = vrControls.getTranslationElevation(0, speedFactor);
+            assert.ok(transVec instanceof THREE.Vector3, 'getTranslationElevation should return a THREE.Vector3');
+            const vec0 = new THREE.Vector3();
+            assert.ok(vec0.equals(transVec), 'getTranslationElevation(0) should return no elevation');
+        });
+
+        it('should apply transformation to XR group', function () {
+            const vrControls = viewer.webXR.vrControls;
+
+            // Create a translation vector and an offset rotation.
+            const trans = new THREE.Vector3(5, 10, 15);
+            const offsetRotation = new THREE.Quaternion();
+            // Set the rotation using Euler angles for demonstration.
+            offsetRotation.setFromEuler(new THREE.Euler(Math.PI / 4, Math.PI / 2, Math.PI / 6));
+
+            // Apply the transformation.
+            vrControls.applyTransformationToXR(trans, offsetRotation);
+
+            // Check that groupXR's position and quaternion match the given values.
+            assert.ok(vrControls.groupXR.position.equals(trans), 'groupXR position should match the provided translation vector');
+            assert.ok(vrControls.groupXR.quaternion.equals(offsetRotation), 'groupXR quaternion should match the provided offset rotation');
+        });
+
+
+        it('should handle active axes and button press', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const webXRManager = viewer.renderer.xr;
+            const controller = webXRManager.getController(0);
+
+            // Simulate active axes: nonzero value in axes array.
+            controller.gamepad = {
+                axes: [0, 0, 0.5, 0],
+                buttons: [
+                    { pressed: true, touched: false },  // simulate a pressed button at index 0
+                ],
+            };
+
+
+            controller.events = [];
+
+            controller.dispatchEvent = function (event) {
+                this.events.push(event);
+            };
+
+            // vrControls.controllers = [fakeController];
+            vrControls.listenGamepad();
+
+            // Expect an axes-changed event because axes are active.
+            const axesChangedEvent = controller.events.find(e => e.type === 'itowns-xr-axes-changed');
+            assert.ok(axesChangedEvent, 'Expected itowns-xr-axes-changed event');
+
+            // Since it was not active before, isStickActive should now be true and endGamePadtrackEmit set to false.
+            assert.strictEqual(controller.isStickActive, true, 'Controller should be marked as stick active');
+            assert.strictEqual(controller.gamepad.endGamePadtrackEmit, false, 'endGamePadtrackEmit should be false');
+
+            // Expect a button-pressed event for the pressed button.
+            const buttonPressedEvent = controller.events.find(e => e.type === 'itowns-xr-button-pressed');
+            assert.ok(buttonPressedEvent, 'Expected itowns-xr-button-pressed event');
+            assert.strictEqual(controller.lastButtonItem, controller.gamepad.buttons[0], 'lastButtonItem should be set to the pressed button');
+        });
+
+        it('should dispatch itowns-xr-axes-stop when stick becomes inactive', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const webXRManager = viewer.renderer.xr;
+            const controller = webXRManager.getController(0);
+            // Simulate inactive axes.
+            controller.gamepad = {
+                axes: [0, 0, 0, 0],
+                buttons: [], // no buttons pressed
+            };
+            // Controller was previously active.
+            controller.isStickActive = true;
+            controller.gamepad.endGamePadtrackEmit = true;
+            controller.events = [];
+            controller.dispatchEvent = function (event) {
+                this.events.push(event);
+            };
+
+            vrControls.listenGamepad();
+
+            const axesStopEvent = controller.events.find(e => e.type === 'itowns-xr-axes-stop');
+            assert.ok(axesStopEvent, 'Expected itowns-xr-axes-stop event');
+            assert.strictEqual(controller.isStickActive, false, 'Controller should be marked as not stick active');
+        });
+
+        it('should dispatch itowns-xr-button-released when button is released', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const webXRManager = viewer.renderer.xr;
+            const controller = webXRManager.getController(0);
+            // Simulate inactive axes.        // Simulate no active axes.
+            controller.gamepad = {
+                axes: [0, 0, 0, 0],
+                buttons: [
+                    { pressed: false, touched: false },  // button is not pressed now
+                ],
+            };
+            // Simulate that a button was previously pressed.
+            controller.lastButtonItem = controller.gamepad.buttons[0];
+            controller.isStickActive = false;
+            controller.events = [];
+            controller.dispatchEvent = function (event) {
+                this.events.push(event);
+            };
+
+            vrControls.listenGamepad();
+
+            const buttonReleasedEvent = controller.events.find(e => e.type === 'itowns-xr-button-released');
+            assert.ok(buttonReleasedEvent, 'Expected itowns-xr-button-released event');
+            assert.strictEqual(controller.lastButtonItem, undefined, 'lastButtonItem should be reset to undefined');
+        });
+
+        it('should return original translation when getCameraCoordinate is unavailable', function () {
+            const vrControls = viewer.webXR.vrControls;
+            // Mock the absence of getCameraCoordinate
+            const originalGetCameraCoordinate = vrControls.view.controls.getCameraCoordinate;
+            vrControls.view.controls.getCameraCoordinate = undefined;
+
+            const trans = new THREE.Vector3(100, 200, 300);
+            const result = vrControls.clampToGround(trans);
+            assert.ok(result.equals(trans), 'Should return original translation');
+
+            // Restore original method
+            vrControls.view.controls.getCameraCoordinate = originalGetCameraCoordinate;
+        });
+
+        it('should trigger correct selectEnd handlers based on handedness', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const ctrlLeft = { userData: { handedness: 'left' } };
+            const ctrlRight = { userData: { handedness: 'right' } };
+
+            // Spy on end handlers
+            let leftEndCalled = false;
+            let rightEndCalled = false;
+            vrControls.onSelectLeftEnd = () => { leftEndCalled = true; };
+            vrControls.onSelectRightEnd = () => { rightEndCalled = true; };
+
+            vrControls.onSelectEnd({ target: ctrlLeft });
+            assert.ok(rightEndCalled, 'Left end should call onSelectRightEnd');
+
+            vrControls.onSelectEnd({ target: ctrlRight });
+            assert.ok(leftEndCalled, 'Right end should call onSelectLeftEnd');
+        });
+
+        it('should handle left axis changes with different dominant axes', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const ctrl = {
+                userData: { handedness: 'left' },
+                gamepad: { axes: [0, 0, 0.8, 0.2] }, // Axis 2 dominant
+            };
+
+            let beforeQuat = vrControls.groupXR.quaternion.clone();
+            vrControls.onLeftAxisChanged(ctrl);
+            assert.ok(!vrControls.groupXR.quaternion.equals(beforeQuat), 'Yaw rotation applied');
+
+            beforeQuat = vrControls.groupXR.quaternion.clone();
+            // Test axis 3 dominant
+            ctrl.gamepad.axes = [0, 0, 0.2, 0.8];
+            vrControls.onLeftAxisChanged(ctrl);
+            assert.ok(!vrControls.groupXR.quaternion.equals(beforeQuat), 'Pitch rotation applied');
+        });
+
+        it('should combine X and Z axes for camera movement', function () {
+            const vrControls = viewer.webXR.vrControls;
+            const ctrl = {
+                gamepad: { axes: [0, 0, 0.5, 0.5] }, // Both axes active
+                userData: { handedness: 'right' },
+            };
+
+            const originalPosition = vrControls.groupXR.position.clone();
+            vrControls.cameraOnFly(ctrl);
+
+            assert.ok(!vrControls.groupXR.position.equals(originalPosition), 'Position should change');
+        });
+
+        it('should clamp position to ground level', function () {
+            const vrControls = viewer.webXR.vrControls;
+            // Mock elevation below MIN_DELTA
+            const lowPosition = new THREE.Vector3(0, 0, 0);
+
+            vrControls.clampAndApplyTransformationToXR(lowPosition, new THREE.Quaternion());
+            const coordinate = new Coordinates(
+                viewer.referenceCrs,
+                vrControls.groupXR.position.x,
+                vrControls.groupXR.position.y,
+                vrControls.groupXR.position.z,
+            );
+            const convertedPos = coordinate.as(viewer.controls.getCameraCoordinate().crs).toVector3();
+            const clampedY = convertedPos.z;
+            // 0.5 is an epsilon for conversion error
+            assert.ok(clampedY >= ELEVATION + VRControls.MIN_DELTA_ALTITUDE - 0.5, 'Y position clamped');
+        });
+
+        it('should clamp speed factor between 2 and 2000', function () {
+            const vrControls = viewer.webXR.vrControls;
+            // Mock altitude values
+            vrControls.view.controls.getCameraCoordinate = () => ({ altitude: 10 });
+            assert.strictEqual(vrControls.getSpeedFactor(), 2, 'Minimum speed');
+
+            vrControls.view.controls.getCameraCoordinate = () => ({ altitude: 100000 });
+            assert.strictEqual(vrControls.getSpeedFactor(), 2000, 'Maximum speed');
+        });
+
+        it('should handle left button release without errors', function () {
+            const vrControls = viewer.webXR.vrControls;
+            // Ensure no exceptions are thrown
+            assert.doesNotThrow(() => vrControls.onLeftButtonReleased());
+        });
     });
 });


### PR DESCRIPTION
## Description
Refactoring of the VR. Following the work done [previously](https://github.com/iTowns/itowns/pull/2230) and [here](https://github.com/iTowns/itowns/issues/2229).

Handling the controllers correctly. To do so, I've created `vrHeadSet` which is containing a clone of the camera (`_camXR`). The `vrHeadSet` will be used to translate the webxr scene around the globe. This is to bypass [this bug](https://discourse.threejs.org/t/staircase-effect-in-the-xr-controller-when-using-float34-coordinates/76584) which cause imprecision.
Then at each animation, I use the `_camXR` to update the position of our cam.
I can't directly use our default cam, because the camera needs a parent and it's position will also be affected by the position of the VR scene, which is usually set using this way:

```
const transform = new XRRigidTransform(offsetPosition, offsetRotation);
const teleportSpaceOffset = this.baseReferenceSpace.getOffsetReferenceSpace(transform);
this.parentRenderer.xr.setReferenceSpace(teleportSpaceOffset);
```

I also had to create callbacks in src/Layer/OGC3DTilesLayer.js to update the 3dtiles while being in VR.
[Related issue](https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/213)

To activate the VR, we have to pass the `webXR` argument in the view option. To activate the controllers, we have to pass the argument `controllers` to true as follows:
```
{ webXR: { controllers: true } }
```

## Motivation and Context
Update the VR and get a better controllers support

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/ed472929-f969-4313-ae6c-e72e467ee513)

[Screencast from 13-02-2025 14:25:53.webm](https://github.com/user-attachments/assets/6aed13a5-7dfc-4a77-a60a-bd82bd0a8750)

##TODO

- [ ] handle xr session end
- [ ] define webxr only in globelayer
- [ ] add more functionnalities (teleportation)
- [ ] better handling of the 3dtiles update/ view update