### PR TITLE
feature(LayeredMaterial) LayeredMaterial expose in API

### DIFF
--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -31,7 +31,7 @@ export { default as FeaturesUtils } from 'Utils/FeaturesUtils';
 export { default as DEMUtils } from 'Utils/DEMUtils';
 export { default as CameraUtils } from 'Utils/CameraUtils';
 export { default as ShaderChunk } from 'Renderer/Shader/ShaderChunk';
-export { getMaxColorSamplerUnitsCount, colorLayerEffects } from 'Renderer/LayeredMaterial';
+export { getMaxColorSamplerUnitsCount, colorLayerEffects, LayeredMaterial } from 'Renderer/LayeredMaterial';
 export { default as Capabilities } from 'Core/System/Capabilities';
 export { CAMERA_TYPE } from 'Renderer/Camera';
 export { default as OBB } from 'Renderer/OBB';

--- a/packages/Main/src/Renderer/LayeredMaterial.js
+++ b/packages/Main/src/Renderer/LayeredMaterial.js
@@ -96,7 +96,7 @@ export const ELEVATION_MODES = {
 
 let nbSamplers;
 const fragmentShader = [];
-class LayeredMaterial extends THREE.ShaderMaterial {
+export class LayeredMaterial extends THREE.ShaderMaterial {
     #_visible = true;
     constructor(options = {}, crsCount) {
         super(options);


### PR DESCRIPTION
## Description

Expose `LayeredMaterial` in the API

## Motivation and Context

In order to make a custom rendering pass based on the LayeredMaterial I need this later to be exposed in the API see also => https://github.com/iTowns/itowns/discussions/2509