### PR TITLE
fix: use a fresh page when loading an example

### DIFF
--- a/test/hooks_functional.js
+++ b/test/hooks_functional.js
@@ -117,6 +117,9 @@ const waitNextRender = async page => page.evaluate(() => new Promise((resolve) =
 const loadExample = async (url, screenshotName) => {
     url = `http://localhost:${itownsPort}/${url}`;
 
+    global.page.close();
+    global.page = await browser.newPage();
+
     const pageErrors = [];
     page.on('pageerror', (e) => { pageErrors.push(e); });
 
@@ -127,7 +130,7 @@ const loadExample = async (url, screenshotName) => {
     }
 
     if (pageErrors.length > 0) {
-        const err = new Error(`page ${url} encoutered ${pageErrors.length} error(s). [${pageErrors.map(e => e.message)}]`, { errors: pageErrors });
+        const err = new Error(`page ${url} encoutered ${pageErrors.length} error(s). [${pageErrors.map(e => e.message)}]`, { cause: pageErrors });
         throw err;
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Create and use a new puppeteer `Page` for every call to `loadExample`. This likely lengthens the functional testing process, but it's an easy way to avoid leakage that leads to bugs that are hard to debug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
We encountered strange CI errors during the last push for the merge of #2477 that we tracked down to being an issue of page state being left over between examples.
