### PR TITLE
Remove reference to layer in PointCloudNode

### DIFF
--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -10,8 +10,6 @@
                 "itowns": "../dist/itowns.js",
                 "debug": "../dist/debug.js",
                 "lil": "https://unpkg.com/lil-gui@0.20.0/dist/lil-gui.esm.js",
-                "dat": "https://unpkg.com/dat.gui@0.7.9/build/dat.gui.module.js",
-                "GuiTools": "./jsm/GUI/GuiTools.js",
                 "LoadingScreen": "./jsm/GUI/LoadingScreen.js",
                 "itowns_widgets": "../dist/itowns_widgets.js",
                 "three": "https://unpkg.com/three@0.170.0/build/three.module.js",
@@ -47,7 +45,6 @@
 
         <script type="module">
             import lil from 'lil';
-            import GuiTools from 'GuiTools';
             import setupLoadingScreen from 'LoadingScreen';
             import * as THREE from 'three';
             import * as itowns from 'itowns';

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -81,7 +81,7 @@
             potreeLayer = new itowns.PotreeLayer('eglise_saint_blaise_arles', {
                 source: new itowns.PotreeSource({
                     file: 'eglise_saint_blaise_arles.js',
-                    url: 'https://raw.githubusercontent.com/gmaillet/dataset/master/',
+                    url: 'https://raw.githubusercontent.com/gmaillet/dataset/master',
                     crs: view.referenceCrs,
                 }),
             });

