### PR TITLE
fix(fetcher): add sanity checks for texture data

### DIFF
--- a/packages/Main/src/Renderer/RasterTile.js
+++ b/packages/Main/src/Renderer/RasterTile.js
@@ -202,8 +202,8 @@ export class RasterElevationTile extends RasterTile {
                     zmax: this.layer.zmax,
                 });
             if (this.min != min || this.max != max) {
-                this.min = min;
-                this.max = max;
+                this.min = isNaN(min) ? this.min : min;
+                this.max = isNaN(max) ? this.max : max;
             }
         }
     }


### PR DESCRIPTION
## Description
IGN's geoplateform WMTS send incorrect BIL data. This causes the terrain to disappear due to this incorrect data.
This PR adds sanity checks for texture data to fail gracefully.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

## Screenshots (if appropriate)
