### PR TITLE
fix: Remove custom fog shader to support standard Three fog

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ The following people have contributed to iTowns.
   * [Anthony Gullient](https://github.com/AnthonyGlt)
   * [Jonathan Garnier](https://github.com/jogarnier)
   * [Irénée Dubourg](https://github.com/airnez)
+  * [Victor Ripplinger](https://github.com/neptilo)
 
 * [Oslandia](http://www.oslandia.com)
   * [Vincent Picavet](https://github.com/vpicavet)

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -148,7 +148,8 @@ interface LayeredMaterialRawUniforms {
     lightPosition: THREE.Vector3;
 
     // Misc
-    fogDistance: number;
+    fogNear: number;
+    fogFar: number;
     fogColor: THREE.Color;
     overlayAlpha: number;
     overlayColor: THREE.Color;
@@ -212,7 +213,6 @@ type RenderModeDefines = DefineMapping<'MODE', typeof RenderMode.MODES>;
 type LayeredMaterialDefines = {
     NUM_VS_TEXTURES: number;
     NUM_FS_TEXTURES: number;
-    USE_FOG: number;
     NUM_CRS: number;
     DEBUG: number;
     MODE: number;
@@ -255,9 +255,6 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
 
         fillInProp(defines, 'NUM_VS_TEXTURES', nbSamplers[0]);
         fillInProp(defines, 'NUM_FS_TEXTURES', nbSamplers[1]);
-        // TODO: We do not use the fog from the scene, is this a desired
-        // behavior?
-        fillInProp(defines, 'USE_FOG', 1);
         fillInProp(defines, 'NUM_CRS', crsCount);
 
         initModeDefines(defines);
@@ -280,6 +277,8 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
 
         this.defines = defines;
 
+        this.fog = true;
+
         this.vertexShader = TileVS;
         // three loop unrolling of ShaderMaterial only supports integer bounds,
         // see https://github.com/mrdoob/three.js/issues/28020
@@ -296,7 +295,8 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
             lightPosition: new THREE.Vector3(-0.5, 0.0, 1.0),
 
             // Misc properties
-            fogDistance: 1000000000.0,
+            fogNear: 1,
+            fogFar: 1000,
             fogColor: new THREE.Color(0.76, 0.85, 1.0),
             overlayAlpha: 0,
             overlayColor: new THREE.Color(1.0, 0.3, 0.0),

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -151,6 +151,7 @@ interface LayeredMaterialRawUniforms {
     fogNear: number;
     fogFar: number;
     fogColor: THREE.Color;
+    fogDensity: number;
     overlayAlpha: number;
     overlayColor: THREE.Color;
     objectId: number;
@@ -298,6 +299,7 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
             fogNear: 1,
             fogFar: 1000,
             fogColor: new THREE.Color(0.76, 0.85, 1.0),
+            fogDensity: 0.00025,
             overlayAlpha: 0,
             overlayColor: new THREE.Color(1.0, 0.3, 0.0),
             objectId: 0,

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -278,7 +278,7 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
 
         this.defines = defines;
 
-        this.fog = true;
+        this.fog = true; // receive the fog defined on the scene, if any
 
         this.vertexShader = TileVS;
         // three loop unrolling of ShaderMaterial only supports integer bounds,

--- a/packages/Main/src/Renderer/Shader/Chunk/fog_fragment.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/fog_fragment.glsl
@@ -1,4 +1,0 @@
-#if defined(USE_FOG)
-    float fogFactor = 1. - min( exp(-vFogDepth / fogDistance), 1.);
-    gl_FragColor.rgb = mix(gl_FragColor.rgb, fogColor, fogFactor);
-#endif

--- a/packages/Main/src/Renderer/Shader/Chunk/fog_pars_fragment.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/fog_pars_fragment.glsl
@@ -1,5 +1,0 @@
-#if defined(USE_FOG)
-uniform vec3  fogColor;
-uniform float fogDistance;
-varying float vFogDepth;
-#endif

--- a/packages/Main/src/Renderer/Shader/ShaderChunk.js
+++ b/packages/Main/src/Renderer/Shader/ShaderChunk.js
@@ -3,8 +3,6 @@ import color_layers_pars_fragment from './Chunk/color_layers_pars_fragment.glsl'
 import elevation_pars_vertex from './Chunk/elevation_pars_vertex.glsl';
 import elevation_vertex from './Chunk/elevation_vertex.glsl';
 import geoid_vertex from './Chunk/geoid_vertex.glsl';
-import fog_fragment from './Chunk/fog_fragment.glsl';
-import fog_pars_fragment from './Chunk/fog_pars_fragment.glsl';
 import lighting_fragment from './Chunk/lighting_fragment.glsl';
 import lighting_pars_fragment from './Chunk/lighting_pars_fragment.glsl';
 import mode_pars_fragment from './Chunk/mode_pars_fragment.glsl';
@@ -28,8 +26,6 @@ const itownsShaderChunk = {
     elevation_pars_vertex,
     elevation_vertex,
     geoid_vertex,
-    fog_fragment,
-    fog_pars_fragment,
     lighting_fragment,
     lighting_pars_fragment,
     mode_depth_fragment,

--- a/packages/Main/src/Renderer/Shader/TileFS.glsl
+++ b/packages/Main/src/Renderer/Shader/TileFS.glsl
@@ -3,7 +3,7 @@
 #include <itowns/pitUV>
 #include <itowns/color_layers_pars_fragment>
 #if MODE == MODE_FINAL
-#include <itowns/fog_pars_fragment>
+#include <fog_pars_fragment>
 #include <itowns/overlay_pars_fragment>
 #include <itowns/lighting_pars_fragment>
 #endif
@@ -52,7 +52,7 @@ void main() {
     }
   #endif
 
-    #include <itowns/fog_fragment>
+    #include <fog_fragment>
     #include <itowns/lighting_fragment>
     #include <itowns/overlay_fragment>
 


### PR DESCRIPTION
## Description
Remove the custom fog shaders used in `LayeredMaterial` to bring back support for Three's standard method of adding a default fog to the scene.

## Motivation and Context
The fog defined in the scene was not applied on the globe or on the plane, but it did on other objects.
This fixes #2569.
Tested on Firefox, Ubuntu.