### PR TITLE
Fix loading issues with potree2

### DIFF
--- a/packages/Main/src/Core/PointCloudNode.js
+++ b/packages/Main/src/Core/PointCloudNode.js
@@ -202,12 +202,16 @@ class PointCloudNode extends THREE.EventDispatcher {
         throw new Error('In extended PointCloudNode, you have to implement the method loadOctree!');
     }
 
-    async load(networkOptions = this.source.networkOptions) {
+    networkOptions() {
+        return this.source.networkOptions;
+    }
+
+    async load() {
         // Query octree/HRC if we don't have children yet.
         if (!this.octreeIsLoaded) {
             await this.loadOctree();
         }
-        return this.source.fetcher(this.url, networkOptions)
+        return this.source.fetcher(this.url, this.networkOptions())
             .then(file => this.source.parser(file, {
                 in: this,
             }));

--- a/packages/Main/src/Core/Potree2Node.js
+++ b/packages/Main/src/Core/Potree2Node.js
@@ -50,6 +50,7 @@ class Potree2Node extends PotreeNode {
         return `${this.baseurl}/octree.bin`;
     }
 
+    // Beware: you should call this method after the hierarchy is loaded
     networkOptions(byteOffset = this.byteOffset, byteSize = this.byteSize) {
         const first = byteOffset;
         const last = first + byteSize - 1n;

--- a/packages/Main/src/Core/PotreeNode.js
+++ b/packages/Main/src/Core/PotreeNode.js
@@ -96,11 +96,8 @@ class PotreeNode extends PointCloudNode {
         childNode.clampOBB.matrixWorldInverse = this.clampOBB.matrixWorldInverse;
     }
 
-    networkOptions() {
-    }
-
     load() {
-        return super.load(this.networkOptions());
+        return super.load();
     }
 
     loadOctree() {


### PR DESCRIPTION
## Description
Potree 2 builds its request using information from the loaded hierarchy. However, #2638 introduced a regression where request building was done before the hierarchy was loaded, introducing invalid values for the request. This PR fixes this regression.

I did not add a new test since I'm currently doing a refactor of all pointcloud related modules.
