### PR TITLE
chore(typescript): add support for __DEBUG__ and glsl imports

### DIFF
--- a/packages/Main/src/global.d.ts
+++ b/packages/Main/src/global.d.ts
@@ -1,0 +1,10 @@
+// Consider all `import '*.glsl'` as imports of modules with a default string
+// export. This is coherent with the behavior of the babel compiler.
+declare module '*.glsl' {
+    const glsl: string;
+    export default glsl;
+}
+
+// Declare the external global variable __DEBUG__. This is replaced by either
+// true or false during the compilation step.
+declare const __DEBUG__: boolean;

--- a/packages/Main/tsconfig.json
+++ b/packages/Main/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "extends": "../../tsconfig.json",
-    "include": [ "src/Main.js" ],
+    "include": [ "src/Main.js", "src/global.d.ts" ],
     "exclude": [ "lib" ],
     "compilerOptions": {
         "declaration": true,


### PR DESCRIPTION
## Description

This PR adds support on the typescript side for the following constructs:
- The `__DEBUG__` global which is not defined prior the compilation step
- The `*.glsl` imports which are not valid javascript/typescript but are inlined as string during the compilation step