### PR TITLE
fix: Custom example with custom projection

### DIFF
--- a/packages/Geographic/src/Crs.ts
+++ b/packages/Geographic/src/Crs.ts
@@ -137,7 +137,7 @@ export function isGeocentric(crs: ProjectionLike) {
 export function isValid(crs: ProjectionLike) {
     const proj = proj4.defs(crs);
     if (!proj) {
-        throw new Error(`Undefined crs '${crs}'. Add it with proj4.defs('${crs}', string)`);
+        throw new Error(`Undefined crs '${crs}'. Add it with itowns.CRS.defs('${crs}', wktString)`);
     }
     if (!unitFromProj4Unit(proj)) {
         throw new Error(`No valid unit found for crs '${crs}', found ${proj.units}`);

--- a/packages/Main/src/Core/LasNodeBase.ts
+++ b/packages/Main/src/Core/LasNodeBase.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from 'three';
+import { Vector3, type Group } from 'three';
 import type { Hierarchy } from 'copc';
 import PointCloudNode, { PointCloudSource } from 'Core/PointCloudNode';
 
@@ -106,8 +106,8 @@ abstract class LasNodeBase extends PointCloudNode {
             childClampBBox.min.z = Math.max(childClampBBox.min.z, this.source.zmin);
         }
 
-        childNode.voxelOBB.matrixWorldInverse = this.voxelOBB.matrixWorldInverse;
-        childNode.clampOBB.matrixWorldInverse = this.clampOBB.matrixWorldInverse;
+        (this.clampOBB.parent as Group).add(childNode.clampOBB);
+        childNode.clampOBB.updateMatrixWorld(true);
     }
 }
 

--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -82,7 +82,7 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
         const centerBbox = new THREE.Vector3();
         this.voxelOBB.box3D.getCenter(centerBbox);
         this._center =  new Coordinates(this.crs)
-            .setFromVector3(centerBbox.applyMatrix4(this.clampOBB.matrixWorld));
+            .setFromVector3(centerBbox.applyMatrix4(this.clampOBB.matrix));
         return this._center;
     }
 
@@ -181,9 +181,6 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
         root.voxelOBB.quaternion.copy(rotation).invert();
 
         root.voxelOBB.updateMatrix();
-        root.voxelOBB.updateMatrixWorld(true);
-
-        root.voxelOBB.matrixWorldInverse = root.voxelOBB.matrixWorld.clone().invert();
 
         root.clampOBB.copy(root.voxelOBB);
 
@@ -194,8 +191,6 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
         if (clampBBox.max.z > zmin) {
             clampBBox.min.z = Math.max(clampBBox.min.z, zmin);
         }
-
-        root.clampOBB.matrixWorldInverse = root.voxelOBB.matrixWorldInverse;
     }
 
     add(node: this, indexChild: number): void {

--- a/packages/Main/src/Core/PotreeNodeBase.ts
+++ b/packages/Main/src/Core/PotreeNodeBase.ts
@@ -1,12 +1,12 @@
-import * as THREE from 'three';
+import { Vector3, type Box3, type Group } from 'three';
 import PointCloudNode from './PointCloudNode';
 
 // Create an A(xis)A(ligned)B(ounding)B(ox) for the child `childIndex`
 // of one aabb. (PotreeConverter protocol builds implicit octree hierarchy
 // by applying the same subdivision algo recursively)
-const dHalfLength = new THREE.Vector3();
+const dHalfLength = new Vector3();
 
-export function computeChildBBox(voxelBBox: THREE.Box3, childIndex: number) {
+export function computeChildBBox(voxelBBox: Box3, childIndex: number) {
     // Code inspired from potree
     const childVoxelBBox = voxelBBox.clone();
     voxelBBox.getCenter(childVoxelBBox.max);
@@ -51,7 +51,7 @@ export abstract class PotreeNodeBase extends PointCloudNode {
 
     childrenBitField: number;
     baseurl: string;
-    offsetBBox?: THREE.Box3;
+    offsetBBox?: Box3;
     crs: string;
 
     private _hierarchyKey: string | undefined;
@@ -111,8 +111,8 @@ export abstract class PotreeNodeBase extends PointCloudNode {
             childClampBBox.min.z = Math.max(childClampBBox.min.z, this.source.zmin);
         }
 
-        childNode.voxelOBB.matrixWorldInverse = this.voxelOBB.matrixWorldInverse;
-        childNode.clampOBB.matrixWorldInverse = this.clampOBB.matrixWorldInverse;
+        (this.clampOBB.parent as Group).add(childNode.clampOBB);
+        childNode.clampOBB.updateMatrixWorld(true);
     }
 }
 

--- a/packages/Main/src/Layer/CopcLayer.ts
+++ b/packages/Main/src/Layer/CopcLayer.ts
@@ -46,6 +46,9 @@ class CopcLayer extends PointCloudLayer {
             this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1, this.crs);
             this.root.setOBBes(cube.slice(0, 3), cube.slice(3, 6));
 
+            this.object3d.add(this.root.clampOBB);
+            this.root.clampOBB.updateMatrixWorld(true);
+
             return this.root.loadOctree().then(resolve);
         });
     }

