### PR TITLE
refactor(PointCloudLayer): homogeneisation

### DIFF
--- a/packages/Main/src/Core/EntwinePointTileNode.js
+++ b/packages/Main/src/Core/EntwinePointTileNode.js
@@ -1,10 +1,5 @@
-import * as THREE from 'three';
 import Fetcher from 'Provider/Fetcher';
 import PointCloudNode from 'Core/PointCloudNode';
-
-const size = new THREE.Vector3();
-const position = new THREE.Vector3();
-const translation = new THREE.Vector3();
 
 function buildId(depth, x, y, z) {
     return `${depth}-${x}-${y}-${z}`;
@@ -22,10 +17,10 @@ function buildId(depth, x, y, z) {
  * @property {number} x - The x coordinate of the node in the tree - see the
  * [Entwine
  * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
- * @property {number} y - The x coordinate of the node in the tree - see the
+ * @property {number} y - The y coordinate of the node in the tree - see the
  * [Entwine
  * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
- * @property {number} z - The x coordinate of the node in the tree - see the
+ * @property {number} z - The z coordinate of the node in the tree - see the
  * [Entwine
  * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
  * @property {string} id - The id of the node, constituted of the four
@@ -43,10 +38,10 @@ class EntwinePointTileNode extends PointCloudNode {
      * @param {number} x - The x coordinate of the node in the tree - see the
      * [Entwine
      * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
-     * @param {number} y - The x coordinate of the node in the tree - see the
+     * @param {number} y - The y coordinate of the node in the tree - see the
      * [Entwine
      * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
-     * @param {number} z - The x coordinate of the node in the tree - see the
+     * @param {number} z - The z coordinate of the node in the tree - see the
      * [Entwine
      * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
      * @param {EntwinePointTileLayer} layer - The layer the node is attached to.
@@ -56,7 +51,6 @@ class EntwinePointTileNode extends PointCloudNode {
      */
     constructor(depth, x, y, z, layer, numPoints = 0) {
         super(numPoints, layer);
-
         this.isEntwinePointTileNode = true;
 
         this.depth = depth;
@@ -69,38 +63,13 @@ class EntwinePointTileNode extends PointCloudNode {
         this.url = `${this.layer.source.url}/ept-data/${this.id}.${this.layer.source.extension}`;
     }
 
-    createChildAABB(node) {
-        // factor to apply, based on the depth difference (can be > 1)
-        const f = 2 ** (node.depth - this.depth);
-
-        // size of the child node bbox (Vector3), based on the size of the
-        // parent node, and divided by the factor
-        this.bbox.getSize(size).divideScalar(f);
-
-        // initialize the child node bbox at the location of the parent node bbox
-        node.bbox.min.copy(this.bbox.min);
-
-        // position of the parent node, if it was at the same depth than the
-        // child, found by multiplying the tree position by the factor
-        position.copy(this).multiplyScalar(f);
-
-        // difference in position between the two nodes, at child depth, and
-        // scale it using the size
-        translation.subVectors(node, position).multiply(size);
-
-        // apply the translation to the child node bbox
-        node.bbox.min.add(translation);
-
-        // use the size computed above to set the max
-        node.bbox.max.copy(node.bbox.min).add(size);
-    }
-
     get octreeIsLoaded() {
         return this.numPoints >= 0;
     }
 
     loadOctree() {
-        return Fetcher.json(`${this.layer.source.url}/ept-hierarchy/${this.id}.json`, this.layer.source.networkOptions).then((hierarchy) => {
+        const hierarchyUrl = `${this.layer.source.url}/ept-hierarchy/${this.id}.json`;
+        return Fetcher.json(hierarchyUrl, this.layer.source.networkOptions).then((hierarchy) => {
             this.numPoints = hierarchy[this.id];
 
             const stack = [];

--- a/packages/Main/src/Core/Potree2Node.js
+++ b/packages/Main/src/Core/Potree2Node.js
@@ -56,6 +56,14 @@ class Potree2Node extends PointCloudNode {
         this.baseurl = layer.source.baseurl;
     }
 
+    get octreeIsLoaded() {
+        return !(this.childrenBitField && this.children.length === 0);
+    }
+
+    get url() {
+        return `${this.baseurl}/octree.bin`;
+    }
+
     add(node, indexChild) {
         super.add(node, indexChild);
         node.id = this.id + indexChild;
@@ -98,14 +106,6 @@ class Potree2Node extends PointCloudNode {
             node.bbox.min.x += dHalfLength.x;
             node.bbox.max.x += dHalfLength.x;
         }
-    }
-
-    get octreeIsLoaded() {
-        return !(this.childrenBitField && this.children.length === 0);
-    }
-
-    get url() {
-        return `${this.baseurl}/octree.bin`;
     }
 
     networkOptions(byteOffset, byteSize) {

--- a/packages/Main/src/Core/PotreeNode.js
+++ b/packages/Main/src/Core/PotreeNode.js
@@ -15,6 +15,14 @@ class PotreeNode extends PointCloudNode {
         this.baseurl = layer.source.baseurl;
     }
 
+    get octreeIsLoaded() {
+        return !(this.childrenBitField && this.children.length === 0);
+    }
+
+    get url() {
+        return `${this.baseurl}/r${this.id}.${this.layer.source.extension}`;
+    }
+
     add(node, indexChild, root) {
         super.add(node, indexChild);
         node.id = this.id + indexChild;
@@ -62,14 +70,6 @@ class PotreeNode extends PointCloudNode {
             node.bbox.min.x += dHalfLength.x;
             node.bbox.max.x += dHalfLength.x;
         }
-    }
-
-    get octreeIsLoaded() {
-        return !(this.childrenBitField && this.children.length === 0);
-    }
-
-    get url() {
-        return `${this.baseurl}/r${this.id}.${this.layer.source.extension}`;
     }
 
     loadOctree() {

--- a/packages/Main/src/Layer/CopcLayer.js
+++ b/packages/Main/src/Layer/CopcLayer.js
@@ -39,8 +39,10 @@ class CopcLayer extends PointCloudLayer {
 
         const resolve = () => this;
         this.whenReady = this.source.whenReady.then((/** @type {CopcSource} */ source) => {
-            const { cube, rootHierarchyPage } = source.info;
-            const { pageOffset, pageLength } = rootHierarchyPage;
+            const { cube } = source.info;
+            const { pageOffset, pageLength } = source.info.rootHierarchyPage;
+
+            this.spacing = source.info.spacing;
 
             this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this, -1);
             this.root.bbox.min.fromArray(cube, 0);
@@ -54,10 +56,6 @@ class CopcLayer extends PointCloudLayer {
 
             return this.root.loadOctree().then(resolve);
         });
-    }
-
-    get spacing() {
-        return this.source.info.spacing;
     }
 }
 

--- a/packages/Main/src/Layer/EntwinePointTileLayer.js
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.js
@@ -57,19 +57,23 @@ class EntwinePointTileLayer extends PointCloudLayer {
 
         const resolve = this.addInitializationStep();
         this.whenReady = this.source.whenReady.then(() => {
+            // NOTE: this spacing is kinda arbitrary here, we take the width and
+            // length (height can be ignored), and we divide by the specified
+            // span in ept.json. This needs improvements.
+            this.spacing = (Math.abs(this.source.bounds[3] - this.source.bounds[0])
+                + Math.abs(this.source.bounds[4] - this.source.bounds[1])) / (2 * this.source.span);
+
             this.root = new EntwinePointTileNode(0, 0, 0, 0, this, -1);
+
             this.root.bbox.min.fromArray(this.source.boundsConforming, 0);
             this.root.bbox.max.fromArray(this.source.boundsConforming, 3);
             this.minElevationRange = this.minElevationRange ?? this.source.boundsConforming[2];
             this.maxElevationRange = this.maxElevationRange ?? this.source.boundsConforming[5];
 
             this.extent = Extent.fromBox3(config.crs || 'EPSG:4326', this.root.bbox);
+
             return this.root.loadOctree().then(resolve);
         });
-    }
-
-    get spacing() {
-        return this.source.spacing;
     }
 }
 

--- a/packages/Main/src/Source/EntwinePointTileSource.js
+++ b/packages/Main/src/Source/EntwinePointTileSource.js
@@ -59,12 +59,6 @@ class EntwinePointTileSource extends Source {
                 }
             }
 
-            // NOTE: this spacing is kinda arbitrary here, we take the width and
-            // length (height can be ignored), and we divide by the specified
-            // span in ept.json. This needs improvements.
-            this.spacing = (Math.abs(metadata.boundsConforming[3] - metadata.boundsConforming[0])
-                + Math.abs(metadata.boundsConforming[4] - metadata.boundsConforming[1])) / (2 * metadata.span);
-
             this.boundsConforming = metadata.boundsConforming;
             this.bounds = metadata.bounds;
             this.span = metadata.span;


### PR DESCRIPTION
refactorisation of PointCloudNode:

- move EntwinePointTileNode.createChildAABB(node) and CopcNode.createChildAABB(node) to parent (PointCloudNode)
- add doc in CopcNode
- move getter in PotreeNode and Potree2Node before the methods
- move spacing property from source to layer for copc and entwine