### PR TITLE
VPC PointCloudData

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -49,6 +49,7 @@
                 "PointCloudLayer",
                 "PotreeLayer",
                 "CopcLayer",
+                "VpcLayer",
                 "Potree2Layer",
                 "OGC3DTilesLayer",
                 "LabelLayer",
@@ -77,6 +78,7 @@
                 "VectorTilesSource",
                 "EntwinePointTileSource",
                 "CopcSource",
+                "VpcSource",
                 "OGC3DTilesSource",
                 "OGC3DTilesIonSource",
                 "OGC3DTilesGoogleSource"

--- a/examples/config.json
+++ b/examples/config.json
@@ -25,7 +25,8 @@
         "laz_dragndrop": "LAS/LAZ viewer",
         "entwine_simple_loader": "Entwine loader",
         "entwine_3d_loader": "Entwine 3D loader",
-        "copc_simple_loader": "COPC loader"
+        "copc_simple_loader": "COPC loader",
+        "vpc_simple_loader": "VPC loader"
     },
 
     "Vector tiles": {

--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -64,7 +64,7 @@
 
             setUrl(uri.searchParams.get('copc'));
 
-            function onLayerReady(layer) {
+            function onLayerReady() {
                 const camera = view.camera.camera3D;
 
                 const lookAt = new THREE.Vector3();

--- a/examples/vpc_simple_loader.html
+++ b/examples/vpc_simple_loader.html
@@ -1,0 +1,168 @@
+<html>
+    <head>
+        <title>Itowns - Vpc simple loader</title>
+
+        <script type="importmap">
+            {
+                "imports": {
+                    "itowns": "../dist/itowns.js",
+                    "debug": "../dist/debug.js",
+                    "LoadingScreen": "./jsm/GUI/LoadingScreen.js",
+                    "itowns_widgets": "../dist/itowns_widgets.js",
+                    "three": "https://unpkg.com/three@0.170.0/build/three.module.js",
+                    "three/addons/": "https://unpkg.com/three@0.170.0/examples/jsm/",
+                    "lil": "https://unpkg.com/lil-gui@0.20.0/dist/lil-gui.esm.js"
+                }
+            }
+        </script>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                left: 10px;
+            }
+        </style>
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19"></script>
+    </head>
+    <body>
+        <div id="description">Specify the URL of a VPC file to load:
+            <input type="text" id="copc_url" />
+            <button id="readUrlBtn">Load</button>
+            <div>
+                <button id="loadAmiensBtn">Load Amiens VPC (copc stack)</button>
+                <button id="loadRouenBtn">Load Rouen VPC (copc stack)</button>
+                <button id="loadOrleansBtn">Load Orleans VPC (ept stack)</button>
+            <div id="share"></div>
+            </div>
+        </div>
+        <div id="viewerDiv"></div>
+
+        <script type="module">
+            import lil from 'lil';
+            import setupLoadingScreen from 'LoadingScreen';
+            import * as THREE from 'three';
+            import * as itowns from 'itowns';
+            import * as debug from 'debug';
+            import * as itowns_widgets from 'itowns_widgets';
+
+            var debugGui = new lil();
+            var viewerDiv = document.getElementById('viewerDiv');
+            viewerDiv.style.display = 'block';
+
+            function readUrl() {
+                const urlParams = new URL(location).searchParams;
+                const url = urlParams.get('vpc');
+
+                const options = {};
+                urlParams.keys().forEach(key => {
+                    if (key !== 'vpc') {
+                        options[key] = parseInt(urlParams.get(key), 10);
+                    }
+                });
+                loadVPC(url, options);
+            }
+
+            readUrl();
+
+            let view;
+            let controls;
+            function setView(crs) {
+                viewerDiv.innerHTML = '';
+                view = new itowns.View(crs, viewerDiv);
+                controls = new itowns.PlanarControls(view);
+                view.mainLoop.gfxEngine.renderer.setClearColor(0xdddddd);
+            }
+
+            var vpcLayer, vpcSource;
+
+            function onLayerReady() {
+                var lookAt = new THREE.Vector3();
+                var size = new THREE.Vector3();
+
+                const rootBbox = vpcLayer.root.children[0].bbox;
+                rootBbox.getSize(size);
+                rootBbox.getCenter(lookAt);
+
+                view.camera3D.far = 20.0 * size.length();
+
+                controls.groundLevel = rootBbox.min.z;
+                var position = rootBbox.min.clone().add(
+                    size.multiply({ x: 0, y: 0, z: size.x / size.z })
+                );
+
+                view.camera3D.position.copy(position);
+                view.camera3D.lookAt(lookAt);
+                view.camera3D.updateProjectionMatrix();
+
+                view.notifyChange(vpcLayer);
+
+                debug.PointCloudDebug.initTools(view, vpcLayer, debugGui);
+            }
+
+            function loadVPC(url, options = {}) {
+                if(!url) return;
+
+                if (vpcLayer) {
+                    vpcLayer.debugUI.destroy()
+                    view.removeLayer('VPC');
+                    view.notifyChange();
+                }
+
+                const vpcSource = new itowns.VpcSource({ url });
+
+                const config = {
+                    source: vpcSource,
+                    sseThreshold: 2,
+                    pointBudget: 3000000,
+                    ...options,
+                };
+
+                vpcSource.whenReady.then(() => {
+                    setView(vpcSource.crs);
+                    vpcLayer = new itowns.VpcLayer('VPC', config);
+                    view.addLayer(vpcLayer).then(onLayerReady);
+                })
+            }
+
+            function loadAmiens() {
+                const options = {
+                    material: {mode: 2},
+                    opacity: 0.9,
+                }
+                loadVPC('https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/amiens.vpc', options);
+            }
+
+            function loadRouen() {
+                const options = {
+                    material: {mode: 2},
+                    opacity: 0.9,
+                }
+                loadVPC('https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/rouen.vpc', options);
+            }
+
+            function loadOrleans() {
+                const options = {
+                    material: {mode: 2},
+                    opacity: 0.9,
+                }
+                loadVPC('https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/vpc/index.vpc', options);
+            }
+
+            const readUrlBtn = document.getElementById('readUrlBtn');
+            const loadAmiensBtn = document.getElementById('loadAmiensBtn');
+            const loadRouenBtn = document.getElementById('loadRouenBtn');
+            const loadOrleansBtn = document.getElementById('loadOrleansBtn');
+
+            readUrlBtn.addEventListener('click', readUrl);
+            loadAmiensBtn.addEventListener('click', loadAmiens);
+            loadRouenBtn.addEventListener('click', loadRouen);
+            loadOrleansBtn.addEventListener('click', loadOrleans);
+
+        </script>
+    </body>
+</html>

--- a/packages/Geographic/test/unit/crs.js
+++ b/packages/Geographic/test/unit/crs.js
@@ -60,3 +60,16 @@ describe('CRS assertions', function () {
         assert.equal(CRS.axisOrder('EPSG:4269'), 'neu');
     });
 });
