### PR TITLE
chore: remove npm token as OIDC is now used

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -190,8 +190,6 @@ jobs:
       - name: publish itowns@latest npm package
         if: ${{ startsWith(github.event.head_commit.message, 'release v' ) }}
         run: npm run publish-latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: publish itowns@next npm package (following a release)
         if: ${{ startsWith(github.event.head_commit.message, 'release v' ) }}
@@ -202,8 +200,6 @@ jobs:
           git add .
           git commit --amend --no-edit
           git push -f
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: publish itowns@next npm package
         if: ${{ !startsWith(github.event.head_commit.message, 'release v' ) }}
@@ -214,8 +210,6 @@ jobs:
           git add .
           git commit --amend --no-edit
           git push
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Deploy on itowns.github.io website
   deploy:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Remove npm token mention in CD script, as we now use OIDC to authenticate publishers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

npm no longer supports tokens with indefinite life time.
