### PR TITLE
Pack textures in texture arrays to reduce number of texture slots per layer

### DIFF
--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -101,17 +101,6 @@ class GlobeLayer extends TiledGeometryLayer {
         return super.preUpdate(context, changeSources);
     }
 
-    countColorLayersTextures(...layers) {
-        let occupancy = 0;
-        for (const layer of layers) {
-            const crs = layer.crs || layer.source.crs;
-            // 'EPSG:3857' occupies the maximum 3 textures on tiles
-            // 'EPSG:4326' occupies 1 textures on tile
-            occupancy += crs == 'EPSG:3857' ? 3 : 1;
-        }
-        return occupancy;
-    }
-
     subdivision(context, layer, node) {
         if (node.level == 5) {
             const row = node.getExtentsByProjection('EPSG:4326')[0].row;

--- a/packages/Main/src/Core/System/Capabilities.js
+++ b/packages/Main/src/Core/System/Capabilities.js
@@ -15,15 +15,10 @@ function _WebGLShader(renderer, type, string) {
     return shader;
 }
 
-function isFirefox() {
-    return navigator && navigator.userAgent && navigator.userAgent.toLowerCase().includes('firefox');
-}
-
 export default {
     isLogDepthBufferSupported() {
         return logDepthBufferSupported;
     },
-    isFirefox,
     getMaxTextureUnitsCount() {
         return maxTexturesUnits;
     },
@@ -48,21 +43,9 @@ export default {
         gl.linkProgram(program);
 
         if (gl.getProgramParameter(program, gl.LINK_STATUS) === false) {
-            if (maxTexturesUnits > 16) {
-                const info = gl.getProgramInfoLog(program);
-                // eslint-disable-next-line no-console
-                console.warn(`${info}: using a maximum of 16 texture units instead of the reported value (${maxTexturesUnits})`);
-                if (isFirefox()) {
-                    // eslint-disable-next-line no-console
-                    console.warn(`It can come from a Mesa/Firefox bug;
-                        the shader compiles to an error when using more than 16 sampler uniforms,
-                        see https://bugzilla.mozilla.org/show_bug.cgi?id=777028`);
-                }
-                maxTexturesUnits = 16;
-            } else {
-                throw (new Error(`The GPU capabilities could not be determined accurately.
-                    Impossible to link a shader with the Maximum texture units ${maxTexturesUnits}`));
-            }
+            // the link operation failed
+            throw new Error(`The GPU capabilities could not be determined accurately.
+                Impossible to link a shader with the Maximum texture units ${maxTexturesUnits}`);
         }
 
         gl.deleteProgram(program);

--- a/packages/Main/src/Core/TileMesh.js
+++ b/packages/Main/src/Core/TileMesh.js
@@ -106,8 +106,13 @@ class TileMesh extends THREE.Mesh {
         }
     }
 
-    onBeforeRender() {
-        this.material.updateLayersUniforms();
+    /**
+     * An optional callback that is executed immediately before a 3D object is rendered.
+     *
+     * @param {THREE.WebGLRenderer} renderer - The renderer used to render textures.
+     */
+    onBeforeRender(renderer) {
+        this.material.updateLayersUniforms(renderer);
     }
 }
 

--- a/packages/Main/src/Core/TileMesh.js
+++ b/packages/Main/src/Core/TileMesh.js
@@ -112,7 +112,9 @@ class TileMesh extends THREE.Mesh {
      * @param {THREE.WebGLRenderer} renderer - The renderer used to render textures.
      */
     onBeforeRender(renderer) {
-        this.material.updateLayersUniforms(renderer);
+        if (this.material.layersNeedUpdate) {
+            this.material.updateLayersUniforms(renderer);
+        }
     }
 }
 

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -7,7 +7,6 @@ import { COLOR_LAYERS_ORDER_CHANGED } from 'Renderer/ColorLayersOrdering';
 import c3DEngine from 'Renderer/c3DEngine';
 import RenderMode from 'Renderer/RenderMode';
 import FeaturesUtils from 'Utils/FeaturesUtils';
-import { getMaxColorSamplerUnitsCount } from 'Renderer/LayeredMaterial';
 import Scheduler from 'Core/Scheduler/Scheduler';
 import Picking from 'Core/Picking';
 import LabelLayer from 'Layer/LabelLayer';
@@ -177,6 +176,7 @@ class View extends THREE.EventDispatcher {
         // options.renderer can be 2 separate things:
         //   - an actual renderer (in this case we don't use viewerDiv)
         //   - options for the renderer to be created
+        // here renderer is passed to engine
         if (options.renderer && options.renderer.domElement) {
             engine = new c3DEngine(options.renderer);
         } else {
@@ -348,17 +348,8 @@ class View extends THREE.EventDispatcher {
             if (layer.isColorLayer) {
                 const layerColors = this.getLayers(l => l.isColorLayer);
                 layer.sequence = layerColors.length;
-
-                const sumColorLayers = parentLayer.countColorLayersTextures(...layerColors, layer);
-
-                if (sumColorLayers <= getMaxColorSamplerUnitsCount()) {
-                    parentLayer.attach(layer);
-                } else {
-                    return layer._reject(new Error(`Cant add color layer ${layer.id}: the maximum layer is reached`));
-                }
-            } else {
-                parentLayer.attach(layer);
             }
+            parentLayer.attach(layer);
         } else {
             if (typeof (layer.update) !== 'function') {
                 return layer._reject(new Error('Cant add GeometryLayer: missing a update function'));

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -176,7 +176,6 @@ class View extends THREE.EventDispatcher {
         // options.renderer can be 2 separate things:
         //   - an actual renderer (in this case we don't use viewerDiv)
         //   - options for the renderer to be created
-        // here renderer is passed to engine
         if (options.renderer && options.renderer.domElement) {
             engine = new c3DEngine(options.renderer);
         } else {

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -347,10 +347,6 @@ class TiledGeometryLayer extends GeometryLayer {
         return convertToTile.convert(requester, extent, this);
     }
 
-    countColorLayersTextures(...layers) {
-        return layers.length;
-    }
-
     // eslint-disable-next-line
     culling(node, camera) {
         return !camera.isBox3Visible(node.obb.box3D, node.matrixWorld);

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -319,6 +319,7 @@ class TiledGeometryLayer extends GeometryLayer {
             let requestChildrenUpdate = false;
 
             node.material.visible = true;
+            node.material.layersNeedUpdate = true;
             this.info.update(node);
 
             if (node.pendingSubdivision || (TiledGeometryLayer.hasEnoughTexturesToSubdivide(context, node) && this.subdivision(context, this, node))) {

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -153,7 +153,6 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
     if (cachedTexture) {
         uTextures.value = cachedTexture;
         uTextureCount.value = count;
-        renderer.initTexture(cachedTexture);
         return;
     }
 
@@ -223,16 +222,12 @@ interface LayeredMaterialRawUniforms {
 
     // Elevation layers
     elevationLayers: Array<StructElevationLayer>;
-    // can be [] on initialization
-    // so we don't have to instantiate an empty DataArrayTexture
     elevationTextures: THREE.DataArrayTexture | null;
     elevationOffsetScales: Array<THREE.Vector4>;
     elevationTextureCount: number;
 
     // Color layers
     colorLayers: Array<StructColorLayer>;
-    // can be [] on initialization
-    // so we don't have to instantiate an empty DataArrayTexture
     colorTextures: THREE.DataArrayTexture | null;
     colorOffsetScales: Array<THREE.Vector4>;
     colorTextureCount: number;

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -158,6 +158,13 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
         return;
     }
 
+    // If the textures are the original array obtained when loaded,
+    // they are not yet handled by our cache, so dispose of them
+    // before replacing them with data array textures.
+    if (!(uTextures.value instanceof THREE.DataArrayTexture)) {
+        for (const texture of uTextures.value) { texture.dispose(); }
+    }
+
     if (!makeDataArrayTexture(uTextures, width, height, count, tiles, max, renderer)) {
         uTextureCount.value = 0;
         return;

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -122,11 +122,14 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
             i < tile.textures.length && count < max;
             ++i, ++count
         ) {
-            textureSetId += `${tile.textures[i].id}.`;
+            const texture = tile.textures[i];
+            if (!texture) { continue; }
+
+            textureSetId += `${texture.id}.`;
             uOffsetScales[count] = tile.offsetScales[i];
             uLayers[count] = tile;
 
-            const img = tile.textures[i].image;
+            const img = texture.image;
             if (!img || img.width <= 0 || img.height <= 0) {
                 console.error('Texture image not loaded or has zero dimensions');
                 uTextureCount.value = 0;

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -9,7 +9,6 @@ import { RasterTile, RasterElevationTile, RasterColorTile } from './RasterTile';
 import { makeDataArrayTexture } from './WebGLComposer';
 
 const identityOffsetScale = new THREE.Vector4(0.0, 0.0, 1.0, 1.0);
-const defaultTex = new THREE.Texture();
 
 // from three.js packDepthToRGBA
 const UnpackDownscale = 255 / 256; // 0..1 -> fraction (excluding 1)

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -23,17 +23,11 @@ export function unpack1K(color: THREE.Vector4Like, factor: number): number {
     return factor ? bitSh.dot(color) * factor : bitSh.dot(color);
 }
 
-// Max sampler color count to LayeredMaterial
-// Because there's a statement limitation to unroll, in getColorAtIdUv method
-const maxSamplersColorCount = 15;
 const samplersElevationCount = 1;
 
 export function getMaxColorSamplerUnitsCount(): number {
     const maxSamplerUnitsCount = Capabilities.getMaxTextureUnitsCount();
-    return Math.min(
-        maxSamplerUnitsCount - samplersElevationCount,
-        maxSamplersColorCount,
-    );
+    return maxSamplerUnitsCount - samplersElevationCount;
 }
 
 export const colorLayerEffects = {

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -158,13 +158,8 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
         return;
     }
 
-    // If the textures are the original array obtained when loaded,
-    // they are not yet handled by our cache, so dispose of them
-    // before replacing them with data array textures.
-    if (!(uTextures.value instanceof THREE.DataArrayTexture)) {
-        for (const texture of uTextures.value) { texture.dispose(); }
-    }
-
+    // Memory management of these textures is only done by `textureArraysCache`,
+    // so we don't have to dispose of them manually.
     if (!makeDataArrayTexture(uTextures, width, height, count, tiles, max, renderer)) {
         uTextureCount.value = 0;
         return;
@@ -229,13 +224,17 @@ interface LayeredMaterialRawUniforms {
 
     // Elevation layers
     elevationLayers: Array<StructElevationLayer>;
-    elevationTextures: Array<THREE.Texture>;
+    // can be [] on initialization
+    // so we don't have to instantiate an empty DataArrayTexture
+    elevationTextures: THREE.DataArrayTexture | [];
     elevationOffsetScales: Array<THREE.Vector4>;
     elevationTextureCount: number;
 
     // Color layers
     colorLayers: Array<StructColorLayer>;
-    colorTextures: THREE.DataArrayTexture;
+    // can be [] on initialization
+    // so we don't have to instantiate an empty DataArrayTexture
+    colorTextures: THREE.DataArrayTexture | [];
     colorOffsetScales: Array<THREE.Vector4>;
     colorTextureCount: number;
 }
@@ -381,14 +380,14 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
         this.initUniforms({
             elevationLayers: new Array(nbSamplers[0])
                 .fill(defaultStructLayers.elevation),
-            elevationTextures: new Array(nbSamplers[0]).fill(defaultTex),
+            elevationTextures: [],
             elevationOffsetScales: new Array(nbSamplers[0])
                 .fill(identityOffsetScale),
             elevationTextureCount: 0,
 
             colorLayers: new Array(nbSamplers[1])
                 .fill(defaultStructLayers.color),
-            colorTextures: new THREE.DataArrayTexture(null, 1, 1, 1),
+            colorTextures: [],
             colorOffsetScales: new Array(nbSamplers[1])
                 .fill(identityOffsetScale),
             colorTextureCount: 0,

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -225,7 +225,7 @@ interface LayeredMaterialRawUniforms {
     elevationLayers: Array<StructElevationLayer>;
     // can be [] on initialization
     // so we don't have to instantiate an empty DataArrayTexture
-    elevationTextures: THREE.DataArrayTexture | [];
+    elevationTextures: THREE.DataArrayTexture | null;
     elevationOffsetScales: Array<THREE.Vector4>;
     elevationTextureCount: number;
 
@@ -233,7 +233,7 @@ interface LayeredMaterialRawUniforms {
     colorLayers: Array<StructColorLayer>;
     // can be [] on initialization
     // so we don't have to instantiate an empty DataArrayTexture
-    colorTextures: THREE.DataArrayTexture | [];
+    colorTextures: THREE.DataArrayTexture | null;
     colorOffsetScales: Array<THREE.Vector4>;
     colorTextureCount: number;
 }
@@ -379,14 +379,14 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
         this.initUniforms({
             elevationLayers: new Array(nbSamplers[0])
                 .fill(defaultStructLayers.elevation),
-            elevationTextures: [],
+            elevationTextures: null,
             elevationOffsetScales: new Array(nbSamplers[0])
                 .fill(identityOffsetScale),
             elevationTextureCount: 0,
 
             colorLayers: new Array(nbSamplers[1])
                 .fill(defaultStructLayers.color),
-            colorTextures: [],
+            colorTextures: null,
             colorOffsetScales: new Array(nbSamplers[1])
                 .fill(identityOffsetScale),
             colorTextureCount: 0,

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -145,6 +145,8 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
     if (textureArraysCache.has(textureSetId)) {
         uTextures.value = textureArraysCache.get(textureSetId);
         uTextureCount.value = count;
+        const renderer: THREE.WebGLRenderer = view.renderer;
+        renderer.initTexture(uTextures.value);
         return;
     }
 

--- a/packages/Main/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
@@ -9,7 +9,7 @@ struct Layer {
 
 #include <itowns/custom_header_colorLayer>
 
-uniform sampler2D   colorTextures[NUM_FS_TEXTURES];
+uniform sampler2DArray   colorTextures;
 uniform vec4        colorOffsetScales[NUM_FS_TEXTURES];
 uniform Layer       colorLayers[NUM_FS_TEXTURES];
 uniform int         colorTextureCount;
@@ -50,7 +50,7 @@ vec4 getOutlineColor(vec3 outlineColor, vec2 uv) {
 #endif
 
 uniform float minBorderDistance;
-vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer layer) {
+vec4 getLayerColor(int textureOffset, sampler2DArray tex, vec4 offsetScale, Layer layer) {
     if ( textureOffset >= colorTextureCount ) return vec4(0);
 
     vec3 uv;
@@ -61,7 +61,7 @@ vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer lay
 
     float borderDistance = getBorderDistance(uv.xy);
     if (textureOffset != layer.textureOffset + int(uv.z) || borderDistance < minBorderDistance ) return vec4(0);
-    vec4 color = texture2D(tex, pitUV(uv.xy, offsetScale));
+    vec4 color = texture(tex, vec3(pitUV(uv.xy, offsetScale), float(textureOffset)));
     if (layer.effect_type == 3) {
         #include <itowns/custom_body_colorLayer>
     } else {

--- a/packages/Main/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
@@ -8,7 +8,7 @@
     };
 
     uniform Layer       elevationLayers[NUM_VS_TEXTURES];
-    uniform sampler2D   elevationTextures[NUM_VS_TEXTURES];
+    uniform sampler2DArray   elevationTextures;
     uniform vec4        elevationOffsetScales[NUM_VS_TEXTURES];
     uniform int         elevationTextureCount;
     uniform float       geoidHeight;
@@ -21,15 +21,15 @@
         return Result;
     }
 
-    float getElevationMode(vec2 uv, sampler2D tex, int mode) {
+    float getElevationMode(vec2 uv, sampler2DArray tex, int mode) {
         if (mode == ELEVATION_RGBA)
-            return decode32(texture2D( tex, uv ).abgr * 255.0);
+            return decode32(texture(tex, vec3(uv, 0.0)).abgr * 255.0);
         if (mode == ELEVATION_DATA || mode == ELEVATION_COLOR)
-            return texture2D( tex, uv ).r;
+            return texture(tex, vec3(uv, 0.0)).r;
         return 0.;
     }
 
-    float getElevation(vec2 uv, sampler2D tex, vec4 offsetScale, Layer layer) {
+    float getElevation(vec2 uv, sampler2DArray tex, vec4 offsetScale, Layer layer) {
         // Elevation textures are inverted along the y-axis
         uv = vec2(uv.x, 1.0 - uv.y);
         uv = uv * offsetScale.zw + offsetScale.xy;

--- a/packages/Main/src/Renderer/Shader/Chunk/elevation_vertex.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/elevation_vertex.glsl
@@ -1,6 +1,6 @@
 #if NUM_VS_TEXTURES > 0
     if(elevationTextureCount > 0) {
-        float elevation = getElevation(uv, elevationTextures[0], elevationOffsetScales[0], elevationLayers[0]);
+        float elevation = getElevation(uv, elevationTextures, elevationOffsetScales[0], elevationLayers[0]);
         transformed += elevation * normal;
     }
 #endif

--- a/packages/Main/src/Renderer/Shader/TileFS.glsl
+++ b/packages/Main/src/Renderer/Shader/TileFS.glsl
@@ -38,7 +38,7 @@ void main() {
     vec4 color;
     #pragma unroll_loop
     for ( int i = 0; i < NUM_FS_TEXTURES; i ++ ) {
-        color = getLayerColor( i , colorTextures[ i ], colorOffsetScales[ i ], colorLayers[ i ]);
+        color = getLayerColor( i , colorTextures, colorOffsetScales[ i ], colorLayers[ i ]);
         gl_FragColor.rgb = mix(gl_FragColor.rgb, color.rgb, color.a);
     }
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -23,35 +23,34 @@ const copyTextureShader = {
 let material: THREE.ShaderMaterial | null = null;
 let quad: THREE.Mesh | null = null;
 const quadCam: THREE.OrthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-const emptyArrayTexture = new THREE.DataArrayTexture(null, 1, 1, 1);
 /**
- * Initializes a THREE.DataArrayTexture with immutable storage and populates
- * its layers by rendering individual 2D textures onto them using the GPU.
+ * Initializes a THREE.WebGLArrayRenderTarget with immutable storage
+ * and populates its layers.
+ * Returns the populated render target so callers can own/dispose it.
  *
- * @param uTextures - The uniform object containing the
- * THREE.DataArrayTexture to be initialized and populated.
  * @param width - The width of each layer in the DataArrayTexture.
  * @param height - The height of each layer in the DataArrayTexture.
  * @param count - The total number of layers the DataArrayTexture should have.
  * @param tiles - An array of RasterTile objects, each containing textures.
  * @param max - The maximum allowed number of layers for the DataArrayTexture.
  * @param renderer - The renderer used to render the texture.
- * @returns True if the function succeeded
+ * @returns The constructed render target, or null
  */
-export function makeDataArrayTexture(
-    uTextures: THREE.IUniform, width: number, height: number, count: number, tiles: RasterTile[],
-    max: number, renderer: THREE.WebGLRenderer): boolean {
-    if (count === 0) { return false; }
+export function makeDataArrayRenderTarget(
+    width: number,
+    height: number,
+    count: number,
+    tiles: RasterTile[],
+    max: number,
+    renderer: THREE.WebGLRenderer,
+): THREE.WebGLArrayRenderTarget | null {
+    if (count === 0) { return null; }
 
-    // Create a temporary THREE.WebGLArrayRenderTarget.
-    // This render target's internal framebuffer
-    // will be used to attach layers.
+    // The render target's internal framebuffer will be used to attach layers.
     const renderTarget = new THREE.WebGLArrayRenderTarget(width, height, count, {
         depthBuffer: false, // No depth buffer needed for simple 2D texture copy
     });
-
     const arrayTexture = renderTarget.texture;
-    uTextures.value = arrayTexture;
 
     // Set up the quad for rendering
     if (!quad) {
@@ -103,10 +102,5 @@ export function makeDataArrayTexture(
     }
     renderer.setRenderTarget(previousRenderTarget);
 
-    // unlink texture so it is not disposed of
-    // when disposing of the render target
-    renderTarget.texture = emptyArrayTexture;
-    renderTarget.dispose();
-
-    return true;
+    return renderTarget;
 }

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -45,9 +45,6 @@ function drawTextureLayer(
     layerIndex: number,
     quad: THREE.Mesh,
 ) {
-    const gl = renderer.getContext();
-
-    // save the previous render target and temporarily set the new one
     const previousRenderTarget = renderer.getRenderTarget();
     renderer.setRenderTarget(renderTarget);
 
@@ -58,6 +55,7 @@ function drawTextureLayer(
 
     // attach the specific layer of the DataArrayTexture to the framebuffer's
     // COLOR_ATTACHMENT0
+    const gl = renderer.getContext();
     if ('framebufferTextureLayer' in gl) {
         gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
             dataArrayTextureWebGL, 0, layerIndex);
@@ -67,8 +65,6 @@ function drawTextureLayer(
     }
 
     renderer.render(quad, quadCam);
-
-    // reset render target to the old one
     renderer.setRenderTarget(previousRenderTarget);
 }
 
@@ -164,11 +160,9 @@ export function makeDataArrayTexture(
     // Create a temporary THREE.WebGLRenderTarget.
     // This render target's internal framebuffer
     // will be used to attach layers.
-    if (!renderTarget) {
-        renderTarget = new THREE.WebGLRenderTarget(width, height, {
-            depthBuffer: false, // No depth buffer needed for simple 2D texture copy
-        });
-    }
+    renderTarget ??= new THREE.WebGLRenderTarget(width, height, {
+        depthBuffer: false, // No depth buffer needed for simple 2D texture copy
+    });
 
     // Set up the quad for rendering
     if (!quad) {

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -200,7 +200,10 @@ export function makeDataArrayTexture(
                 // Allocate immutable storage,
                 // with parameters from the first found texture
                 const glFormat = getInternalFormat(gl, texture.format, texture.type);
-                if (glFormat < 0) { return false; }
+                if (glFormat < 0) {
+                    uTextures.value.dispose();
+                    return false;
+                }
                 gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, glFormat, width, height, count);
             }
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -70,6 +70,7 @@ export function makeDataArrayTexture(
     // loop through each tile and its textures
     // to render them into DataArrayTexture layers
     let currentLayerIndex = 0;
+    const previousRenderTarget = renderer.getRenderTarget();
     for (const tile of tiles) {
         for (
             let i = 0;
@@ -96,12 +97,11 @@ export function makeDataArrayTexture(
             }
 
             // render this source texture into the current layer
-            const previousRenderTarget = renderer.getRenderTarget();
             renderer.setRenderTarget(renderTarget, currentLayerIndex);
             renderer.render(quad, quadCam);
-            renderer.setRenderTarget(previousRenderTarget);
         }
     }
+    renderer.setRenderTarget(previousRenderTarget);
 
     // unlink texture so it is not disposed of
     // when disposing of the render target

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -22,7 +22,8 @@ const copyTextureShader = {
 
 let renderTarget: THREE.WebGLRenderTarget | null = null;
 let material: THREE.ShaderMaterial | null = null;
-let geometry: THREE.PlaneGeometry | null = null;
+let quadScene: THREE.Scene | null = null;
+let quadCam: THREE.OrthographicCamera | null = null;
 
 /**
  * Renders a single 2D texture layer into the DataArrayTexture on the GPU.
@@ -134,13 +135,10 @@ export function makeDataArrayTexture(
     }
 
     // Set up the quad for rendering
-    const quadScene = new THREE.Scene();
-    const quadCam = new THREE.OrthographicCamera(
-        -1, 1, 1, -1, 0, 1);
-    if (!geometry) {
-        geometry = new THREE.PlaneGeometry(2, 2);
-    }
-    if (!material) {
+    if (!quadScene) {
+        quadScene = new THREE.Scene();
+        quadCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+        const geometry = new THREE.PlaneGeometry(2, 2);
         material = new THREE.ShaderMaterial({
             uniforms: {
                 // This uniform will be updated with each source 2D texture
@@ -149,9 +147,9 @@ export function makeDataArrayTexture(
             vertexShader: copyTextureShader.vertexShader,
             fragmentShader: copyTextureShader.fragmentShader,
         });
+        const quad = new THREE.Mesh(geometry, material);
+        quadScene.add(quad);
     }
-    const quad = new THREE.Mesh(geometry, material);
-    quadScene.add(quad);
 
     // loop through each tile and its textures
     // to render them into DataArrayTexture layers
@@ -163,11 +161,11 @@ export function makeDataArrayTexture(
             ++i, ++count
         ) {
             // Set the current source 2D texture on the quad's material
-            material.uniforms.sourceTexture.value = tile.textures[i];
+            material!.uniforms.sourceTexture.value = tile.textures[i];
 
             // render this source texture into the current layer
             drawTextureLayer(renderer, renderTarget, uTextures.value,
-                count, quadScene, quadCam);
+                count, quadScene!, quadCam!);
         }
     }
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -23,7 +23,7 @@ const copyTextureShader = {
 let material: THREE.ShaderMaterial | null = null;
 let quad: THREE.Mesh | null = null;
 const quadCam: THREE.OrthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-
+const emptyArrayTexture = new THREE.DataArrayTexture(null, 1, 1, 1);
 /**
  * Initializes a THREE.DataArrayTexture with immutable storage and populates
  * its layers by rendering individual 2D textures onto them using the GPU.
@@ -100,6 +100,11 @@ export function makeDataArrayTexture(
             renderer.setRenderTarget(previousRenderTarget);
         }
     }
+
+    // unlink texture so it is not disposed of
+    // when disposing of the render target
+    renderTarget.texture = emptyArrayTexture;
+    renderTarget.dispose();
 
     return true;
 }

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -133,15 +133,14 @@ function getInternalFormat(
  * @param count - The total number of layers the DataArrayTexture should have.
  * @param tiles - An array of RasterTile objects, each containing textures.
  * @param max - The maximum allowed number of layers for the DataArrayTexture.
+ * @param renderer - The renderer used to render the texture.
  * @returns True if the function succeeded
  */
 export function makeDataArrayTexture(
     uTextures: THREE.IUniform, width: number, height: number, count: number, tiles: RasterTile[],
-    max: number,
-): boolean {
+    max: number, renderer: THREE.WebGLRenderer): boolean {
     if (count === 0) { return false; }
 
-    const renderer: THREE.WebGLRenderer = view.renderer;
     const gl = renderer.getContext();
     if (!('TEXTURE_2D_ARRAY' in gl && 'texStorage3D' in gl)) {
         console.error('Some WebGL features are missing');

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -23,7 +23,7 @@ const copyTextureShader = {
 let renderTarget: THREE.WebGLRenderTarget | null = null;
 let material: THREE.ShaderMaterial | null = null;
 let quadScene: THREE.Scene | null = null;
-let quadCam: THREE.OrthographicCamera | null = null;
+const quadCam: THREE.OrthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
 /**
  * Renders a single 2D texture layer into the DataArrayTexture on the GPU.
@@ -37,7 +37,6 @@ let quadCam: THREE.OrthographicCamera | null = null;
  * @param layerIndex - The index of the layer
  * in the DataArrayTexture to write to.
  * @param quadScene - The scene containing the quad used for rendering.
- * @param quadCam - The camera for the quad scene.
  */
 function drawTextureLayer(
     renderer: THREE.WebGLRenderer,
@@ -45,7 +44,6 @@ function drawTextureLayer(
     dataArrayTextureToPopulate: THREE.DataArrayTexture,
     layerIndex: number,
     quadScene: THREE.Scene,
-    quadCam: THREE.OrthographicCamera,
 ) {
     const gl = renderer.getContext();
 
@@ -176,7 +174,6 @@ export function makeDataArrayTexture(
     // Set up the quad for rendering
     if (!quadScene) {
         quadScene = new THREE.Scene();
-        quadCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
         const geometry = new THREE.PlaneGeometry(2, 2);
         material = new THREE.ShaderMaterial({
             uniforms: {
@@ -215,7 +212,7 @@ export function makeDataArrayTexture(
 
             // render this source texture into the current layer
             drawTextureLayer(renderer, renderTarget, uTextures.value,
-                currentLayerIndex, quadScene!, quadCam!);
+                currentLayerIndex, quadScene!);
         }
     }
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { RasterTile } from './RasterTile';
 
-// Define the shader for copying a 2D texture to a framebuffer
+// shader for copying a 2D texture to a framebuffer
 const copyTextureShader = {
     vertexShader: `
         varying vec2 vUv;
@@ -48,18 +48,17 @@ function drawTextureLayer(
 ) {
     const gl = renderer.getContext();
 
-    // 1. Set the render target.
-    const current = renderer.getRenderTarget();
+    // save the previous render target and temporarily set the new one
+    const previousRenderTarget = renderer.getRenderTarget();
     renderer.setRenderTarget(renderTarget);
 
-    // 2. Get the raw WebGLTexture object for the DataArrayTexture.
+    // get the raw WebGLTexture object for the DataArrayTexture
     const props = renderer.properties.get(dataArrayTextureToPopulate) as
         { __webglTexture: WebGLTexture };
     const dataArrayTextureWebGL = props.__webglTexture;
 
-    // 3. Attach the specific layer of the DataArrayTexture to the framebuffer's
-    // COLOR_ATTACHMENT0. The framebuffer is already bound by
-    // `renderer.setRenderTarget(renderTarget)`.
+    // attach the specific layer of the DataArrayTexture to the framebuffer's
+    // COLOR_ATTACHMENT0
     if ('framebufferTextureLayer' in gl) {
         gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
             dataArrayTextureWebGL, 0, layerIndex);
@@ -68,19 +67,10 @@ function drawTextureLayer(
         return;
     }
 
-    // 4. Check framebuffer status after attaching the layer.
-    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-    if (status !== gl.FRAMEBUFFER_COMPLETE) {
-        console.error('Framebuffer not complete after attaching layer:', status);
-        return;
-    }
-
-    // 5. Render the quad scene.
     renderer.render(quadScene, quadCam);
 
-    // 6. Reset render target to null. This unbinds the custom framebuffer
-    // and restores the default framebuffer (usually the screen).
-    renderer.setRenderTarget(current);
+    // reset render target to the old one
+    renderer.setRenderTarget(previousRenderTarget);
 }
 
 /**

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -1,0 +1,181 @@
+import * as THREE from 'three';
+import { RasterTile } from './RasterTile';
+
+// Define the shader for copying a 2D texture to a framebuffer
+const copyTextureShader = {
+    vertexShader: `
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: `
+        precision highp float;
+        uniform sampler2D sourceTexture;
+        varying vec2 vUv;
+        void main() {
+            gl_FragColor = texture2D(sourceTexture, vUv);
+        }
+    `,
+};
+
+let renderTarget: THREE.WebGLRenderTarget | null = null;
+let material: THREE.ShaderMaterial | null = null;
+let geometry: THREE.PlaneGeometry | null = null;
+
+/**
+ * Renders a single 2D texture layer into the DataArrayTexture on the GPU.
+ * This function is called for each layer.
+ *
+ * @param renderer - The Three.js WebGLRenderer instance.
+ * @param renderTarget - A temporary WebGLRenderTarget
+ * used to bind the framebuffer.
+ * @param dataArrayTextureToPopulate - The DataArrayTexture
+ * that layers are being written into.
+ * @param layerIndex - The index of the layer
+ * in the DataArrayTexture to write to.
+ * @param quadScene - The scene containing the quad used for rendering.
+ * @param quadCam - The camera for the quad scene.
+ */
+function drawTextureLayer(
+    renderer: THREE.WebGLRenderer,
+    renderTarget: THREE.WebGLRenderTarget,
+    dataArrayTextureToPopulate: THREE.DataArrayTexture,
+    layerIndex: number,
+    quadScene: THREE.Scene,
+    quadCam: THREE.OrthographicCamera,
+) {
+    const gl = renderer.getContext();
+
+    // 1. Set the render target.
+    const current = renderer.getRenderTarget();
+    renderer.setRenderTarget(renderTarget);
+
+    // 2. Get the raw WebGLTexture object for the DataArrayTexture.
+    const props = renderer.properties.get(dataArrayTextureToPopulate) as
+        { __webglTexture: WebGLTexture };
+    const dataArrayTextureWebGL = props.__webglTexture;
+
+    // 3. Attach the specific layer of the DataArrayTexture to the framebuffer's
+    // COLOR_ATTACHMENT0. The framebuffer is already bound by
+    // `renderer.setRenderTarget(renderTarget)`.
+    if ('framebufferTextureLayer' in gl) {
+        gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
+            dataArrayTextureWebGL, 0, layerIndex);
+    } else {
+        console.error('framebufferTextureLayer function not supported');
+        return;
+    }
+
+    // 4. Check framebuffer status after attaching the layer.
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (status !== gl.FRAMEBUFFER_COMPLETE) {
+        console.error('Framebuffer not complete after attaching layer:', status);
+        return;
+    }
+
+    // 5. Render the quad scene.
+    renderer.render(quadScene, quadCam);
+
+    // 6. Reset render target to null. This unbinds the custom framebuffer
+    // and restores the default framebuffer (usually the screen).
+    renderer.setRenderTarget(current);
+}
+
+/**
+ * Initializes a THREE.DataArrayTexture with immutable storage and populates
+ * its layers by rendering individual 2D textures onto them using the GPU.
+ *
+ * @param uTextures - The uniform object containing the
+ * THREE.DataArrayTexture to be initialized and populated.
+ * @param width - The width of each layer in the DataArrayTexture.
+ * @param height - The height of each layer in the DataArrayTexture.
+ * @param count - The total number of layers the DataArrayTexture should have.
+ * @param tiles - An array of RasterTile objects, each containing textures.
+ * @param max - The maximum allowed number of layers for the DataArrayTexture.
+ * @returns True if the function succeeded
+ */
+export function makeDataArrayTexture(
+    uTextures: THREE.IUniform, width: number, height: number, count: number, tiles: RasterTile[],
+    max: number,
+): boolean {
+    // If no textures found, dispose previous DataArrayTexture and reset
+    if (count === 0) {
+        if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
+        uTextures.value = new THREE.DataArrayTexture();
+        return false;
+    }
+
+    const renderer: THREE.WebGLRenderer = view.renderer;
+    const gl = renderer.getContext();
+    if (!('TEXTURE_2D_ARRAY' in gl && 'texStorage3D' in gl)) {
+        console.error('Some WebGL features are missing');
+        return false;
+    }
+
+    // Dispose previous DataArrayTexture to prevent memory leaks if re-creating
+    if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
+
+    // Create a new THREE.DataArrayTexture.
+    uTextures.value = new THREE.DataArrayTexture(null, width, height, count);
+
+    // Manually initialize the WebGL
+    // texture with immutable storage (gl.texStorage3D)
+    // This is a requirement for attaching layers to a framebuffer.
+    const textureProps = renderer.properties.get(uTextures.value) as
+        { __webglTexture: WebGLTexture };
+    textureProps.__webglTexture = gl.createTexture(); // Create a raw WebGL texture
+    gl.bindTexture(gl.TEXTURE_2D_ARRAY, textureProps.__webglTexture);
+    // Allocate immutable storage
+    gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, count);
+
+    // Create a temporary THREE.WebGLRenderTarget.
+    // This render target's internal framebuffer
+    // will be used to attach layers.
+    if (!renderTarget) {
+        renderTarget = new THREE.WebGLRenderTarget(width, height, {
+            depthBuffer: false, // No depth buffer needed for simple 2D texture copy
+        });
+    }
+
+    // Set up the quad for rendering
+    const quadScene = new THREE.Scene();
+    const quadCam = new THREE.OrthographicCamera(
+        -1, 1, 1, -1, 0, 1);
+    if (!geometry) {
+        geometry = new THREE.PlaneGeometry(2, 2);
+    }
+    if (!material) {
+        material = new THREE.ShaderMaterial({
+            uniforms: {
+                // This uniform will be updated with each source 2D texture
+                sourceTexture: { value: null },
+            },
+            vertexShader: copyTextureShader.vertexShader,
+            fragmentShader: copyTextureShader.fragmentShader,
+        });
+    }
+    const quad = new THREE.Mesh(geometry, material);
+    quadScene.add(quad);
+
+    // loop through each tile and its textures
+    // to render them into DataArrayTexture layers
+    count = 0;
+    for (const tile of tiles) {
+        for (
+            let i = 0;
+            i < tile.textures.length && count < max;
+            ++i, ++count
+        ) {
+            // Set the current source 2D texture on the quad's material
+            material.uniforms.sourceTexture.value = tile.textures[i];
+
+            // render this source texture into the current layer
+            drawTextureLayer(renderer, renderTarget, uTextures.value,
+                count, quadScene, quadCam);
+        }
+    }
+
+    return true;
+}

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -141,12 +141,7 @@ export function makeDataArrayTexture(
     uTextures: THREE.IUniform, width: number, height: number, count: number, tiles: RasterTile[],
     max: number,
 ): boolean {
-    // If no textures found, dispose previous DataArrayTexture and reset
-    if (count === 0) {
-        if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
-        uTextures.value = new THREE.DataArrayTexture();
-        return false;
-    }
+    if (count === 0) { return false; }
 
     const renderer: THREE.WebGLRenderer = view.renderer;
     const gl = renderer.getContext();
@@ -155,10 +150,6 @@ export function makeDataArrayTexture(
         return false;
     }
 
-    // Dispose previous DataArrayTexture to prevent memory leaks if re-creating
-    if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
-
-    // Create a new THREE.DataArrayTexture.
     uTextures.value = new THREE.DataArrayTexture(null, width, height, count);
 
     // Manually initialize the WebGL
@@ -203,10 +194,7 @@ export function makeDataArrayTexture(
 
     // Allocate immutable storage
     const glFormat = getInternalFormat(gl, firstTexture.format, firstTexture.type);
-    if (glFormat < 0) {
-        uTextures.value.dispose();
-        return false;
-    }
+    if (glFormat < 0) { return false; }
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, glFormat, width, height, count);
 
     // loop through each tile and its textures

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -130,6 +130,10 @@ export function makeDataArrayTexture(
     // Allocate immutable storage
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, count);
 
+    // Avoid visible seams
+    gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
     // Create a temporary THREE.WebGLRenderTarget.
     // This render target's internal framebuffer
     // will be used to attach layers.

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -22,7 +22,7 @@ const copyTextureShader = {
 
 let renderTarget: THREE.WebGLRenderTarget | null = null;
 let material: THREE.ShaderMaterial | null = null;
-let quadScene: THREE.Scene | null = null;
+let quad: THREE.Mesh | null = null;
 const quadCam: THREE.OrthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
 /**
@@ -36,14 +36,14 @@ const quadCam: THREE.OrthographicCamera = new THREE.OrthographicCamera(-1, 1, 1,
  * that layers are being written into.
  * @param layerIndex - The index of the layer
  * in the DataArrayTexture to write to.
- * @param quadScene - The scene containing the quad used for rendering.
+ * @param quad - The quad used for rendering.
  */
 function drawTextureLayer(
     renderer: THREE.WebGLRenderer,
     renderTarget: THREE.WebGLRenderTarget,
     dataArrayTextureToPopulate: THREE.DataArrayTexture,
     layerIndex: number,
-    quadScene: THREE.Scene,
+    quad: THREE.Mesh,
 ) {
     const gl = renderer.getContext();
 
@@ -66,7 +66,7 @@ function drawTextureLayer(
         return;
     }
 
-    renderer.render(quadScene, quadCam);
+    renderer.render(quad, quadCam);
 
     // reset render target to the old one
     renderer.setRenderTarget(previousRenderTarget);
@@ -172,8 +172,7 @@ export function makeDataArrayTexture(
     }
 
     // Set up the quad for rendering
-    if (!quadScene) {
-        quadScene = new THREE.Scene();
+    if (!quad) {
         const geometry = new THREE.PlaneGeometry(2, 2);
         material = new THREE.ShaderMaterial({
             uniforms: {
@@ -183,8 +182,7 @@ export function makeDataArrayTexture(
             vertexShader: copyTextureShader.vertexShader,
             fragmentShader: copyTextureShader.fragmentShader,
         });
-        const quad = new THREE.Mesh(geometry, material);
-        quadScene.add(quad);
+        quad = new THREE.Mesh(geometry, material);
     }
 
     // loop through each tile and its textures
@@ -212,7 +210,7 @@ export function makeDataArrayTexture(
 
             // render this source texture into the current layer
             drawTextureLayer(renderer, renderTarget, uTextures.value,
-                currentLayerIndex, quadScene!);
+                currentLayerIndex, quad!);
         }
     }
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -91,6 +91,8 @@ export function makeDataArrayTexture(
                 arrayTexture.format = texture.format;
                 arrayTexture.type = texture.type;
                 arrayTexture.internalFormat = texture.internalFormat;
+                arrayTexture.anisotropy = texture.anisotropy;
+                arrayTexture.premultiplyAlpha = texture.premultiplyAlpha;
             }
 
             // render this source texture into the current layer

--- a/packages/Main/test/unit/dataSourceProvider.js
+++ b/packages/Main/test/unit/dataSourceProvider.js
@@ -22,6 +22,7 @@ import Feature2Mesh from 'Converter/Feature2Mesh';
 import { LayeredMaterial } from 'Renderer/LayeredMaterial';
 import { EMPTY_TEXTURE_ZOOM } from 'Renderer/RasterTile';
 import sinon from 'sinon';
+import Renderer from './bootstrap';
 
 import holes from '../data/geojson/holesPoints.geojson';
 
@@ -64,8 +65,13 @@ describe('Provide in Sources', function () {
         stubFetcherJson = sinon.stub(Fetcher, 'json')
             .callsFake(() => Promise.resolve(JSON.parse(holes)));
         stubFetcherTexture = sinon.stub(Fetcher, 'texture')
-            .callsFake(() => Promise.resolve(new THREE.Texture()));
-
+            .callsFake(() => {
+                const texture = new THREE.Texture({
+                    width: 1,
+                    height: 1,
+                });
+                return Promise.resolve(texture);
+            });
         planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());
         colorlayer = new ColorLayer('color', { crs: 'EPSG:3857', source: false });
         elevationlayer = new ElevationLayer('elevation', { crs: 'EPSG:3857', source: false });
@@ -337,9 +343,9 @@ describe('Provide in Sources', function () {
             .then((result) => {
                 tile.material.setColorTileIds([colorlayer.id]);
                 tile.material.getColorTile(colorlayer.id).setTextures(result, [new THREE.Vector4()]);
-                assert.equal(tile.material.uniforms.colorTextures.value[0].anisotropy, 1);
-                tile.material.updateLayersUniforms();
-                assert.equal(tile.material.uniforms.colorTextures.value[0].anisotropy, 16);
+                assert.equal(tile.material.uniforms.colorTextures.value, null);
+                tile.material.updateLayersUniforms(new Renderer());
+                assert.equal(tile.material.uniforms.colorTextures.value.anisotropy, 16);
                 done();
             }).catch(done);
     });

--- a/packages/Main/test/unit/dataSourceProvider.js
+++ b/packages/Main/test/unit/dataSourceProvider.js
@@ -66,10 +66,11 @@ describe('Provide in Sources', function () {
             .callsFake(() => Promise.resolve(JSON.parse(holes)));
         stubFetcherTexture = sinon.stub(Fetcher, 'texture')
             .callsFake(() => {
-                const texture = new THREE.Texture({
+                const texture = new THREE.Texture();
+                texture.image = {
                     width: 1,
                     height: 1,
-                });
+                };
                 return Promise.resolve(texture);
             });
         planarlayer = new PlanarLayer('globe', globalExtent, new THREE.Group());

--- a/packages/Main/test/unit/layeredmaterial.js
+++ b/packages/Main/test/unit/layeredmaterial.js
@@ -67,10 +67,12 @@ describe('material state vs layer state', function () {
 
     it('should update material uniforms', () => {
         layer.visible = false;
+        node.material.layersNeedUpdate = true;
         node.onBeforeRender();
         assert.equal(material.uniforms.colorLayers.value[0].id, undefined);
 
         layer.visible = true;
+        node.material.layersNeedUpdate = true;
         node.onBeforeRender();
         assert.equal(material.uniforms.colorLayers.value[0].id, layer.id);
         assert.equal(material.uniforms.colorLayers.value[0].opacity, layer.opacity);

--- a/test/functional/view_3d_map.js
+++ b/test/functional/view_3d_map.js
@@ -39,7 +39,7 @@ describe('view_3d_map', function _() {
         const maxColorSamplerUnitsCount = await page.evaluate(
             () => itowns.getMaxColorSamplerUnitsCount(),
         );
-        const colorSamplerUnitsCount = await page.evaluate(() => view.tileLayer.countColorLayersTextures(view.getLayers(l => l.isColorLayer)[0]));
+        const colorSamplerUnitsCount = await page.evaluate(() => view.getLayers(l => l.isColorLayer).length);
         const limit = maxColorSamplerUnitsCount - colorSamplerUnitsCount;
 
         // add layers just below the capacity limit


### PR DESCRIPTION
## Description
In order to increase the number of raster layers that can be added to a `LayeredMaterial`, we assemble its textures into a texture arrays. For performance, the operation of copying the texture data to a texture array is done on the GPU.

## Motivation and Context
The number of layers we can add to a view is currently very limited, and users quickly hit that limit.
These changes fix issue #2568.
Tested on Firefox, Ubuntu.

This is work in progress: some functional tests have to be updated, and the use of the global variable `view` has to be changed.