+
+describe('CRS.defsFromWkt()', function () {
+    it('Compound coordinate system', function () {
+        const wkt = 'COMPD_CS["NAD83(2011) / UTM zone 12N + NAVD88 height - Geoid12B (metres)",PROJCS["NAD83(2011) / UTM zone 12N",GEOGCS["NAD83(2011)",DATUM["NAD83_National_Spatial_Reference_System_2011",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","1116"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","6318"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-111],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","6341"]],VERT_CS["NAVD88 height",VERT_DATUM["North American Vertical Datum 1988",2005,AUTHORITY["EPSG","5103"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Up",UP],AUTHORITY["EPSG","5703"]]]';
+        const crs = CRS.defsFromWkt(wkt);
+        assert.equal(crs, 'EPSG:6341');
+    });
+    it('Simple coordinate system', function () {
+        const wkt = 'PROJCS["RGF93 / CC46",GEOGCS["RGF93",DATUM["Reseau_Geodesique_Francais_1993",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6171"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4171"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",45.25],PARAMETER["standard_parallel_2",46.75],PARAMETER["latitude_of_origin",46],PARAMETER["central_meridian",3],PARAMETER["false_easting",1700000],PARAMETER["false_northing",5200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","3946"]]';
+        const crs = CRS.defsFromWkt(wkt);
+        assert.equal(crs, 'EPSG:3946');
+    });
+});

--- a/packages/Main/src/Layer/CopcLayer.js
+++ b/packages/Main/src/Layer/CopcLayer.js
@@ -37,14 +37,14 @@ class CopcLayer extends PointCloudLayer {
          */
         this.isCopcLayer = true;
 
-        const resolve = () => this;
+        const resolve = super.addInitializationStep();
         this.whenReady = this.source.whenReady.then((/** @type {CopcSource} */ source) => {
             const { cube } = source.info;
             const { pageOffset, pageLength } = source.info.rootHierarchyPage;
 
-            this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this.source, -1);
-            this.root.bbox.min.fromArray(cube, 0);
-            this.root.bbox.max.fromArray(cube, 3);
+            const root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this.source, -1);
+            root.bbox.min.fromArray(cube, 0);
+            root.bbox.max.fromArray(cube, 3);
 
             this.minElevationRange = this.minElevationRange ?? source.header.min[2];
             this.maxElevationRange = this.maxElevationRange ?? source.header.max[2];
@@ -52,7 +52,9 @@ class CopcLayer extends PointCloudLayer {
             this.scale = new THREE.Vector3(1.0, 1.0, 1.0);
             this.offset = new THREE.Vector3(0.0, 0.0, 0.0);
 
-            return this.root.loadOctree().then(resolve);
+            this.root = root;
+
+            return root.loadOctree().then(resolve);
         });
     }
 }

