### PR TITLE
fix: add required name in package.json for yarn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2424,8 +2424,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@itowns/debug": {
+      "resolved": "packages/Debug",
+      "link": true
+    },
     "node_modules/@itowns/geographic": {
       "resolved": "packages/Geographic",
+      "link": true
+    },
+    "node_modules/@itowns/widgets": {
+      "resolved": "packages/Widgets",
       "link": true
     },
     "node_modules/@jest/schemas": {
@@ -6224,10 +6232,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
       "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
-    },
-    "node_modules/Debug": {
-      "resolved": "packages/Debug",
-      "link": true
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
@@ -14875,10 +14879,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/Widgets": {
-      "resolved": "packages/Widgets",
-      "link": true
-    },
     "node_modules/wildcard": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -15131,6 +15131,7 @@
       }
     },
     "packages/Debug": {
+      "name": "@itowns/debug",
       "version": "2.45.1",
       "license": "(CECILL-B OR MIT)",
       "dependencies": {
@@ -15183,6 +15184,7 @@
       }
     },
     "packages/Widgets": {
+      "name": "@itowns/widgets",
       "version": "2.45.1",
       "license": "(CECILL-B OR MIT)",
       "dependencies": {

--- a/packages/Debug/package.json
+++ b/packages/Debug/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "@itowns/debug",
   "version": "2.45.1",
   "type": "module",
   "main": "lib/Main.js",

--- a/packages/Widgets/package.json
+++ b/packages/Widgets/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "@itowns/widgets",
   "version": "2.45.1",
   "description": "Widgets",
   "type": "module",


### PR DESCRIPTION
## Description

`yarn` was not working with itowns due to it being stricter than `npm` on the content of `package.json`. It requires the `name` property and ignores a package if this property is missing.
