### PR TITLE
Make polygons use style opacity

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           cache: 'npm'
 
       # Install packages
@@ -94,7 +94,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           cache: 'npm'
 
       # Install packages
@@ -140,7 +140,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           cache: 'npm'
 
       # Install packages
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
           registry-url: https://registry.npmjs.org/
 
       - run: npm ci
@@ -291,7 +291,7 @@ jobs:
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.17
 
       - name: Message commit
         run: echo "is RELEASE => ${{ github.event.head_commit.message }} !!"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ The following people have contributed to iTowns.
   * [Anthony Gullient](https://github.com/AnthonyGlt)
   * [Jonathan Garnier](https://github.com/jogarnier)
   * [Irénée Dubourg](https://github.com/airnez)
+  * [Victor Ripplinger](https://github.com/neptilo)
 
 * [Oslandia](http://www.oslandia.com)
   * [Vincent Picavet](https://github.com/vpicavet)

--- a/packages/Main/src/Core/Prefab/Globe/Atmosphere.js
+++ b/packages/Main/src/Core/Prefab/Globe/Atmosphere.js
@@ -71,7 +71,6 @@ class Atmosphere extends GeometryLayer {
         const sphereGeometry = new THREE.SphereGeometry(1, 64, 64);
         const basicAtmosphereOut = new THREE.Mesh(sphereGeometry, material);
         basicAtmosphereOut.scale.copy(ellipsoidSizes).multiplyScalar(1.14);
-        basicAtmosphereOut.renderOrder = 1;
 
         this.basicAtmosphere = new THREE.Object3D();
         this.realisticAtmosphere = new THREE.Object3D();
@@ -102,7 +101,6 @@ class Atmosphere extends GeometryLayer {
 
         const basicAtmosphereIn = new THREE.Mesh(sphereGeometry, materialAtmoIn);
         basicAtmosphereIn.scale.copy(ellipsoidSizes).multiplyScalar(1.002);
-        basicAtmosphereIn.renderOrder = 2;
 
         this.basicAtmosphere.add(basicAtmosphereIn);
         this.realisticLightingPosition = { x: -0.5, y: 0.0, z: 1.0 };
@@ -207,7 +205,6 @@ class Atmosphere extends GeometryLayer {
             depthWrite: false,
         });
         const ground = new THREE.Mesh(geometryAtmosphereIn, materialAtmosphereIn);
-        ground.renderOrder = 2;
 
         const geometryAtmosphereOut = new THREE.SphereGeometry(atmosphere.outerRadius, 196, 196);
         const materialAtmosphereOut = new THREE.ShaderMaterial({
@@ -218,10 +215,8 @@ class Atmosphere extends GeometryLayer {
             side: THREE.BackSide,
         });
         const sky = new THREE.Mesh(geometryAtmosphereOut, materialAtmosphereOut);
-        sky.renderOrder = 1;
 
         const skyDome = new Sky();
-        skyDome.renderOrder = 1;
         skyDome.frustumCulled = false;
 
         this.realisticAtmosphere.add(ground);

--- a/packages/Main/src/Core/Scheduler/Scheduler.js
+++ b/packages/Main/src/Core/Scheduler/Scheduler.js
@@ -155,7 +155,7 @@ Scheduler.prototype.execute = function execute(command) {
     // parse host
     const layer = command.layer;
     const host = layer.source && layer.source.url && layer.source.url !== 'none' ?
-        new URL(URLBuilder.subDomains(layer.source.url), document.location).host : undefined;
+        new URL(URLBuilder.subDomains(layer.source.url), import.meta.url).host : undefined;
 
     command.promise = new Promise((resolve, reject) => {
         command.resolve = resolve;

--- a/packages/Main/src/Core/System/Capabilities.js
+++ b/packages/Main/src/Core/System/Capabilities.js
@@ -15,15 +15,10 @@ function _WebGLShader(renderer, type, string) {
     return shader;
 }
 
-function isFirefox() {
-    return navigator && navigator.userAgent && navigator.userAgent.toLowerCase().includes('firefox');
-}
-
 export default {
     isLogDepthBufferSupported() {
         return logDepthBufferSupported;
     },
-    isFirefox,
     getMaxTextureUnitsCount() {
         return maxTexturesUnits;
     },
@@ -48,21 +43,9 @@ export default {
         gl.linkProgram(program);
 
         if (gl.getProgramParameter(program, gl.LINK_STATUS) === false) {
-            if (maxTexturesUnits > 16) {
-                const info = gl.getProgramInfoLog(program);
-                // eslint-disable-next-line no-console
-                console.warn(`${info}: using a maximum of 16 texture units instead of the reported value (${maxTexturesUnits})`);
-                if (isFirefox()) {
-                    // eslint-disable-next-line no-console
-                    console.warn(`It can come from a Mesa/Firefox bug;
-                        the shader compiles to an error when using more than 16 sampler uniforms,
-                        see https://bugzilla.mozilla.org/show_bug.cgi?id=777028`);
-                }
-                maxTexturesUnits = 16;
-            } else {
-                throw (new Error(`The GPU capabilities could not be determined accurately.
-                    Impossible to link a shader with the Maximum texture units ${maxTexturesUnits}`));
-            }
+            // the link operation failed
+            throw new Error(`The GPU capabilities could not be determined accurately.
+                Impossible to link a shader with the Maximum texture units ${maxTexturesUnits}`);
         }
 
         gl.deleteProgram(program);

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -7,7 +7,6 @@ import { COLOR_LAYERS_ORDER_CHANGED } from 'Renderer/ColorLayersOrdering';
 import c3DEngine from 'Renderer/c3DEngine';
 import RenderMode from 'Renderer/RenderMode';
 import FeaturesUtils from 'Utils/FeaturesUtils';
-import { getMaxColorSamplerUnitsCount } from 'Renderer/LayeredMaterial';
 import Scheduler from 'Core/Scheduler/Scheduler';
 import Picking from 'Core/Picking';
 import LabelLayer from 'Layer/LabelLayer';
@@ -177,6 +176,7 @@ class View extends THREE.EventDispatcher {
         // options.renderer can be 2 separate things:
         //   - an actual renderer (in this case we don't use viewerDiv)
         //   - options for the renderer to be created
+        // here renderer is passed to engine
         if (options.renderer && options.renderer.domElement) {
             engine = new c3DEngine(options.renderer);
         } else {
@@ -348,17 +348,8 @@ class View extends THREE.EventDispatcher {
             if (layer.isColorLayer) {
                 const layerColors = this.getLayers(l => l.isColorLayer);
                 layer.sequence = layerColors.length;
-
-                const sumColorLayers = parentLayer.countColorLayersTextures(...layerColors, layer);
-
-                if (sumColorLayers <= getMaxColorSamplerUnitsCount()) {
-                    parentLayer.attach(layer);
-                } else {
-                    return layer._reject(new Error(`Cant add color layer ${layer.id}: the maximum layer is reached`));
-                }
-            } else {
-                parentLayer.attach(layer);
             }
+            parentLayer.attach(layer);
         } else {
             if (typeof (layer.update) !== 'function') {
                 return layer._reject(new Error('Cant add GeometryLayer: missing a update function'));

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -420,7 +420,6 @@ class OGC3DTilesLayer extends GeometryLayer {
             });
             pointsMaterial.copy(material);
             material = pointsMaterial;
-            material.depthWrite = false;
         }
 
         if (material) {

--- a/packages/Main/src/Layer/ReferencingLayerProperties.js
+++ b/packages/Main/src/Layer/ReferencingLayerProperties.js
@@ -2,6 +2,7 @@
 // next step is move these properties to Style class
 function ReferLayerProperties(material, layer) {
     if (layer && layer.isGeometryLayer) {
+        let transparent = material.transparent;
         material.layer = layer;
 
         if (material.uniforms && material.uniforms.opacity != undefined) {
@@ -52,6 +53,16 @@ function ReferLayerProperties(material, layer) {
 
         Object.defineProperty(material, 'wireframe', {
             get: () => material.layer.wireframe,
+        });
+
+        Object.defineProperty(material, 'transparent', {
+            get: () => {
+                if (transparent != material.layer.opacity < 1.0) {
+                    material.needsUpdate = true;
+                    transparent = material.layer.opacity < 1.0;
+                }
+                return transparent;
+            },
         });
     }
 

--- a/packages/Main/src/Layer/ReferencingLayerProperties.js
+++ b/packages/Main/src/Layer/ReferencingLayerProperties.js
@@ -5,13 +5,19 @@ function ReferLayerProperties(material, layer) {
         let transparent = material.transparent;
         material.layer = layer;
 
+        const getOpacity = () => {
+            const styleOpacity = material.layer.style.fill?.opacity;
+            const layerOpacity = material.layer.opacity;
+            return styleOpacity ? styleOpacity * layerOpacity : layerOpacity;
+        };
+
         if (material.uniforms && material.uniforms.opacity != undefined) {
             Object.defineProperty(material.uniforms.opacity, 'value', {
-                get: () => material.layer.opacity,
+                get: () => getOpacity(),
             });
         } else if (material.opacity != undefined) {
             Object.defineProperty(material, 'opacity', {
-                get: () => material.layer.opacity,
+                get: () => getOpacity(),
             });
         }
 
@@ -57,9 +63,10 @@ function ReferLayerProperties(material, layer) {
 
         Object.defineProperty(material, 'transparent', {
             get: () => {
-                if (transparent != material.layer.opacity < 1.0) {
+                const needTransparency = getOpacity() < 1.0;
+                if (transparent != needTransparency) {
                     material.needsUpdate = true;
-                    transparent = material.layer.opacity < 1.0;
+                    transparent = needTransparency;
                 }
                 return transparent;
             },

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -136,7 +136,6 @@ class TiledGeometryLayer extends GeometryLayer {
 
         this.tileMatrixSets = tileMatrixSets;
 
-        materialOptions.transparent = materialOptions.transparent ?? true;
         this.materialOptions = materialOptions;
 
         /*

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -122,11 +122,14 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
             i < tile.textures.length && count < max;
             ++i, ++count
         ) {
-            textureSetId += `${tile.textures[i].id}.`;
+            const texture = tile.textures[i];
+            if (!texture) { continue; }
+
+            textureSetId += `${texture.id}.`;
             uOffsetScales[count] = tile.offsetScales[i];
             uLayers[count] = tile;
 
-            const img = tile.textures[i].image;
+            const img = texture.image;
             if (!img || img.width <= 0 || img.height <= 0) {
                 console.error('Texture image not loaded or has zero dimensions');
                 uTextureCount.value = 0;

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -23,17 +23,11 @@ export function unpack1K(color: THREE.Vector4Like, factor: number): number {
     return factor ? bitSh.dot(color) * factor : bitSh.dot(color);
 }
 
-// Max sampler color count to LayeredMaterial
-// Because there's a statement limitation to unroll, in getColorAtIdUv method
-const maxSamplersColorCount = 15;
 const samplersElevationCount = 1;
 
 export function getMaxColorSamplerUnitsCount(): number {
     const maxSamplerUnitsCount = Capabilities.getMaxTextureUnitsCount();
-    return Math.min(
-        maxSamplerUnitsCount - samplersElevationCount,
-        maxSamplersColorCount,
-    );
+    return maxSamplerUnitsCount - samplersElevationCount;
 }
 
 export const colorLayerEffects = {

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -148,8 +148,10 @@ interface LayeredMaterialRawUniforms {
     lightPosition: THREE.Vector3;
 
     // Misc
-    fogDistance: number;
+    fogNear: number;
+    fogFar: number;
     fogColor: THREE.Color;
+    fogDensity: number;
     overlayAlpha: number;
     overlayColor: THREE.Color;
     objectId: number;
@@ -212,7 +214,6 @@ type RenderModeDefines = DefineMapping<'MODE', typeof RenderMode.MODES>;
 type LayeredMaterialDefines = {
     NUM_VS_TEXTURES: number;
     NUM_FS_TEXTURES: number;
-    USE_FOG: number;
     NUM_CRS: number;
     DEBUG: number;
     MODE: number;
@@ -255,9 +256,6 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
 
         fillInProp(defines, 'NUM_VS_TEXTURES', nbSamplers[0]);
         fillInProp(defines, 'NUM_FS_TEXTURES', nbSamplers[1]);
-        // TODO: We do not use the fog from the scene, is this a desired
-        // behavior?
-        fillInProp(defines, 'USE_FOG', 1);
         fillInProp(defines, 'NUM_CRS', crsCount);
 
         initModeDefines(defines);
@@ -280,6 +278,8 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
 
         this.defines = defines;
 
+        this.fog = true; // receive the fog defined on the scene, if any
+
         this.vertexShader = TileVS;
         // three loop unrolling of ShaderMaterial only supports integer bounds,
         // see https://github.com/mrdoob/three.js/issues/28020
@@ -296,8 +296,10 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
             lightPosition: new THREE.Vector3(-0.5, 0.0, 1.0),
 
             // Misc properties
-            fogDistance: 1000000000.0,
+            fogNear: 1,
+            fogFar: 1000,
             fogColor: new THREE.Color(0.76, 0.85, 1.0),
+            fogDensity: 0.00025,
             overlayAlpha: 0,
             overlayColor: new THREE.Color(1.0, 0.3, 0.0),
             objectId: 0,

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -145,6 +145,8 @@ function updateLayersUniforms<Type extends 'c' | 'e'>(
     if (textureArraysCache.has(textureSetId)) {
         uTextures.value = textureArraysCache.get(textureSetId);
         uTextureCount.value = count;
+        const renderer: THREE.WebGLRenderer = view.renderer;
+        renderer.initTexture(uTextures.value);
         return;
     }
 

--- a/packages/Main/src/Renderer/RenderMode.js
+++ b/packages/Main/src/Renderer/RenderMode.js
@@ -14,7 +14,6 @@ function push(object3d, mode) {
         const material = node.material;
         if (material) {
             material.mode = m;
-            material.transparent = m === MODES.FINAL;
         }
     });
 

--- a/packages/Main/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/color_layers_pars_fragment.glsl
@@ -9,7 +9,7 @@ struct Layer {
 
 #include <itowns/custom_header_colorLayer>
 
-uniform sampler2D   colorTextures[NUM_FS_TEXTURES];
+uniform sampler2DArray   colorTextures;
 uniform vec4        colorOffsetScales[NUM_FS_TEXTURES];
 uniform Layer       colorLayers[NUM_FS_TEXTURES];
 uniform int         colorTextureCount;
@@ -50,7 +50,7 @@ vec4 getOutlineColor(vec3 outlineColor, vec2 uv) {
 #endif
 
 uniform float minBorderDistance;
-vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer layer) {
+vec4 getLayerColor(int textureOffset, sampler2DArray tex, vec4 offsetScale, Layer layer) {
     if ( textureOffset >= colorTextureCount ) return vec4(0);
 
     vec3 uv;
@@ -61,7 +61,7 @@ vec4 getLayerColor(int textureOffset, sampler2D tex, vec4 offsetScale, Layer lay
 
     float borderDistance = getBorderDistance(uv.xy);
     if (textureOffset != layer.textureOffset + int(uv.z) || borderDistance < minBorderDistance ) return vec4(0);
-    vec4 color = texture2D(tex, pitUV(uv.xy, offsetScale));
+    vec4 color = texture(tex, vec3(pitUV(uv.xy, offsetScale), float(textureOffset)));
     if (layer.effect_type == 3) {
         #include <itowns/custom_body_colorLayer>
     } else {

--- a/packages/Main/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/elevation_pars_vertex.glsl
@@ -8,7 +8,7 @@
     };
 
     uniform Layer       elevationLayers[NUM_VS_TEXTURES];
-    uniform sampler2D   elevationTextures[NUM_VS_TEXTURES];
+    uniform sampler2DArray   elevationTextures;
     uniform vec4        elevationOffsetScales[NUM_VS_TEXTURES];
     uniform int         elevationTextureCount;
     uniform float       geoidHeight;
@@ -21,15 +21,15 @@
         return Result;
     }
 
-    float getElevationMode(vec2 uv, sampler2D tex, int mode) {
+    float getElevationMode(vec2 uv, sampler2DArray tex, int mode) {
         if (mode == ELEVATION_RGBA)
-            return decode32(texture2D( tex, uv ).abgr * 255.0);
+            return decode32(texture(tex, vec3(uv, 0.0)).abgr * 255.0);
         if (mode == ELEVATION_DATA || mode == ELEVATION_COLOR)
-            return texture2D( tex, uv ).r;
+            return texture(tex, vec3(uv, 0.0)).r;
         return 0.;
     }
 
-    float getElevation(vec2 uv, sampler2D tex, vec4 offsetScale, Layer layer) {
+    float getElevation(vec2 uv, sampler2DArray tex, vec4 offsetScale, Layer layer) {
         // Elevation textures are inverted along the y-axis
         uv = vec2(uv.x, 1.0 - uv.y);
         uv = uv * offsetScale.zw + offsetScale.xy;

--- a/packages/Main/src/Renderer/Shader/Chunk/elevation_vertex.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/elevation_vertex.glsl
@@ -1,6 +1,6 @@
 #if NUM_VS_TEXTURES > 0
     if(elevationTextureCount > 0) {
-        float elevation = getElevation(uv, elevationTextures[0], elevationOffsetScales[0], elevationLayers[0]);
+        float elevation = getElevation(uv, elevationTextures, elevationOffsetScales[0], elevationLayers[0]);
         transformed += elevation * normal;
     }
 #endif

--- a/packages/Main/src/Renderer/Shader/Chunk/fog_fragment.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/fog_fragment.glsl
@@ -1,4 +1,0 @@
-#if defined(USE_FOG)
-    float fogFactor = 1. - min( exp(-vFogDepth / fogDistance), 1.);
-    gl_FragColor.rgb = mix(gl_FragColor.rgb, fogColor, fogFactor);
-#endif

--- a/packages/Main/src/Renderer/Shader/Chunk/fog_pars_fragment.glsl
+++ b/packages/Main/src/Renderer/Shader/Chunk/fog_pars_fragment.glsl
@@ -1,5 +1,0 @@
-#if defined(USE_FOG)
-uniform vec3  fogColor;
-uniform float fogDistance;
-varying float vFogDepth;
-#endif

--- a/packages/Main/src/Renderer/Shader/ShaderChunk.js
+++ b/packages/Main/src/Renderer/Shader/ShaderChunk.js
@@ -3,8 +3,6 @@ import color_layers_pars_fragment from './Chunk/color_layers_pars_fragment.glsl'
 import elevation_pars_vertex from './Chunk/elevation_pars_vertex.glsl';
 import elevation_vertex from './Chunk/elevation_vertex.glsl';
 import geoid_vertex from './Chunk/geoid_vertex.glsl';
-import fog_fragment from './Chunk/fog_fragment.glsl';
-import fog_pars_fragment from './Chunk/fog_pars_fragment.glsl';
 import lighting_fragment from './Chunk/lighting_fragment.glsl';
 import lighting_pars_fragment from './Chunk/lighting_pars_fragment.glsl';
 import mode_pars_fragment from './Chunk/mode_pars_fragment.glsl';
@@ -28,8 +26,6 @@ const itownsShaderChunk = {
     elevation_pars_vertex,
     elevation_vertex,
     geoid_vertex,
-    fog_fragment,
-    fog_pars_fragment,
     lighting_fragment,
     lighting_pars_fragment,
     mode_depth_fragment,

--- a/packages/Main/src/Renderer/Shader/TileFS.glsl
+++ b/packages/Main/src/Renderer/Shader/TileFS.glsl
@@ -38,7 +38,7 @@ void main() {
     vec4 color;
     #pragma unroll_loop
     for ( int i = 0; i < NUM_FS_TEXTURES; i ++ ) {
-        color = getLayerColor( i , colorTextures[ i ], colorOffsetScales[ i ], colorLayers[ i ]);
+        color = getLayerColor( i , colorTextures, colorOffsetScales[ i ], colorLayers[ i ]);
         gl_FragColor.rgb = mix(gl_FragColor.rgb, color.rgb, color.a);
     }
 

--- a/packages/Main/src/Renderer/Shader/TileFS.glsl
+++ b/packages/Main/src/Renderer/Shader/TileFS.glsl
@@ -3,7 +3,7 @@
 #include <itowns/pitUV>
 #include <itowns/color_layers_pars_fragment>
 #if MODE == MODE_FINAL
-#include <itowns/fog_pars_fragment>
+#include <fog_pars_fragment>
 #include <itowns/overlay_pars_fragment>
 #include <itowns/lighting_pars_fragment>
 #endif
@@ -52,7 +52,7 @@ void main() {
     }
   #endif
 
-    #include <itowns/fog_fragment>
+    #include <fog_fragment>
     #include <itowns/lighting_fragment>
     #include <itowns/overlay_fragment>
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -22,7 +22,8 @@ const copyTextureShader = {
 
 let renderTarget: THREE.WebGLRenderTarget | null = null;
 let material: THREE.ShaderMaterial | null = null;
-let geometry: THREE.PlaneGeometry | null = null;
+let quadScene: THREE.Scene | null = null;
+let quadCam: THREE.OrthographicCamera | null = null;
 
 /**
  * Renders a single 2D texture layer into the DataArrayTexture on the GPU.
@@ -134,13 +135,10 @@ export function makeDataArrayTexture(
     }
 
     // Set up the quad for rendering
-    const quadScene = new THREE.Scene();
-    const quadCam = new THREE.OrthographicCamera(
-        -1, 1, 1, -1, 0, 1);
-    if (!geometry) {
-        geometry = new THREE.PlaneGeometry(2, 2);
-    }
-    if (!material) {
+    if (!quadScene) {
+        quadScene = new THREE.Scene();
+        quadCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+        const geometry = new THREE.PlaneGeometry(2, 2);
         material = new THREE.ShaderMaterial({
             uniforms: {
                 // This uniform will be updated with each source 2D texture
@@ -149,9 +147,9 @@ export function makeDataArrayTexture(
             vertexShader: copyTextureShader.vertexShader,
             fragmentShader: copyTextureShader.fragmentShader,
         });
+        const quad = new THREE.Mesh(geometry, material);
+        quadScene.add(quad);
     }
-    const quad = new THREE.Mesh(geometry, material);
-    quadScene.add(quad);
 
     // loop through each tile and its textures
     // to render them into DataArrayTexture layers
@@ -163,11 +161,11 @@ export function makeDataArrayTexture(
             ++i, ++count
         ) {
             // Set the current source 2D texture on the quad's material
-            material.uniforms.sourceTexture.value = tile.textures[i];
+            material!.uniforms.sourceTexture.value = tile.textures[i];
 
             // render this source texture into the current layer
             drawTextureLayer(renderer, renderTarget, uTextures.value,
-                count, quadScene, quadCam);
+                count, quadScene!, quadCam!);
         }
     }
 

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { RasterTile } from './RasterTile';
 
-// Define the shader for copying a 2D texture to a framebuffer
+// shader for copying a 2D texture to a framebuffer
 const copyTextureShader = {
     vertexShader: `
         varying vec2 vUv;
@@ -48,18 +48,17 @@ function drawTextureLayer(
 ) {
     const gl = renderer.getContext();
 
-    // 1. Set the render target.
-    const current = renderer.getRenderTarget();
+    // save the previous render target and temporarily set the new one
+    const previousRenderTarget = renderer.getRenderTarget();
     renderer.setRenderTarget(renderTarget);
 
-    // 2. Get the raw WebGLTexture object for the DataArrayTexture.
+    // get the raw WebGLTexture object for the DataArrayTexture
     const props = renderer.properties.get(dataArrayTextureToPopulate) as
         { __webglTexture: WebGLTexture };
     const dataArrayTextureWebGL = props.__webglTexture;
 
-    // 3. Attach the specific layer of the DataArrayTexture to the framebuffer's
-    // COLOR_ATTACHMENT0. The framebuffer is already bound by
-    // `renderer.setRenderTarget(renderTarget)`.
+    // attach the specific layer of the DataArrayTexture to the framebuffer's
+    // COLOR_ATTACHMENT0
     if ('framebufferTextureLayer' in gl) {
         gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
             dataArrayTextureWebGL, 0, layerIndex);
@@ -68,19 +67,10 @@ function drawTextureLayer(
         return;
     }
 
-    // 4. Check framebuffer status after attaching the layer.
-    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-    if (status !== gl.FRAMEBUFFER_COMPLETE) {
-        console.error('Framebuffer not complete after attaching layer:', status);
-        return;
-    }
-
-    // 5. Render the quad scene.
     renderer.render(quadScene, quadCam);
 
-    // 6. Reset render target to null. This unbinds the custom framebuffer
-    // and restores the default framebuffer (usually the screen).
-    renderer.setRenderTarget(current);
+    // reset render target to the old one
+    renderer.setRenderTarget(previousRenderTarget);
 }
 
 /**

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -1,0 +1,181 @@
+import * as THREE from 'three';
+import { RasterTile } from './RasterTile';
+
+// Define the shader for copying a 2D texture to a framebuffer
+const copyTextureShader = {
+    vertexShader: `
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: `
+        precision highp float;
+        uniform sampler2D sourceTexture;
+        varying vec2 vUv;
+        void main() {
+            gl_FragColor = texture2D(sourceTexture, vUv);
+        }
+    `,
+};
+
+let renderTarget: THREE.WebGLRenderTarget | null = null;
+let material: THREE.ShaderMaterial | null = null;
+let geometry: THREE.PlaneGeometry | null = null;
+
+/**
+ * Renders a single 2D texture layer into the DataArrayTexture on the GPU.
+ * This function is called for each layer.
+ *
+ * @param renderer - The Three.js WebGLRenderer instance.
+ * @param renderTarget - A temporary WebGLRenderTarget
+ * used to bind the framebuffer.
+ * @param dataArrayTextureToPopulate - The DataArrayTexture
+ * that layers are being written into.
+ * @param layerIndex - The index of the layer
+ * in the DataArrayTexture to write to.
+ * @param quadScene - The scene containing the quad used for rendering.
+ * @param quadCam - The camera for the quad scene.
+ */
+function drawTextureLayer(
+    renderer: THREE.WebGLRenderer,
+    renderTarget: THREE.WebGLRenderTarget,
+    dataArrayTextureToPopulate: THREE.DataArrayTexture,
+    layerIndex: number,
+    quadScene: THREE.Scene,
+    quadCam: THREE.OrthographicCamera,
+) {
+    const gl = renderer.getContext();
+
+    // 1. Set the render target.
+    const current = renderer.getRenderTarget();
+    renderer.setRenderTarget(renderTarget);
+
+    // 2. Get the raw WebGLTexture object for the DataArrayTexture.
+    const props = renderer.properties.get(dataArrayTextureToPopulate) as
+        { __webglTexture: WebGLTexture };
+    const dataArrayTextureWebGL = props.__webglTexture;
+
+    // 3. Attach the specific layer of the DataArrayTexture to the framebuffer's
+    // COLOR_ATTACHMENT0. The framebuffer is already bound by
+    // `renderer.setRenderTarget(renderTarget)`.
+    if ('framebufferTextureLayer' in gl) {
+        gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
+            dataArrayTextureWebGL, 0, layerIndex);
+    } else {
+        console.error('framebufferTextureLayer function not supported');
+        return;
+    }
+
+    // 4. Check framebuffer status after attaching the layer.
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (status !== gl.FRAMEBUFFER_COMPLETE) {
+        console.error('Framebuffer not complete after attaching layer:', status);
+        return;
+    }
+
+    // 5. Render the quad scene.
+    renderer.render(quadScene, quadCam);
+
+    // 6. Reset render target to null. This unbinds the custom framebuffer
+    // and restores the default framebuffer (usually the screen).
+    renderer.setRenderTarget(current);
+}
+
+/**
+ * Initializes a THREE.DataArrayTexture with immutable storage and populates
+ * its layers by rendering individual 2D textures onto them using the GPU.
+ *
+ * @param uTextures - The uniform object containing the
+ * THREE.DataArrayTexture to be initialized and populated.
+ * @param width - The width of each layer in the DataArrayTexture.
+ * @param height - The height of each layer in the DataArrayTexture.
+ * @param count - The total number of layers the DataArrayTexture should have.
+ * @param tiles - An array of RasterTile objects, each containing textures.
+ * @param max - The maximum allowed number of layers for the DataArrayTexture.
+ * @returns True if the function succeeded
+ */
+export function makeDataArrayTexture(
+    uTextures: THREE.IUniform, width: number, height: number, count: number, tiles: RasterTile[],
+    max: number,
+): boolean {
+    // If no textures found, dispose previous DataArrayTexture and reset
+    if (count === 0) {
+        if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
+        uTextures.value = new THREE.DataArrayTexture();
+        return false;
+    }
+
+    const renderer: THREE.WebGLRenderer = view.renderer;
+    const gl = renderer.getContext();
+    if (!('TEXTURE_2D_ARRAY' in gl && 'texStorage3D' in gl)) {
+        console.error('Some WebGL features are missing');
+        return false;
+    }
+
+    // Dispose previous DataArrayTexture to prevent memory leaks if re-creating
+    if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
+
+    // Create a new THREE.DataArrayTexture.
+    uTextures.value = new THREE.DataArrayTexture(null, width, height, count);
+
+    // Manually initialize the WebGL
+    // texture with immutable storage (gl.texStorage3D)
+    // This is a requirement for attaching layers to a framebuffer.
+    const textureProps = renderer.properties.get(uTextures.value) as
+        { __webglTexture: WebGLTexture };
+    textureProps.__webglTexture = gl.createTexture(); // Create a raw WebGL texture
+    gl.bindTexture(gl.TEXTURE_2D_ARRAY, textureProps.__webglTexture);
+    // Allocate immutable storage
+    gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, count);
+
+    // Create a temporary THREE.WebGLRenderTarget.
+    // This render target's internal framebuffer
+    // will be used to attach layers.
+    if (!renderTarget) {
+        renderTarget = new THREE.WebGLRenderTarget(width, height, {
+            depthBuffer: false, // No depth buffer needed for simple 2D texture copy
+        });
+    }
+
+    // Set up the quad for rendering
+    const quadScene = new THREE.Scene();
+    const quadCam = new THREE.OrthographicCamera(
+        -1, 1, 1, -1, 0, 1);
+    if (!geometry) {
+        geometry = new THREE.PlaneGeometry(2, 2);
+    }
+    if (!material) {
+        material = new THREE.ShaderMaterial({
+            uniforms: {
+                // This uniform will be updated with each source 2D texture
+                sourceTexture: { value: null },
+            },
+            vertexShader: copyTextureShader.vertexShader,
+            fragmentShader: copyTextureShader.fragmentShader,
+        });
+    }
+    const quad = new THREE.Mesh(geometry, material);
+    quadScene.add(quad);
+
+    // loop through each tile and its textures
+    // to render them into DataArrayTexture layers
+    count = 0;
+    for (const tile of tiles) {
+        for (
+            let i = 0;
+            i < tile.textures.length && count < max;
+            ++i, ++count
+        ) {
+            // Set the current source 2D texture on the quad's material
+            material.uniforms.sourceTexture.value = tile.textures[i];
+
+            // render this source texture into the current layer
+            drawTextureLayer(renderer, renderTarget, uTextures.value,
+                count, quadScene, quadCam);
+        }
+    }
+
+    return true;
+}

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -141,12 +141,7 @@ export function makeDataArrayTexture(
     uTextures: THREE.IUniform, width: number, height: number, count: number, tiles: RasterTile[],
     max: number,
 ): boolean {
-    // If no textures found, dispose previous DataArrayTexture and reset
-    if (count === 0) {
-        if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
-        uTextures.value = new THREE.DataArrayTexture();
-        return false;
-    }
+    if (count === 0) { return false; }
 
     const renderer: THREE.WebGLRenderer = view.renderer;
     const gl = renderer.getContext();
@@ -155,10 +150,6 @@ export function makeDataArrayTexture(
         return false;
     }
 
-    // Dispose previous DataArrayTexture to prevent memory leaks if re-creating
-    if (uTextures.value instanceof THREE.DataArrayTexture) { uTextures.value.dispose(); }
-
-    // Create a new THREE.DataArrayTexture.
     uTextures.value = new THREE.DataArrayTexture(null, width, height, count);
 
     // Manually initialize the WebGL
@@ -203,10 +194,7 @@ export function makeDataArrayTexture(
 
     // Allocate immutable storage
     const glFormat = getInternalFormat(gl, firstTexture.format, firstTexture.type);
-    if (glFormat < 0) {
-        uTextures.value.dispose();
-        return false;
-    }
+    if (glFormat < 0) { return false; }
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, glFormat, width, height, count);
 
     // loop through each tile and its textures

--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -130,6 +130,10 @@ export function makeDataArrayTexture(
     // Allocate immutable storage
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, count);
 
+    // Avoid visible seams
+    gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
     // Create a temporary THREE.WebGLRenderTarget.
     // This render target's internal framebuffer
     // will be used to attach layers.


### PR DESCRIPTION
## Description
This makes use of the opacity defined in the style of polygon features to apply it to their material.

## Motivation and Context
Previously, only the opacity property defined in the layer was applied to polygons. The one defined in the style was not applied.
In this PR, I assumed these two opacity properties were meant to be used in association, multiplying them together to get the actual opacity.
I based it on the yet unmerged `Desplandis/fix/depth-transparency` branch to avoid any conflicts.