### PR TITLE
fix(OGC3DTilesLayer): renderOrder set at 1

### DIFF
--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -429,6 +429,7 @@ class OGC3DTilesLayer extends GeometryLayer {
         }
 
         model.material = material;
+        model.renderOrder = 1;
     }
 
     /**


### PR DESCRIPTION
Linked to reopening of the issue #2561