### PR TITLE
Allow deferred style property definition

### DIFF
--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -611,7 +611,7 @@ function featureToMesh(feature, options) {
             mesh = featureToLine(feature, options);
             break;
         case FEATURE_TYPES.POLYGON:
-            if (style.fill && Object.keys(style.fill).includes('extrusion_height')) {
+            if (style.fill?.extrusionHeightSet) {
                 mesh = featureToExtrudedPolygon(feature, options);
             } else {
                 mesh = featureToPolygon(feature, options);

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -611,7 +611,7 @@ function featureToMesh(feature, options) {
             mesh = featureToLine(feature, options);
             break;
         case FEATURE_TYPES.POLYGON:
-            if (style.fill?.extrusionHeightSet) {
+            if (style.isExtruded()) {
                 mesh = featureToExtrudedPolygon(feature, options);
             } else {
                 mesh = featureToPolygon(feature, options);

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -138,9 +138,6 @@ function defineStyleProperty(style, category, parameter, userValue, defaultValue
             },
             set: (v) => {
                 property = v;
-                if (parameter == 'extrusion_height') {
-                    style[category].extrusionHeightSet = v != undefined;
-                }
             },
         });
 }
@@ -466,7 +463,27 @@ class Style {
         defineStyleProperty(this, 'fill', 'opacity', params.fill.opacity, 1.0);
         defineStyleProperty(this, 'fill', 'pattern', params.fill.pattern);
         defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude, baseAltitudeDefault);
-        defineStyleProperty(this, 'fill', 'extrusion_height', params.fill.extrusion_height);
+
+        // define a special case for extrusion_height
+        // to be able to know if user set it or not without calling the getter
+        this._extrusionHeight = params.fill.extrusion_height;
+        Object.defineProperty(
+            this.fill,
+            'extrusion_height',
+            {
+                get: () => {
+                    if (this._extrusionHeight != undefined) {
+                        return readExpression(this._extrusionHeight, this.context);
+                    }
+                    const dataValue = this.context.featureStyle?.fill?.extrusion_height;
+                    if (dataValue != undefined) { return readExpression(dataValue, this.context); }
+                    return undefined;
+                },
+                set: (v) => {
+                    this._extrusionHeight = v;
+                },
+            },
+        );
 
         this.stroke = {};
         defineStyleProperty(this, 'stroke', 'color', params.stroke.color);
@@ -677,6 +694,14 @@ class Style {
         } else {
             return this.text.anchor;
         }
+    }
+
+    /**
+     * Checks if the style has an extrusion height defined.
+     * @returns {boolean} True if extrusion is enabled, false otherwise.
+     */
+    isExtruded() {
+        return this._extrusionHeight != undefined;
     }
 }
 

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -120,7 +120,7 @@ const textAnchorPosition = {
  * @param {All} [defaultValue] - The default value to return (if needed).
  */
 function defineStyleProperty(style, category, parameter, userValue, defaultValue) {
-    let property;
+    let property = userValue;
     Object.defineProperty(
         style[category],
         parameter,
@@ -128,8 +128,7 @@ function defineStyleProperty(style, category, parameter, userValue, defaultValue
             enumerable: true,
             get: () => {
                 // != to check for 'undefined' and 'null' value)
-                if (property != undefined) { return property; }
-                if (userValue != undefined) { return readExpression(userValue, style.context); }
+                if (property != undefined) { return readExpression(property, style.context); }
                 const dataValue = style.context.featureStyle?.[category]?.[parameter];
                 if (dataValue != undefined) { return readExpression(dataValue, style.context); }
                 if (defaultValue instanceof Function) {
@@ -139,6 +138,9 @@ function defineStyleProperty(style, category, parameter, userValue, defaultValue
             },
             set: (v) => {
                 property = v;
+                if (parameter == 'extrusion_height') {
+                    style[category].extrusionHeightSet = v != undefined;
+                }
             },
         });
 }
@@ -464,9 +466,7 @@ class Style {
         defineStyleProperty(this, 'fill', 'opacity', params.fill.opacity, 1.0);
         defineStyleProperty(this, 'fill', 'pattern', params.fill.pattern);
         defineStyleProperty(this, 'fill', 'base_altitude', params.fill.base_altitude, baseAltitudeDefault);
-        if (params.fill.extrusion_height) {
-            defineStyleProperty(this, 'fill', 'extrusion_height', params.fill.extrusion_height);
-        }
+        defineStyleProperty(this, 'fill', 'extrusion_height', params.fill.extrusion_height);
 
         this.stroke = {};
         defineStyleProperty(this, 'stroke', 'color', params.stroke.color);


### PR DESCRIPTION
## Description
Allow assigning a function to a style property after its declaration.

## Motivation and Context
After a style is constructed from initial properties, the properties can only be (re)defined as a constant value, not assigned to a function. This can be restrictive in some cases, and the doc doesn´t mention this restriction.
Tested on Firefox, Ubuntu.