--- a/packages/Main/src/Layer/EntwinePointTileLayer.js
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.js
@@ -57,16 +57,19 @@ class EntwinePointTileLayer extends PointCloudLayer {
 
         const resolve = this.addInitializationStep();
         this.whenReady = this.source.whenReady.then(() => {
-            this.root = new EntwinePointTileNode(0, 0, 0, 0, this.source, -1);
+            const root = new EntwinePointTileNode(0, 0, 0, 0, this.source, -1);
 
-            this.root.bbox.min.fromArray(this.source.boundsConforming, 0);
-            this.root.bbox.max.fromArray(this.source.boundsConforming, 3);
+            root.bbox.min.fromArray(this.source.boundsConforming, 0);
+            root.bbox.max.fromArray(this.source.boundsConforming, 3);
+
             this.minElevationRange = this.minElevationRange ?? this.source.boundsConforming[2];
             this.maxElevationRange = this.maxElevationRange ?? this.source.boundsConforming[5];
 
-            this.extent = Extent.fromBox3(config.crs || 'EPSG:4326', this.root.bbox);
+            this.extent = Extent.fromBox3(config.crs || 'EPSG:4326', root.bbox);
 
-            return this.root.loadOctree().then(resolve);
+            this.root = root;
+
+            return root.loadOctree().then(resolve);
         });
     }
 }

--- a/packages/Main/src/Layer/LabelLayer.js
+++ b/packages/Main/src/Layer/LabelLayer.js
@@ -66,7 +66,7 @@ class LabelsNode extends THREE.Group {
         this.needsUpdate = true;
     }
 
-    // instanciate dom elements
+    // instantiate dom elements
     initializeDom() {
         // create root dom
         this.domElements = new DomNode();

--- a/packages/Main/src/Layer/Potree2Layer.js
+++ b/packages/Main/src/Layer/Potree2Layer.js
@@ -119,7 +119,7 @@ class Potree2Layer extends PointCloudLayer {
             this.root = root;
 
             this.extent = Extent.fromBox3(this.source.crs || 'EPSG:4326', boundingBox);
-            return this.root.loadOctree().then(resolve);
+            return root.loadOctree().then(resolve);
         });
     }
 }

--- a/packages/Main/src/Layer/PotreeLayer.js
+++ b/packages/Main/src/Layer/PotreeLayer.js
@@ -64,15 +64,17 @@ class PotreeLayer extends PointCloudLayer {
 
             this.supportsProgressiveDisplay = (this.source.extension === 'cin');
 
-            this.root = new PotreeNode(0, 0, this.source);
-            this.root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
-            this.root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
+            const root = new PotreeNode(0, 0, this.source);
+            root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
+            root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
+
+            this.root = root;
 
             this.minElevationRange = this.minElevationRange ?? cloud.boundingBox.lz;
             this.maxElevationRange = this.maxElevationRange ?? cloud.boundingBox.uz;
 
-            this.extent = Extent.fromBox3(this.source.crs || 'EPSG:4326', this.root.bbox);
-            return this.root.loadOctree().then(resolve);
+            this.extent = Extent.fromBox3(this.source.crs || 'EPSG:4326', root.bbox);
+            return root.loadOctree().then(resolve);
         });
     }
 }

