### PR TITLE
Fix monorepo typescript issues

### DIFF
--- a/packages/Debug/tsconfig.json
+++ b/packages/Debug/tsconfig.json
@@ -1,10 +1,11 @@
 {
     "extends": "../../tsconfig.json",
     "include": [ "src/Main.js" ],
-    "exclude": [ "node_modules", "lib" ],
+    "exclude": [ "lib" ],
     "compilerOptions": {
-        "paths": {
-            "*": [ "src/*" ]
-        },
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "lib",
+        "baseUrl": "src"
     }
 }

--- a/packages/Geographic/package.json
+++ b/packages/Geographic/package.json
@@ -4,8 +4,11 @@
   "description": "Geodesy",
   "type": "module",
   "main": "lib/Main.js",
-  "exports": "./lib/Main.js",
-  "types": "./lib/Main.d.ts",
+  "exports": {
+    "types": "./src/Main.ts",
+    "default": "./lib/Main.js"
+  },
+  "types": "./src/Main.ts",
   "scripts": {
     "build": "",
     "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"test/**/*.js\"",

--- a/packages/Geographic/tsconfig.json
+++ b/packages/Geographic/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "include": [ "src/Main.ts" ],
-    "exclude": [ "node_modules", "lib" ],
+    "exclude": [ "lib" ],
     "compilerOptions": {
         "declaration": true,
         "emitDeclarationOnly": true,

--- a/packages/Main/tsconfig.json
+++ b/packages/Main/tsconfig.json
@@ -1,10 +1,11 @@
 {
     "extends": "../../tsconfig.json",
     "include": [ "src/Main.js" ],
-    "exclude": [ "node_modules", "lib" ],
+    "exclude": [ "lib" ],
     "compilerOptions": {
-        "paths": {
-            "*": [ "src/*" ]
-        },
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "lib",
+        "baseUrl": "src"
     }
 }

--- a/packages/Widgets/tsconfig.json
+++ b/packages/Widgets/tsconfig.json
@@ -1,10 +1,11 @@
 {
     "extends": "../../tsconfig.json",
     "include": [ "src/Main.js" ],
-    "exclude": [ "node_modules", "lib" ],
+    "exclude": [ "lib" ],
     "compilerOptions": {
-        "paths": {
-            "*": [ "src/*" ]
-        },
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "lib",
+        "baseUrl": "src"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,10 @@
         "target": "ESNext",
         /* Completeness */
         "skipLibCheck": true
-    }
+    },
+    "files": [],
+    "references": [
+        { "path": "./packages/Geographic" },
+        { "path": "./packages/Main" }
+    ]
 }


### PR DESCRIPTION
## Description
This PR changes the typescript configuration to fully support our new monorepo structure.

This includes:
- fixing the module resolution on the typescript side for both external and internal absolute imports.
- changing the types field in the `package.json` to point to the typescript source instead of the generated declaration files
- adding references at top-level to both published sub-packages (note that I did not add the debug nor the widgets ones for now since we have no plans to migrate them to typescript for the time being)
- forcing the emit of declarations in the lib directories to not pollute the project when invoking the `tsc` command.
