### PR TITLE
Fix Picking - No geometry or unloaded points should not be taken for picking

### DIFF
--- a/packages/Main/src/Core/Picking.js
+++ b/packages/Main/src/Core/Picking.js
@@ -169,6 +169,10 @@ export default {
                 // disable picking mode
                 o.material.enablePicking(false);
 
+                // Skip if geometry is invalid or missing position attribute
+                if (!o.geometry || !o.geometry.attributes || !o.geometry.attributes.position) {
+                    return;
+                }
                 // if baseId matches objId, the clicked point belongs to `o`
                 for (let i = 0; i < candidates.length; i++) {
                     if (candidates[i].objId == o.baseId) {


### PR DESCRIPTION
## Description
During point cloud picking, there is a chance that point being picked are unloaded; due to : 

- The point budget is reached
- Nodes are being loaded/unloaded
- The camera is moving quickly
- The view is being panned/zoomed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This means that in Picking.js line 181
```
pointPos.fromBufferAttribute(o.geometry.attributes.position, candidates[i].index);
```
Will return a (0,0,0) value, thus giving incorrect compute and even crash the line 189 :

```
const dist = pointPosCoord.spatialEuclideanDistanceTo(cameraPosCoord);
```

With no try/catch mecanism; the picking fails and user cannot click anywhere, with a spatialEuclideanDistanceTo problem which is misleading.

We propose to check the geometry.attributes.position validity to ensure we have correct calculation, otherwise we should skip this unloaded point. The check could also have been been done using

```
o.userData.node.octreeIsLoaded
```

But we also need to check is the object picked is a PointCloudNode type and so on. We prefered 

```
  // Skip if geometry is invalid or missing position attribute
  if (!o.geometry || !o.geometry.attributes || !o.geometry.attributes.position) {
      return;
  }
```

as it would be more generic.

<!--- If it fixes an open issue, please link to the issue here. -->

Very likely solve : 
https://github.com/iTowns/itowns/issues/2305 

<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Browser : firefox & chrome 136, itowns latest 2.45.1, macOS 15.

