### PR TITLE
Add Eye-Dome Lighting (EDL) pass for pointcloud examples

### DIFF
--- a/examples/pointcloud_loader_globe.html
+++ b/examples/pointcloud_loader_globe.html
@@ -60,14 +60,15 @@
         <div id="viewerDiv"></div>
 
         <script type="module">
-            import { Vector3 } from 'three';
+            import { WebGLRenderTarget, DepthTexture, FloatType } from 'three';
             import Stats from 'stats-gl';
             import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
             import { getFormat, getPointCloudClass, getDefaultAttribute, zoomToLayerGlobe } from './jsm/PointCloudHelper.js';
 
+            import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+            import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
             import {
                 CRS, MAIN_LOOP_EVENTS, PNTS_MODE,
-                Coordinates,
                 View,
                 GlobeView,
                 Fetcher,
@@ -75,6 +76,7 @@
                 ColorLayer,
                 WMTSSource,
                 ElevationLayer,
+                EDLPass,
             } from 'itowns';
             import { PointCloudDebug } from 'debug';
 
@@ -85,7 +87,24 @@
             const crsInput = document.getElementById('crs');
             const errorMessage = document.getElementById('error-message');
 
-            window.getFormat = getFormat;
+            function withHidden(view, predicate, func) {
+                const visibilitySet = new Set();
+                const layers = view.getLayers(layer => {
+                    return layer.isGeometryLayer && predicate(layer) && layer.visible
+                });
+
+                layers.forEach(layer => {
+                    layer.object3d.visible = false;
+                    visibilitySet.add(layer.object3d);
+                });
+
+                func(view);
+
+                visibilitySet.forEach(object => {
+                    object.visible = true;
+                });
+            }
+
 
             const isEmbedded = window.self !== window.top;
 
@@ -94,11 +113,10 @@
                     history.replaceState(null, '', '?' + params.toString());
                 }
             }
-            window.updateUrlParams = updateUrlParams;
 
             let currentView = null;
 
-            window.load = async function load(url, options = {}) {
+            async function load(url, options = {}) {
                 // Cleanup previous view
                 if (currentView) {
                     currentView.dispose();
@@ -128,6 +146,33 @@
                     }
                 });
                 currentView = view;
+
+                const gfxEngine = view.mainLoop.gfxEngine;
+                const renderer = gfxEngine.renderer;
+                const size = gfxEngine.getWindowSize();
+
+                const renderTarget = new WebGLRenderTarget(size.x, size.y);
+                renderTarget.depthTexture = new DepthTexture(size.x, size.y, FloatType);
+
+                const composer = new EffectComposer(renderer, renderTarget);
+                const renderPass = new RenderPass(view.scene, view.camera3D);
+                const edlPass = new EDLPass(view.camera3D, size.x, size.y);
+                composer.addPass(renderPass);
+                composer.addPass(edlPass);
+
+                view.render = function render() {
+                    // Render point cloud + EDL to screen
+                    withHidden(view, layer => !layer.isPointCloudLayer, () => {
+                        composer.render();
+                    });
+
+                    // Render globe with depth test
+                    withHidden(view, layer => layer.isPointCloudLayer, () => {
+                        renderer.render(view.scene, view.camera3D);
+                    });
+                };
+
+                layer.crs = source.crs;
                 View.prototype.addLayer.call(view, layer);
 
                 const openSMJSON = await Fetcher.json('./layers/JSONLayers/OPENSM.json');
@@ -145,6 +190,14 @@
                         source: new WMTSSource(worldDTMJSON.source),
                     }),
                 );
+
+                await layer.whenReady;
+                zoomToLayerGlobe(view, layer);
+
+                window.addEventListener('resize', () => {
+                    const newSize = gfxEngine.getWindowSize();
+                    composer.setSize(newSize.x, newSize.y);
+                });
 
                 const stats = new Stats();
                 stats.init(view.renderer);
@@ -164,6 +217,12 @@
 
                 const gui = new GUI();
                 PointCloudDebug.initTools(view, layer, gui);
+
+                const edlFolder = gui.addFolder('Eye-Dome Lighting');
+                edlFolder.add(edlPass, 'enabled').name('Enabled').onChange(() => view.notifyChange());
+                edlFolder.add(edlPass, 'strength', 0, 10, 0.1).name('Strength').onChange(() => view.notifyChange());
+                edlFolder.add(edlPass, 'kernelRadius', 0.1, 5, 0.1).name('Radius').onChange(() => view.notifyChange());
+                edlFolder.open();
             }
 
             if (!isEmbedded) {
@@ -176,7 +235,7 @@
                         urlInput.value = url;
                         formatSelect.value = format ?? 'auto';
                         crsInput.value = crs ?? '';
-                        await window.load(url, { format, crs });
+                        await load(url, { format, crs });
                     } catch (error) {
                         console.error(error);
                     }
@@ -208,6 +267,10 @@
                     errorMessage.textContent = message;
                 }
             });