--- a/packages/Main/src/Layer/VpcLayer.js
+++ b/packages/Main/src/Layer/VpcLayer.js
@@ -1,0 +1,125 @@
+import * as THREE from 'three';
+import PointCloudNode from 'Core/PointCloudNode';
+import CopcNode from 'Core/CopcNode';
+import EntwinePointTileNode from 'Core/EntwinePointTileNode';
+import PointCloudLayer from 'Layer/PointCloudLayer';
+
+function _instantiateRootNode(source) {
+    let root;
+    if (source.isCopcSource) {
+        const { info } = source;
+        const { pageOffset, pageLength } = info.rootHierarchyPage;
+        root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1);
+        root.bbox.min.fromArray(info.cube, 0);
+        root.bbox.max.fromArray(info.cube, 3);
+    } else if (source.isEntwinePointTileSource) {
+        root = new EntwinePointTileNode(0, 0, 0, 0, source, -1);
+        root.bbox.min.fromArray(source.boundsConforming, 0);
+        root.bbox.max.fromArray(source.boundsConforming, 3);
+    } else {
+        const msg = '[VPCLayer]: stack point cloud format not supporter';
+        console.warn(msg);
+        PointCloudLayer.handlingError(msg);
+    }
+    return root;
+}
+
+/**
+ * A layer for [Virtual Point Clouds](https://github.com/PDAL/wrench/blob/main/vpc-spec.md) (VPC) datasets.
+ * See {@link PointCloudLayer} class for documentation on base properties.
+ *
+ * @extends {PointCloudLayer}
+ *
+ * @property {boolean} isVpcLayer - Used to checkout whether this layer
+ * is a VpcLayer. Default is `true`. You should not change this, as it is
+ * used internally for optimisation.
+ *
+ *
+ *
+ * @example
+ * // Create a new VPC layer
+ * const vpcSource = new VpcSource({
+ *     url: 'https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/vpc/index.vpc',
+ * });
+ *
+ * const vpcLayer = new VpcLayer('VPC', {
+ *     source: vpcSource,
+ * });
+ *
+ * View.prototype.addLayer.call(view, vpcLayer);
+ */
+class VpcLayer extends PointCloudLayer {
+    /**
+     * @param {string} id - Unique id of the layer.
+     * @param {Object} config - See {@link PointCloudLayer} for base pointcloud
+     * options.
+     */
+    constructor(id, config) {
+        super(id, config);
+
+        /**
+         * @type {boolean}
+         * @readonly
+         */
+        this.isVpcLayer = true;
+
+        this.scale = new THREE.Vector3(1.0, 1.0, 1.0);
+        this.offset = new THREE.Vector3(0.0, 0.0, 0.0);
+
+        const resolve = this.addInitializationStep();
+
+        // a Vpc layer should be ready when all the child sources are
+        this.whenReady = this.source.whenReady.then((/** @type {VpcSource} */ sources) => {
+            this.minElevationRange = this.minElevationRange ?? this.source.minElevation;
+            this.maxElevationRange = this.maxElevationRange ?? this.source.maxElevation;
+
+            const boundsConforming = this.source.boundsConforming;
+            this.root = new PointCloudNode(0, this.source);
+            this.root.bbox.min.fromArray(boundsConforming, 0);
+            this.root.bbox.max.fromArray(boundsConforming, 3);
+            this.root.depth = 0;
+
+            sources.forEach((source, i) => {
+                const boundsConforming = source.boundsConforming;
+                const bbox = new THREE.Box3().setFromArray(boundsConforming);
+                const mockRoot = {
+                    bbox,
+                    children: [],
+                    waitingForSource: true,
+                    source,
+                };
+
+                // As we delayed the intanciation of the source to the moment we need to render a particular node,
+                // we need to wait for the source to be instantiate to be able
+                // to instantiate a node and load the Octree associated.
+                const promise =
+                    source.whenReady.then((src) => {
+                        const root = _instantiateRootNode(src);
+                        this.root.children[i] = root;
+                        return root.loadOctree().then(resolve)
+                            .then(() => root);
+                    });
+
+                mockRoot.loadOctree = promise;
+                // when load() is called on the mockRoot, we need the associated source to be loaded
+                // as well as the octree, before calling load() on the real root.
+                mockRoot.load = () => promise.then(root => root.load());
+                this.root.children.push(mockRoot);
+            });
+            this.ready = true;
+        });
+    }
+
+    loadData(elt, context, layer, bbox) {
+        if (elt.waitingForSource) {
+            layer.source.instantiate(elt.source);
+            elt.loadOctree
+                .then(eltLoaded => super.loadData(eltLoaded, context, layer, bbox))
+                .then(() => context.view.notifyChange(layer));
+        } else {
+            return super.loadData(elt, context, layer, bbox);
+        }
+    }
+}
+
+export default VpcLayer;

--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -72,6 +72,7 @@ export { default as PlanarLayer } from 'Core/Prefab/Planar/PlanarLayer';
 export { default as LabelLayer } from 'Layer/LabelLayer';
 export { default as EntwinePointTileLayer } from 'Layer/EntwinePointTileLayer';
 export { default as CopcLayer } from 'Layer/CopcLayer';
+export { default as VpcLayer } from 'Layer/VpcLayer';
 export { default as GeoidLayer } from 'Layer/GeoidLayer';
 
 // Sources provided by default in iTowns
@@ -96,6 +97,7 @@ export { default as OGC3DTilesGoogleSource } from 'Source/OGC3DTilesGoogleSource
 export { default as EntwinePointTileSource } from 'Source/EntwinePointTileSource';
 export { default as CopcSource } from 'Source/CopcSource';
 export { default as CogSource } from 'Source/CogSource';
+export { default as VpcSource } from 'Source/VpcSource';
 
 // Parsers provided by default in iTowns
 // Custom parser can be implemented as wanted, as long as the main function

