### PR TITLE
Disable atmosphere by default

### DIFF
--- a/examples/mars.html
+++ b/examples/mars.html
@@ -61,7 +61,8 @@
                     outerRadius: 6600000,
                     wavelength: [0.350, 0.470, 0.575],
                     scaleDepth: 0.38,
-                }
+                },
+                realisticLighting: true,
             });
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/mars.html
+++ b/examples/mars.html
@@ -69,7 +69,8 @@
             var tmsMarsSource = new itowns.TMSSource({
                     // crs: 'EPSG:104905',
                     crs: 'EPSG:4326',
-                    url : 'https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0//default/default028mm/${z}/${y}/${x}.jpg',
+                    url: 'https://trek.nasa.gov/tiles/Mars/EQ/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0/default/default028mm/${z}/${y}/${x}.jpg',
+                    // url : 'https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0//default/default028mm/${z}/${y}/${x}.jpg',
                     zoom: { min: 0, max: 9 },
                 })
 

--- a/examples/vector_tile_3d_mesh.html
+++ b/examples/vector_tile_3d_mesh.html
@@ -53,9 +53,7 @@
             const viewerDiv = document.getElementById('viewerDiv');
 
             // Create a GlobeView
-            const view = new itowns.GlobeView(viewerDiv, placement, {
-                realisticLighting: false // disable atmosphere lighting
-            });
+            const view = new itowns.GlobeView(viewerDiv, placement);
 
             // Define poles texture
             view.tileLayer.noTextureColor = new THREE.Color(0x95c1e1);

--- a/examples/vector_tile_3d_mesh_mapbox.html
+++ b/examples/vector_tile_3d_mesh_mapbox.html
@@ -66,9 +66,7 @@
             const viewerDiv = document.getElementById('viewerDiv');
 
             // Create a GlobeView
-            const view = new itowns.GlobeView(viewerDiv, placement, {
-                realisticLighting: false // disable atmosphere lighting
-            });
+            const view = new itowns.GlobeView(viewerDiv, placement);
 
             // Define poles texture
             view.tileLayer.noTextureColor = new THREE.Color(0x95c1e1);

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -48,7 +48,9 @@
             const viewerDiv = document.getElementById('viewerDiv');
 
             // Create a GlobeView
-            const view = new itowns.GlobeView(viewerDiv, placement);
+            const view = new itowns.GlobeView(viewerDiv, placement, {
+                realisticLighting: true,
+            });
 
             // Setup loading screen and debug menu
             setupLoadingScreen(viewerDiv, view);

--- a/examples/view_3d_mns_map.html
+++ b/examples/view_3d_mns_map.html
@@ -55,7 +55,9 @@
             const viewerDiv = document.getElementById('viewerDiv');
 
             // Create a GlobeView
-            const view = new itowns.GlobeView(viewerDiv, placement);
+            const view = new itowns.GlobeView(viewerDiv, placement, {
+                realisticLighting: true,
+            });
 
             // Setup loading screen and debug menu
             setupLoadingScreen(viewerDiv, view);

--- a/examples/view_immersive.html
+++ b/examples/view_immersive.html
@@ -60,7 +60,6 @@
                 handleCollision: false,
                 // Change the subdisvision threshold to get better performances and avoid requesting many unnecessary tiles
                 sseSubdivisionThreshold: 10,
-                realisticLighting: false // disable atmosphere
             });
 
             // create Immersive control

--- a/examples/view_multiglobe.html
+++ b/examples/view_multiglobe.html
@@ -66,7 +66,6 @@
             var view = new itowns.GlobeView(viewerDiv, placement, {
                 noControls: true,
                 object3d,
-                realisticLighting: false
             });
             var cameraThree = view.camera3D;
             setupLoadingScreen(viewerDiv, view);

--- a/examples/vpc_3d_loader.html
+++ b/examples/vpc_3d_loader.html
@@ -11,8 +11,8 @@
                 "GuiTools": "./jsm/GUI/GuiTools.js",
                 "LoadingScreen": "./jsm/GUI/LoadingScreen.js",
                 "itowns_widgets": "../dist/itowns_widgets.js",
-                "three": "https://unpkg.com/three@0.174.0/build/three.module.js",
-                "three/addons/": "https://unpkg.com/three@0.174.0/examples/jsm/",
+                "three": "https://unpkg.com/three@0.182.0/build/three.module.js",
+                "three/addons/": "https://unpkg.com/three@0.182.0/examples/jsm/",
                 "dat": "https://unpkg.com/dat.gui@0.7.9/build/dat.gui.module.js"
             }
         }

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -89,7 +89,7 @@ class GlobeView extends View {
      * The maximum view distance is this factor times the camera's altitude (above sea level).
      * @param {number} [options.fogSpread=0.5] - Proportion of the visible depth range that contains fog.
      * Between 0 and 1.
-     * @param {boolean} [options.realisticLighting=true] - Enable realistic lighting.
+     * @param {boolean} [options.realisticLighting=false] - Enable realistic lighting.
      * If true, it can later be switched by setting this.skyManager.enabled to true/false.
      * If false, it will be impossible to enable it later on.
      */
@@ -166,7 +166,7 @@ class GlobeView extends View {
             this.webXR.initializeWebXR();
         }
 
-        if (options.realisticLighting || options.realisticLighting === undefined) {
+        if (options.realisticLighting === true) {
             this.skyManager = new SkyManager(this);
         }
     }

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -85,7 +85,7 @@ describe('Entwine Point Tile', function () {
 
         before(function (done) {
             renderer = new Renderer();
-            view = new GlobeView(renderer.domElement, {}, { renderer }, { realisticLighting: false });
+            view = new GlobeView(renderer.domElement, {}, { renderer });
             layer = new EntwinePointTileLayer('testEptLayer', { source });
 
             context = {

--- a/packages/Main/test/unit/globeview.js
+++ b/packages/Main/test/unit/globeview.js
@@ -14,7 +14,10 @@ describe('GlobeView', function () {
     // 3919 is the approximate altitude giving a 1/25000 scale, on a screen with a
     // pitch of 0.28. The approximation is corrected below with an epsilon.
     const placement = { coord: new Coordinates('EPSG:4326', 4.631512, 43.675626), range: 3919 };
-    const viewer = new GlobeView(renderer.domElement, placement, { renderer });
+    const viewer = new GlobeView(renderer.domElement, placement, {
+        renderer,
+        realisticLighting: true,
+    });
     const pickedPosition = new THREE.Vector3();
     pickedPosition.copy(viewer.camera.position());
 


### PR DESCRIPTION
## Description

#2589 replaced our own baked atmosphere by `three-geospatial` and enabled atmosphere by default.

However, this leads to :
- incorrect lighting for pointclouds (see #2652)
- jankiness on windows at startup (I will post a reproducible example in an issue)

We also do not have a widget to control the date (i.e. day + time of the day).

Until those points have been addressed, I propose to revert to the old disabled by default behaviour.


P.S.: I also fixed the mars example, the wmts stream URL has changed.