### PR TITLE
feat: add Docker support for running examples locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.dockerignore
+.git
+.github
+.gitignore
+.npm
+node_modules
+dist
+test
+**/coverage/
+**/lib/
+**/test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:lts-alpine3.21
+
+WORKDIR /itowns
+
+COPY package.json package-lock.json ./
+COPY packages/Geographic/package.json ./packages/Geographic/
+COPY packages/Main/package.json ./packages/Main/
+COPY packages/Debug/package.json ./packages/Debug/
+COPY packages/Widgets/package.json ./packages/Widgets/
+
+RUN npm ci --ignore-scripts --prefer-offline --cache .npm
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -39,16 +39,43 @@ here](http://www.itowns-project.org/itowns/examples/). Some examples available:
 
 [![iTowns examples](http://www.itowns-project.org/images/montage.jpg)](http://www.itowns-project.org/itowns/examples/)
 
-## How to run it locally?
+## Running locally
 
-Clone the repo and then run:
+Examples can be run locally using either npm or Docker. Both methods serve them on port `8080`.
 
-```
+### Using npm
+
+Requires [Node.js](https://nodejs.org/) (LTS version recommended).
+
+```bash
+git clone https://github.com/itowns/itowns.git
+cd itowns
 npm install
 npm start
 ```
 
-Try out the examples at http://localhost:8080/examples
+### Using Docker
+
+Requires [Docker](https://www.docker.com/).
+
+```bash
+git clone https://github.com/itowns/itowns.git
+cd itowns
+docker build -t itowns .
+docker run -p 8080:8080 itowns
+```
+
+Alternatively, you can build and run directly from a remote branch of itowns in a single command:
+
+```bash
+docker run -p 8080:8080 $(docker build -q https://github.com/itowns/itowns.git#<branch>)
+```
+
+> Replace `<branch>` with the desired branch name (e.g. `master`, `dev`).
+
+### Accessing the examples
+
+Once the server is running, the examples are available at http://localhost:8080/
 
 ## How to use it in your project?
 


### PR DESCRIPTION
## Description

This PR adds Docker support for running iTowns examples locally by adding a `Dockerfile` using node LTS alpine.

```bash
# Locally
docker build -t itowns .
docker run -p 8080:8080 itowns

# From a remote branch
docker run -p 8080:8080 $(docker build -q https://github.com/itowns/itowns.git#<branch>)
```
where `<branch>` is the desired branch name.

Note that this is not limited to the itowns repository but can be applied on all branches rebased on this commit.

## Motivation and Context
Provides an alternative method to run iTowns examples locally without requiring a local `node` installation. This aims to:
- simplify onboarding of users who want to test features of itowns without having to setup a local node environment
- get reproducible builds (e.g. for some poc or demos)
- easily test different branches using a git URL