### PR TITLE
Fix(CogParser): Fix tile raster dimensions

### DIFF
--- a/packages/Main/src/Parser/CogParser.ts
+++ b/packages/Main/src/Parser/CogParser.ts
@@ -4,6 +4,7 @@ import {
     Vector2,
 } from 'three';
 
+import { TEXTURE_TILE_DIM } from 'Provider/Fetcher';
 import { GeotiffNode } from './GeotiffParser';
 
 import type { TextureWithExtent } from './GeotiffParser';
@@ -76,10 +77,7 @@ async function parse(data: any, options: any) {
 
     const tileExtent = extent.isExtent ? extent.as(crs) : extent.toExtent(crs);
     const tileWorldDimensions = tileExtent.planarDimensions();
-    const tileRasterDimensions = new Vector2(
-        255,
-        Math.round(255 * tileWorldDimensions.y / tileWorldDimensions.x),
-    );
+    const tileRasterDimensions = new Vector2(TEXTURE_TILE_DIM, TEXTURE_TILE_DIM);
 
     // GeoTIFFBase has an experimental readRasters method that has an
     // `bbox` parameter we could use instead of implementing our own

--- a/packages/Main/src/Parser/CogParser.ts
+++ b/packages/Main/src/Parser/CogParser.ts
@@ -5,9 +5,9 @@ import {
 } from 'three';
 
 import { TEXTURE_TILE_DIM } from 'Provider/Fetcher';
-import { GeotiffNode } from './GeotiffParser';
+import { GeotiffNode } from 'Parser/GeotiffParser';
 
-import type { TextureWithExtent } from './GeotiffParser';
+import type { TextureWithExtent } from 'Parser/GeotiffParser';
 
 
 const DEFAULT_MAX_TEXTURE_SIZE = 10 * 1024 * 1024;

--- a/packages/Main/src/Parser/GeotiffParser.ts
+++ b/packages/Main/src/Parser/GeotiffParser.ts
@@ -13,6 +13,8 @@ import {
     Vector2,
 } from 'three';
 
+import { TEXTURE_TILE_DIM } from 'Provider/Fetcher';
+
 import type { TextureDataType } from 'three';
 import type { Extent } from '@itowns/geographic';
 import type {
@@ -293,19 +295,13 @@ async function parse(data: GeoTIFFImage, options: any) {
     const image = data;
     const {
         in: {
-            crs,
             defaultAlpha,
             resampleMethod,
         },
         extent,
     } = options;
 
-    const tileExtent = extent.isExtent ? extent.as(crs) : extent.toExtent(crs);
-    const tileWorldDimensions = tileExtent.planarDimensions();
-    const tileRasterDimensions = new Vector2(
-        255,
-        Math.round(255 * tileWorldDimensions.y / tileWorldDimensions.x),
-    );
+    const tileRasterDimensions = new Vector2(TEXTURE_TILE_DIM, TEXTURE_TILE_DIM);
 
     const geotiffNode = new GeotiffNode({ image });
 

--- a/packages/Main/src/Provider/Fetcher.js
+++ b/packages/Main/src/Provider/Fetcher.js
@@ -1,7 +1,7 @@
 import { TextureLoader, DataTexture, RedFormat, FloatType } from 'three';
 import * as GeoTIFF from 'geotiff';
 
-const TEXTURE_TILE_DIM = 256;
+export const TEXTURE_TILE_DIM = 256;
 const TEXTURE_TILE_SIZE = TEXTURE_TILE_DIM * TEXTURE_TILE_DIM;
 
 const textureLoader = new TextureLoader();

--- a/packages/Main/src/Source/CogSource.ts
+++ b/packages/Main/src/Source/CogSource.ts
@@ -1,9 +1,9 @@
 import * as GeoTIFF from 'geotiff';
 import { Extent } from '@itowns/geographic';
 
-import { selectDataType, GeotiffNode } from '../Parser/GeotiffParser';
-import COGParser from '../Parser/CogParser';
-import Source from './Source';
+import { selectDataType, GeotiffNode } from 'Parser/GeotiffParser';
+import COGParser from 'Parser/CogParser';
+import Source from 'Source/Source';
 
 
 type CogSourceConfig = {


### PR DESCRIPTION
Fix for https://github.com/iTowns/itowns/issues/2625

Tile raster dimensions is normally 256x256, not 255x255.