### PR TITLE
fix(TileLayer): transparence set to true by default

### DIFF
--- a/packages/Main/src/Core/Prefab/Globe/Atmosphere.js
+++ b/packages/Main/src/Core/Prefab/Globe/Atmosphere.js
@@ -71,6 +71,7 @@ class Atmosphere extends GeometryLayer {
         const sphereGeometry = new THREE.SphereGeometry(1, 64, 64);
         const basicAtmosphereOut = new THREE.Mesh(sphereGeometry, material);
         basicAtmosphereOut.scale.copy(ellipsoidSizes).multiplyScalar(1.14);
+        basicAtmosphereOut.renderOrder = 1;
 
         this.basicAtmosphere = new THREE.Object3D();
         this.realisticAtmosphere = new THREE.Object3D();
@@ -101,6 +102,7 @@ class Atmosphere extends GeometryLayer {
 
         const basicAtmosphereIn = new THREE.Mesh(sphereGeometry, materialAtmoIn);
         basicAtmosphereIn.scale.copy(ellipsoidSizes).multiplyScalar(1.002);
+        basicAtmosphereIn.renderOrder = 2;
 
         this.basicAtmosphere.add(basicAtmosphereIn);
         this.realisticLightingPosition = { x: -0.5, y: 0.0, z: 1.0 };
@@ -205,6 +207,7 @@ class Atmosphere extends GeometryLayer {
             depthWrite: false,
         });
         const ground = new THREE.Mesh(geometryAtmosphereIn, materialAtmosphereIn);
+        ground.renderOrder = 2;
 
         const geometryAtmosphereOut = new THREE.SphereGeometry(atmosphere.outerRadius, 196, 196);
         const materialAtmosphereOut = new THREE.ShaderMaterial({
@@ -215,8 +218,10 @@ class Atmosphere extends GeometryLayer {
             side: THREE.BackSide,
         });
         const sky = new THREE.Mesh(geometryAtmosphereOut, materialAtmosphereOut);
+        sky.renderOrder = 1;
 
         const skyDome = new Sky();
+        skyDome.renderOrder = 1;
         skyDome.frustumCulled = false;
 
         this.realisticAtmosphere.add(ground);

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -69,7 +69,7 @@ class TiledGeometryLayer extends GeometryLayer {
             showOutline = false,
             segments,
             disableSkirt = false,
-            materialOptions,
+            materialOptions = {},
             ...configGeometryLayer
         } = config;
 
@@ -136,6 +136,7 @@ class TiledGeometryLayer extends GeometryLayer {
 
         this.tileMatrixSets = tileMatrixSets;
 
+        materialOptions.transparent = materialOptions.transparent ?? true;
         this.materialOptions = materialOptions;
 
         /*

--- a/packages/Main/src/Renderer/RenderMode.js
+++ b/packages/Main/src/Renderer/RenderMode.js
@@ -14,6 +14,7 @@ function push(object3d, mode) {
         const material = node.material;
         if (material) {
             material.mode = m;
+            material.transparent = m === MODES.FINAL;
         }
     });
 


### PR DESCRIPTION
Transparence of material for Tile layer set to true by default to allow opacity variation