### PR TITLE
Fix missing env variable for CI release script

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -325,6 +325,8 @@ jobs:
             --notes-file ./changelog.md \
             --draft=false \
             --prerelease=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Zip assets into bundle
       - name: Zip assets
@@ -335,4 +337,6 @@ jobs:
       - name: Upload release asset
         run: |
           gh release upload v${{ steps.npm_pack.outputs.VERSION }} bundles.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This PR fixes the missing env variable for the CI github release script (see https://github.com/iTowns/itowns/actions/runs/18226951752/job/51901166217). I pushed manually the release on github for the previous release BTW.
