### PR TITLE
[Pointcloud] Add per-node priority update in pointclouds

### DIFF
--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -418,53 +418,62 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
      *
      * @returns The child nodes to update or [] if there is none.
      */
-    update(context: Context, layer: this, elt: PointCloudNode): PointCloudNode[] {
-        if (this.octreeDepthLimit >= 0 && this.octreeDepthLimit < elt.depth) {
-            return [];
-        }
-
-        // get object on which to measure distance
-        let bbox;
-        let object3d;
-        if (elt.obj) {
-            object3d = elt.obj;
-            bbox = object3d.geometry.boundingBox as THREE.Box3;
-        } else {
-            object3d = elt.clampOBB;
-            bbox = object3d.box3D;
-            if (!object3d.parent) {
-                this.obbes.add(object3d);
-                object3d.updateMatrixWorld(true);
+    update(context: Context, layer: this, root: PointCloudNode): PointCloudNode[] {
+        const rootWithWeight = { node: root, weight: Infinity };
+        const queue = new TinyQueue([rootWithWeight], (a, b) => b.weight - a.weight);
+        let numVisiblePoints = 0;
+        while (queue.length > 0 && numVisiblePoints < this.pointBudget) {
+            const { node } = queue.pop() as { node: PointCloudNode };
+            // get object on which to measure distance
+            let bbox;
+            let object3d;
+            if (node.obj) {
+                object3d = node.obj;
+                bbox = object3d.geometry.boundingBox as THREE.Box3;
+            } else {
+                object3d = node.clampOBB;
+                bbox = object3d.box3D;
+                if (!object3d.parent) {
+                    this.obbes.add(object3d);
+                    object3d.updateMatrixWorld(true);
+                }
             }
-        }
 
-        const visible = context.camera.isBox3Visible(bbox, object3d.matrixWorld);
+            if (this.octreeDepthLimit >= 0 && this.octreeDepthLimit < node.depth) {
+                continue;
+            }
 
-        if (!visible) {
-            return [];
-        }
+            const visible = context.camera.isBox3Visible(bbox, object3d.matrixWorld);
 
-        point.copy(context.camera.camera3D.position)
-            .applyMatrix4(object3d.matrixWorldInverse as THREE.Matrix4);
+            if (!visible) {
+                continue;
+            }
 
-        const distanceToCamera = bbox.distanceToPoint(point);
+            numVisiblePoints += node.numPoints;
 
-        elt.sse = computeScreenSpaceError(
-            context,
-            layer.pointSize,
-            elt.pointSpacing,
-            distanceToCamera,
-        ) / this.sseThreshold;
+            point.copy(context.camera.camera3D.position)
+                .applyMatrix4(object3d.matrixWorldInverse as THREE.Matrix4);
 
-        // The visibility here is not definitive, as it will be updated
-        // in the postUpdate phase
-        elt.visible = visible;
-        this._candidateNodes.push(elt);
-        this.loadData(elt, context, layer, distanceToCamera);
+            const distanceToCamera = bbox.distanceToPoint(point);
 
-        if (elt.children && elt.children.length) {
-            if (elt.sse >= 1) {
-                return elt.children;
+            node.sse = computeScreenSpaceError(
+                context,
+                layer.pointSize,
+                node.pointSpacing,
+                distanceToCamera,
+            ) / this.sseThreshold;
+
+            node.visible = visible;
+            node.notVisibleSince = undefined;
+            this._candidateNodes.push(node);
+            this.loadData(node, context, layer, distanceToCamera);
+
+            if (node.children && node.children.length) {
+                if (node.sse >= 1) {
+                    for (const child of node.children) {
+                        queue.push({ node: child, weight: node.sse });
+                    }
+                }
             }
         }
 
@@ -472,17 +481,13 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
     }
 
     postUpdate() {
+        // TODO: Need to only change group meshes here + visibility event
         const visibleLastUpdate = this._visibleNodes;
         this._visibleNodes = new Set();
         this.displayedCount = 0;
 
-        // Push visible nodes until the point budget is reached
         while (this._candidateNodes.length > 0) {
             const node = this._candidateNodes.pop() as PointCloudNode;
-            if (this.displayedCount + node.numPoints > this.pointBudget) {
-                this._candidateNodes.push(node);
-                break;
-            }
             this.displayedCount += node.numPoints;
             this._visibleNodes.add(node);
             node.visible = true;
@@ -490,13 +495,6 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
             if (!visibleLastUpdate.has(node)) {
                 this.setNodeVisible(node, true);
             }
-        }
-
-        // Hide remaining visible nodes that didn't fit in the budget
-        while (this._candidateNodes.length > 0) {
-            const node = this._candidateNodes.pop() as PointCloudNode;
-            node.visible = false;
-            if (node.obj) { node.obj.visible = false; }
         }
 
         // Set symmetric difference between visible nodes from last

--- a/packages/Main/test/unit/pointcloudlayer.js
+++ b/packages/Main/test/unit/pointcloudlayer.js
@@ -188,10 +188,33 @@ describe('PointCloudLayer', function () {
             runUpdate(layer, context, parent);
 
             assert.ok(loadData.calledThrice, 'Expected loadData to be called exactly three times');
-            const { firstCall, secondCall, thirdCall } = loadData;
-            assert.ok(firstCall.calledWith(parent), 'Expected loadData to be called with parent');
-            assert.ok(secondCall.calledWith(child0), 'Expected loadData to be called with child0');
-            assert.ok(thirdCall.calledWith(child1), 'Expected loadData to be called with child1');
+            assert.ok(loadData.firstCall.calledWith(parent), 'Expected loadData to be called with parent first');
+            assert.ok(loadData.calledWith(child0), 'Expected loadData to be called with child0');
+            assert.ok(loadData.calledWith(child1), 'Expected loadData to be called with child1');
+        });
+
+        it('adds clampOBB to obbes group and updates its matrixWorld', function () {
+            const n = createNode();
+            const context = createContext({ camera: { isBox3Visible: () => true } });
+
+            assert.strictEqual(n.clampOBB.parent, null, 'Expected clampOBB to have no parent before update');
+            assert.strictEqual(layer.obbes.children.length, 0, 'Expected obbes to be empty before update');
+
+            layer.update(context, layer, n);
+
+            assert.strictEqual(n.clampOBB.parent, layer.obbes, 'Expected clampOBB to be added to layer.obbes');
+            assert.strictEqual(layer.obbes.children.length, 1, 'Expected obbes to contain the clampOBB');
+        });
+
+        it('does not add clampOBB to obbes again when already parented', function () {
+            const n = createNode();
+            const context = createContext({ camera: { isBox3Visible: () => true } });
+
+            layer.update(context, layer, n);
+            assert.strictEqual(layer.obbes.children.length, 1);
+
+            layer.update(context, layer, n);
+            assert.strictEqual(layer.obbes.children.length, 1, 'Expected clampOBB not to be added twice');
         });
 
         it('does not traverse children when parent SSE < 1', function () {
@@ -274,19 +297,19 @@ describe('PointCloudLayer', function () {
         });
 
         it('hides over-budget nodes', function () {
-            layer.pointBudget = 400;
-            layer._visibleNodes = new Set();
-            const nodeA = createNode({ numPoints: 300, sse: 2 });
-            const nodeB = createNode({ numPoints: 200, sse: 1 });
+            const child = createNode({ numPoints: 200, depth: 1 });
+            layer.root = createNode({ numPoints: 300, depth: 0, children: [child] });
+            layer.pointBudget = 300;
+            const context = createContext();
 
-            layer._candidateNodes.push(nodeA);
-            layer._candidateNodes.push(nodeB);
+            const [root] = layer.preUpdate(context);
+            layer.update(context, layer, root);
             layer.postUpdate();
 
-            assertNodeVisible(nodeA, layer);
-            assertNodeNotVisible(nodeB, layer);
+            assertNodeVisible(layer.root, layer);
+            assertNodeNotVisible(child, layer);
             assert.strictEqual(
-                layer.displayedCount, nodeA.numPoints,
+                layer.displayedCount, layer.root.numPoints,
                 'Expected displayed count to be the number of visible points',
             );
         });
@@ -336,20 +359,26 @@ describe('PointCloudLayer', function () {
 
         it('emits visibility change event when node becomes over-budget', function () {
             const listener = sinon.spy();
-            const n = createNode({ numPoints: 100, sse: 1 });
+            const n = layer.root;
+            layer.pointBudget = 500;
             layer.addEventListener('node-visibility-change', listener);
+            const context = createContext();
 
-            // Frame 1 : set node as visible
-            layer._candidateNodes.push(n);
+            // Frame 1: node becomes visible
+            layer.preUpdate(context);
+            layer.update(context, layer, n);
             layer.postUpdate();
+            assert.ok(listener.calledOnce, 'Expected listener to be called once');
 
-            // Frame 2 : set node as over-budget
+            // Frame 2: node becomes over-budget
             layer.pointBudget = 0;
-            layer._candidateNodes.push(n);
+            layer.preUpdate(context);
+            layer.update(context, layer, n);
             layer.postUpdate();
-
             assert.ok(listener.calledTwice, 'Expected listener to be called twice');
             assertNodeChangeInvisible(n, listener.secondCall);
+
+            layer.removeEventListener('node-visibility-change', listener);
         });
 
         it('never collects points whose are not set for disposal', function () {
@@ -422,18 +451,15 @@ describe('PointCloudLayer', function () {
         // The obj is silently added to layer.group but never scheduled for
         // disposal.
         it('disposes points loaded for node never visible', async function () {
-            const node = createNode({ numPoints: 100, visible: true });
+            const node = createNode({ numPoints: 100 }); // visible: false by default
             const pts = new THREE.Points();
             pts.userData.node = node;
 
             const context = createContext({
-                scheduler: { execute: () => sinon.spy(Promise.resolve(pts)) },
+                scheduler: { execute: () => Promise.resolve(pts) },
             });
 
-            layer.pointBudget = 0;
             layer.loadData(node, context, layer, 0);
-            layer._candidateNodes.push(node);
-            layer.postUpdate();
 
             await context.scheduler.execute();
 


### PR DESCRIPTION
## Description

This PR introduces a priority-based update mechanism for point cloud layers.

Before this PR, the update logic traversed the tree in a depth-first fashion, issued requests during traversal, and only afterward limited the number of point clouds rendered. This often resulted in unnecessary requests and complex update logic.

The new approach uses a priority queue (à la potree) to traverse only the most relevant nodes, sorted by their screen-space size.

Depends #2685.
Blocked by issue #2694 .

Benefits:
- Limit network requests up front
- Avoid traversing unimportant parts of the tree
- Simplify the overall update logic
- Improve performance and predictability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
