### PR TITLE
fix(renderer): track render target usage before cleaning them up, to fix prematurely unloading textures

### DIFF
--- a/packages/Main/src/Core/MainLoop.js
+++ b/packages/Main/src/Core/MainLoop.js
@@ -1,4 +1,5 @@
 import { EventDispatcher } from 'three';
+import { cleanupRts, setCurrentRenderingView } from 'Renderer/LayeredMaterial';
 
 export const RENDERING_PAUSED = 0;
 export const RENDERING_SCHEDULED = 1;
@@ -227,6 +228,8 @@ class MainLoop extends EventDispatcher {
     }
 
     #renderView(view, dt) {
+        setCurrentRenderingView(view.id); // to track render target usage
+
         view.execFrameRequesters(MAIN_LOOP_EVENTS.BEFORE_RENDER, dt, this.#updateLoopRestarted);
 
         if (view.render) {
@@ -237,6 +240,8 @@ class MainLoop extends EventDispatcher {
         }
 
         view.execFrameRequesters(MAIN_LOOP_EVENTS.AFTER_RENDER, dt, this.#updateLoopRestarted);
+
+        cleanupRts();
     }
 }
 

--- a/packages/Main/src/Core/MainLoop.js
+++ b/packages/Main/src/Core/MainLoop.js
@@ -1,5 +1,4 @@
 import { EventDispatcher } from 'three';
-import { cleanupRts, setCurrentRenderingView } from 'Renderer/LayeredMaterial';
 
 export const RENDERING_PAUSED = 0;
 export const RENDERING_SCHEDULED = 1;
@@ -228,8 +227,6 @@ class MainLoop extends EventDispatcher {
     }
 
     #renderView(view, dt) {
-        setCurrentRenderingView(view.id); // to track render target usage
-
         view.execFrameRequesters(MAIN_LOOP_EVENTS.BEFORE_RENDER, dt, this.#updateLoopRestarted);
 
         if (view.render) {
@@ -240,8 +237,6 @@ class MainLoop extends EventDispatcher {
         }
 
         view.execFrameRequesters(MAIN_LOOP_EVENTS.AFTER_RENDER, dt, this.#updateLoopRestarted);
-
-        cleanupRts();
     }
 }
 

--- a/packages/Main/src/Core/TileMesh.ts
+++ b/packages/Main/src/Core/TileMesh.ts
@@ -146,6 +146,10 @@ class TileMesh extends THREE.Mesh<TileGeometry, LayeredMaterial> {
         if (this.material.layersNeedUpdate) {
             this.material.updateLayersUniforms(renderer);
         }
+
+        // Track actual usage every time this mesh is rendered
+        // Use global current rendering view ID set by MainLoop
+        this.material.trackCurrentRenderTargetUsage();
     }
 }
 

--- a/packages/Main/src/Core/TileMesh.ts
+++ b/packages/Main/src/Core/TileMesh.ts
@@ -149,7 +149,7 @@ class TileMesh extends THREE.Mesh<TileGeometry, LayeredMaterial> {
 
         // Track actual usage every time this mesh is rendered
         // Use global current rendering view ID set by MainLoop
-        this.material.trackCurrentRenderTargetUsage();
+        this.material.markAsRendered();
     }
 }
 

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -360,6 +360,16 @@ class TiledGeometryLayer extends GeometryLayer {
         });
     }
 
