### PR TITLE
fix(docs): fix error in config file

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -135,7 +135,7 @@
                 "Navigation",
                 "Minimap",
                 "Scale",
-                "Searchbar",
+                "Searchbar"
             ]
         },
         "tutorialSections": {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

#2567 introduced an error in documentation config file, with an remaining `,` at the end of a JSON element. This induced failing of the CI, when generating the documentation, as can be seen in [this job](https://github.com/iTowns/itowns/actions/runs/15850520984/job/44682584116).