### PR TITLE
fix(camera): don't add default fog in views where camera has static near/far

### DIFF
--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -117,8 +117,7 @@ class GlobeView extends View {
             CameraUtils.transformCameraToLookAtTarget(this, this.camera3D, placement);
 
             // In this case, since the camera's near and far properties aren't
-            // dynamically computed, the default fog won't be adapted, so disable it.
-            this.scene.fog = null;
+            // dynamically computed, the default fog won't be adapted, so don't enable it
         } else {
             this.controls = new GlobeControls(this, placement, options.controls);
             this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
@@ -149,6 +148,8 @@ class GlobeView extends View {
                 fog.far = this.camera3D.far;
                 fog.near = fog.far - this.fogSpread * (fog.far - this.camera3D.near);
             });
+
+            this.scene.fog = new THREE.Fog(0xe2edff, 1, 1000); // default fog
         }
 
         this.addLayer(new Atmosphere('atmosphere', options.atmosphere));

--- a/packages/Main/src/Core/Prefab/PlanarView.js
+++ b/packages/Main/src/Core/Prefab/PlanarView.js
@@ -110,6 +110,7 @@ class PlanarView extends View {
 
         this.farFactor = options.farFactor ?? 20;
         this.fogSpread = options.fogSpread ?? 0.5;
+        this.scene.fog = new THREE.Fog(0xe2edff, 1, 1000); // default fog
     }
 
     addLayer(layer) {

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -191,7 +191,6 @@ class View extends THREE.EventDispatcher {
         if (!options.scene3D) {
             this.scene.matrixWorldAutoUpdate = false;
         }
-        this.scene.fog = new THREE.Fog(0xe2edff, 1, 1000); // default fog
 
         this.camera = new Camera(
             this.referenceCrs,


### PR DESCRIPTION
## Description
Only add a default fog in planar and globe views, not in the generic parent view. In that case, the camera's near/far properties aren't updated dynamically and neither is the fog, so the fog looks much too visible in some cases.

## Motivation and Context

In the Entwine example, a simple View is used, so the fog always keeps its default parameters (with `far` set to 1000), making the entire point cloud look grey.