### PR TITLE
Fix broken copc loader example

### DIFF
--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -10,6 +10,7 @@
                 "itowns": "../dist/itowns.js",
                 "debug": "../dist/debug.js",
                 "lil": "https://unpkg.com/lil-gui@0.20.0/dist/lil-gui.esm.js",
+                "dat": "https://unpkg.com/dat.gui@0.7.9/build/dat.gui.module.js",
                 "GuiTools": "./jsm/GUI/GuiTools.js",
                 "LoadingScreen": "./jsm/GUI/LoadingScreen.js",
                 "itowns_widgets": "../dist/itowns_widgets.js",


### PR DESCRIPTION
## Description
This PR fixes the broken COPC example where the import map for the dat module was missing.