### PR TITLE
feat(VR): add control event

### DIFF
--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -25,6 +25,7 @@ export { default as FirstPersonControls } from 'Controls/FirstPersonControls';
 export { default as StreetControls } from 'Controls/StreetControls';
 export { default as PlanarControls } from 'Controls/PlanarControls';
 export { default as VRControls } from 'Controls/VRControls';
+export { VR_EVENTS } from 'Renderer/WebXR';
 export { CONTROL_EVENTS } from 'Controls/GlobeControls';
 export { PLANAR_CONTROL_EVENT } from 'Controls/PlanarControls';
 export { default as Feature2Mesh } from 'Converter/Feature2Mesh';

--- a/packages/Main/src/Renderer/WebXR.js
+++ b/packages/Main/src/Renderer/WebXR.js
@@ -2,7 +2,10 @@ import * as THREE from 'three';
 import VRControls from 'Controls/VRControls';
 
 // TODO handle xr session end
+export const VR_EVENTS = {
+    CONTROLS_INITIALIZED: 'vrControls-initialized',
 
+};
 
 function updateCamera3D(xr, view) {
     /* This is what's done in updateUserCamera the WebXRManager.js of threejs
@@ -63,7 +66,7 @@ function extractCameraAttributesFromProjectionMatrix(projectionMatrix) {
 /**
  * @property {VRControls} vrControls - WebXR controllers handler
  * */
-class WebXR {
+class WebXR extends THREE.EventDispatcher {
     /**
      * Handler of a webXR session
      *
@@ -75,6 +78,7 @@ class WebXR {
      * @param {boolean} [options.controllers] - Enable the webXR controllers handling (optional).
      */
     constructor(view, options) {
+        super();
         this.view = view;
         this.options = options;
         this.renderCb = options.callback;
@@ -114,6 +118,11 @@ class WebXR {
 
             if (this.options.controllers) {
                 this.vrControls = new VRControls(this.view, vrHeadSet);
+                this.dispatchEvent(
+                    {
+                        type: 'vrControls-initialized',
+                    },
+                );
             }
 
             xr.setAnimationLoop((timestamp) => {


### PR DESCRIPTION
## Description
Add an event when we add the control handler in a webxr context

## Motivation and Context
To access the method of [VRControls.js](https://github.com/iTowns/itowns/blob/3c1bb1c81c79c82685b459df55c3368e6fe568ff/packages/Main/src/Controls/VRControls.js) from [WebXR.js](https://github.com/iTowns/itowns/blob/3c1bb1c81c79c82685b459df55c3368e6fe568ff/packages/Main/src/Renderer/WebXR.js), we need to now when it is initialized.
By adding an event, we can know when we can access it