### PR TITLE
fix(docs): exclude sub-folder node_modules to fix doc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ potree
 /docs/out/
 **/coverage
 .nyc_output/
+buildDocs/

--- a/docs/config.json
+++ b/docs/config.json
@@ -182,7 +182,7 @@
     },
     "source": {
         "include": [ "examples/jsm/plugins", "packages" ],
-        "excludePattern": "(^|\\/|\\\\)lib"
+        "excludePattern": "(^|\\/|\\\\)lib|node_modules"
     },
     "plugins": ["plugins/markdown"]
 }


### PR DESCRIPTION
## Description
Exclude sub-folder node_modules from doc build script

## Motivation and Context
The doc build job is currently broken, preventing new version of iTowns from being published.
Since the integration of three-geospatial, that module is both directly included and included by 3d-tiles-renderer, in different versions, which makes the npm install scripts create a node_modules in the Main package sub-folder, no matter what we do.