### PR TITLE
fix(eslint): allow useless constructors in TS

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -157,6 +157,7 @@ module.exports = {
                 '@typescript-eslint/no-use-before-define': 'error',
                 'valid-jsdoc': 'off',
                 'tsdoc/syntax': 'warn',
+                'no-useless-constructor': 'off',
             },
         },
     ],


### PR DESCRIPTION
## Description
Allow the use of seemingly useless constructors in TypeScript files.

## Motivation and Context
This enables the use of constructors such as
```ts
class Foo {
    public constructor(
        private field: number
    ) { /* empty */ }
}
```
and
```ts
class Bar {
    private constructor() {
        // initialization
    }
}
```
The former allows clean declaration and initialization of fields through the constructor arguments, while the latter allows one to prevent users from instantiating the class directly (useful in cases where a static method might want to return a specific cached or proxied instance of the class).