### PR TITLE
Change document.location uses to fix iframes

### DIFF
--- a/packages/Main/src/Core/Scheduler/Scheduler.js
+++ b/packages/Main/src/Core/Scheduler/Scheduler.js
@@ -155,7 +155,7 @@ Scheduler.prototype.execute = function execute(command) {
     // parse host
     const layer = command.layer;
     const host = layer.source && layer.source.url && layer.source.url !== 'none' ?
-        new URL(URLBuilder.subDomains(layer.source.url), document.location).host : undefined;
+        new URL(URLBuilder.subDomains(layer.source.url), import.meta.url).host : undefined;
 
     command.promise = new Promise((resolve, reject) => {
         command.resolve = resolve;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed the use of `document.location` to ~~`document.baseURI`~~ `import.meta.url`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
`document.location` can be unreliable in certain contexts, like within an iframe created with an `srcdoc` instead of `src`, where it is reported as `about:srcdoc`, while ~~`document.baseURI`~~ `import.meta.url` is generally consistent.