### PR TITLE
fix(OrientationUtils): errors TS6133

### DIFF
--- a/packages/Geographic/src/OrientationUtils.ts
+++ b/packages/Geographic/src/OrientationUtils.ts
@@ -488,7 +488,10 @@ export function quaternionFromCRSToCRS(
 ) {
     if (coordinates) { return quaternionFromCRSToCRS(crsIn, crsOut)(coordinates, target); }
     if (crsIn == crsOut) {
-        return (origin: Coordinates, target = new Quaternion()) => target.set(0, 0, 0, 1);
+        return (origin: Coordinates, target = new Quaternion()) => {
+            void origin;
+            return target.set(0, 0, 0, 1);
+        };
     }
 
     // get rotations from the local East/North/Up (ENU) frame to both CRS.


### PR DESCRIPTION
## Description

### TS6133
In the `OrientationUtils.ts` file, 'origin' is declared, but its value is never read
https://github.com/iTowns/itowns/blob/a969ced58af01bcf7b8e68ecf6c4696bdc07de83/packages/Geographic/src/OrientationUtils.ts#L491

## Motivation and Context
When building a TS project using iTowns, I have this error, and it blocks the build step.

Project dependencies versions:
```json
"dependencies": {
    "itowns": "^2.46.0",
    "react": "^19.1.1",
    "react-dom": "^19.1.1"
  },
  "devDependencies": {
    "@eslint/js": "^9.36.0",
    "@types/node": "^24.6.0",
    "@types/react": "^19.1.16",
    "@types/react-dom": "^19.1.9",
    "@types/three": "^0.180.0",
    "@vitejs/plugin-react": "^5.0.4",
    "eslint": "^9.36.0",
    "eslint-plugin-react-hooks": "^5.2.0",
    "eslint-plugin-react-refresh": "^0.4.22",
    "globals": "^16.4.0",
    "typescript": "~5.9.3",
    "typescript-eslint": "^8.45.0",
    "vite": "^7.1.7"
  }
```