--- a/packages/Main/src/Core/EntwinePointTileNode.js
+++ b/packages/Main/src/Core/EntwinePointTileNode.js
@@ -44,13 +44,13 @@ class EntwinePointTileNode extends PointCloudNode {
      * @param {number} z - The z coordinate of the node in the tree - see the
      * [Entwine
      * documentation](https://entwine.io/entwine-point-tile.html#ept-data)
-     * @param {EntwinePointTileLayer} layer - The layer the node is attached to.
+     * @param {EntwinePointTileSource} source - Data source (Ept) of the node.
      * @param {number} [numPoints=0] - The number of points in this node. If
      * `-1`, it means that the octree hierarchy associated to this node needs to
      * be loaded.
      */
-    constructor(depth, x, y, z, layer, numPoints = 0) {
-        super(numPoints, layer);
+    constructor(depth, x, y, z, source, numPoints = 0) {
+        super(numPoints, source);
         this.isEntwinePointTileNode = true;
 
         this.depth = depth;
@@ -60,7 +60,7 @@ class EntwinePointTileNode extends PointCloudNode {
 
         this.voxelKey = buildVoxelKey(depth, x, y, z);
 
-        this.url = `${this.layer.source.url}/ept-data/${this.voxelKey}.${this.layer.source.extension}`;
+        this.url = `${this.source.url}/ept-data/${this.voxelKey}.${this.source.extension}`;
     }
 
     get octreeIsLoaded() {
@@ -72,8 +72,8 @@ class EntwinePointTileNode extends PointCloudNode {
     }
 
     loadOctree() {
-        const hierarchyUrl = `${this.layer.source.url}/ept-hierarchy/${this.voxelKey}.json`;
-        return Fetcher.json(hierarchyUrl, this.layer.source.networkOptions).then((hierarchy) => {
+        const hierarchyUrl = `${this.source.url}/ept-hierarchy/${this.voxelKey}.json`;
+        return Fetcher.json(hierarchyUrl, this.source.networkOptions).then((hierarchy) => {
             this.numPoints = hierarchy[this.voxelKey];
 
             const stack = [];
@@ -103,7 +103,7 @@ class EntwinePointTileNode extends PointCloudNode {
         const numPoints = hierarchy[voxelKey];
 
         if (typeof numPoints == 'number') {
-            const child = new EntwinePointTileNode(depth, x, y, z, this.layer, numPoints);
+            const child = new EntwinePointTileNode(depth, x, y, z, this.source, numPoints);
             this.add(child);
             stack.push(child);
         }

--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -4,12 +4,19 @@ const size = new THREE.Vector3();
 const position = new THREE.Vector3();
 const translation = new THREE.Vector3();
 
+/**
+ * @property {number} numPoints - The number of points in this node.
+ * @property {PointCloudSource} source - Data source of the node.
+ * @property {PointCloudNode[]} children - The children nodes of this node.
+ * @property {THREE.Box3} bbox - The bounding box of the node.
+ */
 class PointCloudNode extends THREE.EventDispatcher {
-    constructor(numPoints = 0, layer) {
+    constructor(numPoints = 0, source) {
         super();
 
         this.numPoints = numPoints;
-        this.layer = layer;
+
+        this.source = source;
 
         this.children = [];
         this.bbox = new THREE.Box3();
@@ -17,7 +24,7 @@ class PointCloudNode extends THREE.EventDispatcher {
     }
 
     get pointSpacing() {
-        return this.layer.spacing / 2 ** this.depth;
+        return this.source.spacing / 2 ** this.depth;
     }
 
     get id() {
@@ -57,8 +64,10 @@ class PointCloudNode extends THREE.EventDispatcher {
     }
 
     load() {
-        return this.layer.source.fetcher(this.url, this.layer.source.networkOptions)
-            .then(file => this.layer.source.parse(file, { out: this.layer, in: this.layer.source }));
+        return this.source.fetcher(this.url, this.source.networkOptions)
+            .then(file => this.source.parse(file, {
+                in: this.source,
+            }));
     }
 
     findCommonAncestor(node) {

--- a/packages/Main/src/Layer/CopcLayer.js
+++ b/packages/Main/src/Layer/CopcLayer.js
@@ -42,9 +42,7 @@ class CopcLayer extends PointCloudLayer {
             const { cube } = source.info;
             const { pageOffset, pageLength } = source.info.rootHierarchyPage;
 
-            this.spacing = source.info.spacing;
-
-            this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this, -1);
+            this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, this.source, -1);
             this.root.bbox.min.fromArray(cube, 0);
             this.root.bbox.max.fromArray(cube, 3);
 

--- a/packages/Main/src/Layer/EntwinePointTileLayer.js
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.js
@@ -57,13 +57,7 @@ class EntwinePointTileLayer extends PointCloudLayer {
 
         const resolve = this.addInitializationStep();
         this.whenReady = this.source.whenReady.then(() => {
-            // NOTE: this spacing is kinda arbitrary here, we take the width and
-            // length (height can be ignored), and we divide by the specified
-            // span in ept.json. This needs improvements.
-            this.spacing = (Math.abs(this.source.bounds[3] - this.source.bounds[0])
-                + Math.abs(this.source.bounds[4] - this.source.bounds[1])) / (2 * this.source.span);
-
-            this.root = new EntwinePointTileNode(0, 0, 0, 0, this, -1);
+            this.root = new EntwinePointTileNode(0, 0, 0, 0, this.source, -1);
 
             this.root.bbox.min.fromArray(this.source.boundsConforming, 0);
             this.root.bbox.max.fromArray(this.source.boundsConforming, 3);

--- a/packages/Main/src/Layer/Potree2Layer.js
+++ b/packages/Main/src/Layer/Potree2Layer.js
@@ -38,76 +38,9 @@ import PointCloudLayer from 'Layer/PointCloudLayer';
 import Potree2Node from 'Core/Potree2Node';
 import { Extent } from '@itowns/geographic';
 
-import { PointAttribute, Potree2PointAttributes, PointAttributeTypes } from 'Core/Potree2PointAttributes';
-
 const bboxMesh = new THREE.Mesh();
 const box3 = new THREE.Box3();
 bboxMesh.geometry.boundingBox = box3;
-
-const typeNameAttributeMap = {
-    double: PointAttributeTypes.DATA_TYPE_DOUBLE,
-    float: PointAttributeTypes.DATA_TYPE_FLOAT,
-    int8: PointAttributeTypes.DATA_TYPE_INT8,
-    uint8: PointAttributeTypes.DATA_TYPE_UINT8,
-    int16: PointAttributeTypes.DATA_TYPE_INT16,
-    uint16: PointAttributeTypes.DATA_TYPE_UINT16,
-    int32: PointAttributeTypes.DATA_TYPE_INT32,
-    uint32: PointAttributeTypes.DATA_TYPE_UINT32,
-    int64: PointAttributeTypes.DATA_TYPE_INT64,
-    uint64: PointAttributeTypes.DATA_TYPE_UINT64,
-};
-
-function parseAttributes(jsonAttributes) {
-    const attributes = new Potree2PointAttributes();
-
-    const replacements = {
-        rgb: 'rgba',
-    };
-
-    for (const jsonAttribute of jsonAttributes) {
-        const { name, numElements, min, max } = jsonAttribute;
-
-        const type = typeNameAttributeMap[jsonAttribute.type];
-
-        const potreeAttributeName = replacements[name] ? replacements[name] : name;
-
-        const attribute = new PointAttribute(potreeAttributeName, type, numElements);
-
-        if (numElements === 1) {
-            attribute.range = [min[0], max[0]];
-        } else {
-            attribute.range = [min, max];
-        }
-
-        if (name === 'gps-time') { // HACK: Guard against bad gpsTime range in metadata, see potree/potree#909
-            if (attribute.range[0] === attribute.range[1]) {
-                attribute.range[1] += 1;
-            }
-        }
-
-        attribute.initialRange = attribute.range;
-
-        attributes.add(attribute);
-    }
-
-    {
-        // check if it has normals
-        const hasNormals =
-            attributes.attributes.find(a => a.name === 'NormalX') !== undefined &&
-            attributes.attributes.find(a => a.name === 'NormalY') !== undefined &&
-            attributes.attributes.find(a => a.name === 'NormalZ') !== undefined;
-
-        if (hasNormals) {
-            const vector = {
-                name: 'NORMAL',
-                attributes: ['NormalX', 'NormalY', 'NormalZ'],
-            };
-            attributes.addVector(vector);
-        }
-    }
-
-    return attributes;
-}
 
 /**
  * @property {boolean} isPotreeLayer - Used to checkout whether this layer
@@ -158,11 +91,9 @@ class Potree2Layer extends PointCloudLayer {
         this.source.whenReady.then((metadata) => {
             this.scale = new THREE.Vector3(1, 1, 1);
             this.metadata = metadata;
-            this.pointAttributes = parseAttributes(metadata.attributes);
-            this.spacing = metadata.spacing;
 
-            const normal = Array.isArray(this.pointAttributes.attributes) &&
-               this.pointAttributes.attributes.find(elem => elem.name.startsWith('NORMAL'));
+            const normal = Array.isArray(metadata.attributes) &&
+               metadata.attributes.find(elem => elem.name.startsWith('NORMAL'));
             if (normal) {
                 this.material.defines[normal.name] = 1;
             }
@@ -171,7 +102,7 @@ class Potree2Layer extends PointCloudLayer {
             const max = new THREE.Vector3(...metadata.boundingBox.max);
             const boundingBox = new THREE.Box3(min, max);
 
-            const root = new Potree2Node(0, 0, this);
+            const root = new Potree2Node(0, 0, this.source);
 
             root.bbox = boundingBox;
             root.boundingSphere = boundingBox.getBoundingSphere(new THREE.Sphere());

--- a/packages/Main/src/Layer/PotreeLayer.js
+++ b/packages/Main/src/Layer/PotreeLayer.js
@@ -55,8 +55,6 @@ class PotreeLayer extends PointCloudLayer {
 
         this.source.whenReady.then((cloud) => {
             this.scale = new THREE.Vector3().addScalar(cloud.scale);
-            this.spacing = cloud.spacing;
-            this.hierarchyStepSize = cloud.hierarchyStepSize;
 
             const normal = Array.isArray(cloud.pointAttributes) &&
                 cloud.pointAttributes.find(elem => elem.startsWith('NORMAL'));
@@ -66,7 +64,7 @@ class PotreeLayer extends PointCloudLayer {
 
             this.supportsProgressiveDisplay = (this.source.extension === 'cin');
 
-            this.root = new PotreeNode(0, 0, this);
+            this.root = new PotreeNode(0, 0, this.source);
             this.root.bbox.min.set(cloud.boundingBox.lx, cloud.boundingBox.ly, cloud.boundingBox.lz);
             this.root.bbox.max.set(cloud.boundingBox.ux, cloud.boundingBox.uy, cloud.boundingBox.uz);
 

--- a/packages/Main/src/Parser/Potree2BinParser.js
+++ b/packages/Main/src/Parser/Potree2BinParser.js
@@ -42,9 +42,7 @@ export default {
      */
     parse: async function parse(buffer, options) {
         const metadata = options.in.source.metadata;
-        const layer = options.out;
-
-        const pointAttributes = layer.pointAttributes;
+        const pointAttributes = options.in.source.pointAttributes;
         const scale = metadata.scale;
         const box = options.in.bbox;
         const min = box.min;

--- a/packages/Main/src/Source/CopcSource.js
+++ b/packages/Main/src/Source/CopcSource.js
@@ -104,6 +104,8 @@ class CopcSource extends Source {
             this.info = metadata.info;
             this.eb = metadata.eb;
 
+            this.spacing = this.info.spacing;
+
             proj4.defs('unknown', metadata.wkt);
             let projCS;
 

--- a/packages/Main/src/Source/EntwinePointTileSource.js
+++ b/packages/Main/src/Source/EntwinePointTileSource.js
@@ -63,6 +63,12 @@ class EntwinePointTileSource extends Source {
             this.bounds = metadata.bounds; // xMin, yMin, zMin, xMax, yMax, zMax
             this.span = metadata.span;
 
+            // NOTE: this spacing is kinda arbitrary here, we take the width and
+            // length (height can be ignored), and we divide by the specified
+            // span in ept.json. This needs improvements.
+            this.spacing = (Math.abs(this.bounds[3] - this.bounds[0])
+                + Math.abs(this.bounds[4] - this.bounds[1])) / (2 * this.span);
+
             return this;
         });
 

--- a/packages/Main/src/Source/Potree2Source.js
+++ b/packages/Main/src/Source/Potree2Source.js
@@ -2,6 +2,72 @@ import Source from 'Source/Source';
 import Fetcher from 'Provider/Fetcher';
 import Potree2BinParser from 'Parser/Potree2BinParser';
 
+import { PointAttribute, Potree2PointAttributes, PointAttributeTypes } from 'Core/Potree2PointAttributes';
+
+const typeNameAttributeMap = {
+    double: PointAttributeTypes.DATA_TYPE_DOUBLE,
+    float: PointAttributeTypes.DATA_TYPE_FLOAT,
+    int8: PointAttributeTypes.DATA_TYPE_INT8,
+    uint8: PointAttributeTypes.DATA_TYPE_UINT8,
+    int16: PointAttributeTypes.DATA_TYPE_INT16,
+    uint16: PointAttributeTypes.DATA_TYPE_UINT16,
+    int32: PointAttributeTypes.DATA_TYPE_INT32,
+    uint32: PointAttributeTypes.DATA_TYPE_UINT32,
+    int64: PointAttributeTypes.DATA_TYPE_INT64,
+    uint64: PointAttributeTypes.DATA_TYPE_UINT64,
+};
+
+function parseAttributes(jsonAttributes) {
+    const attributes = new Potree2PointAttributes();
+
+    const replacements = {
+        rgb: 'rgba',
+    };
+
+    for (const jsonAttribute of jsonAttributes) {
+        const { name, numElements, min, max } = jsonAttribute;
+
+        const type = typeNameAttributeMap[jsonAttribute.type];
+
+        const potreeAttributeName = replacements[name] ? replacements[name] : name;
+
+        const attribute = new PointAttribute(potreeAttributeName, type, numElements);
+
+        if (numElements === 1) {
+            attribute.range = [min[0], max[0]];
+        } else {
+            attribute.range = [min, max];
+        }
+
+        if (name === 'gps-time') { // HACK: Guard against bad gpsTime range in metadata, see potree/potree#909
+            if (attribute.range[0] === attribute.range[1]) {
+                attribute.range[1] += 1;
+            }
+        }
+
+        attribute.initialRange = attribute.range;
+
+        attributes.add(attribute);
+    }
+
+    {
+        // check if it has normals
+        const hasNormals =
+            attributes.attributes.find(a => a.name === 'NormalX') !== undefined &&
+            attributes.attributes.find(a => a.name === 'NormalY') !== undefined &&
+            attributes.attributes.find(a => a.name === 'NormalZ') !== undefined;
+
+        if (hasNormals) {
+            const vector = {
+                name: 'NORMAL',
+                attributes: ['NormalX', 'NormalY', 'NormalZ'],
+            };
+            attributes.addVector(vector);
+        }
+    }
+
+    return attributes;
+}
 /**
  * Potree2Source are object containing informations on how to fetch potree 2.0 points cloud resources.
  */
@@ -159,10 +225,12 @@ class Potree2Source extends Source {
         this.whenReady = (source.metadata ? Promise.resolve(source.metadata) : Fetcher.json(`${this.url}/${this.file}`, this.networkOptions))
             .then((metadata) => {
                 this.metadata = metadata;
-                this.pointAttributes = metadata.attributes;
+                this.pointAttributes = parseAttributes(metadata.attributes);
                 this.baseurl = `${this.url}`;
                 this.extension = 'bin';
                 this.parser = Potree2BinParser.parse;
+
+                this.spacing = metadata.spacing;
 
                 return metadata;
             });

--- a/packages/Main/src/Source/PotreeSource.js
+++ b/packages/Main/src/Source/PotreeSource.js
@@ -78,6 +78,9 @@ class PotreeSource extends Source {
                 this.extension = cloud.pointAttributes === 'CIN' ? 'cin' : 'bin';
                 this.parse = this.extension === 'cin' ? PotreeCinParser.parse : PotreeBinParser.parse;
 
+                this.spacing = cloud.spacing;
+                this.hierarchyStepSize = cloud.hierarchyStepSize;
+
                 return cloud;
             });
     }

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -40,6 +40,7 @@ describe('Potree', function () {
         const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: -250 };
         let renderer;
         let viewer;
+        let potreeSource;
         let potreeLayer;
         let context;
         let elt;
@@ -57,14 +58,14 @@ describe('Potree', function () {
             renderer = new Renderer();
             viewer = new GlobeView(renderer.domElement, placement, { renderer });
 
-            const source = new PotreeSource({
+            potreeSource = new PotreeSource({
                 file: fileName,
                 url: baseurl,
             });
 
             // Configure Point Cloud layer
             potreeLayer = new PotreeLayer('lion_takanawa', {
-                source,
+                source: potreeSource,
                 crs: viewer.referenceCrs,
             });
 
@@ -118,7 +119,7 @@ describe('Potree', function () {
             const childrenBitField = 5;
 
             it('instance', function (done) {
-                const root = new PotreeNode(numPoints, childrenBitField, potreeLayer);
+                const root = new PotreeNode(numPoints, childrenBitField, potreeSource);
                 assert.equal(root.numPoints, numPoints);
                 assert.equal(root.childrenBitField, childrenBitField);
                 done();
@@ -126,20 +127,18 @@ describe('Potree', function () {
 
             it('construct a correct URL', function () {
                 const node = new PotreeNode(0, 0, {
-                    source: {
-                        baseurl,
-                        extension: 'bin',
-                    },
+                    baseurl,
+                    extension: 'bin',
                 });
                 const hierarchyKey = '044';
 
                 node.hierarchyKey = hierarchyKey;
 
-                assert.equal(node.url, `${baseurl}/r${hierarchyKey}.bin`);
+                assert.equal(node.url, `${baseurl}/${hierarchyKey}.bin`);
             });
 
             it('load octree', function (done) {
-                const root = new PotreeNode(numPoints, childrenBitField, potreeLayer);
+                const root = new PotreeNode(numPoints, childrenBitField, potreeSource);
                 root.loadOctree()
                     .then(() => {
                         assert.equal(6, root.children.length);
@@ -148,7 +147,7 @@ describe('Potree', function () {
             });
 
             it('load child node', function (done) {
-                const root = new PotreeNode(numPoints, childrenBitField, potreeLayer);
+                const root = new PotreeNode(numPoints, childrenBitField, potreeSource);
                 root.loadOctree()
                     .then(() => root.children[0].load()
                         .then(() => {

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -11,7 +11,8 @@ import Renderer from './bootstrap';
 describe('Potree2', function () {
     let renderer;
     let viewer;
-    let potreeLayer;
+    let potree2Source;
+    let potree2Layer;
     let context;
     let elt;
 
@@ -21,12 +22,13 @@ describe('Potree2', function () {
         viewer.camera.camera3D.position.copy(new Vector3(0, 0, 10));
 
         // Configure Point Cloud layer
-        potreeLayer = new Potree2Layer('lion', {
-            source: new Potree2Source({
-                file: 'metadata.json',
-                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
-                networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
-            }),
+        potree2Source = new Potree2Source({
+            file: 'metadata.json',
+            url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/potree2.0/lion',
+            networkOptions: process.env.HTTPS_PROXY ? { agent: new HttpsProxyAgent(process.env.HTTPS_PROXY) } : {},
+        });
+        potree2Layer = new Potree2Layer('lion', {
+            source: potree2Source,
             crs: viewer.referenceCrs,
         });
 
@@ -34,13 +36,13 @@ describe('Potree2', function () {
             camera: viewer.camera,
             engine: viewer.mainLoop.gfxEngine,
             scheduler: viewer.mainLoop.scheduler,
-            geometryLayer: potreeLayer,
+            geometryLayer: potree2Layer,
             view: viewer,
         };
     });
 
     it('Add point potree2 layer', function (done) {
-        View.prototype.addLayer.call(viewer, potreeLayer)
+        View.prototype.addLayer.call(viewer, potree2Layer)
             .then((layer) => {
                 context.camera.camera3D.updateMatrixWorld();
                 assert.equal(layer.root.children.length, 6);
@@ -50,22 +52,22 @@ describe('Potree2', function () {
     });
 
     it('preupdate potree2 layer', function () {
-        elt = potreeLayer.preUpdate(context, new Set([potreeLayer]));
+        elt = potree2Layer.preUpdate(context, new Set([potree2Layer]));
         assert.equal(elt.length, 1);
     });
 
     it('update potree2 layer', function (done) {
-        assert.equal(potreeLayer.group.children.length, 0);
-        potreeLayer.update(context, potreeLayer, elt[0]);
+        assert.equal(potree2Layer.group.children.length, 0);
+        potree2Layer.update(context, potree2Layer, elt[0]);
         elt[0].promise
             .then(() => {
-                assert.equal(potreeLayer.group.children.length, 1);
+                assert.equal(potree2Layer.group.children.length, 1);
                 done();
             }).catch(done);
     }).timeout(5000);
 
     it('postUpdate potree2 layer', function () {
-        potreeLayer.postUpdate(context, potreeLayer);
+        potree2Layer.postUpdate(context, potree2Layer);
     });
 
     describe('potree2 Node', function () {
@@ -73,7 +75,7 @@ describe('Potree2', function () {
         const childrenBitField = 5;
 
         it('instance', function (done) {
-            const root = new Potree2Node(numPoints, childrenBitField, potreeLayer);
+            const root = new Potree2Node(numPoints, childrenBitField, potree2Source);
             root.nodeType = 2;
             assert.equal(root.numPoints, numPoints);
             assert.equal(root.childrenBitField, childrenBitField);
@@ -81,7 +83,7 @@ describe('Potree2', function () {
         });
 
         it('load octree', function (done) {
-            const root = new Potree2Node(numPoints, childrenBitField, potreeLayer);
+            const root = new Potree2Node(numPoints, childrenBitField, potree2Source);
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;
             root.hierarchyByteSize = 12650n;
@@ -93,7 +95,7 @@ describe('Potree2', function () {
         });
 
         it('load child node', function (done) {
-            const root = new Potree2Node(numPoints, childrenBitField, potreeLayer);
+            const root = new Potree2Node(numPoints, childrenBitField, potree2Source);
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;
             root.hierarchyByteSize = 12650n;

--- a/packages/Main/test/unit/potree2BinParser.js
+++ b/packages/Main/test/unit/potree2BinParser.js
@@ -19,30 +19,24 @@ describe('Potree2BinParser', function () {
                         scale: [1, 1, 1],
                         offset: [0, 0, 0],
                     },
+                    pointAttributes: {
+                        attributes: [{
+                            name: 'position',
+                            type: {
+                                name: 'int32',
+                                size: 4,
+                            },
+                            numElements: 3,
+                            byteSize: 12,
+                            description: '',
+                            range: [0, 0],
+                            initialRange: [0, 0],
+                        }],
+                        vectors: [],
+                    },
                 },
                 bbox: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
                 numPoints: nbPoints,
-            },
-            out: {
-                pointAttributes: {
-                    attributes: [{
-                        name: 'position',
-                        type: {
-                            name: 'int32',
-                            size: 4,
-                        },
-                        numElements: 3,
-                        byteSize: 12,
-                        description: '',
-                        range: [0, 0],
-                        initialRange: [0, 0],
-                    }],
-                    vectors: [],
-                },
-                offset: new THREE.Vector3(),
-            },
-            node: {
-                bbox: new THREE.Box3(),
             },
         };
 
@@ -88,63 +82,57 @@ describe('Potree2BinParser', function () {
                         scale: [1, 1, 1],
                         offset: [0, 0, 0],
                     },
+                    pointAttributes: {
+                        attributes: [{
+                            name: 'position',
+                            type: {
+                                name: 'int32',
+                                size: 4,
+                            },
+                            numElements: 3,
+                            byteSize: 12,
+                            description: '',
+                            range: [0, 0],
+                            initialRange: [0, 0],
+                        }, {
+                            name: 'intensity',
+                            type: {
+                                name: 'uint16',
+                                size: 2,
+                            },
+                            numElements: 1,
+                            byteSize: 2,
+                            description: '',
+                            range: [0, 0],
+                            initialRange: [0, 0],
+                        }, {
+                            name: 'rgba',
+                            type: {
+                                name: 'uint16',
+                                size: 2,
+                            },
+                            numElements: 3,
+                            byteSize: 6,
+                            description: '',
+                            range: [0, 0],
+                            initialRange: [0, 0],
+                        }, {
+                            name: 'classification',
+                            type: {
+                                name: 'uint8',
+                                size: 1,
+                            },
+                            numElements: 1,
+                            byteSize: 1,
+                            description: '',
+                            range: [0, 0],
+                            initialRange: [0, 0],
+                        }],
+                        vectors: [],
+                    },
                 },
                 bbox: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
                 numPoints,
-            },
-            out: {
-                pointAttributes: {
-                    attributes: [{
-                        name: 'position',
-                        type: {
-                            name: 'int32',
-                            size: 4,
-                        },
-                        numElements: 3,
-                        byteSize: 12,
-                        description: '',
-                        range: [0, 0],
-                        initialRange: [0, 0],
-                    }, {
-                        name: 'intensity',
-                        type: {
-                            name: 'uint16',
-                            size: 2,
-                        },
-                        numElements: 1,
-                        byteSize: 2,
-                        description: '',
-                        range: [0, 0],
-                        initialRange: [0, 0],
-                    }, {
-                        name: 'rgba',
-                        type: {
-                            name: 'uint16',
-                            size: 2,
-                        },
-                        numElements: 3,
-                        byteSize: 6,
-                        description: '',
-                        range: [0, 0],
-                        initialRange: [0, 0],
-                    }, {
-                        name: 'classification',
-                        type: {
-                            name: 'uint8',
-                            size: 1,
-                        },
-                        numElements: 1,
-                        byteSize: 1,
-                        description: '',
-                        range: [0, 0],
-                        initialRange: [0, 0],
-                    }],
-                    vectors: [],
-                },
-                offset: new THREE.Vector3(),
-            },
-            node: {
-                bbox: new THREE.Box3(),
             },
         };
 


### PR DESCRIPTION
In reaction to PR #2504, we assume it's not the responsabilty of the node to know the layer, but the opposite.
Moreover we use mostly the layer to get his source and his metadata.

This PR aims at removing layer from the Point Cloud Node and focus only on the source.

~PS: 
The 2nd [commit](https://github.com/iTowns/itowns/pull/2603/commits/e49706e3d4eaba38052336747bcec0b619fe43e0) can't be kept, I'm waiting for an other ddataset to change it. I will remove it after the testing and the review if I don't get the new one early enought.~