### PR TITLE
[Example] Add copc_3d_loader to examples menu

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ The following people have contributed to iTowns.
   * [Jonathan Garnier](https://github.com/jogarnier)
   * [Irénée Dubourg](https://github.com/airnez)
   * [Victor Ripplinger](https://github.com/neptilo)
+  * [Moncef Hassani](https://github.com/Nynjin)
 
 * [Oslandia](http://www.oslandia.com)
   * [Vincent Picavet](https://github.com/vpicavet)

--- a/examples/config.json
+++ b/examples/config.json
@@ -26,6 +26,7 @@
         "entwine_simple_loader": "Entwine loader",
         "entwine_3d_loader": "Entwine 3D loader",
         "copc_simple_loader": "COPC loader",
+        "copc_3d_loader": "COPC 3D loader",
         "vpc_simple_loader": "VPC loader"
     },
 


### PR DESCRIPTION
## Description
Added copc_3d_loader to examples menu.

## Motivation and Context
copc_3d_loader example was created on 618d989a33c7fa4532bd19be4a351e2f0e1643c0 but was not added in the examples menu.