### PR TITLE
fix(doc): remove typescript doc for COG/Geotiff

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -76,7 +76,6 @@
                 "Potree2Source",
                 "VectorTilesSource",
                 "EntwinePointTileSource",
-                "CogSource",
                 "CopcSource",
                 "OGC3DTilesSource",
                 "OGC3DTilesIonSource",
@@ -97,7 +96,6 @@
                 "B3dmParser",
                 "ShapefileParser",
                 "LASParser",
-                "GeotiffParser",
                 "GTXParser",
                 "GDFParser",
                 "ISGParser"


### PR DESCRIPTION
## Before contributing

Read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
<!--- Describe your changes in detail -->

I didn't realize in #2558 but typescript files with tsdoc can't be exported in our existing jsdoc generation pipeline. This causes a fail in documentation generation (as can be seen in [this workflow](https://github.com/iTowns/itowns/actions/runs/18980811723)).

I propose a quick fix removing `GeotiffParser` and `CogSource` documentation from our pipeline before fixing the pipeline itself. There are also other issues with documentation from sub-packages: docs for `@itowns/geographic` is not built anymore. I will open an issue about the kinda urgent need to remake all the documentation generation to include multi-packages and typescript.