### PR TITLE
fix(Picking): Fix traversePickingCircle for pickPointsAt

### DIFF
--- a/packages/Main/src/Core/Picking.js
+++ b/packages/Main/src/Core/Picking.js
@@ -147,7 +147,12 @@ export default {
         const candidates = [];
 
         traversePickingCircle(radius, (x, y) => {
-            const idx = (y * 2 * radius + x) * 4;
+            // x, y are offset from the center of the picking circle,
+            // and pixels is a square where 0, 0 is the top-left corner.
+            // So we need to shift x,y by radius.
+            const xi = x + radius;
+            const yi = y + radius;
+            const idx = (yi * (radius * 2 + 1) + xi) * 4;
             const data = buffer.slice(idx, idx + 4);
 
             // see PotreeProvider and the construction of unique_id


### PR DESCRIPTION
## Description
Fix for https://github.com/iTowns/itowns/issues/2596

## Motivation and Context
In `traversePickingCircle` there's a bug in the buffer indexing calculation.
If we use the same logic at `traversePickingCircle` for `pickObjectsAt` it solve the problem.
Picking output on point cloud is now a complete circle (as expected).

## Screenshots
<img width="1600" height="931" alt="Capture d’écran 2025-09-19 à 16 46 35" src="https://github.com/user-attachments/assets/ee2c5b31-2873-4360-a81c-7e73e7451239" />
