### PR TITLE
fix(test): vpc test time out

### DIFF
--- a/packages/Main/test/data/vpc/copcStack.json
+++ b/packages/Main/test/data/vpc/copcStack.json
@@ -1,0 +1,733 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+      ],
+      "id": "LHD_FXX_0636_6934_PTS_LAMB93_IGN69.copc",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              2.116943942067139,
+              49.49313959650045,
+              112.95
+            ],
+            [
+              2.116789618004861,
+              49.50212646409752,
+              112.95
+            ],
+            [
+              2.130588656073412,
+              49.50222620238229,
+              171.89
+            ],
+            [
+              2.130740569411375,
+              49.49323931834933,
+              171.89
+            ],
+            [
+              2.116943942067139,
+              49.49313959650045,
+              112.95
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "bbox": [
+        2.116789618004861,
+        49.49313959650045,
+        112.95,
+        2.1307405694113752,
+        49.50222620238229,
+        171.89
+      ],
+      "properties": {
+        "datetime": "2025-09-08T00:00:00Z",
+        "pc:count": 30266895,
+        "pc:encoding": "?",
+        "pc:schemas": [
+          {
+            "name": "X",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Y",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Z",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Intensity",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "ReturnNumber",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "NumberOfReturns",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanDirectionFlag",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "EdgeOfFlightLine",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Classification",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanAngleRank",
+            "size": 4,
+            "type": "floating"
+          },
+          {
+            "name": "UserData",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "PointSourceId",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "GpsTime",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "ScanChannel",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ClassFlags",
+            "size": 1,
+            "type": "unsigned"
+          }
+        ],
+        "pc:type": "lidar",
+        "proj:bbox": [
+          636000.0,
+          6933000.0,
+          112.95,
+          637000.0,
+          6934000.0,
+          171.89
+        ],
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                636000.0,
+                6933000.0,
+                112.95
+              ],
+              [
+                636000.0,
+                6934000.0,
+                112.95
+              ],
+              [
+                637000.0,
+                6934000.0,
+                171.89
+              ],
+              [
+                637000.0,
+                6933000.0,
+                171.89
+              ],
+              [
+                636000.0,
+                6933000.0,
+                112.95
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]"
+      },
+      "links": [],
+      "assets": {
+        "data": {
+          "href": "https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/NUALHD_1-0__LAZ_LAMB93_KC_2025-06-03/LHD_FXX_0636_6934_PTS_LAMB93_IGN69.copc.laz",
+          "roles": [
+            "data"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+      ],
+      "id": "LHD_FXX_0636_6935_PTS_LAMB93_IGN69.copc",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              2.116789618004861,
+              49.50212646409752,
+              119.2
+            ],
+            [
+              2.116635239995645,
+              49.51111324209545,
+              119.2
+            ],
+            [
+              2.130436689631018,
+              49.511212996819275,
+              172.0
+            ],
+            [
+              2.130588656073412,
+              49.50222620238229,
+              172.0
+            ],
+            [
+              2.116789618004861,
+              49.50212646409752,
+              119.2
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "bbox": [
+        2.1166352399956447,
+        49.50212646409752,
+        119.2,
+        2.1305886560734115,
+        49.511212996819275,
+        172.0
+      ],
+      "properties": {
+        "datetime": "2025-09-08T00:00:00Z",
+        "pc:count": 19981123,
+        "pc:encoding": "?",
+        "pc:schemas": [
+          {
+            "name": "X",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Y",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Z",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Intensity",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "ReturnNumber",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "NumberOfReturns",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanDirectionFlag",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "EdgeOfFlightLine",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Classification",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanAngleRank",
+            "size": 4,
+            "type": "floating"
+          },
+          {
+            "name": "UserData",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "PointSourceId",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "GpsTime",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "ScanChannel",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ClassFlags",
+            "size": 1,
+            "type": "unsigned"
+          }
+        ],
+        "pc:type": "lidar",
+        "proj:bbox": [
+          636000.0,
+          6934000.0,
+          119.2,
+          637000.0,
+          6935000.0,
+          172.0
+        ],
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                636000.0,
+                6934000.0,
+                119.2
+              ],
+              [
+                636000.0,
+                6935000.0,
+                119.2
+              ],
+              [
+                637000.0,
+                6935000.0,
+                172.0
+              ],
+              [
+                637000.0,
+                6934000.0,
+                172.0
+              ],
+              [
+                636000.0,
+                6934000.0,
+                119.2
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]"
+      },
+      "links": [],
+      "assets": {
+        "data": {
+          "href": "https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/NUALHD_1-0__LAZ_LAMB93_KC_2025-06-03/LHD_FXX_0636_6935_PTS_LAMB93_IGN69.copc.laz",
+          "roles": [
+            "data"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+      ],
+      "id": "LHD_FXX_0636_6936_PTS_LAMB93_IGN69.copc",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              2.116635239995645,
+              49.51111324209545,
+              132.24
+            ],
+            [
+              2.116480808011199,
+              49.520099930262184,
+              132.24
+            ],
+            [
+              2.130284670056346,
+              49.52019970142825,
+              167.7
+            ],
+            [
+              2.130436689631018,
+              49.511212996819275,
+              167.7
+            ],
+            [
+              2.116635239995645,
+              49.51111324209545,
+              132.24
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "bbox": [
+        2.116480808011199,
+        49.51111324209545,
+        132.24,
+        2.130436689631018,
+        49.52019970142825,
+        167.7
+      ],
+      "properties": {
+        "datetime": "2025-09-09T00:00:00Z",
+        "pc:count": 15215297,
+        "pc:encoding": "?",
+        "pc:schemas": [
+          {
+            "name": "X",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Y",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Z",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Intensity",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "ReturnNumber",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "NumberOfReturns",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanDirectionFlag",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "EdgeOfFlightLine",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Classification",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanAngleRank",
+            "size": 4,
+            "type": "floating"
+          },
+          {
+            "name": "UserData",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "PointSourceId",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "GpsTime",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "ScanChannel",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ClassFlags",
+            "size": 1,
+            "type": "unsigned"
+          }
+        ],
+        "pc:type": "lidar",
+        "proj:bbox": [
+          636000.0,
+          6935000.0,
+          132.24,
+          637000.0,
+          6936000.0,
+          167.7
+        ],
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                636000.0,
+                6935000.0,
+                132.24
+              ],
+              [
+                636000.0,
+                6936000.0,
+                132.24
+              ],
+              [
+                637000.0,
+                6936000.0,
+                167.7
+              ],
+              [
+                637000.0,
+                6935000.0,
+                167.7
+              ],
+              [
+                636000.0,
+                6935000.0,
+                132.24
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]"
+      },
+      "links": [],
+      "assets": {
+        "data": {
+          "href": "https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/NUALHD_1-0__LAZ_LAMB93_KC_2025-06-03/LHD_FXX_0636_6936_PTS_LAMB93_IGN69.copc.laz",
+          "roles": [
+            "data"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+      ],
+      "id": "LHD_FXX_0636_6937_PTS_LAMB93_IGN69.copc",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              2.116480808011199,
+              49.520099930262184,
+              145.97
+            ],
+            [
+              2.116326322023214,
+              49.52908652836568,
+              145.97
+            ],
+            [
+              2.130132597321527,
+              49.52918631597714,
+              157.84
+            ],
+            [
+              2.130284670056346,
+              49.52019970142825,
+              157.84
+            ],
+            [
+              2.116480808011199,
+              49.520099930262184,
+              145.97
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "bbox": [
+        2.116326322023214,
+        49.520099930262184,
+        145.97,
+        2.130284670056346,
+        49.52918631597714,
+        157.84
+      ],
+      "properties": {
+        "datetime": "2025-09-09T00:00:00Z",
+        "pc:count": 14305037,
+        "pc:encoding": "?",
+        "pc:schemas": [
+          {
+            "name": "X",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Y",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Z",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Intensity",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "ReturnNumber",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "NumberOfReturns",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanDirectionFlag",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "EdgeOfFlightLine",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Classification",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanAngleRank",
+            "size": 4,
+            "type": "floating"
+          },
+          {
+            "name": "UserData",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "PointSourceId",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "GpsTime",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "ScanChannel",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ClassFlags",
+            "size": 1,
+            "type": "unsigned"
+          }
+        ],
+        "pc:type": "lidar",
+        "proj:bbox": [
+          636000.0,
+          6936000.0,
+          145.97,
+          637000.0,
+          6937000.0,
+          157.84
+        ],
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                636000.0,
+                6936000.0,
+                145.97
+              ],
+              [
+                636000.0,
+                6937000.0,
+                145.97
+              ],
+              [
+                637000.0,
+                6937000.0,
+                157.84
+              ],
+              [
+                637000.0,
+                6936000.0,
+                157.84
+              ],
+              [
+                636000.0,
+                6936000.0,
+                145.97
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]"
+      },
+      "links": [],
+      "assets": {
+        "data": {
+          "href": "https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/NUALHD_1-0__LAZ_LAMB93_KC_2025-06-03/LHD_FXX_0636_6937_PTS_LAMB93_IGN69.copc.laz",
+          "roles": [
+            "data"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/Main/test/data/vpc/eptStack.json
+++ b/packages/Main/test/data/vpc/eptStack.json
@@ -1,0 +1,853 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "stac_extensions": [
+                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            ],
+            "id": "jg",
+            "geometry": {
+                "coordinates": [
+                    [
+                        [
+                            1.4802841765932482,
+                            47.6875059490178,
+                            72.0
+                        ],
+                        [
+                            1.4802841765932482,
+                            48.14423631325537,
+                            72.0
+                        ],
+                        [
+                            2.1395107106640903,
+                            48.14423631325537,
+                            330.0
+                        ],
+                        [
+                            2.1395107106640903,
+                            47.6875059490178,
+                            330.0
+                        ],
+                        [
+                            1.4802841765932482,
+                            47.6875059490178,
+                            72.0
+                        ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "bbox": [
+                47.6875059490178,
+                1.4802841765932482,
+                72.0,
+                48.14423631325537,
+                2.1395107106640903,
+                330.0
+            ],
+            "properties": {
+                "datetime": null,
+                "pc:count": 49430668823,
+                "pc:encoding": "?",
+                "pc:schemas": [
+                    {
+                        "name": "X",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Y",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Z",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Intensity",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ReturnNumber",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "NumberOfReturns",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanDirectionFlag",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "EdgeOfFlightLine",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Classification",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Synthetic",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "KeyPoint",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Withheld",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Overlap",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanAngleRank",
+                        "size": 4,
+                        "type": "float"
+                    },
+                    {
+                        "name": "UserData",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "PointSourceId",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "GpsTime",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "ScanChannel",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "dtm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "dsm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "OriginId",
+                        "size": 4,
+                        "type": "unsigned"
+                    }
+                ],
+                "pc:type": "lidar",
+                "proj:bbox": [
+                    585999.0,
+                    6732999.0,
+                    72.0,
+                    636001.0,
+                    6783001.0,
+                    330.0
+                ],
+                "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]",
+                "proj:geometry": {
+                    "coordinates": [
+                        [
+                            [
+                                6732999.0,
+                                585999.0,
+                                72.0
+                            ],
+                            [
+                                6732999.0,
+                                636001.0,
+                                72.0
+                            ],
+                            [
+                                6783001.0,
+                                636001.0,
+                                330.0
+                            ],
+                            [
+                                6783001.0,
+                                585999.0,
+                                330.0
+                            ],
+                            [
+                                6732999.0,
+                                585999.0,
+                                72.0
+                            ]
+                        ]
+                    ],
+                    "type": "Polygon"
+                }
+            },
+            "links": [],
+            "assets": {
+                "data": {
+                    "href": "https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/jg/ept.json",
+                    "roles": [
+                        "data"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "stac_extensions": [
+                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            ],
+            "id": "kg",
+            "geometry": {
+                "coordinates": [
+                    [
+                        [
+                            2.146748211293641,
+                            47.69426796680322,
+                            67.0
+                        ],
+                        [
+                            2.146748211293641,
+                            48.14722401181038,
+                            67.0
+                        ],
+                        [
+                            2.8117713776087476,
+                            48.14722401181038,
+                            257.0
+                        ],
+                        [
+                            2.8117713776087476,
+                            47.69426796680322,
+                            257.0
+                        ],
+                        [
+                            2.146748211293641,
+                            47.69426796680322,
+                            67.0
+                        ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "bbox": [
+                47.69426796680322,
+                2.146748211293641,
+                67.0,
+                48.14722401181038,
+                2.8117713776087476,
+                257.0
+            ],
+            "properties": {
+                "datetime": null,
+                "pc:count": 46945999969,
+                "pc:encoding": "?",
+                "pc:schemas": [
+                    {
+                        "name": "X",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Y",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Z",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Intensity",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ReturnNumber",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "NumberOfReturns",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanDirectionFlag",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "EdgeOfFlightLine",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Classification",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Synthetic",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "KeyPoint",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Withheld",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Overlap",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanAngleRank",
+                        "size": 4,
+                        "type": "float"
+                    },
+                    {
+                        "name": "UserData",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "PointSourceId",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "GpsTime",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "ScanChannel",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "dtm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "dsm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "OriginId",
+                        "size": 4,
+                        "type": "unsigned"
+                    }
+                ],
+                "pc:type": "lidar",
+                "proj:bbox": [
+                    635999.0,
+                    6732999.0,
+                    67.0,
+                    686001.0,
+                    6783001.0,
+                    257.0
+                ],
+                "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]",
+                "proj:geometry": {
+                    "coordinates": [
+                        [
+                            [
+                                6732999.0,
+                                635999.0,
+                                67.0
+                            ],
+                            [
+                                6732999.0,
+                                686001.0,
+                                67.0
+                            ],
+                            [
+                                6783001.0,
+                                686001.0,
+                                257.0
+                            ],
+                            [
+                                6783001.0,
+                                635999.0,
+                                257.0
+                            ],
+                            [
+                                6732999.0,
+                                635999.0,
+                                67.0
+                            ]
+                        ]
+                    ],
+                    "type": "Polygon"
+                }
+            },
+            "links": [],
+            "assets": {
+                "data": {
+                    "href": "https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/kg/ept.json",
+                    "roles": [
+                        "data"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "stac_extensions": [
+                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            ],
+            "id": "jh",
+            "geometry": {
+                "coordinates": [
+                    [
+                        [
+                            1.493003444164779,
+                            47.237501999044255,
+                            69.0
+                        ],
+                        [
+                            1.493003444164779,
+                            47.69427706424736,
+                            69.0
+                        ],
+                        [
+                            2.1467613980534423,
+                            47.69427706424736,
+                            219.0
+                        ],
+                        [
+                            2.1467613980534423,
+                            47.237501999044255,
+                            219.0
+                        ],
+                        [
+                            1.493003444164779,
+                            47.237501999044255,
+                            69.0
+                        ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "bbox": [
+                47.237501999044255,
+                1.493003444164779,
+                69.0,
+                47.69427706424736,
+                2.1467613980534423,
+                219.0
+            ],
+            "properties": {
+                "datetime": null,
+                "pc:count": 86520911492,
+                "pc:encoding": "?",
+                "pc:schemas": [
+                    {
+                        "name": "X",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Y",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Z",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Intensity",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ReturnNumber",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "NumberOfReturns",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanDirectionFlag",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "EdgeOfFlightLine",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Classification",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Synthetic",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "KeyPoint",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Withheld",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Overlap",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanAngleRank",
+                        "size": 4,
+                        "type": "float"
+                    },
+                    {
+                        "name": "UserData",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "PointSourceId",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "GpsTime",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "ScanChannel",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "dtm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "dsm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "OriginId",
+                        "size": 4,
+                        "type": "unsigned"
+                    }
+                ],
+                "pc:type": "lidar",
+                "proj:bbox": [
+                    585999.0,
+                    6682999.0,
+                    69.0,
+                    636000.0,
+                    6733000.0,
+                    219.0
+                ],
+                "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]",
+                "proj:geometry": {
+                    "coordinates": [
+                        [
+                            [
+                                6682999.0,
+                                585999.0,
+                                69.0
+                            ],
+                            [
+                                6682999.0,
+                                636000.0,
+                                69.0
+                            ],
+                            [
+                                6733000.0,
+                                636000.0,
+                                219.0
+                            ],
+                            [
+                                6733000.0,
+                                585999.0,
+                                219.0
+                            ],
+                            [
+                                6682999.0,
+                                585999.0,
+                                69.0
+                            ]
+                        ]
+                    ],
+                    "type": "Polygon"
+                }
+            },
+            "links": [],
+            "assets": {
+                "data": {
+                    "href": "https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/jh/ept.json",
+                    "roles": [
+                        "data"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "stac_extensions": [
+                "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+            ],
+            "id": "kh",
+            "geometry": {
+                "coordinates": [
+                    [
+                        [
+                            2.1538906981311077,
+                            47.24420882613282,
+                            113.0
+                        ],
+                        [
+                            2.1538906981311077,
+                            47.697240425400715,
+                            113.0
+                        ],
+                        [
+                            2.8133471387830484,
+                            47.697240425400715,
+                            639.0
+                        ],
+                        [
+                            2.8133471387830484,
+                            47.24420882613282,
+                            639.0
+                        ],
+                        [
+                            2.1538906981311077,
+                            47.24420882613282,
+                            113.0
+                        ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "bbox": [
+                47.24420882613282,
+                2.1538906981311077,
+                113.0,
+                47.697240425400715,
+                2.8133471387830484,
+                639.0
+            ],
+            "properties": {
+                "datetime": null,
+                "pc:count": 72229534811,
+                "pc:encoding": "?",
+                "pc:schemas": [
+                    {
+                        "name": "X",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Y",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Z",
+                        "size": 4,
+                        "type": "signed"
+                    },
+                    {
+                        "name": "Intensity",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ReturnNumber",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "NumberOfReturns",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanDirectionFlag",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "EdgeOfFlightLine",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Classification",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Synthetic",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "KeyPoint",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Withheld",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "Overlap",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "ScanAngleRank",
+                        "size": 4,
+                        "type": "float"
+                    },
+                    {
+                        "name": "UserData",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "PointSourceId",
+                        "size": 2,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "GpsTime",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "ScanChannel",
+                        "size": 1,
+                        "type": "unsigned"
+                    },
+                    {
+                        "name": "dtm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "dsm_marker",
+                        "size": 8,
+                        "type": "float"
+                    },
+                    {
+                        "name": "OriginId",
+                        "size": 4,
+                        "type": "unsigned"
+                    }
+                ],
+                "pc:type": "lidar",
+                "proj:bbox": [
+                    635999.0,
+                    6682999.0,
+                    113.0,
+                    686000.0,
+                    6733000.0,
+                    639.0
+                ],
+                "proj:wkt2": "PROJCS[\"RGF93 v1 / Lambert-93\",GEOGCS[\"RGF93 v1\",DATUM[\"Reseau_Geodesique_Francais_1993_v1\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6171\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4171\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",46.5],PARAMETER[\"central_meridian\",3],PARAMETER[\"standard_parallel_1\",49],PARAMETER[\"standard_parallel_2\",44],PARAMETER[\"false_easting\",700000],PARAMETER[\"false_northing\",6600000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2154\"]]",
+                "proj:geometry": {
+                    "coordinates": [
+                        [
+                            [
+                                6682999.0,
+                                635999.0,
+                                113.0
+                            ],
+                            [
+                                6682999.0,
+                                686000.0,
+                                113.0
+                            ],
+                            [
+                                6733000.0,
+                                686000.0,
+                                639.0
+                            ],
+                            [
+                                6733000.0,
+                                635999.0,
+                                639.0
+                            ],
+                            [
+                                6682999.0,
+                                635999.0,
+                                113.0
+                            ]
+                        ]
+                    ],
+                    "type": "Polygon"
+                }
+            },
+            "links": [],
+            "assets": {
+                "data": {
+                    "href": "https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/kh/ept.json",
+                    "roles": [
+                        "data"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/packages/Main/test/unit/vpc.js
+++ b/packages/Main/test/unit/vpc.js
@@ -4,17 +4,45 @@ import GlobeView from 'Core/Prefab/GlobeView';
 import { Coordinates, CRS } from '@itowns/geographic';
 import VpcSource from 'Source/VpcSource';
 import VpcLayer from 'Layer/VpcLayer';
+import sinon from 'sinon';
+import Fetcher from 'Provider/Fetcher';
 import Renderer from './bootstrap';
 
-const vpcEptUrl = 'https://data.geopf.fr/chunk/telechargement/download/lidarhd_fxx_ept/vpc/index.vpc';
-const vpcCopcUrl = 'https://data.geopf.fr/chunk/telechargement/download/LiDARHD-NUALID/VPC/amiens.vpc';
+import eptStack from '../data/vpc/eptStack.json';
+import copcStack from '../data/vpc/copcStack.json';
+
+import eptFile from '../data/entwine/ept.json';
+import eptHierarchyFile from '../data/entwine/ept-hierarchy/0-0-0-0.json';
+
+// url of the vpc stack
+const baseurl = 'https://data.geopf.fr/chunk/telechargement/download';
+const vpcEptUrl = `${baseurl}/lidarhd_fxx_ept/vpc/index.vpc`;
+const vpcCopcUrl = `${baseurl}/LiDARHD-NUALID/VPC/amiens.vpc`;
+
+const resources = {
+    [vpcEptUrl]: JSON.parse(eptStack),
+    [vpcCopcUrl]: JSON.parse(copcStack),
+    [`${baseurl}/lidarhd_fxx_ept/kg/ept.json`]: JSON.parse(eptFile),
+    [`${baseurl}/lidarhd_fxx_ept/kg/ept-hierarchy/0-0-0-0.json`]: JSON.parse(eptHierarchyFile),
+};
+
 CRS.defs('EPSG:2154', '+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
 
 describe('VPC', function () {
     let vpcEptSource;
     let vpcCopcSource;
 
-    describe('Source', function () {
+    describe('VPC Source', function () {
+        let stubFetcherJson;
+        before(function () {
+            stubFetcherJson = sinon.stub(Fetcher, 'json')
+                .callsFake(url => Promise.resolve(resources[url]));
+        });
+
+        after(async function () {
+            stubFetcherJson.restore();
+        });
+
         describe('ept stack', function () {
             it('instantiation', function () {
                 vpcEptSource = new VpcSource({
@@ -30,7 +58,7 @@ describe('VPC', function () {
                         assert.ok(vpcEptSource.sources.length > 0);
                         done();
                     }).catch(done);
-            }).timeout(5000);
+            });
         });
 
         describe('copc stack', function () {
@@ -48,31 +76,31 @@ describe('VPC', function () {
                         assert.ok(vpcCopcSource.sources.length > 0);
                         done();
                     }).catch(done);
-            }).timeout(5000);
-        });
-
-        describe('stack sources', function (done) {
-            it('ept stack', function () {
-                const eptMockSource = vpcEptSource.sources[0];
-                vpcEptSource.instantiate(eptMockSource);
-
-                eptMockSource.whenReady
-                    .then(() => {
-                        assert.ok(vpcEptSource.sources[0].isEntwinePointTileSource);
-                        done();
-                    }).catch(done);
-            });
-            it('copc stack', function () {
-                const copcMockSource = vpcCopcSource.sources[0];
-                vpcCopcSource.instantiate(copcMockSource);
-
-                copcMockSource.whenReady
-                    .then(() => {
-                        assert.ok(vpcCopcSource.sources[0].isCopcSource);
-                        done();
-                    }).catch(done);
             });
         });
+    });
+
+    describe('Stacked sources', function () {
+        it('instantiate ept stacked source', function (done) {
+            const eptMockSource = vpcEptSource.sources[0];
+            vpcEptSource.instantiate(eptMockSource);
+
+            eptMockSource.whenReady
+                .then(() => {
+                    assert.ok(vpcEptSource.sources[0].isEntwinePointTileSource);
+                    done();
+                }).catch(done);
+        }).timeout(10000);
+        it('instanciated copc stacked source', function (done) {
+            const copcMockSource = vpcCopcSource.sources[0];
+            vpcCopcSource.instantiate(copcMockSource);
+
+            copcMockSource.whenReady
+                .then(() => {
+                    assert.ok(vpcCopcSource.sources[0].isCopcSource);
+                    done();
+                }).catch(done);
+        }).timeout(10000);
     });
 
     describe('Layer', function () {
@@ -97,9 +125,19 @@ describe('VPC', function () {
                 }).catch(done);
         });
 
-        let context;
         describe('loadData()', () => {
             let node;
+            let context;
+
+            let stubFetcherJson;
+            before(function () {
+                stubFetcherJson = sinon.stub(Fetcher, 'json')
+                    .callsFake(url => Promise.resolve(resources[url]));
+            });
+
+            after(async function () {
+                stubFetcherJson.restore();
+            });
 
             it('on a mockRoot', async function () {
                 context = {
@@ -110,16 +148,18 @@ describe('VPC', function () {
                     view,
                 };
 
-                const mockRoot = vpcLayer.root.children[0];
-                assert.equal(vpcEptSource.sources[0].isEntwinePointTileSource, undefined, 'source already instanciated');
+                const sources = vpcLayer.source.sources;
+                assert.equal(sources[1].isEntwinePointTileSource, undefined, 'source already instantiated');
+                const mockRoot = vpcLayer.root.children[1];
                 vpcLayer.loadData(mockRoot, context, vpcLayer, mockRoot.bbox);
 
                 await mockRoot.source.whenReady;
-                assert.ok(vpcEptSource.sources[0].isEntwinePointTileSource);
+                assert.ok(sources[1].isEntwinePointTileSource);
                 const root = await mockRoot.loadOctree;
                 node = root.children[0];
                 assert.ok(root.numPoints > 0);
             });
+
             it('on a "commun" node', async function () {
                 vpcLayer.loadData(node, context, vpcLayer, node.bbox);
                 if (node.obj) {


### PR DESCRIPTION
The units test for vpc layer are currently pretty often timed out...
This PR aims to chnage them to avoid these error linked to the network.