### PR TITLE
Fix(pointcloud): incorrect loading mechanism & add layer events

### DIFF
--- a/packages/Main/test/unit/potree2layerprocessing.js
+++ b/packages/Main/test/unit/potree2layerprocessing.js
@@ -58,33 +58,12 @@ describe('preUpdate Potree2Layer', function () {
             Potree2Layer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
 
-    it('should return root if no common ancestors', () => {
+    it('should return root', () => {
         const sources = new Set();
         sources.add(layer.root.children[0].children[0]);
         sources.add(layer.root.children[2].children[1]);
         assert.deepStrictEqual(
             layer.root,
-            Potree2Layer.prototype.preUpdate.call(layer, context, sources)[0]);
-    });
-
-    it('should return common ancestor', () => {
-        const sources = new Set();
-        sources.add(layer.root.children[2].children[0]);
-        sources.add(layer.root.children[2].children[1]);
-        sources.add(layer.root.children[2].children[1].children[2]);
-        sources.add(layer.root.children[2].children[1].children[3]);
-        assert.deepStrictEqual(
-            layer.root.children[2],
-            Potree2Layer.prototype.preUpdate.call(layer, context, sources)[0]);
-    });
-
-    it('should not search ancestors if layer are different root if no common ancestors', () => {
-        const sources = new Set();
-        sources.add(layer.root.children[2].children[0]);
-        sources.add(layer.root.children[2].children[1].children[3]);
-        layer.root.children[2].children[1].children[3].obj = { layer: {}, isPoints: true };
-        assert.deepStrictEqual(
-            layer.root.children[2].children[0],
             Potree2Layer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
 });

--- a/packages/Main/test/unit/potreelayerprocessing.js
+++ b/packages/Main/test/unit/potreelayerprocessing.js
@@ -66,25 +66,4 @@ describe('preUpdate PotreeLayer', function () {
             layer.root,
             PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
     });
-
-    it('should return common ancestor', () => {
-        const sources = new Set();
-        sources.add(layer.root.children[2].children[0]);
-        sources.add(layer.root.children[2].children[1]);
-        sources.add(layer.root.children[2].children[1].children[2]);
-        sources.add(layer.root.children[2].children[1].children[3]);
-        assert.deepStrictEqual(
-            layer.root.children[2],
-            PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
-    });
-
-    it('should not search ancestors if layer are different root if no common ancestors', () => {
-        const sources = new Set();
-        sources.add(layer.root.children[2].children[0]);
-        sources.add(layer.root.children[2].children[1].children[3]);
-        layer.root.children[2].children[1].children[3].obj = { layer: {}, isPoints: true };
-        assert.deepStrictEqual(
-            layer.root.children[2].children[0],
-            PotreeLayer.prototype.preUpdate.call(layer, context, sources)[0]);
-    });
 });


### PR DESCRIPTION
## Description
This PR fixes the current loading mechanism of pointclouds. Those were added directly visible on the scene on load and bypassed the `notifyChange` mechanism.

This PR also adds layer events for model load, error and dispose for end-users and debugging purpose (the events types were based on those of `OGC3DTilesLayer`).

## Motivation and Context
This could maybe help #2665 #2666 (@ketourneau if you can rebase on this and see if it fixes at least the points pop?)

Based on #2672
