### PR TITLE
Revamp examples page

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -42,6 +42,13 @@ body {
     }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
 /* MAIN SECTION (RIGHT) */
 #main {
     width: calc(100% * 9 / 16);
@@ -64,7 +71,7 @@ body {
     transition-duration: 200ms;
 }
 
-/* NAVIGATION (LEFT) */
+/* EDITOR (LEFT) */
 #editor-panel {
     background-color: light-dark(white, #202030);
     width: calc(100% * 7 / 16);
@@ -83,6 +90,22 @@ body {
 
 #editor-panel>hr {
     margin: 0 1em;
+}
+
+#editor-collapse {
+    display: flex;
+    position: absolute;
+    background-color: #0023;
+    border-width: 0;
+    left: calc(100% * 7 / 16 - 1%);
+    width: 1%;
+    aspect-ratio: 1 / 2;
+    flex-direction: row;
+    flex: 0;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    transition-duration: 200ms;
 }
 
 .switch input {

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -7,8 +7,13 @@
 }
 
 /* GENERAL */
+* {
+    transition-duration: 200ms;
+}
+
 html,
 body {
+    background-color: black;
     margin: 0;
     padding: 0;
     height: 100%;
@@ -60,6 +65,7 @@ body {
 
 /* NAVIGATION (LEFT) */
 #editor-panel {
+    background-color: white;
     width: calc(100% * 7 / 16);
     height: 100%;
     position: absolute;
@@ -108,20 +114,29 @@ body {
     gap: 1em;
 }
 
+.selector {
+    border: 0;
+    background-color: #404e73;
+    color: white;
+    padding: 1em;
+    border-radius: 0.3em;
+}
+
+#example-selector {
+    width: 30%;
+    flex-grow: 3;
+}
+
+#font-size-selector {
+    width: 4em;
+}
+
 #editor-header> :nth-child(3)>div {
     display: flex;
     flex-flow: row;
     justify-content: space-around;
     align-items: center;
     gap: inherit;
