### PR TITLE
Migrate pointcloud-related modules to typescript

### DIFF
--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -7,6 +7,15 @@ const size = new THREE.Vector3();
 const position = new THREE.Vector3();
 const translation = new THREE.Vector3();
 
+export interface PointCloudSource {
+    spacing: number;
+    crs: string;
+    zmin: number;
+    zmax: number;
+}
+
+type ExtentedOBB = OBB & { matrixWorldInverse: THREE.Matrix4 };
+
 /**
  * @property {number} numPoints - The number of points in this node.
  * @property {PointCloudSource} source - Data source of the node.
@@ -16,26 +25,62 @@ const translation = new THREE.Vector3();
  * @property {OBB} clampOBB - The cubique obb clamped to zmin and zmax.
  * @property {number} sse - The sse of the node set at an nitial value of -1.
  */
-class PointCloudNode extends THREE.EventDispatcher {
-    constructor(numPoints = 0, source) {
+abstract class PointCloudNode extends THREE.EventDispatcher {
+    abstract crs: string;
+    abstract source: PointCloudSource;
+
+    x: number;
+    y: number;
+    z: number;
+    depth: number;
+
+    numPoints: number;
+    children: this[];
+    parent: this | undefined;
+
+    voxelOBB: ExtentedOBB;
+    clampOBB: ExtentedOBB;
+
+    // Properties used internally by PointCloud layer
+    visible: boolean;
+    sse: number;
+    notVisibleSince: number | undefined;
+    promise: Promise<unknown> | null;
+    obj: THREE.Points | undefined;
+
+    private _center: Coordinates | undefined;
+    private _origin: Coordinates | undefined;
+    private _rotation: THREE.Quaternion | undefined;
+
+    constructor(numPoints = 0) {
         super();
+
+        this.x = 0;
+        this.y = 0;
+        this.z = 0;
+        this.depth = 0;
 
         this.numPoints = numPoints;
 
-        this.source = source;
-
         this.children = [];
-        this.voxelOBB = new OBB();
-        this.clampOBB = new OBB();
+        this.parent = undefined;
+
+        this.voxelOBB = new OBB() as ExtentedOBB;
+        this.clampOBB = new OBB() as ExtentedOBB;
         this.sse = -1;
+
+        this.visible = false;
+        this.promise = null;
     }
+
+    abstract get octreeIsLoaded(): boolean;
+    abstract get id(): string;
+    abstract get url(): string;
+    abstract load(networkOptions?: RequestInit): Promise<THREE.BufferGeometry>;
+    abstract loadOctree(): Promise<void>;
 
     get pointSpacing() {
         return this.source.spacing / 2 ** this.depth;
-    }
-
-    get id() {
-        throw new Error('In extended PointCloudNode, you have to implement the getter id!');
     }
 
     // get the center of the node i.e. the center of the bounding box.
@@ -69,7 +114,8 @@ class PointCloudNode extends THREE.EventDispatcher {
         return this._rotation;
     }
 
-    setOBBes(min, max) {
+    setOBBes(min: number[], max: number[]) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
         const root = this;
         const crs = {
             in: root.source.crs,
@@ -78,7 +124,7 @@ class PointCloudNode extends THREE.EventDispatcher {
         const zmin = root.source.zmin;
         const zmax = root.source.zmax;
 
-        let forward = (x => x);
+        let forward = (x: [number, number, number]) => x;
         if (crs.in !== crs.out) {
             try {
                 forward = proj4(crs.in, crs.out).forward;
@@ -144,7 +190,7 @@ class PointCloudNode extends THREE.EventDispatcher {
         root.clampOBB.matrixWorldInverse = root.voxelOBB.matrixWorldInverse;
     }
 
-    add(node, indexChild) {
+    add(node: this, indexChild: number) {
         this.children.push(node);
         node.parent = this;
         this.createChildAABB(node, indexChild);
@@ -155,7 +201,8 @@ class PointCloudNode extends THREE.EventDispatcher {
      * `this` is its parent.
      * @param {CopcNode} childNode - The child node
      */
-    createChildAABB(childNode) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    createChildAABB(childNode: this, _indexChild: number) {
         // initialize the child node obb
         childNode.voxelOBB.copy(this.voxelOBB);
         const voxelBBox = this.voxelOBB.box3D;
@@ -198,36 +245,17 @@ class PointCloudNode extends THREE.EventDispatcher {
         childNode.clampOBB.matrixWorldInverse = this.clampOBB.matrixWorldInverse;
     }
 
-    async loadOctree() {
-        throw new Error('In extended PointCloudNode, you have to implement the method loadOctree!');
-    }
-
-    networkOptions() {
-        return this.source.networkOptions;
-    }
-
-    async load() {
-        // Query octree/HRC if we don't have children yet.
-        if (!this.octreeIsLoaded) {
-            await this.loadOctree();
-        }
-        return this.source.fetcher(this.url, this.networkOptions())
-            .then(file => this.source.parser(file, {
-                in: this,
-            }));
-    }
-
-    findCommonAncestor(node) {
+    findCommonAncestor(node: this): this | undefined {
         if (node.depth == this.depth) {
             if (node.id == this.id) {
                 return node;
             } else if (node.depth != 0) {
-                return this.parent.findCommonAncestor(node.parent);
+                return (this.parent as this).findCommonAncestor(node.parent as this);
             }
         } else if (node.depth < this.depth) {
-            return this.parent.findCommonAncestor(node);
+            return (this.parent as this).findCommonAncestor(node);
         } else {
-            return this.findCommonAncestor(node.parent);
+            return this.findCommonAncestor(node.parent as this);
         }
     }
 }

--- a/packages/Main/src/Layer/CopcLayer.ts
+++ b/packages/Main/src/Layer/CopcLayer.ts
@@ -1,11 +1,14 @@
+import PointCloudLayer, { type PointCloudLayerParameters } from 'Layer/PointCloudLayer';
 import CopcNode from 'Core/CopcNode';
-import PointCloudLayer from 'Layer/PointCloudLayer';
+import type CopcSource from 'Source/CopcSource';
+
+interface CopcLayerParameters extends PointCloudLayerParameters {
+    source : CopcSource;
+}
 
 /**
  * A layer for [Cloud Optimised Point Cloud](https://copc.io) (COPC) datasets.
  * See {@link PointCloudLayer} class for documentation on base properties.
- *
- * @extends {PointCloudLayer}
  *
  * @example
  * // Create a new COPC layer
@@ -22,27 +25,25 @@ import PointCloudLayer from 'Layer/PointCloudLayer';
  * View.prototype.addLayer.call(view, copcLayer);
  */
 class CopcLayer extends PointCloudLayer {
-    /**
-     * @param {string} id - Unique id of the layer.
-     * @param {Object} config - See {@link PointCloudLayer} for base pointcloud
-     * options.
-     */
-    constructor(id, config) {
-        super(id, config);
+    readonly isCopcLayer: true;
 
-        /**
-         * @type {boolean}
-         * @readonly
-         */
+    source: CopcSource;
+    /**
+     * @param id - Unique id of the layer.
+     * @param config - See {@link PointCloudLayer} for base pointcloud options.
+     */
+    constructor(id: string, config: CopcLayerParameters) {
+        super(id, config);
         this.isCopcLayer = true;
+        this.source = config.source;
 
         const resolve = super.addInitializationStep();
-        this.whenReady = this.source.whenReady.then((/** @type {CopcSource} */ source) => {
+        this.whenReady = this.source.whenReady.then((source) => {
             this.setElevationRange();
 
-            const { pageOffset, pageLength } = source.info.rootHierarchyPage;
+            const { rootHierarchyPage, cube } = source.info;
+            const { pageOffset, pageLength } = rootHierarchyPage;
             this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1, this.crs);
-            const { cube } = source.info;
             this.root.setOBBes(cube.slice(0, 3), cube.slice(3, 6));
 
             return this.root.loadOctree().then(resolve);

--- a/packages/Main/src/Layer/EntwinePointTileLayer.ts
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.ts
@@ -1,5 +1,11 @@
+import PointCloudLayer, { type PointCloudLayerParameters } from 'Layer/PointCloudLayer';
 import EntwinePointTileNode from 'Core/EntwinePointTileNode';
-import PointCloudLayer from 'Layer/PointCloudLayer';
+import type EntwinePointTileSource from 'Source/EntwinePointTileSource';
+
+interface EntwinePointTileLayerParameters extends PointCloudLayerParameters {
+    crs?: string;
+    source: EntwinePointTileSource;
+}
 
 /**
  * @property {boolean} isEntwinePointTileLayer - Used to checkout whether this
@@ -8,7 +14,9 @@ import PointCloudLayer from 'Layer/PointCloudLayer';
  *
  * @extends PointCloudLayer
  */
-class EntwinePointTileLayer extends PointCloudLayer {
+class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
+    readonly isEntwinePointTileLayer: true;
+
     /**
      * Constructs a new instance of Entwine Point Tile layer.
      *
@@ -23,27 +31,19 @@ class EntwinePointTileLayer extends PointCloudLayer {
      *
      * View.prototype.addLayer.call(view, points);
      *
-     * @param {string} id - The id of the layer, that should be unique. It is
+     * @param id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
-     * {@link View} that already has a layer going by that id.
-     * @param {Object} config - Configuration, all elements in it
+     * View that already has a layer going by that id.
+     * @param config - Configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
      * contains three elements `name, protocol, extent`, these elements will be
      * available using `layer.name` or something else depending on the property
      * name. See the list of properties to know which one can be specified.
      */
-    constructor(id, config) {
+    constructor(id: string, config: EntwinePointTileLayerParameters) {
         super(id, config);
 
-        /**
-         * @type {boolean}
-         * @readonly
-         */
         this.isEntwinePointTileLayer = true;
-
-        /**
-         * @type {THREE.Vector3}
-         */
 
         const resolve = this.addInitializationStep();
         this.whenReady = this.source.whenReady.then(() => {

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -3,12 +3,64 @@ import GeometryLayer from 'Layer/GeometryLayer';
 import PointsMaterial, { PNTS_MODE } from 'Renderer/PointsMaterial';
 import Picking from 'Core/Picking';
 
+import type PointCloudNode from 'Core/PointCloudNode';
+
 const point = new THREE.Vector3();
 const bboxMesh = new THREE.Mesh();
 const box3 = new THREE.Box3();
 bboxMesh.geometry.boundingBox = box3;
 
-function computeSSEPerspective(context, pointSize, pointSpacing, distance) {
+export interface PointCloudSource {
+    zmin: number;
+    zmax: number;
+}
+
+export interface PointCloudLayerParameters {
+    source: PointCloudSource;
+    object3d?: THREE.Group;
+    group?: THREE.Group;
+    bboxes?: THREE.Group;
+    octreeDepthLimit?: number;
+    pointBudget?: number;
+    pointSize?: number;
+    sseThreshold?: number;
+    minIntensityRange?: number;
+    maxIntensityRange?: number;
+    minElevationRange?: number;
+    maxElevationRange?: number;
+    minAngleRange?: number;
+    maxAngleRange?: number;
+    material?: THREE.Material;
+    mode?: number;
+}
+
+interface Context {
+    camera: {
+        camera3D: THREE.PerspectiveCamera;
+        preSSE: number;
+        width: number;
+        height: number;
+        isBox3Visible: (bbox: THREE.Box3, matrixWorld: THREE.Matrix4) => boolean;
+    };
+    scheduler: {
+        execute: (command: {
+            layer: PointCloudLayer;
+            requester: PointCloudNode;
+            view: object;
+            priority: number;
+            redraw: boolean;
+            earlyDropFunction?: (cmd: { requester: PointCloudNode }) => boolean;
+        }) => Promise<THREE.Points>;
+    };
+    view: object;
+}
+
+function computeSSEPerspective(
+    context: Context,
+    pointSize: number,
+    pointSpacing: number,
+    distance: number,
+) {
     if (distance <= 0) {
         return Infinity;
     }
@@ -21,7 +73,11 @@ function computeSSEPerspective(context, pointSize, pointSpacing, distance) {
     return Math.max(0.0, onScreenSpacing - pointSize);
 }
 
-function computeSSEOrthographic(context, pointSize, pointSpacing) {
+function computeSSEOrthographic(
+    context: Context,
+    pointSize: number,
+    pointSpacing: number,
+) {
     // Given an identity view matrix, project pointSpacing from world space to
     // clip space. v' = vVP = vP
     const v = new THREE.Vector4(pointSpacing);
@@ -35,15 +91,20 @@ function computeSSEOrthographic(context, pointSize, pointSpacing) {
     return Math.max(0.0, distance - pointSize);
 }
 
-function computeScreenSpaceError(context, pointSize, pointSpacing, distance) {
-    if (context.camera.camera3D.isOrthographicCamera) {
+function computeScreenSpaceError(
+    context: Context,
+    pointSize: number,
+    pointSpacing: number,
+    distance: number,
+) {
+    if (context.camera.camera3D instanceof THREE.OrthographicCamera) {
         return computeSSEOrthographic(context, pointSize, pointSpacing);
     }
 
     return computeSSEPerspective(context, pointSize, pointSpacing, distance);
 }
 
-function markForDeletion(elt) {
+function markForDeletion(elt: PointCloudNode) {
     if (elt.obj) {
         elt.obj.visible = false;
     }
@@ -58,38 +119,24 @@ function markForDeletion(elt) {
     }
 }
 
-function changeIntensityRange(layer) {
+function changeIntensityRange(layer: PointCloudLayer) {
+    // @ts-expect-error PointsMaterial is not typed yet
     layer.material.intensityRange?.set(layer.minIntensityRange, layer.maxIntensityRange);
 }
 
-function changeElevationRange(layer) {
+function changeElevationRange(layer: PointCloudLayer) {
+    // @ts-expect-error PointsMaterial is not typed yet
     layer.material.elevationRange?.set(layer.minElevationRange, layer.maxElevationRange);
 }
 
-function changeAngleRange(layer) {
+function changeAngleRange(layer: PointCloudLayer) {
+    // @ts-expect-error PointsMaterial is not typed yet
     layer.material.angleRange?.set(layer.minAngleRange, layer.maxAngleRange);
 }
 
 /**
  * The basis for all point clouds related layers.
  *
- * @property {boolean} isPointCloudLayer - Used to checkout whether this layer
- * is a PointCloudLayer. Default is `true`. You should not change this, as it is
- * used internally for optimisation.
- * @property {THREE.Group|THREE.Object3D} group - Contains the created
- * `THREE.Points` meshes, usually with an instance of a `THREE.Points` per node.
- * @property {THREE.Group|THREE.Object3D} bboxes - Contains the bounding boxes
- * (`THREE.Box3`) of the tree, usually one per node.
- * @property {number} octreeDepthLimit - The depth limit at which to stop
- * browsing the octree. Can be used to limit the browsing, without having to
- * edit manually the source of the point cloud. No limit by default (`-1`).
- * @property {number} [pointBudget=2000000] - Maximum number of points to
- * display at the same time. This influences the performance of rendering.
- * Default to two millions points.
- * @property {number} [sseThreshold=2] - Threshold of the **S**creen **S**pace
- * **E**rror. Default to `2`.
- * @property {number} [pointSize=4] - The size (in pixels) of the points.
- * Default to `4`.
  * @property {THREE.Material|PointsMaterial} [material=new PointsMaterial] - The
  * material to use to display the points of the cloud. Be default it is a new
  * `PointsMaterial`.
@@ -106,7 +153,86 @@ function changeAngleRange(layer) {
  *
  * @extends GeometryLayer
  */
-class PointCloudLayer extends GeometryLayer {
+abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource> extends GeometryLayer {
+    /**
+     * Read-only flag to assert that a given object is of type PointCloudLayer.
+     * Used internally for optimisation.
+     */
+    readonly isPointCloudLayer: true;
+
+    /** Used internally for scheduling tasks. */
+    readonly protocol: 'pointcloud';
+
+    // @ts-expect-error Source is not typed yet
+    source: S;
+
+    /**
+     * Container group for the points.
+     * Add this to the three.js scene in order to render it.
+     */
+    readonly group: THREE.Group;
+
+    /**
+     * Container group for the points bounding boxes.
+     * Add this to the three.js scene in order to render it.
+     */
+    readonly bboxes: THREE.Group;
+
+    /**
+     * Maximum depth to which points will be loaded and rendered.
+     * Setting it to 1 will only render the root node.
+     * Default to `Infinity`.
+     */
+    octreeDepthLimit: number;
+
+    /**
+     * Maximum number of points to display at the same time.
+     * Defaults to 2 millions points.
+     */
+    pointBudget: number;
+
+    /**
+     * Size of the points (in pixels) rendered on the screen.
+     * In attenuated point size mode, this value is used as basis for the
+     * attenuation.
+     * Defaults to 2 pixels.
+     */
+    pointSize: number;
+
+    /**
+     * Screen space error (in pixels) to target when updating the geometry.
+     * Points below this threshold will not rendered.
+     * Defaults to 2 pixels.
+     */
+    sseThreshold: number;
+
+    /** Minimal intensity value of the layer. */
+    minIntensityRange!: number;
+    /** Maximal intensity value of the layer. */
+    maxIntensityRange!: number;
+    /** Minimal elevation value of the layer. */
+    minElevationRange!: number;
+    /** Maximal elevation value of the layer. */
+    maxElevationRange!: number;
+    /** Minimal angle value of the layer. */
+    minAngleRange!: number;
+    /** Maximal angle value of the layer. */
+    maxAngleRange!: number;
+
+    /** Number of points displayed in the last update. */
+    displayedCount: number;
+
+    /**
+     * @deprecated This property is no longer used and will be removed in
+     * a future version.
+     */
+    supportsProgressiveDisplay: boolean;
+
+    /** Root node of the point cloud tree. */
+    root: PointCloudNode | undefined;
+
+    material: THREE.PointsMaterial;
+
     /**
      * Constructs a new instance of point cloud layer.
      * Constructs a new instance of a Point Cloud Layer. This should not be used
@@ -124,7 +250,7 @@ class PointCloudLayer extends GeometryLayer {
      * @param {number}  [options.minElevationRange] - Min value for the elevation range (default value will be taken from the source.metadata).
      * @param {number}  [options.maxElevationRange] - Max value for the elevation range (default value will be taken from the source.metadata).
      */
-    constructor(id, config = {}) {
+    constructor(id: string, config: PointCloudLayerParameters) {
         const {
             object3d = new THREE.Group(),
             group = new THREE.Group(),
@@ -146,10 +272,6 @@ class PointCloudLayer extends GeometryLayer {
 
         super(id, object3d, geometryLayerConfig);
 
-        /**
-         * @type {boolean}
-         * @readonly
-         */
         this.isPointCloudLayer = true;
         this.protocol = 'pointcloud';
 
@@ -164,25 +286,9 @@ class PointCloudLayer extends GeometryLayer {
 
         this.group.updateMatrixWorld();
 
-        // default config
-        /**
-         * @type {number}
-         */
         this.octreeDepthLimit = octreeDepthLimit;
-
-        /**
-         * @type {number}
-         */
         this.pointBudget = pointBudget;
-
-        /**
-         * @type {number}
-         */
         this.pointSize = pointSize;
-
-        /**
-         * @type {number}
-         */
         this.sseThreshold = sseThreshold;
 
         this.defineLayerProperty('minIntensityRange', minIntensityRange, changeIntensityRange);
@@ -192,22 +298,28 @@ class PointCloudLayer extends GeometryLayer {
         this.defineLayerProperty('minAngleRange', minAngleRange, changeAngleRange);
         this.defineLayerProperty('maxAngleRange', maxAngleRange, changeAngleRange);
 
-        /**
-         * @type {THREE.Material}
-         */
+        // @ts-expect-error PointsMaterial is not typed yet
         this.material = material;
         if (!this.material.isMaterial) {
+            // @ts-expect-error PointsMaterial is not typed yet
             this.material.intensityRange = new THREE.Vector2(this.minIntensityRange, this.maxIntensityRange);
+            // @ts-expect-error PointsMaterial is not typed yet
             this.material.elevationRange = new THREE.Vector2(this.minElevationRange, this.maxElevationRange);
+            // @ts-expect-error PointsMaterial is not typed yet
             this.material.angleRange = new THREE.Vector2(this.minAngleRange, this.maxAngleRange);
+            // @ts-expect-error PointsMaterial is not typed yet
             this.material = new PointsMaterial(this.material);
         }
 
+        // @ts-expect-error PointsMaterial is not typed yet
         this.material.mode = mode || PNTS_MODE.COLOR;
         /**
          * @type {PointCloudNode | undefined}
          */
         this.root = undefined;
+
+        this.displayedCount = 0;
+        this.supportsProgressiveDisplay = false;
     }
 
     setElevationRange() {
@@ -215,7 +327,8 @@ class PointCloudLayer extends GeometryLayer {
         this.maxElevationRange = this.maxElevationRange ?? this.source.zmax;
     }
 
-    preUpdate(context, changeSources) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    preUpdate(context: Context, changeSources: any) {
         // See https://cesiumjs.org/hosted-apps/massiveworlds/downloads/Ring/WorldScaleTerrainRendering.pptx
         // slide 17
         context.camera.preSSE =
@@ -226,8 +339,11 @@ class PointCloudLayer extends GeometryLayer {
             this.material.visible = this.visible;
             this.material.opacity = this.opacity;
             this.material.size = this.pointSize;
+            // @ts-expect-error PointsMaterial is not typed yet
             this.material.scale = context.camera.preSSE;
+            // @ts-expect-error PointsMaterial is not typed yet
             if (this.material.updateUniforms) {
+                // @ts-expect-error PointsMaterial is not typed yet
                 this.material.updateUniforms();
             }
         }
@@ -280,7 +396,7 @@ class PointCloudLayer extends GeometryLayer {
      *
      * @return {pointCloudNode[]} The child nodes to update (if needed).
      */
-    loadData(elt, context, layer, distanceToCamera) {
+    loadData(elt: PointCloudNode, context: Context, layer: this, distanceToCamera: number) {
         elt.notVisibleSince = undefined;
 
         // only load geometry if this elements has points
@@ -298,14 +414,14 @@ class PointCloudLayer extends GeometryLayer {
                     priority,
                     redraw: true,
                     earlyDropFunction: cmd => !cmd.requester.visible || !this.visible,
-                }).then((pts) => {
+                }).then((pts: THREE.Points) => {
                     elt.obj = pts;
 
                     // make sure to add it here, otherwise it might never
                     // be added nor cleaned
                     this.group.add(elt.obj);
                     elt.obj.updateMatrixWorld(true);
-                }).catch((err) => {
+                }).catch((err: { isCancelledCommandException: boolean }) => {
                     if (!err.isCancelledCommandException) {
                         return err;
                     }
@@ -338,7 +454,7 @@ class PointCloudLayer extends GeometryLayer {
      *
      * @return {pointCloudNode[]} The child nodes to update or [] if ther is none.
      */
-    update(context, layer, elt) {
+    update(context: Context, layer: this, elt: PointCloudNode) {
         elt.visible = false;
 
         if (this.octreeDepthLimit >= 0 && this.octreeDepthLimit < elt.depth) {
@@ -351,7 +467,7 @@ class PointCloudLayer extends GeometryLayer {
         let object3d;
         if (elt.obj) {
             object3d = elt.obj;
-            bbox = object3d.geometry.boundingBox;
+            bbox = object3d.geometry.boundingBox as THREE.Box3;
         } else {
             object3d = elt.clampOBB;
             bbox = object3d.box3D;
@@ -364,6 +480,7 @@ class PointCloudLayer extends GeometryLayer {
             return;
         }
 
+        // @ts-expect-error matrixWorldInverse is not typable
         point.copy(context.camera.camera3D.position).applyMatrix4(object3d.matrixWorldInverse);
         const distanceToCamera = bbox.distanceToPoint(point);
 
@@ -372,7 +489,7 @@ class PointCloudLayer extends GeometryLayer {
 
     postUpdate() {
         this.displayedCount = 0;
-        for (const pts of this.group.children) {
+        for (const pts of this.group.children as THREE.Points[]) {
             if (pts.visible) {
                 const count = pts.geometry.attributes.position.count;
                 pts.geometry.setDrawRange(0, count);
@@ -387,7 +504,7 @@ class PointCloudLayer extends GeometryLayer {
                 // so we can draw a percentage of each node and still get a correct
                 // representation
                 const reduction = this.pointBudget / this.displayedCount;
-                for (const pts of this.group.children) {
+                for (const pts of this.group.children as THREE.Points[]) {
                     if (pts.visible) {
                         const count = Math.floor(pts.geometry.drawRange.count * reduction);
                         if (count > 0) {
@@ -406,7 +523,7 @@ class PointCloudLayer extends GeometryLayer {
 
                 let limitHit = false;
                 this.displayedCount = 0;
-                for (const pts of this.group.children) {
+                for (const pts of this.group.children as THREE.Points[]) {
                     const count = pts.geometry.attributes.position.count;
                     if (limitHit || (this.displayedCount + count) > this.pointBudget) {
                         pts.visible = false;
@@ -420,24 +537,24 @@ class PointCloudLayer extends GeometryLayer {
 
         const now = Date.now();
         for (let i = this.group.children.length - 1; i >= 0; i--) {
-            const obj = this.group.children[i];
+            const obj = this.group.children[i] as THREE.Points;
             if (!obj.visible && (now - obj.userData.node.notVisibleSince) > 10000) {
                 // remove from group
                 this.group.children.splice(i, 1);
 
                 // no need to dispose obj.material, as it is shared by all objects of this layer
                 obj.geometry.dispose();
-                obj.material = null;
-                obj.geometry = null;
                 obj.userData.node.obj = null;
             }
         }
     }
 
+    // @ts-expect-error Layer and Picking are not typed yet
     pickObjectsAt(view, mouse, radius, target = []) {
         return Picking.pickPointsAt(view, mouse, radius, this, target);
     }
 
+    // @ts-expect-error Layer is not typed yet
     getObjectToUpdateForAttachedLayers(meta) {
         if (meta.obj) {
             const p = meta.parent;

--- a/packages/Main/src/Layer/PotreeLayer.ts
+++ b/packages/Main/src/Layer/PotreeLayer.ts
@@ -1,5 +1,11 @@
-import PointCloudLayer from 'Layer/PointCloudLayer';
+import PointCloudLayer, { PointCloudLayerParameters } from 'Layer/PointCloudLayer';
 import PotreeNode from 'Core/PotreeNode';
+import type PotreeSource from 'Source/PotreeSource';
+
+interface PotreeLayerParameters extends PointCloudLayerParameters {
+    crs?: string;
+    source: PotreeSource;
+}
 
 /**
  * @property {boolean} isPotreeLayer - Used to checkout whether this layer
@@ -8,7 +14,9 @@ import PotreeNode from 'Core/PotreeNode';
  *
  * @extends PointCloudLayer
  */
-class PotreeLayer extends PointCloudLayer {
+class PotreeLayer extends PointCloudLayer<PotreeSource> {
+    readonly isPotreeLayer: true;
+
     /**
      * Constructs a new instance of Potree layer.
      *
@@ -24,32 +32,29 @@ class PotreeLayer extends PointCloudLayer {
      *
      * View.prototype.addLayer.call(view, points);
      *
-     * @param {string} id - The id of the layer, that should be unique. It is
+     * @param id - The id of the layer, that should be unique. It is
      * not mandatory, but an error will be emitted if this layer is added a
-     * {@link View} that already has a layer going by that id.
-     * @param {Object} config - Configuration, all elements in it
+     * View that already has a layer going by that id.
+     * @param config - Configuration, all elements in it
      * will be merged as is in the layer. For example, if the configuration
      * contains three elements `name, protocol, extent`, these elements will be
      * available using `layer.name` or something else depending on the property
      * name. See the list of properties to know which one can be specified.
-     * @param {string} [config.crs='ESPG:4326'] - The CRS of the {@link View} this
+     * @param config.crs - The CRS of the View this
      * layer will be attached to. This is used to determine the extent of this
      * layer.  Default to `EPSG:4326`.
      */
-    constructor(id, config) {
+    constructor(id: string, config: PotreeLayerParameters) {
         super(id, config);
 
-        /**
-         * @type {boolean}
-         * @readonly
-         */
         this.isPotreeLayer = true;
 
         const resolve = this.addInitializationStep();
         this.whenReady = this.source.whenReady.then((cloud) => {
             const normal = Array.isArray(cloud.pointAttributes) &&
-                cloud.pointAttributes.find(elem => elem.startsWith('NORMAL'));
+                cloud.pointAttributes.find((elem: string) => elem.startsWith('NORMAL'));
             if (normal) {
+                // @ts-expect-error PointsMaterial is not typed
                 this.material.defines[normal] = 1;
             }
 

--- a/packages/Main/src/Layer/VpcLayer.js
+++ b/packages/Main/src/Layer/VpcLayer.js
@@ -72,7 +72,8 @@ class VpcLayer extends PointCloudLayer {
             this.setElevationRange();
 
             const boundsConforming = this.source.boundsConforming;
-            this.root = new PointCloudNode(0, this.source);
+            this.root = new PointCloudNode(0);
+            this.root.source = this.source;
             this.root.crs = this.crs;
             this.root.setOBBes(boundsConforming.slice(0, 3), boundsConforming.slice(3, 6));
             this.root.depth = 0;

--- a/packages/Main/src/Parser/LASParser.js
+++ b/packages/Main/src/Parser/LASParser.js
@@ -88,14 +88,15 @@ export default {
      * @param {ArrayBuffer} data - The file content to parse.
      * @param {Object} options
      * @param {Object} options.in - Options to give to the parser.
-     * @param {number} options.in.pointCount - Number of points encoded in this
+     * @param {number} options.in.numPoints - Number of points encoded in this
      * data chunk.
-     * @param {Object} options.in.header - Partial LAS file header.
-     * @param {number} options.in.header.pointDataRecordFormat - Type of Point
-     * Data Record contained in the LAS file.
-     * @param {number} options.in.header.pointDataRecordLength - Size (in bytes)
-     * of the Point Data Record.
-     * @param {Object} [options.eb] - Extra bytes LAS VLRs headers.
+     * @param {Object} options.in.source - Source information.
+     * @param {Object} options.in.source.header - Partial LAS file header.
+     * @param {number} options.in.source.header.pointDataRecordFormat - Type of
+     * Point Data Record contained in the LAS file.
+     * @param {number} options.in.source.header.pointDataRecordLength - Size
+     * (in bytes) of the Point Data Record.
+     * @param {Object} [options.in.source.eb] - Extra bytes LAS VLRs headers.
      * @param { 8 | 16 } [options.in.colorDepth] - Color depth (in bits).
      * Defaults to 8 bits for LAS 1.2 and 16 bits for later versions
      * (as mandatory by the specification)

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -115,7 +115,7 @@ describe('Entwine Point Tile', function () {
             const originalQuaternion = cam.quaternion.clone();
             cam.quaternion.identity(); // look away from dataset
             layer.update(context, layer, layer.root);
-            assert.strictEqual(layer.root.promise, undefined);
+            assert.strictEqual(layer.root.promise, null);
             cam.quaternion.copy(originalQuaternion);
         });
 


### PR DESCRIPTION
## Description

This PR migrates most of pointcloud-related modules (i.e. nodes, sources and layers) to typescript. It also set what is the public API of both pointcloud sources and layers. This a first step towards a refactoring of all pointclouds.


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
