### PR TITLE
fix(TileLayer): fix material opacity

### DIFF
--- a/packages/Main/src/Layer/ReferencingLayerProperties.js
+++ b/packages/Main/src/Layer/ReferencingLayerProperties.js
@@ -8,13 +8,13 @@ function ReferLayerProperties(material, layer) {
         if (material.uniforms && material.uniforms.opacity != undefined) {
             opacity = material.uniforms.opacity.value;
             Object.defineProperty(material.uniforms.opacity, 'value', {
-                get: () => material.layer.opacity || opacity,
+                get: () => material.layer.opacity * opacity,
                 set: (value) => { opacity = value; },
             });
         } else if (material.opacity != undefined) {
             opacity = material.opacity;
             Object.defineProperty(material, 'opacity', {
-                get: () => material.layer.opacity,
+                get: () => material.layer.opacity * opacity,
                 set: (value) => { opacity = value; },
             });
         }


### PR DESCRIPTION
## Description

Since #2602, it is impossible to set the opacity of the tile layer (thanks @ketourneau for the issue). This PR fixes it.

I would like to backport this fix, push it in a v2.36 branch and manually release it in npm as 2.36.1. WDYT?