-}
-
-#example-selector {
-    border: 0;
-    background-color: #404e73;
-    color: white;
-    padding: 1em;
-    border-radius: 0.3em;
 }
 
 .header-button {
@@ -149,6 +164,16 @@ body {
     background-size: 3em;
 }
 
+.CodeMirror {
+    font-size: 1em;
+}
+
+.CodeMirror-gutter-wrapper,
+.CodeMirror-gutter,
+.CodeMirror-gutters,
+.CodeMirror-linenumber {
+    transition-duration: 0ms;
+}
 
 @media (width > 1700px) {
     #editor-header {
@@ -179,6 +204,10 @@ body {
 
     #editor-header>hr {
         margin: 0 1em;
+    }
+
+    #editor-header> :nth-child(3) {
+        padding-top: 1.5em;
     }
 }
 

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -125,6 +125,7 @@ body {
 
 .switch:hover .checkmark {
     background-color: #404e73;
+    cursor: pointer;
 }
 
 .checkmark:after {
@@ -195,6 +196,7 @@ body {
     color: white;
     padding: 1em;
     border-radius: 0.3em;
+    cursor: pointer;
 }
 
 #example-selector {
@@ -204,6 +206,7 @@ body {
 
 #font-size-selector {
     width: 4em;
+    cursor: text;
 }
 
 #editor-header> :nth-child(3)>div {
@@ -218,6 +221,7 @@ body {
     width: 3em;
     height: 3em;
     border: 0;
+    cursor: pointer;
 }
 
 @media(prefers-color-scheme: light) {

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -66,9 +66,8 @@ body {
     width: calc(100% * 9 / 16);
 }
 
-/* Makes the iframe canvas bouncy on resize. No practical reason but it sure looks neat. */
 #viewerDiv>canvas:nth-child(2) {
-    transition-duration: 200ms;
+    transition-duration: 0ms;
 }
 
 /* EDITOR (LEFT) */
@@ -95,10 +94,11 @@ body {
 #editor-collapse {
     display: flex;
     position: absolute;
-    background-color: #0023;
+    background-color: #0027;
     border-width: 0;
-    left: calc(100% * 7 / 16 - 1%);
-    width: 1%;
+    top: 49%;
+    left: calc(100% * 7 / 16 - 1em);
+    width: 1em;
     aspect-ratio: 1 / 2;
     flex-direction: row;
     flex: 0;
@@ -106,6 +106,17 @@ body {
     justify-content: center;
     user-select: none;
     transition-duration: 200ms;
+    padding: 1px;
+}
+
+#editor-collapse:hover {
+    opacity: 1 !important;
+    transition-duration: 100ms;
+}
+
+#editor-collapse>svg {
+    width: 5em;
+    height: 5em;
 }
 
 .switch input {
@@ -415,26 +426,4 @@ body {
     -webkit-user-select: none;
     -ms-user-select: none;
     user-select: none;
-}
-
-/* Tooltip container */
-.tooltip {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-}
-
-.tooltip-text {
-    visibility: hidden;
-    width: 130px;
-    background-color: #1127;
-    color: #fff;
-    padding: .5em 0;
-    border-radius: .2em;
-    position: absolute;
-    z-index: 1;
-}
-
-.tooltip>button:hover tooltip-text {
-    visibility: visible;
 }

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -417,52 +417,24 @@ body {
     user-select: none;
 }
 
+/* Tooltip container */
 .tooltip {
-    display: none;
-    background-image: linear-gradient(rgba(167, 164, 164, 0.95),
-            rgba(60, 60, 60, 0.95));
-    box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
-    margin-top: 20px;
-    margin-left: 20px;
-    padding: 10px;
-    position: absolute;
-    z-index: 1000;
-    color: #cecece;
-    font-family: "Open Sans", sans-serif;
-    font-size: 14px;
-    line-height: 18px;
-    text-align: left;
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
 }
 
-.tooltip li,
-.coord {
-    font-size: 12px;
-    padding-left: 20px;
-    color: #93b7c0;
-    text-shadow:
-        0px 1px 0px rgba(200, 200, 200, 0.3),
-        0px -1px 0px rgba(30, 30, 30, 0.7);
+.tooltip-text {
+    visibility: hidden;
+    width: 130px;
+    background-color: #1127;
+    color: #fff;
+    padding: .5em 0;
+    border-radius: .2em;
+    position: absolute;
+    z-index: 1;
 }
 
-/* Circle for Sse helper */
-.circleBase {
-    display: none;
-    border-radius: 50%;
-    margin-top: 0px;
-    margin-left: 0px;
-    padding: 0px;
-    position: absolute;
-    z-index: 9;
-    font-family: "Open Sans", sans-serif;
-    font-size: 20px;
-    line-height: 0px;
-    text-align: center;
-    pointer-events: none;
-    width: 10px;
-    height: 10px;
-    background: rgba(170, 170, 170, 0.4);
-    border: 2px solid #7ad7ff;
-    color: #b5e8ff;
-    vertical-align: middle;
-    text-shadow: 0px 0px 3px black;
+.tooltip>button:hover tooltip-text {
+    visibility: visible;
 }

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -1,5 +1,6 @@
 /* GENERAL */
-html, body {
+html,
+body {
     margin: 0;
     padding: 0;
     height: 100%;
@@ -12,11 +13,6 @@ body {
     overflow: hidden;
 }
 
-.scroll-section {
-    height: 100%;
-    position: absolute;
-}
-
 #description {
     position: absolute;
     top: 10px;
@@ -24,17 +20,19 @@ body {
     overflow: hidden;
 }
 
-#description, .text {
+#description,
+.text {
     z-index: 1;
     color: #eee;
-    font: 16px 'Lucida Grande',sans-serif;
+    font: 16px 'Lucida Grande', sans-serif;
     max-width: 40%;
     background: #1a1a1a;
     opacity: 0.8;
     padding: 10px;
 }
 
-#description p, #description ul {
+#description p,
+#description ul {
     margin: 0px;
 }
 
@@ -46,10 +44,11 @@ body {
     overflow: hidden;
 }
 
-#attribution, .text {
+#attribution,
+.text {
     z-index: 2;
     color: #eee;
-    font: 13px 'Lucida Grande',sans-serif;
+    font: 13px 'Lucida Grande', sans-serif;
     max-width: 40%;
     background: #1a1a1a;
     opacity: 0.8;
@@ -64,7 +63,7 @@ body {
     color: #f0c0c0;
 }
 
-.text > ul {
+.text>ul {
     padding: 0 2rem;
 }
 
@@ -113,40 +112,42 @@ body {
 #view-source:hover {
     cursor: pointer;
 }
+
 #view-source:active {
     background-color: #222222;
 }
 
 /* NAVIGATION (LEFT) */
-nav {
-    width: calc(100% * 7 / 16 - 4em);
+#editor-header {
+    display: flex;
+    flex-flow: column;
+    width: 100%;
     padding: 0 2rem;
     overflow: auto;
     font-family: Consolas, Monaco, 'Andale Mono', monospace;
 }
 
-nav img {
+#editor-header img {
     margin-top: 20px;
 }
 
-.nav-section {
-    margin-top: 0px;
-}
-
-nav .package {
+#editor-header .package {
     padding-bottom: 20px;
 }
 
-nav ul {
+#editor-header ul {
     padding: 0;
     margin: 0;
 }
 
-nav li {
+#editor-header li {
     list-style: none;
 }
 
-a, a:visited, nav ul a, nav ul a:visited {
+a,
+a:visited,
+nav ul a,
+nav ul a:visited {
     cursor: pointer;
     color: #6091b2;
     text-decoration: underline;
@@ -157,7 +158,11 @@ a:hover {
     color: #6091b2aa;
 }
 
-h1, h2, h3, h4, h5 {
+h1,
+h2,
+h3,
+h4,
+h5 {
     font-weight: bold;
     color: #4b4b4b;
 }
@@ -170,28 +175,6 @@ h3 {
 .title-divider {
     margin: 26px 0;
 }
-
-#version-switch {
-    text-align: justify;
-    line-height: 1.6;
-}
-
-.switch-button {
-    width: 100%;
-    height: 30px;
-    border: 1px solid #222222;
-    border-radius: 7px;
-    margin-bottom: 10px;
-}
-.switch-button:hover {
-    cursor: pointer;
-    background-color: #E5E5E5;
-}
-.switch-button:active {
-    background-color: #404E76;
-    color: white;
-}
-
 
 /* IFRAME/EXAMPLE CONTENT */
 #viewerDiv {
@@ -211,8 +194,9 @@ h3 {
     z-index: 0;
 }
 
-#menuDiv, .ac {
-/* Disable select DAT.gui */
+#menuDiv,
+.ac {
+    /* Disable select DAT.gui */
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;
@@ -253,7 +237,7 @@ h3 {
 
 .tooltip {
     display: none;
-    background-image: linear-gradient(rgba(167, 164, 164, 0.95), rgba(60, 60, 60,0.95));
+    background-image: linear-gradient(rgba(167, 164, 164, 0.95), rgba(60, 60, 60, 0.95));
     box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
     margin-top: 20px;
     margin-left: 20px;
@@ -267,11 +251,12 @@ h3 {
     text-align: left;
 }
 
-.tooltip li, .coord {
+.tooltip li,
+.coord {
     font-size: 12px;
     padding-left: 20px;
     color: #93B7C0;
-    text-shadow: 0px 1px 0px rgba(200,200,200,.3), 0px -1px 0px rgba(30,30,30,.7);
+    text-shadow: 0px 1px 0px rgba(200, 200, 200, .3), 0px -1px 0px rgba(30, 30, 30, .7);
 }
 
 /* Circle for Sse helper */
@@ -284,7 +269,7 @@ h3 {
     position: absolute;
     z-index: 9;
     font-family: 'Open Sans',
-    sans-serif;
+        sans-serif;
     font-size: 20px;
     line-height: 0px;
     text-align: center;
@@ -299,7 +284,89 @@ h3 {
 }
 
 :root {
-  --text_stroke_display: 'none';
-  --text_stroke_width: 0px;
-  --text_stroke_color: 'white';
+    --text_stroke_display: 'none';
+    --text_stroke_width: 0px;
+    --text_stroke_color: 'white';
 }
+
+.editor-panel {
+    width: calc(100% * 7 / 16);
+    height: 100%;
+    position: absolute;
+    display: flex;
+    grid-template-columns: auto auto;
+    background-color: dodgerblue;
+}
+
+.editor-panel>* {
+    background-color: white;
+}
+
+/* /** VERSION SWITCH */
+/* /* The switch - the box around the slider */
+/* .switch { */
+/*     font-size: 12px; */
+/*     position: relative; */
+/*     display: inline-block; */
+/*     overflow: visible; */
+/*     width: 2em; */
+/*     height: 1em; */
+/* } */
+/**/
+/* /* Hide default HTML checkbox */
+/* .switch input { */
+/*     opacity: 0; */
+/*     width: 0; */
+/*     height: 0; */
+/* } */
+/**/
+/* /* The slider */
+/* .slider { */
+/*     position: absolute; */
+/*     cursor: pointer; */
+/*     top: 0; */
+/*     left: 0; */
+/*     right: 0; */
+/*     bottom: 0; */
+/*     background-color: #ccc; */
+/*     -webkit-transition: .4s; */
+/*     transition: .4s; */
+/*     border-radius: 1em; */
+/* } */
+/**/
+/* .slider:before { */
+/*     position: absolute; */
+/*     content: ""; */
+/*     height: .8em; */
+/*     width: .8em; */
+/*     left: .2em; */
+/*     bottom: .1em; */
+/*     background-color: white; */
+/*     -webkit-transition: .4s; */
+/*     transition: .4s; */
+/*     border-radius: 50%; */
+/* } */
+/**/
+/* input:disabled+.slider { */
+/*     background-color: #bbb; */
+/* } */
+/**/
+/* input:disabled+.slider:before { */
+/*     background-color: #ccc; */
+/* } */
+/**/
+/* input:checked+.slider { */
+/*     background-color: #2196F3; */
+/* } */
+/**/
+/* input:focus+.slider { */
+/*     box-shadow: 0 0 1px #2196F3; */
+/* } */
+/**/
+/* input:checked+.slider:before { */
+/*     -webkit-transform: translateX(1.2em); */
+/*     -ms-transform: translateX(1.2em); */
+/*     transform: translateX(1.2em); */
+/* } */
+
+/* .itowns-info {} */

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -76,7 +76,7 @@ body {
 
 /* MAIN SECTION (RIGHT) */
 #main {
-    width: calc(100% - 300px);
+    width: calc(100% * 9 / 16);
     height: 100%;
     display: inline;
     position: fixed;
@@ -88,7 +88,7 @@ body {
     position: fixed;
     top: 0;
     right: 0;
-    width: calc(100% - 300px);
+    width: calc(100% * 9 / 16);
 }
 
 #view-source {
@@ -119,7 +119,7 @@ body {
 
 /* NAVIGATION (LEFT) */
 nav {
-    width: calc(300px - 4rem);
+    width: calc(100% * 7 / 16 - 4em);
     padding: 0 2rem;
     overflow: auto;
     font-family: Consolas, Monaco, 'Andale Mono', monospace;

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -1,3 +1,11 @@
+/* CONSTS */
+:root {
+    --text_stroke_display: "none";
+    --text_stroke_width: 0px;
+    --text_stroke_color: "white";
+    --screen_size_threshold: 1700px;
+}
+
 /* GENERAL */
 html,
 body {
@@ -10,49 +18,9 @@ body {
 }
 
 body {
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
-}
-
-#description {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    overflow: hidden;
-}
-
-#description,
-.text {
-    z-index: 1;
-    color: #eee;
-    font: 16px 'Lucida Grande', sans-serif;
-    max-width: 40%;
-    background: #1a1a1a;
-    opacity: 0.8;
-    padding: 10px;
-}
-
-#description p,
-#description ul {
-    margin: 0px;
-}
-
-#attribution {
-    position: absolute;
-    bottom: 10px;
-    right: 10px;
-    width: 25%;
-    overflow: hidden;
-}
-
-#attribution,
-.text {
-    z-index: 2;
-    color: #eee;
-    font: 13px 'Lucida Grande', sans-serif;
-    max-width: 40%;
-    background: #1a1a1a;
-    opacity: 0.8;
-    padding: 10px;
 }
 
 .text a {
@@ -90,90 +58,139 @@ body {
     width: calc(100% * 9 / 16);
 }
 
-#view-source {
-    position: fixed;
-    right: 25px;
-    bottom: 10px;
-    width: 30px;
-    height: 30px;
-    padding: 0;
-    box-sizing: border-box;
-
-    border: 1px solid #222222;
-    border-radius: 7px;
-    background-color: #313336bb;
-
-    background-image: url('../images/code-logo.svg');
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: 90%;
-}
-
-#view-source:hover {
-    cursor: pointer;
-}
-
-#view-source:active {
-    background-color: #222222;
-}
-
 /* NAVIGATION (LEFT) */
+#editor-panel {
+    width: calc(100% * 7 / 16);
+    height: 100%;
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+}
+
+#editor-panel>hr {
+    margin: 0 1em;
+}
+
 #editor-header {
     display: flex;
+    flex-flow: row;
+    align-content: flex-start;
+    font-family: Consolas, Monaco, "Andale Mono", monospace;
+}
+
+#editor-header> :not(hr) {
+    padding: 0 2em;
+}
+
+#editor-header>div {
+    display: flex;
     flex-flow: column;
-    width: 100%;
-    padding: 0 2rem;
-    overflow: auto;
-    font-family: Consolas, Monaco, 'Andale Mono', monospace;
+    padding: 2em;
 }
 
-#editor-header img {
-    margin-top: 20px;
-}
-
-#editor-header .package {
-    padding-bottom: 20px;
-}
-
-#editor-header ul {
-    padding: 0;
+#editor-header>hr {
+    height: 100%;
     margin: 0;
 }
 
-#editor-header li {
-    list-style: none;
+#editor-header> :nth-child(1) {
+    justify-content: center;
 }
 
-a,
-a:visited,
-nav ul a,
-nav ul a:visited {
-    cursor: pointer;
-    color: #6091b2;
-    text-decoration: underline;
+#editor-header> :nth-child(3) {
+    display: flex;
+    flex-flow: row;
+    flex-grow: 1;
+    flex-shrink: 1;
+    justify-content: space-evenly;
+    align-items: center;
+    gap: 1em;
 }
 
-a:hover {
-    text-decoration: underline;
-    color: #6091b2aa;
+#editor-header> :nth-child(3)>div {
+    display: flex;
+    flex-flow: row;
+    justify-content: space-around;
+    align-items: center;
+    gap: inherit;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5 {
-    font-weight: bold;
-    color: #4b4b4b;
+#example-selector {
+    border: 0;
+    background-color: #404e73;
+    color: white;
+    padding: 1em;
+    border-radius: 0.3em;
 }
 
-h3 {
-    font-size: 16px;
-    margin-bottom: 5px;
+.header-button {
+    width: 3em;
+    height: 3em;
+    border: 0;
+    filter: invert(28%) sepia(13%) saturate(1533%) hue-rotate(186deg) brightness(97%) contrast(90%);
 }
 
-.title-divider {
-    margin: 26px 0;
+.header-button:hover {
+    filter: invert(70%);
+}
+
+.header-button:active {
+    filter: invert(52%) sepia(67%) saturate(5866%) hue-rotate(168deg) brightness(104%) contrast(105%);
+}
+
+#run-button {
+    background: url("../images/run-icon.svg") center no-repeat;
+    background-size: 3em;
+}
+
+#share-button {
+    background: url("../images/share-icon.svg") center no-repeat;
+    background-size: 3em;
+}
+
+
+@media (width > 1700px) {
+    #editor-header {
+        flex-flow: row;
+        max-height: 200px;
+    }
+
+    .CodeMirror {
+        height: calc(100% - 200px);
+    }
+}
+
+@media (width <=1700px) {
+    #editor-header> :nth-child(1) {
+        flex-flow: row;
+        gap: 2em;
+        align-items: center;
+    }
+
+    #editor-header {
+        flex-flow: column;
+        max-height: 200px;
+    }
+
+    .CodeMirror {
+        height: calc(100% - 200px);
+    }
+
+    #editor-header>hr {
+        margin: 0 1em;
+    }
+}
+
+@media (width < 1100px) {
+    #editor-panel {
+        width: 0%;
+        opacity: 0;
+    }
+
+    #content {
+        width: 100%;
+    }
 }
 
 /* IFRAME/EXAMPLE CONTENT */