+    /**
+     * All layer's 3D objects are removed from the scene and disposed from the video device.
+     * Also disposes the render target cache.
+     * @param {boolean} [clearCache=false] Whether to clear the layer cache or not
+     */
+    delete(clearCache) {
+        super.delete(clearCache);
+        this.renderTargetCache.dispose();
+    }
+
     // eslint-disable-next-line
     culling(node, camera) {
         return !camera.isBox3Visible(node.obb.box3D, node.matrixWorld);

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -6,7 +6,7 @@ import convertToTile from 'Converter/convertToTile';
 import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import { getColorLayersIdOrderedBySequence } from 'Layer/ImageryLayers';
 import { CACHE_POLICIES } from 'Core/Scheduler/Cache';
-import { LRUCache } from 'lru-cache';
+import { RenderTargetCache } from 'Renderer/RenderTargetCache';
 
 const subdivisionVector = new THREE.Vector3();
 const boundingSphereCenter = new THREE.Vector3();
@@ -18,9 +18,7 @@ const boundingSphereCenter = new THREE.Vector3();
  * as it is used internally for optimisation.
  * @property {boolean} hideSkirt (default false) - Used to hide the skirt (tile borders).
  * Useful when the layer opacity < 1
- * @property {Map<string, THREE.WebGLArrayRenderTarget>} pendingRtDisposal
- * @property {Set<string>} usedRts
- * @property {LRUCache<string, THREE.WebGLArrayRenderTarget>} rtCache
+ * @property {RenderTargetCache} renderTargetCache - Manages render target caching and disposal
  *
  * @extends GeometryLayer
  */
@@ -153,23 +151,9 @@ class TiledGeometryLayer extends GeometryLayer {
         this.diffuse = diffuse;
 
         /**
-         * @type {Map<string, THREE.WebGLArrayRenderTarget>}
+         * @type {RenderTargetCache}
          */
-        this.pendingRtDisposal = new Map();
-        /**
-         * @type {Set<string>}
-         */
-        this.usedRts = new Set();
-
-        /**
-         * @type {LRUCache<string, THREE.WebGLArrayRenderTarget>}
-         */
-        this.rtCache = new LRUCache({
-            max: 200,
-            dispose: (rt, key) => {
-                this.pendingRtDisposal.set(key, rt);
-            },
-        });
+        this.renderTargetCache = new RenderTargetCache();
 
         this.level0Nodes = [];
         const promises = [];
@@ -275,16 +259,7 @@ class TiledGeometryLayer extends GeometryLayer {
         this.colorLayersOrder = getColorLayersIdOrderedBySequence(context.colorLayers);
 
         // Dispose render targets that are queued for disposal and not used by this view
-        if (this.usedRts.size) { // important: only clean up if last loop did rendering
-            for (const [id, renderTarget] of this.pendingRtDisposal) {
-                if (this.usedRts.has(id)) { continue; }
-                renderTarget.dispose();
-                this.pendingRtDisposal.delete(id);
-            }
-
-            // initialize render target usage tracking for next render
-            this.usedRts.clear();
-        }
+        this.renderTargetCache.cleanup();
 
         let commonAncestor;
         for (const source of sources.values()) {
@@ -380,9 +355,7 @@ class TiledGeometryLayer extends GeometryLayer {
 
     convert(requester, extent) {
         return convertToTile.convert(requester, extent, this).then((tileMesh) => {
-            tileMesh.material.rtCache = this.rtCache;
-            tileMesh.material.usedRts = this.usedRts;
-            tileMesh.material.pendingRtDisposal = this.pendingRtDisposal;
+            tileMesh.material.renderTargetCache = this.renderTargetCache;
             return tileMesh;
         });
     }

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -275,7 +275,7 @@ class TiledGeometryLayer extends GeometryLayer {
         this.colorLayersOrder = getColorLayersIdOrderedBySequence(context.colorLayers);
 
         // Dispose render targets that are queued for disposal and not used by this view
-        if (this.usedRts.length) { // important: only clean up if last loop did rendering
+        if (this.usedRts.size) { // important: only clean up if last loop did rendering
             for (const [id, renderTarget] of this.pendingRtDisposal) {
                 if (this.usedRts.has(id)) { continue; }
                 renderTarget.dispose();

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -380,9 +380,6 @@ class TiledGeometryLayer extends GeometryLayer {
 
     convert(requester, extent) {
         return convertToTile.convert(requester, extent, this).then((tileMesh) => {
-            if (this.level0Nodes.length && this.level0Nodes[0].material != tileMesh.material) {
-                console.error('Inconsistent tile material detected');
-            }
             tileMesh.material.rtCache = this.rtCache;
             tileMesh.material.usedRts = this.usedRts;
             tileMesh.material.pendingRtDisposal = this.pendingRtDisposal;

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -529,15 +529,19 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
      * Track usage of current render targets for deferred disposal.
      * Should be called every time this material is rendered.
      */
-    public trackCurrentRenderTargetUsage(): void {
+    public markAsRendered(): void {
+        if (!this.renderTargetCache) {
+            throw new Error('renderTargetCache is not initialized');
+        }
+
         const colorTextures = this.getUniform('colorTextures');
         if (colorTextures?.userData?.textureSetId) {
-            this.renderTargetCache!.markAsUsed(colorTextures.userData.textureSetId);
+            this.renderTargetCache.markAsUsed(colorTextures.userData.textureSetId);
         }
 
         const elevationTextures = this.getUniform('elevationTextures');
         if (elevationTextures?.userData?.textureSetId) {
-            this.renderTargetCache!.markAsUsed(elevationTextures.userData.textureSetId);
+            this.renderTargetCache.markAsUsed(elevationTextures.userData.textureSetId);
         }
     }
 

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -461,10 +461,10 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
             }
         }
 
-        let cachedRT = this.rtCache!.get(textureSetId);
+        let cachedRT = this.rtCache?.get(textureSetId);
 
         if (!cachedRT) {
-            cachedRT = this.pendingRtDisposal!.get(textureSetId);
+            cachedRT = this.pendingRtDisposal?.get(textureSetId);
             if (cachedRT) {
                 this.rtCache!.set(textureSetId, cachedRT);
                 this.pendingRtDisposal!.delete(textureSetId);
@@ -483,7 +483,7 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
             return;
         }
 
-        this.rtCache!.set(textureSetId, rt);
+        this.rtCache?.set(textureSetId, rt);
         rt.texture.userData = { textureSetId };
         uniforms.textures.value = rt.texture;
 

--- a/packages/Main/src/Renderer/LayeredMaterial.ts
+++ b/packages/Main/src/Renderer/LayeredMaterial.ts
@@ -78,151 +78,6 @@ const defaultStructLayers: Readonly<{
     },
 };
 
-// Deferred disposal data structures
-const pendingRtDisposal = new Map<string, THREE.WebGLArrayRenderTarget>();
-const viewRtUsage = new Map<number, Set<string>>();
-
-let currentRenderingViewId: number | undefined;
-
-const rtCache = new LRUCache<string, THREE.WebGLArrayRenderTarget>({
-    max: 200,
-    dispose: (rt, key) => {
-        pendingRtDisposal.set(key, rt);
-    },
-});
-
-/**
- * Updates the uniforms for layered textures,
- * including populating the DataArrayTexture
- * with content from individual 2D textures on the GPU.
- *
- * @param uniforms - The uniforms object for your material.
- * @param tiles - An array of RasterTile objects, each containing textures.
- * @param max - The maximum number of layers for the DataArrayTexture.
- * @param type - Layer set identifier: 'c' for color, 'e' for elevation.
- * @param renderer - The renderer used to render textures.
- */
-function updateLayersUniforms<Type extends 'c' | 'e'>(
-    uniforms: { [name: string]: THREE.IUniform },
-    tiles: RasterTile[],
-    max: number,
-    type: Type,
-    renderer: THREE.WebGLRenderer) {
-    // Aliases for readability
-    const uLayers = uniforms.layers.value;
-    const uTextures = uniforms.textures;
-    const uOffsetScales = uniforms.offsetScales.value;
-    const uTextureCount = uniforms.textureCount;
-
-    // Flatten the 2d array: [i, j] -> layers[_layerIds[i]].textures[j]
-    let count = 0;
-    let width = 0;
-    let height = 0;
-
-    // Determine total count of textures and dimensions
-    // (assuming all textures are same size)
-    let textureSetId: string = type;
-    for (const tile of tiles) {
-        // FIXME: RasterElevationTile are always passed to this function alone
-        // so this works, but it's really not great even ignoring the dynamic
-        // addition of a field.
-        // @ts-expect-error: adding field to passed layer
-        tile.textureOffset = count;
-
-        for (
-            let i = 0;
-            i < tile.textures.length && count < max;
-            ++i, ++count
-        ) {
-            const texture = tile.textures[i];
-            if (!texture) { continue; }
-
-            textureSetId += `${texture.id}.`;
-            uOffsetScales[count] = tile.offsetScales[i];
-            uLayers[count] = tile;
-
-            const img = texture.image;
-            if (!img || img.width <= 0 || img.height <= 0) {
-                console.error('Texture image not loaded or has zero dimensions');
-                uTextureCount.value = 0;
-                return;
-            } else if (count == 0) {
-                width = img.width;
-                height = img.height;
-            } else if (width !== img.width || height !== img.height) {
-                console.error('Texture dimensions mismatch');
-                uTextureCount.value = 0;
-                return;
-            }
-        }
-    }
-
-    let cachedRT = rtCache.get(textureSetId);
-
-    if (!cachedRT) {
-        cachedRT = pendingRtDisposal.get(textureSetId);
-        if (cachedRT) {
-            rtCache.set(textureSetId, cachedRT);
-            pendingRtDisposal.delete(textureSetId);
-        }
-    }
-
-    if (cachedRT) {
-        uTextures.value = cachedRT.texture;
-        uTextureCount.value = count;
-        return;
-    }
-
-    const rt = makeDataArrayRenderTarget(width, height, count, tiles, max, renderer);
-    if (!rt) {
-        uTextureCount.value = 0;
-        return;
-    }
-
-    rtCache.set(textureSetId, rt);
-    rt.texture.userData = { textureSetId };
-    uniforms.textures.value = rt.texture;
-
-    if (count > max) {
-        console.warn(
-            `LayeredMaterial: Not enough texture units (${max} < ${count}), `
-            + 'excess textures have been discarded.',
-        );
-    }
-    uTextureCount.value = count;
-}
-
-/**
- * Set the current view being rendered and
- * initialize its render target usage tracking.
- * @param viewId - The ID of the view currently being rendered
- */
-export function setCurrentRenderingView(viewId: number) {
-    currentRenderingViewId = viewId;
-
-    const viewUsage = viewRtUsage.get(viewId);
-    if (viewUsage) { viewUsage.clear(); }
-}
-
-/**
- * Disposes render targets that are queued for disposal and not used by any view
- */
-export function cleanupRts() {
-    for (const [id, renderTarget] of pendingRtDisposal) {
-        let usedByAnyView = false;
-        for (const [, usedRts] of viewRtUsage) {
-            if (usedRts.has(id)) {
-                usedByAnyView = true;
-                break;
-            }
-        }
-
-        if (!usedByAnyView) {
-            renderTarget.dispose();
-            pendingRtDisposal.delete(id);
-        }
-    }
-}
 
 export const ELEVATION_MODES = {
     RGBA: 0,
@@ -345,6 +200,11 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
     public elevationTileId: string | undefined;
 
     public layersNeedUpdate: boolean;
+
+    // Deferred disposal data structures
+    public pendingRtDisposal: LRUCache<string, THREE.WebGLArrayRenderTarget> | undefined;
+    public usedRts: Set<string> | undefined;
+    public rtCache: LRUCache<string, THREE.WebGLArrayRenderTarget> | undefined;
 
     public override defines: LayeredMaterialDefines;
 
@@ -535,6 +395,113 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
         };
     }
 
+    /**
+     * Updates the uniforms for layered textures of a specific type,
+     * including populating the DataArrayTexture
+     * with content from individual 2D textures on the GPU.
+     *
+     * @param uniforms - The uniforms object for your material.
+     * @param tiles - An array of RasterTile objects, each containing textures.
+     * @param max - The maximum number of layers for the DataArrayTexture.
+     * @param type - Layer set identifier: 'c' for color, 'e' for elevation.
+     * @param renderer - The renderer used to render textures.
+     */
+    private _updateLayersUniformsForType<Type extends 'c' | 'e'>(
+        uniforms: { [name: string]: THREE.IUniform },
+        tiles: RasterTile[],
+        max: number,
+        type: Type,
+        renderer: THREE.WebGLRenderer) {
+        // Aliases for readability
+        const uLayers = uniforms.layers.value;
+        const uTextures = uniforms.textures;
+        const uOffsetScales = uniforms.offsetScales.value;
+        const uTextureCount = uniforms.textureCount;
+
+        // Flatten the 2d array: [i, j] -> layers[_layerIds[i]].textures[j]
+        let count = 0;
+        let width = 0;
+        let height = 0;
+
+        // Determine total count of textures and dimensions
+        // (assuming all textures are same size)
+        let textureSetId: string = type;
+        for (const tile of tiles) {
+            // FIXME: RasterElevationTile are always passed to this function
+            // alone so this works, but it's really not great even ignoring
+            // the dynamic addition of a field.
+            // @ts-expect-error: adding field to passed layer
+            tile.textureOffset = count;
+
+            for (
+                let i = 0;
+                i < tile.textures.length && count < max;
+                ++i, ++count
+            ) {
+                const texture = tile.textures[i];
+                if (!texture) { continue; }
+
+                textureSetId += `${texture.id}.`;
+                uOffsetScales[count] = tile.offsetScales[i];
+                uLayers[count] = tile;
+
+                const img = texture.image;
+                if (!img || img.width <= 0 || img.height <= 0) {
+                    console.error('Texture image not loaded or has zero dimensions');
+                    uTextureCount.value = 0;
+                    return;
+                } else if (count == 0) {
+                    width = img.width;
+                    height = img.height;
+                } else if (width !== img.width || height !== img.height) {
+                    console.error('Texture dimensions mismatch');
+                    uTextureCount.value = 0;
+                    return;
+                }
+            }
+        }
+
+        let cachedRT = this.rtCache!.get(textureSetId);
+
+        if (!cachedRT) {
+            cachedRT = this.pendingRtDisposal!.get(textureSetId);
+            if (cachedRT) {
+                this.rtCache!.set(textureSetId, cachedRT);
+                this.pendingRtDisposal!.delete(textureSetId);
+            }
+        }
+
+        if (cachedRT) {
+            uTextures.value = cachedRT.texture;
+            uTextureCount.value = count;
+            return;
+        }
+
+        const rt = makeDataArrayRenderTarget(width, height, count, tiles, max, renderer);
+        if (!rt) {
+            uTextureCount.value = 0;
+            return;
+        }
+
+        this.rtCache!.set(textureSetId, rt);
+        rt.texture.userData = { textureSetId };
+        uniforms.textures.value = rt.texture;
+
+        if (count > max) {
+            console.warn(
+                `LayeredMaterial: Not enough texture units (${max} < ${count}), `
+                + 'excess textures have been discarded.',
+            );
+        }
+        uTextureCount.value = count;
+    }
+
+    /**
+     * Updates uniforms for both color and elevation layers.
+     * Orchestrates the processing of visible color layers and elevation tiles.
+     *
+     * @param renderer - The renderer used to render textures into arrays.
+     */
     public updateLayersUniforms(renderer: THREE.WebGLRenderer): void {
         const colorlayers = this.colorTiles
             .filter(rt => rt.visible && rt.opacity > 0);
@@ -542,7 +509,7 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
             this.colorTileIds.indexOf(a.id) - this.colorTileIds.indexOf(b.id),
         );
 
-        updateLayersUniforms(
+        this._updateLayersUniformsForType(
             this.getLayerUniforms('color'),
             colorlayers,
             this.defines.NUM_FS_TEXTURES,
@@ -552,7 +519,7 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
 
         if (this.elevationTileId !== undefined && this.getElevationTile()) {
             if (this.elevationTile !== undefined) {
-                updateLayersUniforms(
+                this._updateLayersUniformsForType(
                     this.getLayerUniforms('elevation'),
                     [this.elevationTile],
                     this.defines.NUM_VS_TEXTURES,
@@ -570,21 +537,14 @@ export class LayeredMaterial extends THREE.ShaderMaterial {
      * Should be called every time this material is rendered.
      */
     public trackCurrentRenderTargetUsage(): void {
-        if (currentRenderingViewId === undefined) { return; }
-
-        if (!viewRtUsage.has(currentRenderingViewId)) {
-            viewRtUsage.set(currentRenderingViewId, new Set<string>());
-        }
-        const viewUsage = viewRtUsage.get(currentRenderingViewId)!;
-
         const colorTextures = this.getUniform('colorTextures');
         if (colorTextures?.userData?.textureSetId) {
-            viewUsage.add(colorTextures.userData.textureSetId);
+            this.usedRts!.add(colorTextures.userData.textureSetId);
         }
 
         const elevationTextures = this.getUniform('elevationTextures');
         if (elevationTextures?.userData?.textureSetId) {
-            viewUsage.add(elevationTextures.userData.textureSetId);
+            this.usedRts!.add(elevationTextures.userData.textureSetId);
         }
     }
 

--- a/packages/Main/src/Renderer/RenderTargetCache.ts
+++ b/packages/Main/src/Renderer/RenderTargetCache.ts
@@ -38,18 +38,19 @@ export class RenderTargetCache {
      * Perform cleanup of render targets that are not used in this render cycle.
      */
     public cleanup(): void {
-        if (this._usedIds.size) { // important: only clean up if last loop did rendering
-            for (const [id, renderTarget] of this._pendingDisposal) {
-                if (this._usedIds.has(id)) {
-                    continue;
-                }
-                renderTarget.dispose();
-                this._pendingDisposal.delete(id);
-            }
+        // important: only clean up if last loop did rendering
+        if (!this._usedIds.size) { return; }
 
-            // initialize render target usage tracking for next render
-            this._usedIds.clear();
+        for (const [id, renderTarget] of this._pendingDisposal) {
+            if (this._usedIds.has(id)) {
+                continue;
+            }
+            renderTarget.dispose();
+            this._pendingDisposal.delete(id);
         }
+
+        // initialize render target usage tracking for next render
+        this._usedIds.clear();
     }
 
     /**
@@ -89,5 +90,22 @@ export class RenderTargetCache {
      */
     public set(id: string, rt: THREE.WebGLArrayRenderTarget): void {
         this._cache.set(id, rt);
+    }
+
+    /**
+     * Dispose all render targets and clear the cache completely.
+     */
+    public dispose(): void {
+        for (const [, renderTarget] of this._cache) {
+            renderTarget.dispose();
+        }
+        this._cache.clear();
+
+        for (const [, renderTarget] of this._pendingDisposal) {
+            renderTarget.dispose();
+        }
+        this._pendingDisposal.clear();
+
+        this._usedIds.clear();
     }
 }

--- a/packages/Main/src/Renderer/RenderTargetCache.ts
+++ b/packages/Main/src/Renderer/RenderTargetCache.ts
@@ -1,0 +1,93 @@
+import * as THREE from 'three';
+import { LRUCache } from 'lru-cache';
+
+/**
+ * Manages render target cache with deferred disposal for better memory
+ * management. Tracks which render targets are currently in use and
+ * disposes those that are no longer needed.
+ */
+export class RenderTargetCache {
+    /**
+     * Render targets queued for disposal.
+     */
+    private _pendingDisposal: Map<string, THREE.WebGLArrayRenderTarget>;
+
+    /**
+     * Render targets used in the current render cycle.
+     */
+    private _usedIds: Set<string>;
+
+    /**
+     * LRU cache of render targets, automatically discards least recently
+     * used when max is exceeded.
+     */
+    private _cache: LRUCache<string, THREE.WebGLArrayRenderTarget>;
+
+    constructor(maxCacheSize: number = 200) {
+        this._pendingDisposal = new Map();
+        this._usedIds = new Set();
+        this._cache = new LRUCache({
+            max: maxCacheSize,
+            dispose: (rt: THREE.WebGLArrayRenderTarget, key: string) => {
+                this._pendingDisposal.set(key, rt);
+            },
+        });
+    }
+
+    /**
+     * Perform cleanup of render targets that are not used in this render cycle.
+     */
+    public cleanup(): void {
+        if (this._usedIds.size) { // important: only clean up if last loop did rendering
+            for (const [id, renderTarget] of this._pendingDisposal) {
+                if (this._usedIds.has(id)) {
+                    continue;
+                }
+                renderTarget.dispose();
+                this._pendingDisposal.delete(id);
+            }
+
+            // initialize render target usage tracking for next render
+            this._usedIds.clear();
+        }
+    }
+
+    /**
+     * Track usage of a render target in the current render cycle.
+     *
+     * @param id - The identifier of the render target to track
+     */
+    public markAsUsed(id: string): void {
+        this._usedIds.add(id);
+    }
+
+    /**
+     * Get a render target from cache or pending disposal.
+     *
+     * @param id - The identifier of the render target
+     * @returns The render target or undefined if not found
+     */
+    public get(id: string): THREE.WebGLArrayRenderTarget | undefined {
+        let rt = this._cache.get(id);
+
+        if (!rt) {
+            rt = this._pendingDisposal.get(id);
+            if (rt) {
+                this._cache.set(id, rt);
+                this._pendingDisposal.delete(id);
+            }
+        }
+
+        return rt;
+    }
+
+    /**
+     * Add or update a render target in cache.
+     *
+     * @param id - The identifier of the render target
+     * @param rt - The render target to cache
+     */
+    public set(id: string, rt: THREE.WebGLArrayRenderTarget): void {
+        this._cache.set(id, rt);
+    }
+}

--- a/packages/Main/test/unit/layeredmaterial.js
+++ b/packages/Main/test/unit/layeredmaterial.js
@@ -66,6 +66,8 @@ describe('material state vs layer state', function () {
     });
 
     it('should update material uniforms', () => {
+        node.material.renderTargetCache = view.tileLayer.renderTargetCache;
+
         layer.visible = false;
         node.material.layersNeedUpdate = true;
         node.onBeforeRender();


### PR DESCRIPTION
## Description
Track which array render targets are actually used when rendering each view.
Then, when they would normally be disposed of because the cache managing them reaches its limit, we keep them in another map to only dispose of them once they are not used for rendering in any view.

## Motivation and Context
When rendering array textures for new tiles, some tiles' textures were sometimes prematurely unloaded, leaving holes in the terrain where those tiles should be.

## Screenshots
[Screencast from 19-11-2025 09:34:36.webm](https://github.com/user-attachments/assets/f5faa5fe-a578-44cc-8843-399536f993f0)

