### PR TITLE
Fix interferences between array texture generation and VR

### DIFF
--- a/packages/Main/src/Renderer/WebGLComposer.ts
+++ b/packages/Main/src/Renderer/WebGLComposer.ts
@@ -66,10 +66,16 @@ export function makeDataArrayRenderTarget(
         quad = new THREE.Mesh(geometry, material);
     }
 
+    // Store renderer state and temporarily disable VR
+    const previousRenderTarget = renderer.getRenderTarget();
+    const gl = renderer.getContext();
+    const glViewport = gl.getParameter(gl.VIEWPORT);
+    const wasVREnabled = renderer.xr.enabled;
+    if (wasVREnabled) { renderer.xr.enabled = false; }
+
     // loop through each tile and its textures
     // to render them into DataArrayTexture layers
     let currentLayerIndex = 0;
-    const previousRenderTarget = renderer.getRenderTarget();
     for (const tile of tiles) {
         for (
             let i = 0;
@@ -100,7 +106,12 @@ export function makeDataArrayRenderTarget(
             renderer.render(quad, quadCam);
         }
     }
+
+    // Restore renderer state
     renderer.setRenderTarget(previousRenderTarget);
+    // renderer.setViewport is not enough to update internal GL state
+    gl.viewport(glViewport[0], glViewport[1], glViewport[2], glViewport[3]);
+    if (wasVREnabled) { renderer.xr.enabled = true; }
 
     return renderTarget;
 }

--- a/packages/Main/test/unit/bootstrap.js
+++ b/packages/Main/test/unit/bootstrap.js
@@ -395,6 +395,7 @@ class Renderer {
                 xrCompatible: false,
             }),
             getExtension: () => null,
+            viewport: () => { },
         };
         this.capabilities = {
             logarithmicDepthBuffer: true,


### PR DESCRIPTION
## Description
The array texture generation was interfering with the VR rendering, causing flashes in the view.
Before rending the textures, we already stored the previous render target to restore it afterwards.
This fix now does the same thing for the VR state and for the viewport.

## Motivation and Context
The entire view was flashing in VR, switching from the standard camera to the XR camera between frames, making VR unusable, as well as generating wrong textures.
After the first part of the fix, only storing and restoring the XR state, the view was no longer flashing but some tiles were blinking after a new array texture was rendered, as shown in the video.
Storing and restoring the GL viewport fixed that second part.

Tested in Chrome/Linux with the Immersive Web Emulator extension, and on a Pico headset.

## Screenshots
[Screencast from 20-11-2025 17:48:49.webm](https://github.com/user-attachments/assets/2d2f557e-5596-4004-99bf-f727ff04fc32)
