### PR TITLE
feat: Add gamma and ambient boost option for Point Shader

### DIFF
--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -156,6 +156,13 @@ export default {
         if (layer.material.shape != undefined) {
             styleUI.add(layer.material, 'shape', PNTS_SHAPE).name('Shape mode').onChange(update);
         }
+        if (layer.material.gamma != undefined) {
+            styleUI.add(layer.material, 'gamma', 1, 10).name('Gamma').onChange(update);
+        }
+        if (layer.material.ambientBoost != undefined) {
+            styleUI.add(layer.material, 'ambientBoost', 0, 0.5).name('Ambient Boost').onChange(update);
+        }
+
         styleUI.add(layer, 'opacity', 0, 1).name('Layer opacity').onChange(update);
         styleUI.add(layer, 'pointSize', 0, 15).name('Point size').onChange(update);
         if (layer.material.sizeMode != undefined && view.camera.camera3D.isPerspectiveCamera) {

--- a/packages/Main/src/Renderer/PointsMaterial.js
+++ b/packages/Main/src/Renderer/PointsMaterial.js
@@ -204,7 +204,9 @@ class PointsMaterial extends THREE.ShaderMaterial {
             minAttenuatedSize = 3,
             maxAttenuatedSize = 10,
             gradient,
+            gamma = 1.0,
             scale = 0.05 * 0.5 / Math.tan(1.0 / 2.0),
+            ambientBoost = 0.0,
             ...materialOptions
         } = options;
 
@@ -242,6 +244,8 @@ class PointsMaterial extends THREE.ShaderMaterial {
         CommonMaterial.setUniformProperty(this, 'scale', scale);
         CommonMaterial.setUniformProperty(this, 'minAttenuatedSize', minAttenuatedSize);
         CommonMaterial.setUniformProperty(this, 'maxAttenuatedSize', maxAttenuatedSize);
+        CommonMaterial.setUniformProperty(this, 'gamma', gamma);
+        CommonMaterial.setUniformProperty(this, 'ambientBoost', ambientBoost);
 
         // add classification texture to apply classification lut.
         const data = new Uint8Array(256 * 4);
@@ -369,6 +373,26 @@ class PointsMaterial extends THREE.ShaderMaterial {
         this.sizeMode = value ?
             PNTS_SIZE_MODE.ATTENUATED :
             PNTS_SIZE_MODE.VALUE;
+    }
+
+    /** @returns {number} */
+    get gamma() {
+        return this.uniforms.gamma.value;
+    }
+
+    /** @param {number} gamma */
+    set gamma(gamma) {
+        this.uniforms.gamma.value = gamma;
+    }
+
+    /** @returns {number} */
+    get ambientBoost() {
+        return this.uniforms.ambientBoost.value;
+    }
+
+    /** @param {number} ambientBoost */
+    set ambientBoost(ambientBoost) {
+        this.uniforms.ambientBoost.value = ambientBoost;
     }
 
     recomputeClassification() {

--- a/packages/Main/src/Renderer/Shader/PointsFS.glsl
+++ b/packages/Main/src/Renderer/Shader/PointsFS.glsl
@@ -10,6 +10,8 @@
 
 uniform vec3 diffuse;
 uniform float opacity;
+uniform float gamma;
+uniform float ambientBoost;
 
 uniform bool picking;
 uniform int shape;
@@ -35,6 +37,11 @@ void main() {
 #include <alphahash_fragment>
 
     vec3 outgoingLight = diffuseColor.rgb;
+    
+    outgoingLight = max(outgoingLight, vec3(ambientBoost));
+    
+    outgoingLight = pow(outgoingLight, vec3(1.0 / gamma));
+    
 #include <opaque_fragment> // gl_FragColor
 #include <tonemapping_fragment>
 #include <fog_fragment>


### PR DESCRIPTION
To have better visualization of Point cloud under shadowed conditions (trees, underground utilities, capture device shadow...)

## Description
Had two options for point cloud vizualisation on the point cloud shader : 
- Gamma : Enhance gamma with explanation here https://pyimagesearch.com/2015/10/05/opencv-gamma-correction/ 
- Ambient boost : Have clamped illumination for pixels with explanation here : https://docs.opencv.org/4.x/d3/dc1/tutorial_basic_linear_transform.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

In point cloud data, some acquisition techniques do have shadows in their results.
Shadows that comes from trees, side of a trench, captation device (lidar, people with camstick...) and so on.

Having those two options greatly helps for better understanding of those shadowed area, video here : 
![shadow_point_cloud2](https://github.com/user-attachments/assets/0bf2af77-63fc-4247-a96e-ff4347290e88)

<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Itowns 2.45.1.
