### PR TITLE
refactor(PointCloudLayer): PointCloudNode.id rename and pointSpacing rework

### DIFF
--- a/examples/potree2_25d_map.html
+++ b/examples/potree2_25d_map.html
@@ -34,7 +34,7 @@
         </div>
 
         <div>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19"></script>
             <script src="../dist/itowns.js"></script>
             <script src="js/GUI/LoadingScreen.js"></script>
             <script src="../dist/debug.js"></script>
@@ -52,7 +52,7 @@
                 viewerDiv = document.getElementById('viewerDiv');
                 viewerDiv.style.display = 'block';
 
-                debugGui = new dat.GUI();
+                debugGui = new lil.GUI();
 
                 // TODO: do we really need to disable logarithmicDepthBuffer ?
                 view = new itowns.View('EPSG:3946', viewerDiv);

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -34,7 +34,7 @@
         </div>
 
         <div>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19"></script>
             <script src="../dist/itowns.js"></script>
             <script src="js/GUI/LoadingScreen.js"></script>
             <script src="../dist/debug.js"></script>
@@ -52,7 +52,7 @@
                 viewerDiv = document.getElementById('viewerDiv');
                 viewerDiv.style.display = 'block';
 
-                debugGui = new dat.GUI();
+                debugGui = new lil.GUI();
 
                 // TODO: do we really need to disable logarithmicDepthBuffer ?
                 view = new itowns.View('EPSG:3946', viewerDiv);

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -32,7 +32,7 @@
     <body>
         <div id="viewerDiv"></div>
         <div id="info"></div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.6/dat.gui.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.19"></script>
         <script src="../dist/itowns.js"></script>
         <script src="js/GUI/LoadingScreen.js"></script>
         <script src="../dist/debug.js"></script>
@@ -46,7 +46,7 @@
             viewerDiv = document.getElementById('viewerDiv');
             viewerDiv.style.display = 'block';
 