--- a/packages/Main/src/Layer/EntwinePointTileLayer.ts
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.ts
@@ -49,6 +49,9 @@ class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
             const { bounds } = this.source;
             this.root.setOBBes(bounds.slice(0, 3), bounds.slice(3, 6));
 
+            this.object3d.add(this.root.clampOBB);
+            this.root.clampOBB.updateMatrixWorld(true);
+
             return this.root.loadOctree().then(resolve);
         });
     }

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -479,8 +479,10 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
             return [];
         }
 
-        // @ts-expect-error matrixWorldInverse is not typable
-        point.copy(context.camera.camera3D.position).applyMatrix4(object3d.matrixWorldInverse);
+        // TODO: See if we can limit the calcul of the matrixWorlInverse.
+        point.copy(context.camera.camera3D.position)
+            .applyMatrix4(object3d.matrixWorld.clone().invert());
+
         const distanceToCamera = bbox.distanceToPoint(point);
 
         return this.loadData(elt, context, layer, distanceToCamera);

--- a/packages/Main/src/Layer/Potree2Layer.ts
+++ b/packages/Main/src/Layer/Potree2Layer.ts
@@ -97,6 +97,8 @@ class Potree2Layer extends PointCloudLayer<Potree2Source> {
             const root = new Potree2Node(0, -1, 0, 0, this.source, this.crs);
             const { boundingBox, hierarchy } = metadata;
             root.setOBBes(boundingBox.min, boundingBox.max);
+            this.object3d.add(root.clampOBB);
+            root.clampOBB.updateMatrixWorld(true);
 
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;

--- a/packages/Main/src/Layer/PotreeLayer.ts
+++ b/packages/Main/src/Layer/PotreeLayer.ts
@@ -63,6 +63,9 @@ class PotreeLayer extends PointCloudLayer<PotreeSource> {
             this.root.setOBBes([boundingBox.lx, boundingBox.ly, boundingBox.lz],
                 [boundingBox.ux, boundingBox.uy, boundingBox.uz]);
 
+            this.object3d.add(this.root.clampOBB);
+            this.root.clampOBB.updateMatrixWorld(true);
+
             return this.root.loadOctree().then(resolve);
         });
     }

