### PR TITLE
Better handle near and far camera values depending on camera position

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v4
-      - name: Use Node.js 22.x
+      - name: Use Node.js 22.17
         uses: actions/setup-node@v4
         with:
           node-version: 22.17
@@ -91,7 +91,7 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v4
-      - name: Use Node.js 22.x
+      - name: Use Node.js 22.17
         uses: actions/setup-node@v4
         with:
           node-version: 22.17
@@ -137,7 +137,7 @@ jobs:
 
       # Use specific Node.js version
       - uses: actions/checkout@v4
-      - name: Use Node.js 22.x
+      - name: Use Node.js 22.17
         uses: actions/setup-node@v4
         with:
           node-version: 22.17
@@ -288,7 +288,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js 22.17
         uses: actions/setup-node@v4
         with:
           node-version: 22.17

--- a/packages/Main/src/Controls/PlanarControls.js
+++ b/packages/Main/src/Controls/PlanarControls.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
+import { VIEW_EVENTS } from 'Core/View';
 
 // event keycode
 export const keys = {
@@ -336,30 +337,31 @@ class PlanarControls extends THREE.EventDispatcher {
             dt = 16;
         }
         const onMovement = this.state !== STATE.NONE;
+        let camChanged = true;
         switch (this.state) {
             case STATE.TRAVEL:
                 this.handleTravel(dt);
-                this.view.notifyChange(this.camera);
                 break;
             case STATE.ORTHO_ZOOM:
                 this.handleZoomOrtho(dt);
-                this.view.notifyChange(this.camera);
                 break;
             case STATE.DRAG:
                 this.handleDragMovement();
-                this.view.notifyChange(this.camera);
                 break;
             case STATE.ROTATE:
                 this.handleRotation();
-                this.view.notifyChange(this.camera);
                 break;
             case STATE.PAN:
                 this.handlePanMovement();
-                this.view.notifyChange(this.camera);
                 break;
             case STATE.NONE:
             default:
+                camChanged = false;
                 break;
+        }
+        if (camChanged) {
+            this.view.dispatchEvent({ type: VIEW_EVENTS.CAMERA_MOVED });
+            this.view.notifyChange(this.camera);
         }
         // We test if camera collides to the geometry layer or is too close to the ground, and adjust its altitude in
         // case

--- a/packages/Main/src/Core/Prefab/PlanarView.js
+++ b/packages/Main/src/Core/Prefab/PlanarView.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-import View from 'Core/View';
+import View, { VIEW_EVENTS } from 'Core/View';
 import CameraUtils from 'Utils/CameraUtils';
 
 import PlanarControls from 'Controls/PlanarControls';
@@ -25,6 +25,10 @@ class PlanarView extends View {
      * @param {CameraUtils~CameraTransformOptions|Extent} [options.placement] - The
      * {@link CameraUtils~CameraTransformOptions} to apply to view's camera or the extent it must display at
      * initialization. By default, camera will display the view's extent (given in `extent` parameter).
+     * @param {number} [options.farFactor=20] - Controls how far the camera can see.
+     * The maximum view distance is this factor times the camera’s altitude (above sea level).
+     * @param {number} [options.fogSpread=0.5] - Proportion of the visible depth range that contains fog.
+     *  Between 0 and 1.
      */
     constructor(viewerDiv, extent, options = {}) {
         THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
@@ -36,14 +40,57 @@ class PlanarView extends View {
         // Configure camera
         const dim = extent.planarDimensions();
         const max = Math.max(dim.x, dim.y);
-        this.camera3D.near = 0.1;
-        this.camera3D.far = this.camera3D.isOrthographicCamera ? 2000 : 2 * max;
-        this.camera3D.updateProjectionMatrix();
 
         const tileLayer = new PlanarLayer('planar', extent, options.object3d, options);
         this.mainLoop.gfxEngine.label2dRenderer.infoTileLayer = tileLayer.info;
 
         this.addLayer(tileLayer);
+
+        this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, () => {
+            // update camera's near and far
+
+            // compute layer's bounding box
+            if (!this.tileLayer) { return; }
+            const obj = this.tileLayer.object3d;
+            const box = new THREE.Box3();
+            obj.traverse((child) => {
+                if (child.isMesh && child.geometry) {
+                    child.geometry.computeBoundingBox();
+                    const childBox = new THREE.Box3().copy(child.geometry.boundingBox)
+                        .applyMatrix4(child.matrixWorld);
+                    box.union(childBox);
+                }
+            });
+            if (box.isEmpty()) { return; }
+
+            // calculate the greatest distance to the corners of the box
+            let maxDistSq = 0;
+            const camPos = this.camera3D.position;
+            for (const x of [box.min.x, box.max.x]) {
+                for (const y of [box.min.y, box.max.y]) {
+                    for (const z of [box.min.z, box.max.z]) {
+                        const distSq = camPos.distanceToSquared({ x, y, z });
+                        if (distSq > maxDistSq) {
+                            maxDistSq = distSq;
+                        }
+                    }
+                }
+            }
+            const maxDist = Math.sqrt(maxDistSq);
+
+            const camToGroundDistMin = this.camera3D.position.z - View.ALTITUDE_MAX;
+            this.camera3D.near = Math.max(1, camToGroundDistMin * this.fovDepthFactor);
+
+            const boxBottomToCam = camPos.z - box.min.z;
+            const far = this.farFactor * boxBottomToCam;
+            this.camera3D.far = Math.min(far, maxDist);
+            this.camera3D.updateProjectionMatrix();
+
+            const fog = this.scene.fog;
+            if (!fog) { return; }
+            fog.far = far;
+            fog.near = fog.far - this.fogSpread * (fog.far - this.camera3D.near);
+        });
 
         // Configure camera
         const placement = options.placement || {};
@@ -60,10 +107,17 @@ class PlanarView extends View {
         }
 
         this.tileLayer = tileLayer;
+
+        this.farFactor = options.farFactor ?? 20;
+        this.fogSpread = options.fogSpread ?? 0.5;
     }
 
     addLayer(layer) {
-        return super.addLayer(layer, this.tileLayer);
+        const p = super.addLayer(layer, this.tileLayer);
+        p.then(() => {
+            this.dispatchEvent({ type: VIEW_EVENTS.CAMERA_MOVED });
+        });
+        return p;
     }
 }
 

--- a/packages/Main/src/Renderer/WebXR.js
+++ b/packages/Main/src/Renderer/WebXR.js
@@ -74,8 +74,8 @@ class WebXR extends THREE.EventDispatcher {
      * @param {GlobeView} view - The view where the webXR session will be started
      * @param {Object} [options] - WebXR configuration - its presence alone
      * enable WebXR to switch on VR visualization.
-     * @param {function} [options.callback] - WebXR rendering callback (optional).
-     * @param {boolean} [options.controllers] - Enable the webXR controllers handling (optional).
+     * @param {function} [options.callback] - WebXR rendering callback.
+     * @param {boolean} [options.controllers] - Enable the webXR controllers handling.
      */
     constructor(view, options) {
         super();

--- a/packages/Main/src/Source/EntwinePointTileSource.js
+++ b/packages/Main/src/Source/EntwinePointTileSource.js
@@ -60,7 +60,7 @@ class EntwinePointTileSource extends Source {
             }
 
             this.boundsConforming = metadata.boundsConforming;
-            this.bounds = metadata.bounds;
+            this.bounds = metadata.bounds; // xMin, yMin, zMin, xMax, yMax, zMax
             this.span = metadata.span;
 
             return this;

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -118,8 +118,7 @@ describe('Entwine Point Tile', function () {
 
         it('tries to update on the root and succeeds', function (done) {
             view.controls.lookAtCoordinate({
-                coord: source.center,
-                range: 250,
+                range: -250,
             }, false)
                 .then(() => {
                     layer.update(context, layer, layer.root);

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -37,7 +37,7 @@ describe('Potree', function () {
     }).timeout(5000);
 
     describe('unit tests', function () {
-        const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 250 };
+        const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: -250 };
         let renderer;
         let viewer;
         let potreeLayer;

--- a/packages/Main/tsconfig.json
+++ b/packages/Main/tsconfig.json
@@ -6,6 +6,7 @@
         "declaration": true,
         "emitDeclarationOnly": true,
         "outDir": "lib",
+        "rootDir": ".",
         "baseUrl": "src"
     }
 }

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -168,7 +168,7 @@ describe('GlobeControls with globe example', function _() {
             };
             view.controls.addEventListener('animation-ended', endAni);
         }));
-
+        await new Promise((resolve) => { setTimeout(resolve, 500); });
         await page.evaluate(() => { view.controls.enableDamping = false; });
         await page.mouse.click(middleWidth, middleHeight);
         await page.mouse.click(middleWidth, middleHeight);


### PR DESCRIPTION
## Description
Optimize the camera's near and far planes based on the camera position and the currently observable part of the view, and make them dynamic. Make some parameters configurable.

## Motivation and Context
The near and far plane were fixed in the GlobeView and the PlanarView. This loads too many unnecessary far-away tiles.
Fixes #2049.
Tested on Firefox, Ubuntu.