+
+            window.load = load;
+            window.getFormat = getFormat;
+            window.updateUrlParams = updateUrlParams;
         </script>
 
         <script type="module">

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -18,7 +18,7 @@ export interface PointCloudSource {
 }
 
 export interface PointCloudLayerParameters {
-    /** Description and options of the source See @Layer. */
+    /** Description and options of the source {@link Layer}. */
     source: PointCloudSource;
     object3d?: THREE.Group;
     group?: THREE.Group;

--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -126,3 +126,6 @@ export { default as C3DTExtensions } from './Core/3DTiles/C3DTExtensions';
 export { C3DTilesTypes, C3DTilesBoundingVolumeTypes } from './Core/3DTiles/C3DTilesEnums';
 export { default as C3DTBatchTableHierarchyExtension } from './Core/3DTiles/C3DTBatchTableHierarchyExtension';
 export { process3dTilesNode, $3dTilesCulling, $3dTilesSubdivisionControl } from 'Process/3dTilesProcessing';
+
+// Postprocessing
+export { EDLPass } from 'Renderer/Postprocessing/EDLPass';

--- a/packages/Main/src/Renderer/Postprocessing/EDLPass.ts
+++ b/packages/Main/src/Renderer/Postprocessing/EDLPass.ts
@@ -1,0 +1,151 @@
+import {
+    NoBlending,
+    ShaderMaterial,
+    UniformsUtils,
+    PerspectiveCamera,
+    type OrthographicCamera,
+    type WebGLRenderer,
+    type WebGLRenderTarget,
+} from 'three';
+// eslint-disable-next-line
+import { Pass, FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
+import { EDLShader } from './EDLShader';
+
+/**
+ * Generates a kernel of evenly distributed 2D sample directions around a
+ * circle.
+ *
+ * @param kernelSize - Number of sample directions
+ * @returns a flat array of (x, y) pairs
+ */
+function generateKernel(kernelSize: number): Float32Array {
+    const kernel = new Float32Array(kernelSize * 2);
+
+    for (let i = 0; i < kernelSize; ++i) {
+        const angle = (2 * Math.PI * i) / kernelSize;
+        kernel[(i * 2) + 0] = Math.cos(angle);
+        kernel[(i * 2) + 1] = Math.sin(angle);
+    }
+
+    return kernel;
+}
+
+// Algorithm by Christian Boucheny. See:
+// - Phd thesis (page 115-127, french):
+//   https://tel.archives-ouvertes.fr/tel-00438464/document
+// - Implementation in Cloud Compare (last update 2022):
+//   https://github.com/CloudCompare/CloudCompare/tree/master/plugins/core/GL/qEDL/shaders/EDL
+// Parameters by Markus Schuetz (Potree). See:
+// - Master thesis (pages 38-41):
+//   https://www.cg.tuwien.ac.at/research/publications/2016/SCHUETZ-2016-POT/SCHUETZ-2016-POT-thesis.pdf
+// - Implementation in Potree (last update 2019):
+//   https://github.com/potree/potree/blob/develop/src/materials/shaders/edl.fs
+
+/**
+ * @experimental
+ */
+class EDLPass extends Pass {
+    width: number;
+    height: number;
+    camera: PerspectiveCamera | OrthographicCamera;
+    private _kernel: Float32Array;
+    private edlMaterial: ShaderMaterial;
+    private _fsQuad: FullScreenQuad;
+
+    constructor(
+        camera: PerspectiveCamera | OrthographicCamera,
+        width = 256,
+        height = 256,
+        kernelSize = 8,
+    ) {
+        super();
+
+        /**
+         * The width of the render target.
+         * @defaultValue 256
+         */
+        this.width = width;
+
+        /**
+         * The height of the render target.
+         * @defaultValue 256
+         */
+        this.height = height;
+
+        /**
+         * Overwritten to true to ensure the render target is cleared.
+         * @defaultValue true
+         */
+        this.clear = true;
+
+        this.camera = camera;
+
+        this._kernel = generateKernel(kernelSize);
+
+        this.edlMaterial = new ShaderMaterial({
+            defines: { ...EDLShader.defines },
+            uniforms: UniformsUtils.clone(EDLShader.uniforms),
+            vertexShader: EDLShader.vertexShader,
+            fragmentShader: EDLShader.fragmentShader,
+            blending: NoBlending,
+            depthWrite: true,
+            depthTest: true,
+        });
+
+        this.edlMaterial.defines.KERNEL_SIZE = kernelSize;
+        this.edlMaterial.defines.PERSPECTIVE_CAMERA =
+            camera instanceof PerspectiveCamera ? 1 : 0;
+
+        const uniforms = this.edlMaterial.uniforms;
+        uniforms.kernel.value = this._kernel;
+        uniforms.resolution.value.set(this.width, this.height);
+        uniforms.cameraNear.value = this.camera.near;
+        uniforms.cameraFar.value = this.camera.far;
+
+        this._fsQuad = new FullScreenQuad(this.edlMaterial);
+    }
+
+    setSize(width: number, height: number) {
+        this.width = width;
+        this.height = height;
+
+        this.edlMaterial.uniforms.resolution.value.set(width, height);
+    }
+
+    get strength(): number {
+        return this.edlMaterial.uniforms.edlStrength.value;
+    }
+
+    set strength(value: number) {
+        this.edlMaterial.uniforms.edlStrength.value = value;
+    }
+
+    get kernelRadius(): number {
+        return this.edlMaterial.uniforms.kernelRadius.value;
+    }
+
+    set kernelRadius(value: number) {
+        this.edlMaterial.uniforms.kernelRadius.value = value;
+    }
+
+    override render(
+        renderer: WebGLRenderer,
+        writeBuffer: WebGLRenderTarget,
+        readBuffer: WebGLRenderTarget,
+    ) {
+        this.edlMaterial.uniforms.cameraNear.value = this.camera.near;
+        this.edlMaterial.uniforms.cameraFar.value = this.camera.far;
+
+        this.edlMaterial.uniforms.tDepth.value = readBuffer.depthTexture;
+        this.edlMaterial.uniforms.tDiffuse.value = readBuffer.texture;
+
+        renderer.setRenderTarget(this.renderToScreen ? null : writeBuffer);
+        this._fsQuad.render(renderer);
+    }
+
+    dispose() {
+        this._fsQuad.dispose();
+    }
+}
+
+export { EDLPass };

--- a/packages/Main/src/Renderer/Postprocessing/EDLShader.ts
+++ b/packages/Main/src/Renderer/Postprocessing/EDLShader.ts
@@ -1,0 +1,104 @@
+import { Vector2, type Texture } from 'three';
+
+const vertexShader = /* glsl */ `
+out vec2 vUv;
+
+void main() {
+    vUv = uv;
+#include <begin_vertex>
+#include <project_vertex>
+}
+`;
+
+const fragmentShader = /* glsl */ `
+#include <packing>
+
+#ifdef USE_REVERSED_DEPTH_BUFFER
+#define DEPTH_THRESHOLD 0.0
+#else
+#define DEPTH_THRESHOLD 1.0
+#endif
+
+uniform sampler2D tDepth;
+uniform sampler2D tDiffuse;
+
+uniform vec2 kernel[KERNEL_SIZE];
+
+uniform vec2 resolution;
+uniform float cameraNear;
+uniform float cameraFar;
+
+uniform float kernelRadius;
+uniform float edlStrength;
+
+in vec2 vUv;
+
+float getDepth(const in vec2 screenPosition) {
+    return texture2D(tDepth, screenPosition).x;
+}
+
+float getLinearDepth(const in vec2 screenPosition) {
+    #if PERSPECTIVE_CAMERA == 1
+        float fragCoordZ = texture2D(tDepth, screenPosition).x;
+        float viewZ = perspectiveDepthToViewZ(fragCoordZ, cameraNear, cameraFar);
+        return viewZToOrthographicDepth(viewZ, cameraNear, cameraFar);
+    #else
+        return texture2D(tDepth, screenPosition).x;
+    #endif
+}
+
+float getLogDepth(const in vec2 screenPosition) {
+    float linear = getLinearDepth(screenPosition);
+    return log2(max(linear, 0.0000001));
+}
+
+void main() {
+    float depth = getDepth(vUv);
+    vec4 color = texture2D(tDiffuse, vUv);
+
+    if (depth == DEPTH_THRESHOLD) {
+        discard;
+    }
+
+    float logDepth = getLogDepth(vUv);
+    vec2 uvRadius = kernelRadius / resolution;
+
+    float edl = 0.0;
+    for (int i = 0; i < KERNEL_SIZE; ++i) {
+        vec2 uvNeighbour = clamp(vUv + uvRadius * kernel[i], 0.0, 1.0);
+        edl = edl + max(0.0, logDepth - getLogDepth(uvNeighbour));
+    }
+    edl = edl / float(KERNEL_SIZE);
+
+    edl = exp(-edl * 300.0 * edlStrength);
+
+    gl_FragColor = vec4(color.rgb * edl, color.a);
+    gl_FragDepth = depth;
+}
+
+`;
+
+const EDLShader = {
+    name: 'EDLShader',
+
+    defines: {
+        KERNEL_SIZE: 8,
+        PERSPECTIVE_CAMERA: 1,
+    },
+
+    uniforms: {
+        tDepth: { value: null as Texture | null },
+        tDiffuse: { value: null as Texture | null },
+        kernel: { value: null as Float32Array | null },
+        resolution: { value: new Vector2() },
+        cameraNear: { value: null as number | null },
+        cameraFar: { value: null as number | null },
+        kernelRadius: { value: 1.5 },
+        edlStrength: { value: 0.7 },
+    },
+
+    vertexShader,
+    fragmentShader,
+};
+
+export { EDLShader };


### PR DESCRIPTION
## Description

This is some code I used for IGN's [LiDAR HD viewer](https://diffusion-lidarhd.ign.fr) to implement Eye-Dome Lighting (EDL).

It is implemented as a three.js pass and the API shall be considered experimental until we converge on the post-processing proposal (https://github.com/iTowns/itowns/issues/2719).

Linked proposal: #2193