--- a/packages/Main/src/Layer/VpcLayer.js
+++ b/packages/Main/src/Layer/VpcLayer.js
@@ -95,6 +95,7 @@ class VpcLayer extends PointCloudLayer {
                 const promise =
                     source.whenReady.then((src) => {
                         const root = _instantiateRootNode(src, this.crs);
+                        this.object3d.add(root.clampOBB);
                         this.root.children[i] = root;
                         return root.loadOctree().then(resolve)
                             .then(() => root);

--- a/packages/Main/src/Provider/PointCloudProvider.js
+++ b/packages/Main/src/Provider/PointCloudProvider.js
@@ -40,9 +40,6 @@ export default {
             const quaternion = node.rotation.clone().invert();
             points.quaternion.copy(quaternion);
             points.updateMatrix();
-            points.updateMatrixWorld(true);
-
-            points.matrixWorldInverse = points.matrixWorld.clone().invert();
 
             points.layer = layer;
             points.userData.node = node;

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { Object3D } from 'three';
 import CopcSource from 'Source/CopcSource';
 import CopcLayer from 'Layer/CopcLayer';
 import CopcNode from 'Core/CopcNode';
@@ -43,9 +44,11 @@ describe('COPC', function () {
 
     describe('COPC Node', function () {
         let root;
-        before(function () {
+        before('create octree', function () {
+            const object3d = new Object3D();
             const source = { url: 'http://server.geo', extension: 'laz' };
             root = new CopcNode(0, 0, 0, 0, 0, 1000, source, 4000);
+            object3d.add(root.clampOBB);
             root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
             root.add(new CopcNode(1, 0, 0, 0, 0, 1000, source, 3000));

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { Vector3 } from 'three';
+import { Vector3, Object3D } from 'three';
 import View from 'Core/View';
 import GlobeView from 'Core/Prefab/GlobeView';
 import { Coordinates } from '@itowns/geographic';
@@ -142,8 +142,10 @@ describe('Entwine Point Tile', function () {
 
     describe('Entwine Point Tile Node', function () {
         let root;
+        const object3d = new Object3D();
         before(function () {
             root = new EntwinePointTileNode(0, 0, 0, 0, source, -1, 'EPSG:3857');
+            object3d.add(root.clampOBB);
         });
 
         after(async function () {
@@ -161,6 +163,7 @@ describe('Entwine Point Tile', function () {
                 mockParser.restore();
                 assert.ok(spyLoadOctree.calledOnce);
             });
+
             it('load a sub-node not yet loaded', async () => {
                 const node = root.children.filter(node => node.numPoints === -1)[0];
 
@@ -177,10 +180,11 @@ describe('Entwine Point Tile', function () {
 
         describe('finds the common ancestor of two nodes', () => {
             let root;
-            before(function () {
+            before('create octree', function () {
                 const source = { url: 'http://server.geo', extension: 'laz' };
                 root = new EntwinePointTileNode(0, 0, 0, 0, source, 4000);
                 root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+                object3d.add(root.clampOBB);
 
                 root.add(new EntwinePointTileNode(1, 0, 0, 0, source, 3000));
                 root.add(new EntwinePointTileNode(1, 0, 0, 1, source, 3000));

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { Object3D } from 'three';
 import PotreeLayer from 'Layer/PotreeLayer';
 import PotreeSource from 'Source/PotreeSource';
 import View from 'Core/View';
@@ -11,6 +12,7 @@ import Fetcher from 'Provider/Fetcher';
 import Renderer from './bootstrap';
 
 const resources = new Map();
+const object3d = new Object3D();
 
 // potree 1.7
 const baseurl = 'https://raw.githubusercontent.com/potree/potree/develop/pointclouds/lion_takanawa';
@@ -151,6 +153,7 @@ describe('Potree', function () {
                     baseurl,
                     extension,
                 });
+                object3d.add(root.clampOBB);
                 root.add(nodeChild);
                 nodeChild.add(nodeGChild);
 
@@ -159,6 +162,7 @@ describe('Potree', function () {
 
             it('load octree', function (done) {
                 const root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource);
+                object3d.add(root.clampOBB);
                 root.loadOctree()
                     .then(() => {
                         assert.equal(6, root.children.length);
@@ -168,6 +172,7 @@ describe('Potree', function () {
 
             it('load child node', function (done) {
                 const root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource, 'EPSG:4978');
+                object3d.add(root.clampOBB);
                 root.loadOctree()
                     .then(() => root.children[0].load()
                         .then(() => {

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -1,12 +1,14 @@
 import assert from 'assert';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { Vector3, Object3D } from 'three';
+import View from 'Core/View';
 import Potree2Layer from 'Layer/Potree2Layer';
 import Potree2Source from 'Source/Potree2Source';
 import Potree2BinParser from 'Parser/Potree2BinParser';
-import View from 'Core/View';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import Potree2Node from 'Core/Potree2Node';
-import { Vector3 } from 'three';
 import Renderer from './bootstrap';
+
+const object3d = new Object3D();
 
 describe('Potree2', function () {
     let renderer;
@@ -98,6 +100,7 @@ describe('Potree2', function () {
 
         it('load octree', function (done) {
             const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source);
+            object3d.add(root.clampOBB);
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;
             root.hierarchyByteSize = 12650n;
@@ -110,6 +113,7 @@ describe('Potree2', function () {
 
         it('load child node', function (done) {
             const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source, 'EPSG:4978');
+            object3d.add(root.clampOBB);
             root.nodeType = 2;
             root.hierarchyByteOffset = 0n;
             root.hierarchyByteSize = 12650n;

--- a/packages/Main/test/unit/potree2layerprocessing.js
+++ b/packages/Main/test/unit/potree2layerprocessing.js
@@ -1,49 +1,55 @@
 import assert from 'assert';
+import { Group } from 'three';
 import Potree2Layer from 'Layer/Potree2Layer';
 import Potree2Node from 'Core/Potree2Node';
 
 describe('preUpdate Potree2Layer', function () {
     const context = { camera: { height: 1, camera3D: { fov: 1 } } };
+    const source = { baseurl: 'server.geo' };
     const layer = {
         id: 'a',
-        source: { baseurl: 'server.geo' },
+        source,
         hierarchyStepSize: 1,
+        object3d: new Group(),
     };
-    layer.root = new Potree2Node(0, -1, 4000, 0, layer);
-    layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+    before('create octree', () => {
+        layer.root = new Potree2Node(0, -1, 4000, 0, source);
+        layer.object3d.add(layer.root.clampOBB);
+        layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
-    layer.root.add(new Potree2Node(1, 0, 3000, 0, layer), 1, layer.root);
-    layer.root.children[0].obj = { layer, isPoints: true };
-    layer.root.add(new Potree2Node(1, 1, 3000, 0, layer), 2, layer.root);
-    layer.root.children[1].obj = { layer, isPoints: true };
-    layer.root.add(new Potree2Node(1, 2, 3000, 0, layer), 3, layer.root);
-    layer.root.children[2].obj = { layer, isPoints: true };
+        layer.root.add(new Potree2Node(1, 0, 3000, 0, source), 1);
+        layer.root.children[0].obj = { layer, isPoints: true };
+        layer.root.add(new Potree2Node(1, 1, 3000, 0, source), 2);
+        layer.root.children[1].obj = { layer, isPoints: true };
+        layer.root.add(new Potree2Node(1, 2, 3000, 0, source), 3);
+        layer.root.children[2].obj = { layer, isPoints: true };
 
-    layer.root.children[0].add(new Potree2Node(2, 0, 2000, 0, layer), 1, layer.root);
-    layer.root.children[0].children[0].obj = { layer, isPoints: true };
-    layer.root.children[0].add(new Potree2Node(2, 1, 2000, 0, layer), 2, layer.root);
-    layer.root.children[0].children[1].obj = { layer, isPoints: true };
-    layer.root.children[1].add(new Potree2Node(2, 2, 2000, 0, layer), 1, layer.root);
-    layer.root.children[1].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].add(new Potree2Node(2, 3, 2000, 0, layer), 2, layer.root);
-    layer.root.children[2].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].add(new Potree2Node(2, 4, 2000, 0, layer), 3, layer.root);
-    layer.root.children[2].children[1].obj = { layer, isPoints: true };
+        layer.root.children[0].add(new Potree2Node(2, 0, 2000, 0, source), 1);
+        layer.root.children[0].children[0].obj = { layer, isPoints: true };
+        layer.root.children[0].add(new Potree2Node(2, 1, 2000, 0, source), 2);
+        layer.root.children[0].children[1].obj = { layer, isPoints: true };
+        layer.root.children[1].add(new Potree2Node(2, 2, 2000, 0, source), 1);
+        layer.root.children[1].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].add(new Potree2Node(2, 3, 2000, 0, source), 2);
+        layer.root.children[2].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].add(new Potree2Node(2, 4, 2000, 0, source), 3);
+        layer.root.children[2].children[1].obj = { layer, isPoints: true };
 
-    layer.root.children[0].children[0].add(new Potree2Node(3, 0, 1000, 0, layer), 1, layer.root);
-    layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
-    layer.root.children[0].children[0].add(new Potree2Node(3, 1, 1000, 0, layer), 5, layer.root);
-    layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
-    layer.root.children[0].children[1].add(new Potree2Node(3, 2, 1000, 0, layer), 4, layer.root);
-    layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new Potree2Node(3, 3, 1000, 0, layer), 1, layer.root);
-    layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new Potree2Node(3, 4, 1000, 0, layer), 2, layer.root);
-    layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new Potree2Node(3, 5, 1000, 0, layer), 3, layer.root);
-    layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new Potree2Node(3, 6, 1000, 0, layer), 4, layer.root);
-    layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
+        layer.root.children[0].children[0].add(new Potree2Node(3, 0, 1000, 0, source), 1);
+        layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
+        layer.root.children[0].children[0].add(new Potree2Node(3, 1, 1000, 0, source), 5);
+        layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
+        layer.root.children[0].children[1].add(new Potree2Node(3, 2, 1000, 0, source), 4);
+        layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new Potree2Node(3, 3, 1000, 0, source), 1);
+        layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new Potree2Node(3, 4, 1000, 0, source), 2);
+        layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new Potree2Node(3, 5, 1000, 0, source), 3);
+        layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new Potree2Node(3, 6, 1000, 0, source), 4);
+        layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
+    });
 
     it('should return root if no change source', () => {
         const sources = new Set();

--- a/packages/Main/test/unit/potreelayerprocessing.js
+++ b/packages/Main/test/unit/potreelayerprocessing.js
@@ -1,49 +1,55 @@
 import assert from 'assert';
+import { Group } from 'three';
 import PotreeLayer from 'Layer/PotreeLayer';
 import PotreeNode from 'Core/PotreeNode';
 
 describe('preUpdate PotreeLayer', function () {
     const context = { camera: { height: 1, camera3D: { fov: 1 } } };
+    const source = { baseurl: 'server.geo' };
     const layer = {
         id: 'a',
-        source: { baseurl: 'server.geo' },
+        source,
         hierarchyStepSize: 1,
+        object3d: new Group(),
     };
-    layer.root = new PotreeNode(0, -1, 4000, 0, layer);
-    layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+    before('create octree', () => {
+        layer.root = new PotreeNode(0, -1, 4000, 0, source);
+        layer.object3d.add(layer.root.clampOBB);
+        layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
-    layer.root.add(new PotreeNode(1, 0, 3000, 0, layer), 1, layer.root);
-    layer.root.children[0].obj = { layer, isPoints: true };
-    layer.root.add(new PotreeNode(1, 1, 3000, 0, layer), 2, layer.root);
-    layer.root.children[1].obj = { layer, isPoints: true };
-    layer.root.add(new PotreeNode(1, 2, 3000, 0, layer), 3, layer.root);
-    layer.root.children[2].obj = { layer, isPoints: true };
+        layer.root.add(new PotreeNode(1, 0, 3000, 0, source), 1);
+        layer.root.children[0].obj = { layer, isPoints: true };
+        layer.root.add(new PotreeNode(1, 1, 3000, 0, source), 2);
+        layer.root.children[1].obj = { layer, isPoints: true };
+        layer.root.add(new PotreeNode(1, 2, 3000, 0, source), 3);
+        layer.root.children[2].obj = { layer, isPoints: true };
 
-    layer.root.children[0].add(new PotreeNode(2, 0, 2000, 0, layer), 1, layer.root);
-    layer.root.children[0].children[0].obj = { layer, isPoints: true };
-    layer.root.children[0].add(new PotreeNode(2, 1, 2000, 0, layer), 2, layer.root);
-    layer.root.children[0].children[1].obj = { layer, isPoints: true };
-    layer.root.children[1].add(new PotreeNode(2, 2, 2000, 0, layer), 1, layer.root);
-    layer.root.children[1].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].add(new PotreeNode(2, 3, 2000, 0, layer), 2, layer.root);
-    layer.root.children[2].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].add(new PotreeNode(2, 4, 2000, 0, layer), 3, layer.root);
-    layer.root.children[2].children[1].obj = { layer, isPoints: true };
+        layer.root.children[0].add(new PotreeNode(2, 0, 2000, 0, source), 1);
+        layer.root.children[0].children[0].obj = { layer, isPoints: true };
+        layer.root.children[0].add(new PotreeNode(2, 1, 2000, 0, source), 2);
+        layer.root.children[0].children[1].obj = { layer, isPoints: true };
+        layer.root.children[1].add(new PotreeNode(2, 2, 2000, 0, source), 1);
+        layer.root.children[1].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].add(new PotreeNode(2, 3, 2000, 0, source), 2);
+        layer.root.children[2].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].add(new PotreeNode(2, 4, 2000, 0, source), 3);
+        layer.root.children[2].children[1].obj = { layer, isPoints: true };
 
-    layer.root.children[0].children[0].add(new PotreeNode(3, 0, 1000, 0, layer), 1, layer.root);
-    layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
-    layer.root.children[0].children[0].add(new PotreeNode(3, 1, 1000, 0, layer), 5, layer.root);
-    layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
-    layer.root.children[0].children[1].add(new PotreeNode(3, 2, 1000, 0, layer), 4, layer.root);
-    layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new PotreeNode(3, 3, 1000, 0, layer), 1, layer.root);
-    layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new PotreeNode(3, 4, 1000, 0, layer), 2, layer.root);
-    layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new PotreeNode(3, 5, 1000, 0, layer), 3, layer.root);
-    layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
-    layer.root.children[2].children[1].add(new PotreeNode(3, 6, 1000, 0, layer), 4, layer.root);
-    layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
+        layer.root.children[0].children[0].add(new PotreeNode(3, 0, 1000, 0, source), 1);
+        layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
+        layer.root.children[0].children[0].add(new PotreeNode(3, 1, 1000, 0, source), 5);
+        layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
+        layer.root.children[0].children[1].add(new PotreeNode(3, 2, 1000, 0, source), 4);
+        layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new PotreeNode(3, 3, 1000, 0, source), 1);
+        layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new PotreeNode(3, 4, 1000, 0, source), 2);
+        layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new PotreeNode(3, 5, 1000, 0, source), 3);
+        layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
+        layer.root.children[2].children[1].add(new PotreeNode(3, 6, 1000, 0, source), 4);
+        layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
+    });
 
     it('should return root if no change source', () => {
         const sources = new Set();


### PR DESCRIPTION
linked to the issue #2633.

A proposal to solve the problemethat appeared with the custom example 
https://github.com/bloc-in-bloc/itowns/blob/f/custom-pointcloud-sample/examples/demo_hackathon_orvault_planarView.html

The custome transformation apply to the global object3d wasn't apply to the newly generated OBB, thus considering that they were elsewhere.