@@ -223,11 +240,12 @@ h3 {
     border-top: none;
     text-align: center;
     display: block;
-    background-image: linear-gradient(rgba(200, 200, 200, 0.3), rgba(200, 200, 200, 0.3));
+    background-image: linear-gradient(rgba(200, 200, 200, 0.3),
+            rgba(200, 200, 200, 0.3));
     width: 200px;
     height: 18px;
     color: black;
-    font-family: 'Open Sans', sans-serif;
+    font-family: "Open Sans", sans-serif;
     font-size: 16px;
     -moz-user-select: none;
     -webkit-user-select: none;
@@ -237,15 +255,16 @@ h3 {
 
 .tooltip {
     display: none;
-    background-image: linear-gradient(rgba(167, 164, 164, 0.95), rgba(60, 60, 60, 0.95));
+    background-image: linear-gradient(rgba(167, 164, 164, 0.95),
+            rgba(60, 60, 60, 0.95));
     box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.5);
     margin-top: 20px;
     margin-left: 20px;
     padding: 10px;
     position: absolute;
     z-index: 1000;
-    color: #CECECE;
-    font-family: 'Open Sans', sans-serif;
+    color: #cecece;
+    font-family: "Open Sans", sans-serif;
     font-size: 14px;
     line-height: 18px;
     text-align: left;
@@ -255,8 +274,10 @@ h3 {
 .coord {
     font-size: 12px;
     padding-left: 20px;
-    color: #93B7C0;
-    text-shadow: 0px 1px 0px rgba(200, 200, 200, .3), 0px -1px 0px rgba(30, 30, 30, .7);
+    color: #93b7c0;
+    text-shadow:
+        0px 1px 0px rgba(200, 200, 200, 0.3),
+        0px -1px 0px rgba(30, 30, 30, 0.7);
 }
 
 /* Circle for Sse helper */
@@ -268,8 +289,7 @@ h3 {
     padding: 0px;
     position: absolute;
     z-index: 9;
-    font-family: 'Open Sans',
-        sans-serif;
+    font-family: "Open Sans", sans-serif;
     font-size: 20px;
     line-height: 0px;
     text-align: center;
@@ -282,91 +302,3 @@ h3 {
     vertical-align: middle;
     text-shadow: 0px 0px 3px black;
 }
-
-:root {
-    --text_stroke_display: 'none';
-    --text_stroke_width: 0px;
-    --text_stroke_color: 'white';
-}
-
-.editor-panel {
-    width: calc(100% * 7 / 16);
-    height: 100%;
-    position: absolute;
-    display: flex;
-    grid-template-columns: auto auto;
-    background-color: dodgerblue;
-}
-
-.editor-panel>* {
-    background-color: white;
-}
-
-/* /** VERSION SWITCH */
-/* /* The switch - the box around the slider */
-/* .switch { */
-/*     font-size: 12px; */
-/*     position: relative; */
-/*     display: inline-block; */
-/*     overflow: visible; */
-/*     width: 2em; */
-/*     height: 1em; */
-/* } */
-/**/
-/* /* Hide default HTML checkbox */
-/* .switch input { */
-/*     opacity: 0; */
-/*     width: 0; */
-/*     height: 0; */
-/* } */
-/**/
-/* /* The slider */
-/* .slider { */
-/*     position: absolute; */
-/*     cursor: pointer; */
-/*     top: 0; */
-/*     left: 0; */
-/*     right: 0; */
-/*     bottom: 0; */
-/*     background-color: #ccc; */
-/*     -webkit-transition: .4s; */
-/*     transition: .4s; */
-/*     border-radius: 1em; */
-/* } */
-/**/
-/* .slider:before { */
-/*     position: absolute; */
-/*     content: ""; */
-/*     height: .8em; */
-/*     width: .8em; */
-/*     left: .2em; */
-/*     bottom: .1em; */
-/*     background-color: white; */
-/*     -webkit-transition: .4s; */
-/*     transition: .4s; */
-/*     border-radius: 50%; */
-/* } */
-/**/
-/* input:disabled+.slider { */
-/*     background-color: #bbb; */
-/* } */
-/**/
-/* input:disabled+.slider:before { */
-/*     background-color: #ccc; */
-/* } */
-/**/
-/* input:checked+.slider { */
-/*     background-color: #2196F3; */
-/* } */
-/**/
-/* input:focus+.slider { */
-/*     box-shadow: 0 0 1px #2196F3; */
-/* } */
-/**/
-/* input:checked+.slider:before { */
-/*     -webkit-transform: translateX(1.2em); */
-/*     -ms-transform: translateX(1.2em); */
-/*     transform: translateX(1.2em); */
-/* } */
-
-/* .itowns-info {} */

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -7,11 +7,6 @@
     color-scheme: light dark;
 }
 
-/* GENERAL */
-* {
-    transition-duration: 200ms;
-}
-
 html,
 body {
     background-color: black;
@@ -64,6 +59,11 @@ body {
     width: calc(100% * 9 / 16);
 }
 
+/* Makes the iframe canvas bouncy on resize. No practical reason but it sure looks neat. */
+#viewerDiv>canvas:nth-child(2) {
+    transition-duration: 200ms;
+}
+
 /* NAVIGATION (LEFT) */
 #editor-panel {
     background-color: light-dark(white, #202030);
@@ -73,6 +73,12 @@ body {
     display: flex;
     flex-direction: column;
     justify-content: start;
+    /* Drawer-style animation on resize */
+    transition-duration: 200ms;
+}
+
+#editor-panel>* {
+    transition-duration: 200ms;
 }
 
 #editor-panel>hr {
@@ -277,6 +283,7 @@ body {
 }
 
 .CodeMirror * {
+    overscroll-behavior: none;
     transition-duration: 0ms;
 }
 

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -3,7 +3,8 @@
     --text_stroke_display: "none";
     --text_stroke_width: 0px;
     --text_stroke_color: "white";
-    --screen_size_threshold: 1700px;
+
+    color-scheme: light dark;
 }
 
 /* GENERAL */
@@ -18,7 +19,7 @@ body {
     padding: 0;
     height: 100%;
     width: 100%;
-    color: #202020;
+    color: light-dark(#202020, #F0F0F0);
     font-size: 13px;
 }
 
@@ -65,7 +66,7 @@ body {
 
 /* NAVIGATION (LEFT) */
 #editor-panel {
-    background-color: white;
+    background-color: light-dark(white, #202030);
     width: calc(100% * 7 / 16);
     height: 100%;
     position: absolute;
@@ -76,6 +77,80 @@ body {
 
 #editor-panel>hr {
     margin: 0 1em;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    cursor: pointer;
+}
+
+.switch {
+    display: flex;
+    flex-direction: row;
+    gap: .2em;
+    cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.switch .checkmark {
+    display: inline-block;
+    position: relative;
+    top: .15em;
+    width: 1em;
+    height: 1em;
+    background-color: #7ea8c5;
+    border-radius: .3em;
+}
+
+.switch>* {
+    margin: 0;
+}
+
+.switch:has(input:disabled) {
+    cursor: default;
+}
+
+.switch:has(input:disabled) .checkmark {
+    background-color: light-dark(#c0c0c0, #303e63);
+}
+
+.switch:has(input:checked) {
+    font-weight: bold;
+}
+
+.switch:hover .checkmark {
+    background-color: #404e73;
+}
+
+.checkmark:after {
+    content: "";
+    position: relative;
+    display: none;
+}
+
+.switch input:checked~.checkmark:after {
+    display: block;
+}
+
+.switch .checkmark:after {
+    left: .29em;
+    top: .1em;
+    width: .2em;
+    height: .5em;
+    border: solid white;
+    border-width: 0 .3em .3em 0;
+    -webkit-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
+    transform: rotate(45deg);
+}
+
+.switch input:disabled~label {
+    color: #c0c0c0;
 }
 
 #editor-header {
@@ -143,15 +218,43 @@ body {
     width: 3em;
     height: 3em;
     border: 0;
-    filter: invert(28%) sepia(13%) saturate(1533%) hue-rotate(186deg) brightness(97%) contrast(90%);
 }
 
-.header-button:hover {
-    filter: invert(70%);
+@media(prefers-color-scheme: light) {
+    .header-button {
+        filter: invert(28%) sepia(13%) saturate(1533%) hue-rotate(186deg) brightness(97%) contrast(90%);
+    }
+
+    .header-button:hover {
+        filter: invert(70%);
+    }
+
+    .header-button:active {
+        filter: invert(52%) sepia(67%) saturate(5866%) hue-rotate(168deg) brightness(104%) contrast(105%);
+    }
 }
 
-.header-button:active {
-    filter: invert(52%) sepia(67%) saturate(5866%) hue-rotate(168deg) brightness(104%) contrast(105%);
+@media(prefers-color-scheme: dark) {
+    #itowns-logo {
+        filter: drop-shadow(-1px -1px 0.5px #7ea8c5) drop-shadow(-1px 1px 0.5px #7ea8c5) drop-shadow(1px -1px 0.5px #7ea8c5) drop-shadow(1px 1px 0.5px #7ea8c5);
+    }
+
+    .header-button {
+        filter: brightness(0) saturate(100%) invert(64%) sepia(70%) saturate(186%) hue-rotate(161deg) brightness(89%) contrast(86%);
+    }
+
+    .header-button:before {
+        background-color: white;
+        background-size: 1em;
+    }
+
+    .header-button:hover {
+        filter: invert(70%);
+    }
+
+    .header-button:active {
+        filter: invert(52%) sepia(67%) saturate(5866%) hue-rotate(168deg) brightness(104%) contrast(105%);
+    }
 }
 
 #run-button {
@@ -166,12 +269,10 @@ body {
 
 .CodeMirror {
     font-size: 1em;
+    border-radius: .5em;
 }
 
-.CodeMirror-gutter-wrapper,
-.CodeMirror-gutter,
-.CodeMirror-gutters,
-.CodeMirror-linenumber {
+.CodeMirror * {
     transition-duration: 0ms;
 }
 
@@ -182,7 +283,7 @@ body {
     }
 
     .CodeMirror {
-        height: calc(100% - 200px);
+        height: calc(100% - 200px - 1em);
     }
 }
 
@@ -199,7 +300,7 @@ body {
     }
 
     .CodeMirror {
-        height: calc(100% - 200px);
+        height: calc(100% - 200px - 2em);
     }
 
     #editor-header>hr {

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -49,6 +49,29 @@ body {
     }
 }
 
+#description {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    overflow: hidden;
+}
+
+#description,
+.text {
+    z-index: 1;
+    color: #eee;
+    font: 16px 'Lucida Grande', sans-serif;
+    max-width: 40%;
+    background: #1a1a1a;
+    opacity: 0.8;
+    padding: 10px;
+}
+
+#description p,
+#description ul {
+    margin: 0px;
+}
+
 /* MAIN SECTION (RIGHT) */
 #main {
     width: calc(100% * 9 / 16);

--- a/examples/images/run-icon.svg
+++ b/examples/images/run-icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg height="800px" width="800px" version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 512 512"  xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#000000;}
+</style>
+<g>
+	<path class="st0" d="M256,0C114.625,0,0,114.625,0,256c0,141.374,114.625,256,256,256c141.374,0,256-114.626,256-256
+		C512,114.625,397.374,0,256,0z M351.062,258.898l-144,85.945c-1.031,0.626-2.344,0.657-3.406,0.031
+		c-1.031-0.594-1.687-1.702-1.687-2.937v-85.946v-85.946c0-1.218,0.656-2.343,1.687-2.938c1.062-0.609,2.375-0.578,3.406,0.031
+		l144,85.962c1.031,0.586,1.641,1.718,1.641,2.89C352.703,257.187,352.094,258.297,351.062,258.898z"/>
+</g>
+</svg>

--- a/examples/images/share-icon.svg
+++ b/examples/images/share-icon.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 16 16"
+   fill="none"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="share-icon.svg"
+   xml:space="preserve"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs1" /><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true"
+     inkscape:zoom="0.70975843"
+     inkscape:cx="193.02342"
+     inkscape:cy="285.30834"
+     inkscape:window-width="1890"
+     inkscape:window-height="1016"
+     inkscape:window-x="2575"
+     inkscape:window-y="49"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" /><path
+     id="path2"
+     style="fill:#000000;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.0399003;stroke-linecap:round"
+     d="M 8.0000001,0.01995053 A 7.9800438,7.9800438 0 0 0 0.01995053,8.0000001 7.9800438,7.9800438 0 0 0 8.0000001,15.98005 7.9800438,7.9800438 0 0 0 15.98005,8.0000001 7.9800438,7.9800438 0 0 0 8.0000001,0.01995053 Z M 9.183249,4.5394629 c 0.7167191,0 1.297715,0.5810174 1.297715,1.2977148 0,0.7166975 -0.5809959,1.2976934 -1.297715,1.2976934 -0.3056079,0 -0.5865535,-0.1056508 -0.8082913,-0.2824147 L 6.9897428,7.718205 c 0.020084,0.090726 0.030684,0.1850257 0.030684,0.2817951 0,0.096769 -0.0106,0.1910687 -0.030684,0.2817951 L 8.3749577,9.1475654 C 8.5966955,8.970775 8.8776413,8.865129 9.183249,8.865129 c 0.7167191,0 1.297715,0.5809742 1.297715,1.297693 0,0.716719 -0.5809959,1.297715 -1.297715,1.297715 -0.7166971,0 -1.2976934,-0.580996 -1.2976934,-1.297715 0,-0.09676 0.0106,-0.1910639 0.030684,-0.2817733 L 6.5310244,9.0152787 C 6.3092824,9.1920684 6.02835,9.2976936 5.7227332,9.2976936 c -0.7166975,0 -1.2977148,-0.5809961 -1.2977148,-1.2976935 0,-0.7166975 0.5810173,-1.2976934 1.2977148,-1.2976934 0.3056168,0 0.5865492,0.1056508 0.8082912,0.2824147 l 1.3852149,-0.86577 C 7.8961554,6.028225 7.8855556,5.9339471 7.8855556,5.8371777 c 0,-0.7166974 0.5809961,-1.2977148 1.2976934,-1.2977148 z" /><style
+     type="text/css"
+     id="style1">
+	.st0{fill:#000000;}
+</style></svg>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,15 +11,27 @@
 <body data-spy="scroll" data-target="nav" onload="onLoad()">
 
     <div id="main">
-        <iframe id="content" class="scroll-section" frameborder="0" height="100%"></iframe>
+        <iframe id="content" frameborder="0" height="100%"></iframe>
         <button id="view-source" class="text" title="View source"></button>
     </div>
 
-    <nav class="scroll-section">
-        <a href="/">
-            <img src="images/itowns_logo.png" width="245px" id="itowns-logo">
-        </a>
-    </nav>
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.4.0/codemirror.js"></script> -->
+    <div class="editor-panel">
+        <nav id="editor-header">
+            <a href="/">
+                <img src="images/itowns_logo.png" width="245px" id="itowns-logo">
+            </a>
+            <div class="switch">
+                <label for="version-switch">Latest</label>
+                <input id="version-switch" type="checkbox" name="version-switch">
+                <span class="slider"></span>
+            </div>
+            <!-- <div id="itowns-info"> -->
+            <!-- </div> -->
+            <!-- <div id="settings"> -->
+            <!-- </div> -->
+        </nav>
+    </div>
 
     <script type="text/javascript">
         var baseURI = document.baseURI;
@@ -62,34 +74,56 @@
 
         /** @param {Record<string, Record<string, string>>} list - List of examples */
         function initNavigation(list) {
-            // Add version switch :
-            const versionSwitchText = document.createElement('p');
-            versionSwitchText.innerHTML = `iTowns examples of the ${(baseURI.includes("/itowns/dev/") && "next version (current master branch)")
-                || "latest released version"}.`;
+            const nav = document.getElementById('editor-header');
 
-            const versionSwitchButton = document.createElement('button');
-            versionSwitchButton.classList.add('switch-button');
-            versionSwitchButton.innerHTML = `Switch to ${(baseURI.includes("/itowns/dev/") && "latest release") || "next version"
-                }`;
-            versionSwitchButton.onclick = () => {
-                if (baseURI.includes("/itowns/dev/")) {
-                    window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
-                } else {
-                    window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
+            const versionSwitch = document.getElementById('version-switch');
+            if (!baseURI.includes('/itowns/')) {
+                versionSwitch.setAttribute('disabled', '');
+            } else {
+                versionSwitch.onchange = (event) => {
+                    console.log('toggled');
+                    if (baseURI.includes("/itowns/dev/")) {
+                        window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
+                    } else {
+                        window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
+                    }
                 }
-            };
-
-            const nav = document.getElementsByTagName('nav')[0];
-            const versionSwitch = document.createElement('div');
-            versionSwitch.id = "version-switch";
-            versionSwitch.appendChild(versionSwitchText);
-            versionSwitch.appendChild(versionSwitchButton);
-            nav.appendChild(versionSwitch);
-
-            // Add horizontal divider :
-            const titleDivider = document.createElement('hr');
-            titleDivider.classList.add('title-divider');
-            nav.appendChild(titleDivider);
+                if (baseURI.includes('/itowns/dev/')) {
+                    versionSwitch.setAttribute('checked', '');
+                }
+            }
+            // Add version switch :
+            // const versionSwitchText = document.createElement('p');
+            // versionSwitchText.innerHTML = `iTowns examples of the ${(baseURI.includes("/itowns/dev/") && "next version (current master branch)")
+            //     || "latest released version"}.`;
+            // const versionSwitchButton = document.createElement('button');
+            // versionSwitchButton.classList.add('switch-button');
+            // versionSwitchButton.innerHTML = `Switch to ${(baseURI.includes("/itowns/dev/") && "latest release") || "next version"
+            //     }`;
+            // versionSwitchButton.onclick = () => {
+            //     if (baseURI.includes("/itowns/dev/")) {
+            //         window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
+            //     } else {
+            //         window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
+            //     }
+            // };
+            //
+            // const versionSwitch = document.createElement('div');
+            // versionSwitch.id = "version-switch";
+            // versionSwitch.appendChild(versionSwitchText);
+            // versionSwitch.appendChild(versionSwitchButton);
+            // const versionSwitch = document.createElement('label');
+            // versionSwitch.className = 'switch';
+            //
+            // const versionSwitchCheckbox = document.createElement('input');
+            // versionSwitchCheckbox.setAttribute('type', 'checkbox');
+            // versionSwitch.appendChild(versionSwitchCheckbox);
+            //
+            // const versionSwitchSlider = document.createElement('span');
+            // versionSwitchSlider.className = 'slider';
+            // versionSwitch.appendChild(versionSwitchSlider);
+            //
+            // nav.appendChild(versionSwitch);
 
             // Dropdown example selector
             const examples = Object.entries(list).flatMap(([sectionName, section]) => {
@@ -107,10 +141,12 @@
                 console.log('changed');
                 // TODO: Change this to a change of the edit area
                 const oldUrl = window.location.href;
-                const newUrl = oldUrl.slice(0, oldUrl.lastIndexOf('#')) + `#${event.target.value}`;
-                console.log(`${oldUrl} -> ${newUrl}`);
+                const navIndex = oldUrl.lastIndexOf('#');
+                const newUrl = oldUrl.slice(0, navIndex) + `#${event.target.value}`;
                 window.open(newUrl, '_self');
-                window.location.reload()
+                if (navIndex >= 0) {
+                    window.location.reload()
+                }
             }
 
             // Set displayed default to current example
@@ -126,6 +162,17 @@
             }
 
             nav.appendChild(exampleSelector)
+
+            // Add horizontal divider :
+            const titleDivider = document.createElement('hr');
+            titleDivider.classList.add('title-divider');
+            nav.appendChild(titleDivider);
+
+            // const textArea = document.createElement('textarea');
+            // // nav.appendChild(textArea);
+            // const navParent = document.getElementsByTagName('nav');
+            // navParent.appendChild(textArea);
+            // const editor = CodeMirror.fromTextArea(textArea, {lineNumbers: true});
         }
 
         function onLoad() {

--- a/examples/index.html
+++ b/examples/index.html
@@ -64,12 +64,7 @@
                 <select id="example-selector" class="selector"></select>
                 <input id="font-size-selector" class="selector" type="number" min="8" step="1" />
                 <div>
-                    <div class="tooltip">
-                        <button type="button" id="run-button" class="header-button"></button>
-                        <div class="tooltip-text">
-                            Run the code
-                        </div>
-                    </div>
+                    <button type="button" id="run-button" class="header-button"></button>
                     <button type="button" id="share-button" class="header-button" />
                 </div>
             </div>
@@ -80,7 +75,7 @@
         </div>
     </div>
     <button id="editor-collapse">
-        <svg height="10" width="10">
+        <svg viewBox="0 0 10 10">
             <polygon points="0,5 10,0 10,10" style="fill:white" />
         </svg>
     </button>
@@ -188,23 +183,26 @@
             if (!editorHidden) {
                 editorCollapse.style.left = "0";
                 editorCollapse.style.transform = "scaleX(-1)";
+                setTimeout(() => editorCollapse.style.opacity = "0", 1000);
                 editorPanel.style.left = "calc(-100% * 7 / 16)";
                 iframe.style.left = "0";
                 iframe.style.width = "100%";
             } else {
-                editorCollapse.style.left = "calc(100% * 7 / 16 - 1%)";
+                editorCollapse.style.left = "calc(100% * 7 / 16 - 1em)";
                 editorCollapse.style.transform = "scaleX(1)";
+                editorCollapse.style.opacity = "";
                 editorPanel.style.left = "0";
                 iframe.style.left = "";
                 iframe.style.width = "calc(100% * 9 / 16)";
             }
             editorHidden = !editorHidden;
         };
+        editorCollapse.onhover = () => console.log("toto");
         const searchParams = new URL(
             document.location.toString(),
         ).searchParams;
-        const hide_editor = searchParams.get("hide_editor");
-        if (!!hide_editor) {
+        const hideEditor = parseInt(searchParams.get("hide_editor"));
+        if (hideEditor) {
             editorCollapse.style["transition-duration"] = "";
             editorPanel.style["transition-duration"] = "";
             iframe.style["transition-duration"] = "";
@@ -212,6 +210,9 @@
             editorCollapse.style["transition-duration"] = "200ms";
             editorPanel.style["transition-duration"] = "200ms";
             iframe.style["transition-duration"] = "200ms";
+
+            setTimeout(() => editorCollapse.style.opacity = "1", 1000);
+            setTimeout(() => {if (editorHidden) {editorCollapse.style.opacity = "0";} }, 5000);
         }
 
         /** @param {string} slug - An example's slug */

--- a/examples/index.html
+++ b/examples/index.html
@@ -62,7 +62,7 @@
             <hr />
             <div>
                 <select id="example-selector" class="selector"></select>
-                <input type="number" id="font-size-selector" class="selector" />
+                <input id="font-size-selector" class="selector" type="number" min="8" step="1" />
                 <div>
                     <button type="button" id="run-button" class="header-button" />
                     <button type="button" id="share-button" class="header-button" />
@@ -127,6 +127,8 @@
         }
         document.getElementById("share-button").onclick = shareCode;
 
+        const fontSizeSelector = document.getElementById("font-size-selector");
+
         /** @returns {number} - The CodeMirror editor's font size */
         function getEditorFontSize() {
             const editor = document.getElementsByClassName("CodeMirror")[0];
@@ -135,13 +137,16 @@
 
         /** @param {number} size_px - The new font size to apply */
         function setEditorFontSize(size_px) {
-            console.info("Setting editor font size");
+            const size = Math.max(8, Math.round(size_px));
             const editor = document.getElementsByClassName("CodeMirror")[0];
-            editor.style.fontSize = `${size_px}px`;
+            editor.style.fontSize = `${size}px`;
+            // Must release focus to change value
+            document.activeElement.blur();
+            fontSizeSelector.value = size;
+            fontSizeSelector.focus();
         }
-        const fontSizeSelector = document.getElementById("font-size-selector");
         fontSizeSelector.value = getEditorFontSize();
-        fontSizeSelector.onchange = (event) => setEditorFontSize(event.target.value);
+        fontSizeSelector.onchange = (event) => setEditorFontSize(event.target.value || 13);
 
         /** @param {string} slug - An example's slug */
         function cacheExample(slug) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,188 +1,222 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Itowns Examples</title>
 
-    <link type="text/css" rel="stylesheet" href="css/example.css">
+    <!-- Code Mirror CSS -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css"
+        integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link cype="text/css" rel="stylesheet" href="css/example.css" />
 </head>
 
 <body data-spy="scroll" data-target="nav" onload="onLoad()">
+    <!-- Code Mirror Main -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.js"
+        integrity="sha512-tXHFLFVaasTvIEFYN8K6UlGvb6Sh1ealAA8YxjpezWMio6u0vU9KfGFzKVth49xh2affuBfmLGY8t2G5pZH+zg=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Code Mirror JavaScript support -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/javascript/javascript.min.js"
+        integrity="sha512-Cbz+kvn+l5pi5HfXsEB/FYgZVKjGIhOgYNBwj4W2IHP2y8r3AdyDCQRnEUqIQ+6aJjygKPTyaNT2eIihaykJlw=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Code Mirror XML support -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/xml/xml.min.js"
+        integrity="sha512-LarNmzVokUmcA7aUDtqZ6oTS+YXmUKzpGdm8DxC46A6AHu+PQiYCUlwEGWidjVYMo/QXZMFMIadZtrkfApYp/g=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Code Mirror CSS support -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/css/css.min.js"
+        integrity="sha512-rQImvJlBa8MV1Tl1SXR5zD2bWfmgCEIzTieFegGg89AAt7j/NBEe50M5CqYQJnRwtkjKMmuYgHBqtD1Ubbk5ww=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Code Mirror HTML Mixed support-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/mode/htmlmixed/htmlmixed.min.js"
+        integrity="sha512-HN6cn6mIWeFJFwRN9yetDAMSh+AK9myHF1X9GlSlKmThaat65342Yw8wL7ITuaJnPioG0SYG09gy0qd5+s777w=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     <div id="main">
         <iframe id="content" frameborder="0" height="100%"></iframe>
-        <button id="view-source" class="text" title="View source"></button>
     </div>
 
-    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.4.0/codemirror.js"></script> -->
-    <div class="editor-panel">
-        <nav id="editor-header">
-            <a href="/">
-                <img src="images/itowns_logo.png" width="245px" id="itowns-logo">
-            </a>
-            <div class="switch">
-                <label for="version-switch">Latest</label>
-                <input id="version-switch" type="checkbox" name="version-switch">
-                <span class="slider"></span>
+    <div id="editor-panel">
+        <div id="editor-header">
+            <div>
+                <a href="/">
+                    <picture>
+                        <source media="(width <= 1700px)" srcset="./images/itowns_logo.svg" width="245" />
+                        <source media="(width > 1700px)" srcset="images/itowns_logo.png" width="245" />
+                        <!-- Fallback Image -->
+                        <img src="images/itowns_logo.png" width="245px" id="itowns-logo" />
+                    </picture>
+                </a>
+                <div class="switch">
+                    <label for="version-switch">Latest</label>
+                    <input id="version-switch" type="checkbox" name="version-switch" />
+                    <span class="slider"></span>
+                </div>
             </div>
-            <!-- <div id="itowns-info"> -->
-            <!-- </div> -->
-            <!-- <div id="settings"> -->
-            <!-- </div> -->
-        </nav>
+            <hr />
+            <div>
+                <select id="example-selector"></select>
+                <div>
+                    <button type="button" id="run-button" class="header-button" />
+                    <button type="button" id="share-button" class="header-button" />
+                </div>
+            </div>
+        </div>
+        <hr />
+        <div style="display: flex; padding: 1em; height: 100%">
+            <textarea id="code-editor"></textarea>
+        </div>
     </div>
 
     <script type="text/javascript">
+        const iframe = document.getElementById("content");
+        const exampleSelector = document.getElementById("example-selector");
+        const codeEditorTextArea = document.getElementById("code-editor");
+        const codeEditor = CodeMirror.fromTextArea(codeEditorTextArea, {
+            lineNumbers: true,
+            mode: "htmlmixed",
+        });
+
+        const exampleCache = {};
+
         var baseURI = document.baseURI;
-
-        if (baseURI.includes('/itowns/dev/')) {
-            document.getElementById('itowns-logo').setAttribute('src', 'images/itowns_logo_next.png');
+        if (baseURI.includes("/itowns/dev/")) {
+            document
+                .getElementById("itowns-logo")
+                .setAttribute("src", "images/itowns_logo_next.png");
+            document
+                .getElementById("version-switch")
+                .setAttribute("checked", "");
         }
 
-        function bindIframe() {
-            var navLinks = document.getElementsByClassName('nav-link');
-            for (var i = 0; i < navLinks.length; i++) {
-                navLinks[i].addEventListener('click', function (e) {
-                    e.preventDefault();
-                    var target = e.target.localName === 'b' ? e.target.parentNode : e.target;
-                    var url = target.href.replace('#', '') + '.html';
-                    var slug = target.hash;
-                    goTo(url, slug);
+        function runCode() {
+            iframe.srcdoc = codeEditor.getValue();
+        }
+        document.getElementById("run-button").onclick = runCode;
+        codeEditor.setOption("extraKeys", {
+            "Ctrl-Enter": runCode,
+        });
+
+        function shareCode() {
+            const code = btoa(codeEditor.getValue());
+            const url = new URL(document.location.toString());
+            url.hash = "";
+            url.search = "?code=" + encodeURIComponent(code);
+            navigator.clipboard.writeText(url);
+        }
+        document.getElementById("share-button").onclick = shareCode;
+
+        /** @param {string} slug - An example's slug */
+        function cacheExample(slug) {
+            console.info(
+                `Caching example '${slug.replace("'", "&quot;")}'`,
+            );
+            const src = `https://raw.githubusercontent.com/itowns/itowns/refs/heads/master/examples/${slug}.html`;
+            return fetch(src)
+                .then((response) => response.text())
+                .then((text) => {
+                    exampleCache[slug] = text;
+                    return text;
                 });
-            }
-
-            // load page if setted
-            if (document.location.hash) {
-                var url = document.location.href.replace('#', '') + '.html';
-                goTo(url);
-            } else {
-                goTo('view_3d_map.html');
-            }
         }
 
-        function goTo(url, slug) {
-            if (slug) window.location.hash = slug;
-            var iframe = document.getElementById('content');
-            iframe.src = url.replace('index.html', '');
-            iframe.focus();
-
-            let viewSrc = `https://github.com/iTowns/itowns/blob/master/examples/${window.location.hash.substr(1) || 'view_3d_map'
-                }.html`;
-            document.getElementById('view-source').onclick = () => {window.open(viewSrc);};
+        /** @param {string} slug - An example's slug */
+        async function loadExample(slug) {
+            console.info(
+                `Loading example '${slug.replace("'", "&quot;")}'`,
+            );
+            const example =
+                exampleCache[slug] ??
+                (await (() => {
+                    codeEditor.setValue("Loading...");
+                    return cacheExample(slug);
+                })());
+            codeEditor.setValue(example);
+            window.location.hash = slug;
+            window.location.search = "";
+            runCode();
         }
 
         /** @param {Record<string, Record<string, string>>} list - List of examples */
         function initNavigation(list) {
-            const nav = document.getElementById('editor-header');
-
-            const versionSwitch = document.getElementById('version-switch');
-            if (!baseURI.includes('/itowns/')) {
-                versionSwitch.setAttribute('disabled', '');
+            const nav = document.getElementById("editor-header");
+            const versionSwitch = document.getElementById("version-switch");
+            if (!baseURI.includes("/itowns/")) {
+                versionSwitch.setAttribute("disabled", "");
             } else {
                 versionSwitch.onchange = (event) => {
-                    console.log('toggled');
-                    if (baseURI.includes("/itowns/dev/")) {
-                        window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
-                    } else {
-                        window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
-                    }
-                }
-                if (baseURI.includes('/itowns/dev/')) {
-                    versionSwitch.setAttribute('checked', '');
+                    console.log("toggled");
+                    window.location.href = document.location.href.replace();
+                    const isDev = baseURI.includes("/itowns/dev/");
+                    const options = ["/itowns/", "/itowns/dev/"];
+                    window.location.href = document.location.href.replace(
+                        options[isDev],
+                        options[!isDev],
+                    );
+                };
+                if (baseURI.includes("/itowns/dev/")) {
+                    versionSwitch.setAttribute("checked", "");
                 }
             }
-            // Add version switch :
-            // const versionSwitchText = document.createElement('p');
-            // versionSwitchText.innerHTML = `iTowns examples of the ${(baseURI.includes("/itowns/dev/") && "next version (current master branch)")
-            //     || "latest released version"}.`;
-            // const versionSwitchButton = document.createElement('button');
-            // versionSwitchButton.classList.add('switch-button');
-            // versionSwitchButton.innerHTML = `Switch to ${(baseURI.includes("/itowns/dev/") && "latest release") || "next version"
-            //     }`;
-            // versionSwitchButton.onclick = () => {
-            //     if (baseURI.includes("/itowns/dev/")) {
-            //         window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
-            //     } else {
-            //         window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
-            //     }
-            // };
-            //
-            // const versionSwitch = document.createElement('div');
-            // versionSwitch.id = "version-switch";
-            // versionSwitch.appendChild(versionSwitchText);
-            // versionSwitch.appendChild(versionSwitchButton);
-            // const versionSwitch = document.createElement('label');
-            // versionSwitch.className = 'switch';
-            //
-            // const versionSwitchCheckbox = document.createElement('input');
-            // versionSwitchCheckbox.setAttribute('type', 'checkbox');
-            // versionSwitch.appendChild(versionSwitchCheckbox);
-            //
-            // const versionSwitchSlider = document.createElement('span');
-            // versionSwitchSlider.className = 'slider';
-            // versionSwitch.appendChild(versionSwitchSlider);
-            //
-            // nav.appendChild(versionSwitch);
 
             // Dropdown example selector
-            const examples = Object.entries(list).flatMap(([sectionName, section]) => {
-                return [
-                    `<optgroup label="${sectionName}"`,
-                    ...Object.entries(section).map(([slug, name]) => `<option value=${slug}>${name}</option>`),
-                    '</optgroup>',
-                ];
-            });
+            const examples = [
+                "<option hidden value='custom'>Custom</option>",
+                ...Object.entries(list).flatMap(
+                    ([sectionName, section]) => {
+                        return [
+                            `<optgroup label="${sectionName}">`,
+                            ...Object.entries(section).map(
+                                ([slug, name]) =>
+                                    `<option value=${slug}>${name}</option>`,
+                            ),
+                            "</optgroup>",
+                        ];
+                    },
+                ),
+            ];
 
-            const exampleSelector = document.createElement('select');
-            exampleSelector.setAttribute('name', 'example');
-            exampleSelector.insertAdjacentHTML('afterbegin', examples.join('\n'));
-            exampleSelector.onchange = (event) => {
-                console.log('changed');
-                // TODO: Change this to a change of the edit area
-                const oldUrl = window.location.href;
-                const navIndex = oldUrl.lastIndexOf('#');
-                const newUrl = oldUrl.slice(0, navIndex) + `#${event.target.value}`;
-                window.open(newUrl, '_self');
-                if (navIndex >= 0) {
-                    window.location.reload()
-                }
-            }
+            const exampleSelector =
+                document.getElementById("example-selector");
+            exampleSelector.insertAdjacentHTML(
+                "afterbegin",
+                examples.join("\n"),
+            );
+            exampleSelector.onchange = (event) =>
+                loadExample(event.target.value);
 
-            // Set displayed default to current example
-            // TODO: Change this once the editor is in
-            const url = window.location.href;
-            const currentExample = url.slice(url.lastIndexOf('#') + 1);
-            if (currentExample) {
-                const children = Array.from(exampleSelector.children).flatMap(optgroup => Array.from(optgroup.children));
-                const selected = children.find(child => child.value == currentExample);
-                if (selected) {
-                    selected.setAttribute('selected', '');
-                }
-            }
-
-            nav.appendChild(exampleSelector)
-
-            // Add horizontal divider :
-            const titleDivider = document.createElement('hr');
-            titleDivider.classList.add('title-divider');
-            nav.appendChild(titleDivider);
-
-            // const textArea = document.createElement('textarea');
-            // // nav.appendChild(textArea);
-            // const navParent = document.getElementsByTagName('nav');
-            // navParent.appendChild(textArea);
-            // const editor = CodeMirror.fromTextArea(textArea, {lineNumbers: true});
+            const hash = window.location.hash;
+            const currentExample = hash.slice(1) || "custom";
+            exampleSelector.value = currentExample;
         }
 
         function onLoad() {
             // Get the configuration
-            fetch('./config.json').then(function _(response) {
-                return response.json();
-            }).then(function _(config) {
-                initNavigation(config);
-                bindIframe();
-            });
+            fetch("./config.json")
+                .then(function _(response) {
+                    return response.json();
+                })
+                .then(function _(config) {
+                    initNavigation(config);
+
+                    const searchParams = new URL(
+                        document.location.toString(),
+                    ).searchParams;
+                    const code = searchParams.get("code");
+
+                    if (!code) {
+                        loadExample(
+                            window.location.hash.replace("#", "") ||
+                            "view_3d_map",
+                        );
+                    } else {
+                        codeEditor.setValue(atob(decodeURIComponent(code)));
+                        // TODO: Security check
+                        runCode();
+                    }
+                });
         }
     </script>
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -64,7 +64,12 @@
                 <select id="example-selector" class="selector"></select>
                 <input id="font-size-selector" class="selector" type="number" min="8" step="1" />
                 <div>
-                    <button type="button" id="run-button" class="header-button" />
+                    <div class="tooltip">
+                        <button type="button" id="run-button" class="header-button"></button>
+                        <div class="tooltip-text">
+                            Run the code
+                        </div>
+                    </div>
                     <button type="button" id="share-button" class="header-button" />
                 </div>
             </div>
@@ -195,6 +200,19 @@
             }
             editorHidden = !editorHidden;
         };
+        const searchParams = new URL(
+            document.location.toString(),
+        ).searchParams;
+        const hide_editor = searchParams.get("hide_editor");
+        if (!!hide_editor) {
+            editorCollapse.style["transition-duration"] = "";
+            editorPanel.style["transition-duration"] = "";
+            iframe.style["transition-duration"] = "";
+            editorCollapse.click();
+            editorCollapse.style["transition-duration"] = "200ms";
+            editorPanel.style["transition-duration"] = "200ms";
+            iframe.style["transition-duration"] = "200ms";
+        }
 
         /** @param {string} slug - An example's slug */
         function cacheExample(slug) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -110,7 +110,27 @@
                 .setAttribute("checked", "");
         }
 
+        /**
+         * UTF-8 fix to btoa.
+         * @param {string} string - A valid UTF-8 string.
+         * @returns {string} The encoded string.
+         */
+        function toBase64(string) {
+            return btoa(Array.from(new TextEncoder().encode(string), byte => String.fromCodePoint(byte)).join(""));
+        }
+
+        /* UTF-8 fix to atob.
+         * @param {string} bytes - A base64-encoded string.
+         * @returns {string} The decoded string.
+         */
+        function fromBase64(bytes) {
+            return new TextDecoder().decode(Uint8Array.from(atob(bytes), m => m.codePointAt(0)));
+        }
+
         function runCode() {
+            const code = codeEditor.getValue();
+            localStorage.setItem("code", toBase64(code));
+
             iframe.srcdoc = codeEditor.getValue();
         }
         document.getElementById("run-button").onclick = runCode;
@@ -119,10 +139,13 @@
         });
 
         function shareCode() {
-            const code = btoa(codeEditor.getValue());
+            const code = codeEditor.getValue();
+            const base64 = toBase64(code);
+            localStorage.setItem("code", base64);
+
             const url = new URL(document.location.toString());
             url.hash = "";
-            url.search = "?code=" + encodeURIComponent(code);
+            url.search = "?code=" + encodeURIComponent(base64);
             navigator.clipboard.writeText(url);
         }
         document.getElementById("share-button").onclick = shareCode;
@@ -150,9 +173,6 @@
 
         /** @param {string} slug - An example's slug */
         function cacheExample(slug) {
-            console.info(
-                `Caching example '${slug.replace("'", "&quot;")}'`,
-            );
             const src = `https://raw.githubusercontent.com/itowns/itowns/refs/heads/master/examples/${slug}.html`;
             return fetch(src)
                 .then((response) => response.text())
@@ -164,15 +184,10 @@
 
         /** @param {string} slug - An example's slug */
         async function loadExample(slug) {
-            console.info(
-                `Loading example '${slug.replace("'", "&quot;")}'`,
-            );
-            const example =
-                exampleCache[slug] ??
-                (await (() => {
-                    codeEditor.setValue("Loading...");
-                    return cacheExample(slug);
-                })());
+            const example = exampleCache[slug] ?? (await (() => {
+                codeEditor.setValue("Loading...");
+                return cacheExample(slug);
+            })());
             codeEditor.setValue(example);
             window.location.hash = slug;
             window.location.search = "";
@@ -187,7 +202,6 @@
                 versionSwitch.setAttribute("disabled", "");
             } else {
                 versionSwitch.onchange = (event) => {
-                    console.log("toggled");
                     window.location.href = document.location.href.replace();
                     const isDev = baseURI.includes("/itowns/dev/");
                     const options = ["/itowns/", "/itowns/dev/"];
@@ -244,17 +258,24 @@
                     const searchParams = new URL(
                         document.location.toString(),
                     ).searchParams;
-                    const code = searchParams.get("code");
+                    const urlCode = searchParams.get("code");
 
-                    if (!code) {
-                        loadExample(
-                            window.location.hash.replace("#", "") ||
-                            "view_3d_map",
-                        );
+                    const localCode = localStorage.getItem("code");
+
+                    if (!urlCode) {
+                        if (!localCode) {
+                            loadExample(
+                                window.location.hash.replace("#", "") ||
+                                "view_3d_map",
+                            );
+                        }
+                        else {
+                            codeEditor.setValue(fromBase64(localCode));
+                            runCode();
+                        }
                     } else {
-                        codeEditor.setValue(atob(decodeURIComponent(code)));
-                        // TODO: Security check
-                        runCode();
+                        codeEditor.setValue(fromBase64(decodeURIComponent(urlCode)));
+                        alert('Please check foreign code before running it!');
                     }
                 });
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,6 +9,10 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.19/codemirror.min.css"
         integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- Code Mirror Shadowfox dark theme -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/theme/shadowfox.min.css"
+        integrity="sha512-Xt1Gi99yJFMZ0ocjkdHqKWLjtb/l8pzJo5cCmHV2GvBFwJiOCLR2HXQBrcFmqY6i8+gXnRaKTGzoBVOl3YUwjw=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link cype="text/css" rel="stylesheet" href="css/example.css" />
 </head>
 
@@ -42,18 +46,18 @@
         <div id="editor-header">
             <div>
                 <a href="/">
-                    <picture>
+                    <picture id="itowns-logo">
                         <source media="(width <= 1700px)" srcset="./images/itowns_logo.svg" width="245" />
                         <source media="(width > 1700px)" srcset="images/itowns_logo.png" width="245" />
                         <!-- Fallback Image -->
-                        <img src="images/itowns_logo.png" width="245px" id="itowns-logo" />
+                        <img src="images/itowns_logo.png" width="245px" />
                     </picture>
                 </a>
-                <div class="switch">
-                    <label for="version-switch">Latest</label>
+                <label class="switch">
                     <input id="version-switch" type="checkbox" name="version-switch" />
-                    <span class="slider"></span>
-                </div>
+                    <span class="checkmark"></span>
+                    Latest
+                </label>
             </div>
             <hr />
             <div>
@@ -75,9 +79,23 @@
         const iframe = document.getElementById("content");
         const exampleSelector = document.getElementById("example-selector");
         const codeEditorTextArea = document.getElementById("code-editor");
+
+        /**
+         * @param {boolean} isDark - Which theme name to get
+         * @returns {string}
+         */
+        function getTheme(isDark) {
+            return isDark ? "shadowfox" : "default";
+        }
+
         const codeEditor = CodeMirror.fromTextArea(codeEditorTextArea, {
             lineNumbers: true,
             mode: "htmlmixed",
+            theme: getTheme(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches),
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            codeEditor.setOption("theme", getTheme(event.matches));
         });
 
         const exampleCache = {};

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <title>Itowns Examples</title>
@@ -9,117 +10,134 @@
 
 <body data-spy="scroll" data-target="nav" onload="onLoad()">
 
-<div id="main">
-    <iframe id="content" class="scroll-section" frameborder="0" height="100%"></iframe>
-    <button id="view-source" class="text" title="View source"></button>
-</div>
+    <div id="main">
+        <iframe id="content" class="scroll-section" frameborder="0" height="100%"></iframe>
+        <button id="view-source" class="text" title="View source"></button>
+    </div>
 
-<nav class="scroll-section">
-    <a href="/">
-        <img src="images/itowns_logo.png" width="245px" id="itowns-logo">
-    </a>
-</nav>
+    <nav class="scroll-section">
+        <a href="/">
+            <img src="images/itowns_logo.png" width="245px" id="itowns-logo">
+        </a>
+    </nav>
 
-<script type="text/javascript">
-    var baseURI = document.baseURI;
+    <script type="text/javascript">
+        var baseURI = document.baseURI;
 
-    if (baseURI.includes('/itowns/dev/')) {
-        document.getElementById('itowns-logo').setAttribute('src', 'images/itowns_logo_next.png');
-    }
+        if (baseURI.includes('/itowns/dev/')) {
+            document.getElementById('itowns-logo').setAttribute('src', 'images/itowns_logo_next.png');
+        }
 
-    function bindIframe() {
-        var navLinks = document.getElementsByClassName('nav-link');
-        for (var i = 0; i < navLinks.length; i++) {
-            navLinks[i].addEventListener('click', function(e) {
-                e.preventDefault();
-                var target = e.target.localName === 'b' ? e.target.parentNode : e.target;
-                var url = target.href.replace('#', '') + '.html';
-                var slug = target.hash;
-                goTo(url, slug);
+        function bindIframe() {
+            var navLinks = document.getElementsByClassName('nav-link');
+            for (var i = 0; i < navLinks.length; i++) {
+                navLinks[i].addEventListener('click', function (e) {
+                    e.preventDefault();
+                    var target = e.target.localName === 'b' ? e.target.parentNode : e.target;
+                    var url = target.href.replace('#', '') + '.html';
+                    var slug = target.hash;
+                    goTo(url, slug);
+                });
+            }
+
+            // load page if setted
+            if (document.location.hash) {
+                var url = document.location.href.replace('#', '') + '.html';
+                goTo(url);
+            } else {
+                goTo('view_3d_map.html');
+            }
+        }
+
+        function goTo(url, slug) {
+            if (slug) window.location.hash = slug;
+            var iframe = document.getElementById('content');
+            iframe.src = url.replace('index.html', '');
+            iframe.focus();
+
+            let viewSrc = `https://github.com/iTowns/itowns/blob/master/examples/${window.location.hash.substr(1) || 'view_3d_map'
+                }.html`;
+            document.getElementById('view-source').onclick = () => {window.open(viewSrc);};
+        }
+
+        /** @param {Record<string, Record<string, string>>} list - List of examples */
+        function initNavigation(list) {
+            // Add version switch :
+            const versionSwitchText = document.createElement('p');
+            versionSwitchText.innerHTML = `iTowns examples of the ${(baseURI.includes("/itowns/dev/") && "next version (current master branch)")
+                || "latest released version"}.`;
+
+            const versionSwitchButton = document.createElement('button');
+            versionSwitchButton.classList.add('switch-button');
+            versionSwitchButton.innerHTML = `Switch to ${(baseURI.includes("/itowns/dev/") && "latest release") || "next version"
+                }`;
+            versionSwitchButton.onclick = () => {
+                if (baseURI.includes("/itowns/dev/")) {
+                    window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
+                } else {
+                    window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
+                }
+            };
+
+            const nav = document.getElementsByTagName('nav')[0];
+            const versionSwitch = document.createElement('div');
+            versionSwitch.id = "version-switch";
+            versionSwitch.appendChild(versionSwitchText);
+            versionSwitch.appendChild(versionSwitchButton);
+            nav.appendChild(versionSwitch);
+
+            // Add horizontal divider :
+            const titleDivider = document.createElement('hr');
+            titleDivider.classList.add('title-divider');
+            nav.appendChild(titleDivider);
+
+            // Dropdown example selector
+            const examples = Object.entries(list).flatMap(([sectionName, section]) => {
+                return [
+                    `<optgroup label="${sectionName}"`,
+                    ...Object.entries(section).map(([slug, name]) => `<option value=${slug}>${name}</option>`),
+                    '</optgroup>',
+                ];
+            });
+
+            const exampleSelector = document.createElement('select');
+            exampleSelector.setAttribute('name', 'example');
+            exampleSelector.insertAdjacentHTML('afterbegin', examples.join('\n'));
+            exampleSelector.onchange = (event) => {
+                console.log('changed');
+                // TODO: Change this to a change of the edit area
+                const oldUrl = window.location.href;
+                const newUrl = oldUrl.slice(0, oldUrl.lastIndexOf('#')) + `#${event.target.value}`;
+                console.log(`${oldUrl} -> ${newUrl}`);
+                window.open(newUrl, '_self');
+                window.location.reload()
+            }
+
+            // Set displayed default to current example
+            // TODO: Change this once the editor is in
+            const url = window.location.href;
+            const currentExample = url.slice(url.lastIndexOf('#') + 1);
+            if (currentExample) {
+                const children = Array.from(exampleSelector.children).flatMap(optgroup => Array.from(optgroup.children));
+                const selected = children.find(child => child.value == currentExample);
+                if (selected) {
+                    selected.setAttribute('selected', '');
+                }
+            }
+
+            nav.appendChild(exampleSelector)
+        }
+
+        function onLoad() {
+            // Get the configuration
+            fetch('./config.json').then(function _(response) {
+                return response.json();
+            }).then(function _(config) {
+                initNavigation(config);
+                bindIframe();
             });
         }
-
-        // load page if setted
-        if (document.location.hash) {
-            var url = document.location.href.replace('#', '') + '.html';
-            goTo(url);
-        } else {
-            goTo('view_3d_map.html');
-        }
-    }
-
-    function goTo(url, slug) {
-        if (slug) window.location.hash = slug;
-        var iframe = document.getElementById('content');
-        iframe.src = url.replace('index.html', '');
-        iframe.focus();
-
-        let viewSrc = `https://github.com/iTowns/itowns/blob/master/examples/${
-            window.location.hash.substr(1) || 'view_3d_map'
-        }.html`;
-        document.getElementById('view-source').onclick = () => { window.open(viewSrc); };
-    }
-
-    function initNavigation(list) {
-        // Add version switch :
-        const versionSwitchText = document.createElement('p');
-        versionSwitchText.innerHTML = `iTowns examples of the ${
-            (baseURI.includes("/itowns/dev/") && "next version (current master branch)")
-                || "latest released version"
-        }.`;
-
-        const versionSwitchButton = document.createElement('button');
-        versionSwitchButton.classList.add('switch-button');
-        versionSwitchButton.innerHTML = `Switch to ${
-            (baseURI.includes("/itowns/dev/") && "latest release") || "next version"
-        }`;
-        versionSwitchButton.onclick = () => {
-            if (baseURI.includes("/itowns/dev/")) {
-                window.location.href = document.location.href.replace('/itowns/dev/', '/itowns/');
-            } else {
-                window.location.href = document.location.href.replace('/itowns/', '/itowns/dev/');
-            }
-        };
-
-        const versionSwitch = document.createElement('div');
-        versionSwitch.id = "version-switch";
-        versionSwitch.appendChild(versionSwitchText);
-        versionSwitch.appendChild(versionSwitchButton);
-        document.getElementsByTagName('nav')[0].appendChild(versionSwitch);
-
-        // Add horizontal divider :
-        const titleDivider = document.createElement('hr');
-        titleDivider.classList.add('title-divider');
-        document.getElementsByTagName('nav')[0].appendChild(titleDivider);
-
-        var nav = '<h2>Examples</h2>';
-
-        for (var section in list) {
-            nav += '<div class="package">';
-            nav += `<h3 class="nav-section">${section}</h3>`;
-            nav += '<ul>';
-
-            for (var example in list[section]) {
-                nav += '<li class="nav-item">';
-                nav += `<a class="nav-link" href="#${example}">`;
-                nav += `${list[section][example]}</a></li>`;
-            }
-
-            nav += '</ul></div>';
-        }
-
-        document.getElementsByTagName('nav')[0].insertAdjacentHTML('beforeend', nav);
-    }
-
-    function onLoad() {
-        // Get the configuration
-        fetch('./config.json').then(function _(response) {
-            return response.json();
-        }).then(function _(config) {
-            initNavigation(config);
-            bindIframe();
-        });
-    }
-</script>
+    </script>
 </body>
+
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -74,9 +74,15 @@
             <textarea id="code-editor"></textarea>
         </div>
     </div>
+    <button id="editor-collapse">
+        <svg height="10" width="10">
+            <polygon points="0,5 10,0 10,10" style="fill:white" />
+        </svg>
+    </button>
 
     <script type="text/javascript">
         const iframe = document.getElementById("content");
+        const editorPanel = document.getElementById("editor-panel");
         const exampleSelector = document.getElementById("example-selector");
         const codeEditorTextArea = document.getElementById("code-editor");
 
@@ -170,6 +176,25 @@
         }
         fontSizeSelector.value = getEditorFontSize();
         fontSizeSelector.onchange = (event) => setEditorFontSize(event.target.value || 13);
+
+        let editorHidden = false;
+        const editorCollapse = document.getElementById("editor-collapse");
+        editorCollapse.onclick = () => {
+            if (!editorHidden) {
+                editorCollapse.style.left = "0";
+                editorCollapse.style.transform = "scaleX(-1)";
+                editorPanel.style.left = "calc(-100% * 7 / 16)";
+                iframe.style.left = "0";
+                iframe.style.width = "100%";
+            } else {
+                editorCollapse.style.left = "calc(100% * 7 / 16 - 1%)";
+                editorCollapse.style.transform = "scaleX(1)";
+                editorPanel.style.left = "0";
+                iframe.style.left = "";
+                iframe.style.width = "calc(100% * 9 / 16)";
+            }
+            editorHidden = !editorHidden;
+        };
 
         /** @param {string} slug - An example's slug */
         function cacheExample(slug) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -57,7 +57,8 @@
             </div>
             <hr />
             <div>
-                <select id="example-selector"></select>
+                <select id="example-selector" class="selector"></select>
+                <input type="number" id="font-size-selector" class="selector" />
                 <div>
                     <button type="button" id="run-button" class="header-button" />
                     <button type="button" id="share-button" class="header-button" />
@@ -107,6 +108,22 @@
             navigator.clipboard.writeText(url);
         }
         document.getElementById("share-button").onclick = shareCode;
+
+        /** @returns {number} - The CodeMirror editor's font size */
+        function getEditorFontSize() {
+            const editor = document.getElementsByClassName("CodeMirror")[0];
+            return parseFloat(window.getComputedStyle(editor, null).getPropertyValue("font-size"));
+        }
+
+        /** @param {number} size_px - The new font size to apply */
+        function setEditorFontSize(size_px) {
+            console.info("Setting editor font size");
+            const editor = document.getElementsByClassName("CodeMirror")[0];
+            editor.style.fontSize = `${size_px}px`;
+        }
+        const fontSizeSelector = document.getElementById("font-size-selector");
+        fontSizeSelector.value = getEditorFontSize();
+        fontSizeSelector.onchange = (event) => setEditorFontSize(event.target.value);
 
         /** @param {string} slug - An example's slug */
         function cacheExample(slug) {


### PR DESCRIPTION
Requires #2590 

## Description
<!--- Describe your changes in detail -->
Redesign of the examples page:
- CodeMirror 5 editor to edit the examples and run the editor content in the `<iframe>` instead of a direct link to the example blob on GitHub.
- Cleanup of the index HTML and CSS, moving to a flex-based layout.
- More responsive UI to accommodate smaller screens (including mobile by simply hiding the editor and example picker for now).
- Share button to improve not only the user experience of sharing examples with others but also make reporting reproducible bugs significantly easier.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
The examples page is one of the first things people will see when researching which library to use. By providing immediately editable examples, we provide a way for prospective users to toy around and see if iTowns matches their needs for a very low time investment on their end. 

## Things to be done after merge
- [ ] Add button redirecting to a gallery with a thumbnail of every example. Will be added in https://github.com/iTowns/itowns.github.io/pull/34
- [ ] Add tip in issue/PR template about using the examples page to reproduce a bug.

## Screenshots
1080p full width
<img width="1919" height="965" alt="Screenshot from 2025-08-20 10-52-16" src="https://github.com/user-attachments/assets/35563c56-1a9a-4fdf-8dc6-f835f59399fe" />
Lower resolution / reduced width
<img width="1474" height="874" alt="Screenshot from 2025-08-20 10-52-53" src="https://github.com/user-attachments/assets/9bff7c70-961c-46b3-98e9-7d02d5065ea0" />
Mobile ratio (editor shows up in landscape mode)
<img width="385" height="852" alt="image" src="https://github.com/user-attachments/assets/dad6e49d-4505-4abf-a932-f58fda8f44ba" />