-            debugGui = new dat.GUI();
+            debugGui = new lil.GUI();
 
             var placement = {
                 coord: new itowns.Coordinates('EPSG:4326',  4.631512, 43.675626),

--- a/packages/Main/src/Core/CopcNode.js
+++ b/packages/Main/src/Core/CopcNode.js
@@ -48,6 +48,7 @@ class CopcNode extends PointCloudNode {
         this.y = y;
         this.z = z;
 
+        this.pointSpacing = this.layer.spacing / 2 ** depth;
         this.voxelKey = buildVoxelKey(depth, x, y, z);
     }
 

--- a/packages/Main/src/Core/CopcNode.js
+++ b/packages/Main/src/Core/CopcNode.js
@@ -48,7 +48,6 @@ class CopcNode extends PointCloudNode {
         this.y = y;
         this.z = z;
 
-        this.pointSpacing = this.layer.spacing / 2 ** depth;
         this.voxelKey = buildVoxelKey(depth, x, y, z);
     }
 

--- a/packages/Main/src/Core/EntwinePointTileNode.js
+++ b/packages/Main/src/Core/EntwinePointTileNode.js
@@ -58,7 +58,6 @@ class EntwinePointTileNode extends PointCloudNode {
         this.y = y;
         this.z = z;
 
-        this.pointSpacing = this.layer.spacing / 2 ** depth;
         this.voxelKey = buildVoxelKey(depth, x, y, z);
 
         this.url = `${this.layer.source.url}/ept-data/${this.voxelKey}.${this.layer.source.extension}`;

--- a/packages/Main/src/Core/EntwinePointTileNode.js
+++ b/packages/Main/src/Core/EntwinePointTileNode.js
@@ -58,6 +58,7 @@ class EntwinePointTileNode extends PointCloudNode {
         this.y = y;
         this.z = z;
 
+        this.pointSpacing = this.layer.spacing / 2 ** depth;
         this.voxelKey = buildVoxelKey(depth, x, y, z);
 
         this.url = `${this.layer.source.url}/ept-data/${this.voxelKey}.${this.layer.source.extension}`;

--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -16,6 +16,10 @@ class PointCloudNode extends THREE.EventDispatcher {
         this.sse = -1;
     }
 
+    get id() {
+        throw new Error('In extended PointCloudNode, you have to implement the getter id!');
+    }
+
     add(node, indexChild) {
         this.children.push(node);
         node.parent = this;

--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -57,11 +57,6 @@ class PointCloudNode extends THREE.EventDispatcher {
     }
 
     load() {
-        // Query octree/HRC if we don't have children potreeNode yet.
-        if (!this.octreeIsLoaded) {
-            this.loadOctree();
-        }
-
         return this.layer.source.fetcher(this.url, this.layer.source.networkOptions)
             .then(file => this.layer.source.parse(file, { out: this.layer, in: this.layer.source }));
     }

--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -14,6 +14,8 @@ class PointCloudNode extends THREE.EventDispatcher {
         this.children = [];
         this.bbox = new THREE.Box3();
         this.sse = -1;
+
+        this.pointSpacing = layer.spacing;
     }
 
     get id() {

--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -14,8 +14,10 @@ class PointCloudNode extends THREE.EventDispatcher {
         this.children = [];
         this.bbox = new THREE.Box3();
         this.sse = -1;
+    }
 
-        this.pointSpacing = layer.spacing;
+    get pointSpacing() {
+        return this.layer.spacing / 2 ** this.depth;
     }
 
     get id() {

--- a/packages/Main/src/Core/Potree2Node.js
+++ b/packages/Main/src/Core/Potree2Node.js
@@ -100,8 +100,8 @@ class Potree2Node extends PotreeNode {
     }
 
     async loadHierarchy() {
-        const hierarchyPath = `${this.baseurl}/hierarchy.bin`;
-        const buffer = await this.layer.source.fetcher(hierarchyPath, this.networkOptions(this.hierarchyByteOffset, this.hierarchyByteSize));
+        const hierarchyUrl = `${this.baseurl}/hierarchy.bin`;
+        const buffer = await this.layer.source.fetcher(hierarchyUrl, this.networkOptions(this.hierarchyByteOffset, this.hierarchyByteSize));
         this.parseHierarchy(buffer);
     }
 

--- a/packages/Main/src/Core/Potree2Node.js
+++ b/packages/Main/src/Core/Potree2Node.js
@@ -162,7 +162,6 @@ class Potree2Node extends PotreeNode {
                 }
 
                 const child = new Potree2Node(numPoints, childMask, this.layer);
-                child.spacing = current.spacing / 2;
 
                 current.add(child, childIndex);
                 stack.push(child);

--- a/packages/Main/src/Core/PotreeNode.js
+++ b/packages/Main/src/Core/PotreeNode.js
@@ -74,6 +74,14 @@ class PotreeNode extends PointCloudNode {
         }
     }
 
+    load() {
+        // Query octree/HRC if we don't have children potreeNode yet.
+        if (!this.octreeIsLoaded) {
+            this.loadOctree();
+        }
+        return super.load();
+    }
+
     loadOctree() {
         const octreeUrl = `${this.baseurl}/${this.hierarchyKey}.${this.layer.source.extensionOctree}`;
         return this.layer.source.fetcher(octreeUrl, this.layer.source.networkOptions).then((blob) => {

--- a/packages/Main/src/Core/PotreeNode.js
+++ b/packages/Main/src/Core/PotreeNode.js
@@ -10,8 +10,11 @@ class PotreeNode extends PointCloudNode {
     constructor(numPoints = 0, childrenBitField = 0, layer) {
         super(numPoints, layer);
         this.childrenBitField = childrenBitField;
-        this.id = '';
+
         this.depth = 0;
+
+        this.hierarchyKey = 'r';
+
         this.baseurl = layer.source.baseurl;
     }
 
@@ -20,11 +23,15 @@ class PotreeNode extends PointCloudNode {
     }
 
     get url() {
-        return `${this.baseurl}/r${this.id}.${this.layer.source.extension}`;
+        return `${this.baseurl}/${this.hierarchyKey}.${this.layer.source.extension}`;
+    }
+
+    get id() {
+        return this.hierarchyKey;
     }
 
     add(node, indexChild) {
-        node.id = this.id + indexChild;
+        node.hierarchyKey = this.hierarchyKey + indexChild;
         node.depth = this.depth + 1;
         super.add(node, indexChild);
     }
@@ -68,7 +75,7 @@ class PotreeNode extends PointCloudNode {
     }
 
     loadOctree() {
-        const octreeUrl = `${this.baseurl}/r${this.id}.${this.layer.source.extensionOctree}`;
+        const octreeUrl = `${this.baseurl}/${this.hierarchyKey}.${this.layer.source.extensionOctree}`;
         return this.layer.source.fetcher(octreeUrl, this.layer.source.networkOptions).then((blob) => {
             const view = new DataView(blob);
             const stack = [];

--- a/packages/Main/src/Layer/Potree2Layer.js
+++ b/packages/Main/src/Layer/Potree2Layer.js
@@ -179,8 +179,6 @@ class Potree2Layer extends PointCloudLayer {
             this.minElevationRange = this.minElevationRange ?? metadata.boundingBox.min[2];
             this.maxElevationRange = this.maxElevationRange ?? metadata.boundingBox.max[2];
 
-            root.id = 'r';
-            root.depth = 0;
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;
             root.hierarchyByteSize = BigInt(metadata.hierarchy.firstChunkSize);

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -159,21 +159,32 @@ describe('Entwine Point Tile', function () {
             root.children[2].children[1].add(new EntwinePointTileNode(3, 1, 6, 7, layer));
         });
 
-        it('finds the common ancestor of two nodes', () => {
-            let ancestor = root.children[2].children[1].children[0].findCommonAncestor(root.children[2].children[0].children[0]);
-            assert.deepStrictEqual(ancestor, root.children[2]);
+        describe('finds the common ancestor of two nodes', () => {
+            let ancestor;
+            it('cousins => grand parent', () => {
+                ancestor = root.children[2].children[1].children[0].findCommonAncestor(root.children[2].children[0].children[0]);
+                assert.deepStrictEqual(ancestor, root.children[2]);
+            });
 
-            ancestor = root.children[0].children[0].children[0].findCommonAncestor(root.children[0].children[0].children[1]);
-            assert.deepStrictEqual(ancestor, root.children[0].children[0]);
+            it('brothers => parent', () => {
+                ancestor = root.children[0].children[0].children[0].findCommonAncestor(root.children[0].children[0].children[1]);
+                assert.deepStrictEqual(ancestor, root.children[0].children[0]);
+            });
 
-            ancestor = root.children[0].children[1].findCommonAncestor(root.children[2].children[1].children[0]);
-            assert.deepStrictEqual(ancestor, root);
+            it('grand child and grand grand child => root', () => {
+                ancestor = root.children[0].children[1].findCommonAncestor(root.children[2].children[1].children[0]);
+                assert.deepStrictEqual(ancestor, root);
+            });
 
-            ancestor = root.children[1].findCommonAncestor(root.children[1].children[0].children[0]);
-            assert.deepStrictEqual(ancestor, root.children[1]);
+            it('parent and child => parent', () => {
+                ancestor = root.children[1].findCommonAncestor(root.children[1].children[0].children[0]);
+                assert.deepStrictEqual(ancestor, root.children[1]);
+            });
 
-            ancestor = root.children[2].children[0].findCommonAncestor(root.children[2]);
-            assert.deepStrictEqual(ancestor, root.children[2]);
+            it('child and parent => parent', () => {
+                ancestor = root.children[2].children[0].findCommonAncestor(root.children[2]);
+                assert.deepStrictEqual(ancestor, root.children[2]);
+            });
         });
     });
 });

--- a/test/hooks_functional.js
+++ b/test/hooks_functional.js
@@ -130,7 +130,9 @@ const loadExample = async (url, screenshotName) => {
     }
 
     if (pageErrors.length > 0) {
-        const err = new Error(`page ${url} encoutered ${pageErrors.length} error(s). [${pageErrors.map(e => e.message)}]`, { cause: pageErrors });
+        const err = new Error(`page ${url} encoutered ${pageErrors.length} error(s):\n` +
+            `${pageErrors.map((e, i) => `\t${i + 1}. ${e.message.replaceAll('\n', '\n\t    ')}`).join('\n')}`,
+        { cause: pageErrors[0] });
         throw err;
     }
 


### PR DESCRIPTION
light refactorisation of PointCloudNode:
- rename id property as voxelKey for copc and entwine and as hierarchyKey for potre and potree2
  - add a getter for id at PointCloudNode level
- move pointSpacing from layer to node