### PR TITLE
Dynamic extruded polygon style update

### DIFF
--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -524,7 +524,7 @@ function updateExtrudedPolygonVertices(featureMesh, options, vertices, colors, b
     coord.setCrs(context.collection.crs);
 
     // geometry range
-    const geometry = context.getGeometry();
+    const geometry = context.geometry;
     const start = geometry.indices[0].offset;
     const lastIndex = geometry.indices.slice(-1)[0];
     const end = lastIndex.offset + lastIndex.count;

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -751,7 +751,7 @@ export default {
         let colors;
         let posAttr;
         const newColor = options.style?.fill?.color;
-        if (featureMesh.oldColor !== newColor) {
+        if (featureMesh.oldColor && !featureMesh.oldColor.equals(newColor)) {
             featureMesh.oldColor = newColor;
             colors = new Uint8Array(numVertices * 2);
         }

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -193,6 +193,10 @@ export class StyleContext {
         return this.#localCoordinates.setFromArray(vertices, offset);
     }
 
+    getGeometry() {
+        return this.#geometry;
+    }
+
     get properties() {
         return this.#geometry.properties;
     }

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -193,7 +193,7 @@ export class StyleContext {
         return this.#localCoordinates.setFromArray(vertices, offset);
     }
 
-    getGeometry() {
+    get geometry() {
         return this.#geometry;
     }
 

--- a/packages/Main/src/Process/FeatureProcessing.js
+++ b/packages/Main/src/Process/FeatureProcessing.js
@@ -29,11 +29,7 @@ export default {
 
                 // update existing features
                 for (const featureMesh of f.meshes.children) {
-                    const newColor = layer.style?.fill?.color;
-                    if (featureMesh.oldColor !== newColor) {
-                        featureMesh.oldColor = newColor;
-                        Feature2Mesh.updateColors(featureMesh, { style: layer.style });
-                    }
+                    Feature2Mesh.updateFillStyle(featureMesh, { style: layer.style });
                 }
             });
             return;

--- a/packages/Main/src/Process/FeatureProcessing.js
+++ b/packages/Main/src/Process/FeatureProcessing.js
@@ -3,6 +3,7 @@ import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import handlingError from 'Process/handlerNodeError';
 import { Coordinates } from '@itowns/geographic';
 import { geoidLayerIsVisible } from 'Layer/GeoidLayer';
+import Feature2Mesh from 'Converter/Feature2Mesh';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
@@ -25,6 +26,15 @@ export default {
                 f.layer.object3d.add(f);
                 f.meshes.position.z = geoidLayerIsVisible(layer.parent) ? node.geoidHeight : 0;
                 f.meshes.updateMatrixWorld();
+
+                // update existing features
+                for (const featureMesh of f.meshes.children) {
+                    const newColor = layer.style?.fill?.color;
+                    if (featureMesh.oldColor !== newColor) {
+                        featureMesh.oldColor = newColor;
+                        Feature2Mesh.updateColors(featureMesh, { style: layer.style });
+                    }
+                }
             });
             return;
         }


### PR DESCRIPTION
## Description
This allows style properties of extruded polygons to be updated after their creation, without re-instantiating geometries or recreating layers.

## Motivation and Context
To modify the style of a polygon after its creation, the only way was previously to recreate the entire layer, which is very sub-optimal, and the fact of recreating layers currently even leads to bugs.

Tested on Firefox, Ubuntu.