--- a/packages/Main/src/Renderer/Label2DRenderer.js
+++ b/packages/Main/src/Renderer/Label2DRenderer.js
@@ -87,7 +87,7 @@ const worldPosition = new THREE.Vector3();
 /**
  * This renderer is inspired by the
  * [`THREE.CSS2DRenderer`](https://threejs.org/docs/#examples/en/renderers/CSS2DRenderer).
- * It is instanciated in `c3DEngine`, as another renderer to handles Labels.
+ * It is instantiated in `c3DEngine`, as another renderer to handles Labels.
  */
 class Label2DRenderer {
     constructor() {

--- a/packages/Main/src/Source/CopcSource.js
+++ b/packages/Main/src/Source/CopcSource.js
@@ -1,6 +1,5 @@
-import proj4 from 'proj4';
 import { Binary, Info, Las } from 'copc';
-import { Extent } from '@itowns/geographic';
+import { CRS, Extent } from '@itowns/geographic';
 import Fetcher from 'Provider/Fetcher';
 import LASParser from 'Parser/LASParser';
 import Source from 'Source/Source';
@@ -71,7 +70,7 @@ class CopcSource extends Source {
      * @param {Object} config - Source configuration
      * @param {string} config.url - URL of the COPC resource.
      * @param {8 | 16} [config.colorDepth=16] - Encoding of the `color`
-     * attribute. Either `8` or `16` bits.
+     * attribute. Either `8` or `16` bits. By default it is to 16.
      * @param {string} [config._lazPerfBaseUrl] - (experimental) Overrides base
      * url of the `las-zip.wasm` file of the `laz-perf` library.
      * @param {string} [config.crs='EPSG:4326'] - Native CRS of the COPC
@@ -106,20 +105,7 @@ class CopcSource extends Source {
 
             this.spacing = this.info.spacing;
 
-            proj4.defs('unknown', metadata.wkt);
-            let projCS;
-
-            if (proj4.defs('unknown').type === 'COMPD_CS') {
-                console.warn('CopcSource: compound coordinate system is not yet supported.');
-                projCS = proj4.defs('unknown').PROJCS;
-            } else {
-                projCS = proj4.defs('unknown');
-            }
-
-            this.crs = projCS.title || projCS.name || 'EPSG:4326';
-            if (!(this.crs in proj4.defs)) {
-                proj4.defs(this.crs, projCS);
-            }
+            this.crs = CRS.defsFromWkt(metadata.wkt);
 
             const bbox = new THREE.Box3();
             bbox.min.fromArray(this.info.cube, 0);

--- a/packages/Main/src/Source/Source.js
+++ b/packages/Main/src/Source/Source.js
@@ -150,7 +150,6 @@ class Source {
     loadData(extent, out) {
         const cache = this._featuresCaches[out.crs];
         const key = this.getDataKey(extent);
-        // console.log('Source.loadData', key);
         // try to get parsed data from cache
         let features = cache.get(key);
         if (!features) {

--- a/packages/Main/src/Source/VpcSource.js
+++ b/packages/Main/src/Source/VpcSource.js
@@ -1,0 +1,141 @@
+import { CRS } from '@itowns/geographic';
+import LASParser from 'Parser/LASParser';
+import Fetcher from 'Provider/Fetcher';
+import Source from 'Source/Source';
+import EntwinePointTileSource from 'Source/EntwinePointTileSource';
+import CopcSource from 'Source/CopcSource';
+import { LRUCache } from 'lru-cache';
+
+const cachedSources = new LRUCache({ max: 500 });
+
+/**
+ * An object defining the source of Entwine Point Tile data. It fetches and
+ * parses the main configuration file of Entwine Point Tile format,
+ * [`ept.json`](https://entwine.io/entwine-point-tile.html#ept-json).
+ *
+ * @extends Source
+ *
+ * @property {boolean} isEntwinePointTileSource - Used to checkout whether this
+ * source is a EntwinePointTileSource. Default is true. You should not change
+ * this, as it is used internally for optimisation.
+ * @property {string} url - The URL of the directory containing the whole
+ * Entwine Point Tile structure.
+ * @property {Object[]|PointCloudSource[]} sources - Array of all the source described in the VPC.
+ * initialized with mockSource that will be replace by COPC or EPT Source as soon as any data need
+ * to be loaded.
+ */
+class VpcSource extends Source {
+    /**
+     * @param {Object} config - The configuration, see {@link Source} for
+     * available values.
+     * @param {number} [config.colorDepth] - Color depth (in bits).
+     * Either 8 or 16 bits. By defaults it will be set to 8 bits for LAS 1.2 and
+     * 16 bits for later versions (as mandatory by the specification).
+     */
+    constructor(config) {
+        super(config);
+
+        this.isVpcSource = true;
+        this.sources = [];
+
+        this.parser = LASParser.parseChunk;
+        this.fetcher = Fetcher.arrayBuffer;
+
+        this.colorDepth = config.colorDepth;
+
+        this.spacing = Infinity;
+
+        this.whenReady = Fetcher.json(this.url, this.networkOptions)
+            .then((metadata) => {
+                this.metadata = metadata;
+
+                // Set boundsConformings (the bbox) of the VPC Layer
+                const boundsConformings = metadata.features.map(f => f.properties['proj:bbox']);
+                this.boundsConforming = [
+                    Math.min(...boundsConformings.map(b => b[0])),
+                    Math.min(...boundsConformings.map(b => b[1])),
+                    Math.min(...boundsConformings.map(b => b[2])),
+                    Math.max(...boundsConformings.map(b => b[3])),
+                    Math.max(...boundsConformings.map(b => b[4])),
+                    Math.max(...boundsConformings.map(b => b[5])),
+                ];
+
+                // Set the zmin and zmax from the source
+                this.minElevation = this.boundsConforming[2];
+                this.maxElevation = this.boundsConforming[5];
+
+                // Set the Crs of the VPC Layer (currently we only use the first)
+                const projsWkt2 = [...new Set(metadata.features.map(f => f.properties['proj:wkt2']))];
+                if (projsWkt2.length !== 1) {
+                    console.warn('Only 1 crs is currently supported for 1 vpc. The extra crs will not be considered');
+                }
+                this.crs = CRS.defsFromWkt(projsWkt2[0]);
+
+                /* Set  several object (MockSource) to mock the source that will need to be instantiated.
+                 We don't want all child source to be instantiated at once as it will send the fetch request
+                 (current architectural choice) thus we want to delay the instanciation of the child source
+                 when the data need to be load on a particular node.
+                 Creation of 1 mockSource for each item in the stack (that will be replace by a real source
+                 when needed, when we will call the load on a node depending of that source).
+                */
+                this._promises = [];
+                this.urls = metadata.features.map(f => f.assets.data.href);
+                this.urls.forEach((url, i) => {
+                    const whenReady = new Promise((re, rj) => {
+                        // waiting for this.instantiate(source);
+                        this._promises.push({ resolve: re, reject: rj });
+                    }).then((res) => {
+                        // replace the mock source by the real source (instantiated)
+                        this.sources[i] = res;
+                        return res;
+                    }).catch((err) => {
+                        console.warn(err);
+                        this.handlingError(err);
+                    });
+
+                    const mockSource = {
+                        url,
+                        boundsConforming: boundsConformings[i],
+                        whenReady,
+                        sId: i,
+                    };
+                    this.sources.push(mockSource);
+                });
+
+                return this.sources;
+            });
+    }
+
+    /**
+     * We created several objects mocking a source at the intantiation of the vpc layer.
+     * The following method will be called when we need to instantiate the real source (COPC or EPT).
+     * The mock source contain the url to instantiate the source as well as a promise that
+     * will be resolve when the source.whenReady promise will resolve.
+     * To avoid instanciating several time the same source, we use a cache to store the
+     * whenReady promise of the source (cachedSources).
+     *
+     * @param {object} source - The mock source used to instantiate the real source.
+     * @param {object} source.url - The url of the source to instanciate.
+     */
+    instantiate(source) {
+        let newSource;
+        const url = source.url;
+        let cachedSrc = cachedSources.get(url);
+        if (!cachedSrc) {
+            if (url.includes('.copc')) {
+                newSource = new CopcSource({ url });
+            } else if (url.includes('.json')) {
+                newSource = new EntwinePointTileSource({ url });
+            } else {
+                const msg = '[VPCLayer]: stack point cloud format not supporter';
+                console.warn(msg);
+                this.handlingError(msg);
+            }
+            cachedSrc = newSource;
+            cachedSources.set(url, cachedSrc);
+        }
+        this._promises[source.sId].resolve(cachedSrc.whenReady);
+    }
+}
+
+export default VpcSource;

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -1,11 +1,25 @@
 import assert from 'assert';
+import View from 'Core/View';
+import GlobeView from 'Core/Prefab/GlobeView';
+import { Coordinates } from '@itowns/geographic';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import CopcSource from 'Source/CopcSource';
+import CopcLayer from 'Layer/CopcLayer';
+import CopcNode from 'Core/CopcNode';
+import LASParser from 'Parser/LASParser';
+import Renderer from './bootstrap';
 
 const copcUrl = 'https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz';
 
 describe('COPC', function () {
     let source;
+    before(function () {
+        LASParser.enableLazPerf('../../examples/libs/laz-perf');
+    });
+
+    after(async function () {
+        await LASParser.terminate();
+    });
 
     describe('Copc Source', function () {
         describe('retrieving crs from wkt information', function () {
@@ -24,6 +38,115 @@ describe('COPC', function () {
                         done();
                     }).catch(done);
             }).timeout(5000);
+        });
+    });
+
+    describe('Layer', function () {
+        let renderer;
+        let placement;
+        let view;
+        let layer;
+        let context;
+
+        before(function (done) {
+            renderer = new Renderer();
+            placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
+            view = new GlobeView(renderer.domElement, placement, { renderer });
+            layer = new CopcLayer('testCopcLayer', { source });
+
+            context = {
+                camera: view.camera,
+                engine: view.mainLoop.gfxEngine,
+                scheduler: view.mainLoop.scheduler,
+                geometryLayer: layer,
+                view,
+            };
+
+            View.prototype.addLayer.call(view, layer)
+                .then(() => {
+                    done();
+                }).catch(done);
+        });
+
+        it('pre updates and finds the root', () => {
+            const element = layer.preUpdate(context, new Set([layer]));
+            assert.strictEqual(element.length, 1);
+            assert.deepStrictEqual(element[0], layer.root);
+        });
+
+        it('tries to update on the root and fails', function () {
+            layer.update(context, layer, layer.root);
+            assert.strictEqual(layer.root.promise, undefined);
+        });
+
+        it('tries to update on the root and succeeds', function (done) {
+            view.controls.lookAtCoordinate({
+                range: -250,
+            }, false)
+                .then(() => {
+                    layer.update(context, layer, layer.root);
+                    layer.root.promise
+                        .then(() => {
+                            done();
+                        });
+                }).catch(done);
+        });
+
+        it('post updates', function () {
+            layer.postUpdate(context, layer);
+        });
+    });
+
+    describe('Node', function () {
+        let root;
+        before(function () {
+            const layer = { source: { url: 'http://server.geo', extension: 'laz' } };
+            root = new CopcNode(0, 0, 0, 0, layer, 4000);
+            root.bbox.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+
+            root.add(new CopcNode(1, 0, 0, 0, layer, 3000));
+            root.add(new CopcNode(1, 0, 0, 1, layer, 3000));
+            root.add(new CopcNode(1, 0, 1, 1, layer, 3000));
+
+            root.children[0].add(new CopcNode(2, 0, 0, 0, layer, 2000));
+            root.children[0].add(new CopcNode(2, 0, 1, 0, layer, 2000));
+            root.children[1].add(new CopcNode(2, 0, 1, 3, layer, 2000));
+            root.children[2].add(new CopcNode(2, 0, 2, 2, layer, 2000));
+            root.children[2].add(new CopcNode(2, 0, 3, 3, layer, 2000));
+
+            root.children[0].children[0].add(new CopcNode(3, 0, 0, 0, layer, 1000));
+            root.children[0].children[0].add(new CopcNode(3, 0, 1, 0, layer, 1000));
+            root.children[1].children[0].add(new CopcNode(3, 0, 2, 7, layer, 1000));
+            root.children[2].children[0].add(new CopcNode(3, 0, 5, 4, layer, 1000));
+            root.children[2].children[1].add(new CopcNode(3, 1, 6, 7, layer));
+        });
+
+        describe('finds the common ancestor of two nodes', () => {
+            let ancestor;
+            it('cousins => grand parent', () => {
+                ancestor = root.children[2].children[1].children[0].findCommonAncestor(root.children[2].children[0].children[0]);
+                assert.deepStrictEqual(ancestor, root.children[2]);
+            });
+
+            it('brothers => parent', () => {
+                ancestor = root.children[0].children[0].children[0].findCommonAncestor(root.children[0].children[0].children[1]);
+                assert.deepStrictEqual(ancestor, root.children[0].children[0]);
+            });
+
+            it('grand child and grand grand child => root', () => {
+                ancestor = root.children[0].children[1].findCommonAncestor(root.children[2].children[1].children[0]);
+                assert.deepStrictEqual(ancestor, root);
+            });
+
+            it('parent and child => parent', () => {
+                ancestor = root.children[1].findCommonAncestor(root.children[1].children[0].children[0]);
+                assert.deepStrictEqual(ancestor, root.children[1]);
+            });
+
+            it('child and parent => parent', () => {
+                ancestor = root.children[2].children[0].findCommonAncestor(root.children[2]);
+                assert.deepStrictEqual(ancestor, root.children[2]);
+            });
         });
     });
 });

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -89,7 +89,7 @@ describe('Entwine Point Tile', function () {
             renderer = new Renderer();
             placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
             view = new GlobeView(renderer.domElement, placement, { renderer });
-            layer = new EntwinePointTileLayer('test', { source }, view);
+            layer = new EntwinePointTileLayer('testEptLayer', { source });
 
             context = {
                 camera: view.camera,

--- a/packages/Main/test/unit/source/filesource.js
+++ b/packages/Main/test/unit/source/filesource.js
@@ -48,7 +48,7 @@ describe('FileSource', function () {
     it('should instance FileSource with source.fetchedData and parse data with a layer', function (done) {
         // TO DO need cleareance: what is this test for ?
         //  - testing instanceation Filesource when fetchedData and source.feature is already available ?
-        //  - testing instanciate Layer ?
+        //  - testing instantiate Layer ?
         //  - testing source.onLayerAdded ?
         //  - testing souce.loadData ?
         const source = new FileSource({

--- a/packages/Main/test/unit/vpc.js
+++ b/packages/Main/test/unit/vpc.js
@@ -1,0 +1,135 @@
+import assert from 'assert';
+import View from 'Core/View';
+import GlobeView from 'Core/Prefab/GlobeView';
+import { Coordinates } from '@itowns/geographic';
+import VpcSource from 'Source/VpcSource';
+import VpcLayer from 'Layer/VpcLayer';
+import Renderer from './bootstrap';
+
+const vpcEptUrl = 'https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/vpc/index.vpc';
+const vpcCopcUrl = 'https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/amiens.vpc';
+
+describe('VPC', function () {
+    let vpcEptSource;
+    let vpcCopcSource;
+
+    describe('Source', function () {
+        describe('ept stack', function () {
+            it('instantiation', function () {
+                vpcEptSource = new VpcSource({
+                    url: vpcEptUrl,
+                });
+                assert.ok(vpcEptSource.isVpcSource);
+            });
+            it('whenReady', function (done) {
+                vpcEptSource.whenReady
+                    .then(() => {
+                        assert.ok(vpcEptSource.minElevation);
+                        assert.ok(vpcEptSource.maxElevation);
+                        assert.ok(vpcEptSource.sources.length > 0);
+                        done();
+                    }).catch(done);
+            }).timeout(5000);
+        });
+
+        describe('copc stack', function () {
+            it('instantiation', function () {
+                vpcCopcSource = new VpcSource({
+                    url: vpcCopcUrl,
+                });
+                assert.ok(vpcCopcSource.isVpcSource);
+            });
+            it('whenReady', function (done) {
+                vpcCopcSource.whenReady
+                    .then(() => {
+                        assert.ok(vpcCopcSource.minElevation);
+                        assert.ok(vpcCopcSource.maxElevation);
+                        assert.ok(vpcCopcSource.sources.length > 0);
+                        done();
+                    }).catch(done);
+            }).timeout(5000);
+        });
+
+        describe('stack sources', function (done) {
+            it('ept stack', function () {
+                const eptMockSource = vpcEptSource.sources[0];
+                vpcEptSource.instantiate(eptMockSource);
+
+                eptMockSource.whenReady
+                    .then(() => {
+                        assert.ok(vpcEptSource.sources[0].isEntwinePointTileSource);
+                        done();
+                    }).catch(done);
+            });
+            it('copc stack', function () {
+                const copcMockSource = vpcCopcSource.sources[0];
+                vpcCopcSource.instantiate(copcMockSource);
+
+                copcMockSource.whenReady
+                    .then(() => {
+                        assert.ok(vpcCopcSource.sources[0].isCopcSource);
+                        done();
+                    }).catch(done);
+            });
+        });
+    });
+
+    describe('Layer', function () {
+        let renderer;
+        let placement;
+        let view;
+        let vpcLayer;
+
+        before(function () {
+            renderer = new Renderer();
+            placement = { coord: new Coordinates('EPSG:4326', 0, 0), range: 250 };
+            view = new GlobeView(renderer.domElement, placement, { renderer });
+        });
+
+        it('instantiate', () => {
+            vpcLayer = new VpcLayer('testVpcLayer', { source: vpcEptSource });
+            assert.ok(vpcLayer.isVpcLayer);
+        });
+
+        it('add to the view', (done) => {
+            View.prototype.addLayer.call(view, vpcLayer)
+                .then(() => {
+                    done();
+                }).catch(done);
+        });
+
+        let context;
+        describe('loadData()', () => {
+            let node;
+
+            it('on a mockRoot', async function () {
+                context = {
+                    camera: view.camera,
+                    engine: view.mainLoop.gfxEngine,
+                    scheduler: view.mainLoop.scheduler,
+                    geometryLayer: vpcLayer,
+                    view,
+                };
+
+                const mockRoot = vpcLayer.root.children[0];
+                assert.equal(vpcEptSource.sources[0].isEntwinePointTileSource, undefined, 'source already instanciated');
+                vpcLayer.loadData(mockRoot, context, vpcLayer, mockRoot.bbox);
+
+                await mockRoot.source.whenReady;
+                assert.ok(vpcEptSource.sources[0].isEntwinePointTileSource);
+                const root = await mockRoot.loadOctree;
+                node = root.children[0];
+                assert.ok(root.numPoints > 0);
+            });
+            it('on a "commun" node', async function () {
+                vpcLayer.loadData(node, context, vpcLayer, node.bbox);
+                if (node.obj) {
+                    assert.ok(node.promise === null);
+                } else if (node.promise) {
+                    await node.promise;
+                    assert.ok(node.promise === null);
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR aims at supporting the VPC format (vpc is a stack of ept or copc data)

New classes VpcSource and VpcLayer had been added. VpcSource beeing a class instanciating sub source (ept or copc source dependings).

The first try was to instanciate all sub sources as soon as the VpcSource was instanciate, but this lead to long delay at start.
Thus I decided to instanciate subsources only when the needed node was updated what leads to the use of mocked sources and promised sources.
(this is open for discussion)

~~(1er commit is not yet sqaushed as I feell like it's easier to check what was added for the mocked sources)~~


Other modifications:
- ~~A new id has been added to copcNode and eptNode (sId) to link the node and its subsource to ne used for the fetch.~~

- ~~The whole update of PointCloud had been copied and modified on vpcLayer, to avoid breaking the current PointCloud update, but at the end it probalby should be reunified.~~ DONE

