### PR TITLE
example(3DTiles): fix function naming error

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -236,7 +236,7 @@
             loadLyonButton.addEventListener('click', loadLyon);
             loadSeteButton.addEventListener('click', loadSete);
             loadLilleButton.addEventListener('click', loadLille);
-            readUrlButton.addEventListener('click', readEPTURL);
+            readUrlButton.addEventListener('click', readURL);
 
             window.readURL = readURL;
             window.loadLyon = loadLyon;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fix function naming error in 3D Tiles loader example, which prevents loading 3D Tiles from any user given URL.