### PR TITLE
refactor: migrate MainLoop to TypeScript

### DIFF
--- a/examples/vector_tile_raster_2d.html
+++ b/examples/vector_tile_raster_2d.html
@@ -78,7 +78,7 @@
             view.addLayer(mvtLayer).then(menuGlobe.addLayerGUI.bind(menuGlobe));
 
             // Request redraw
-            view.notifyChange(true);
+            view.notifyChange({});
             debug.createTileDebugUI(menuGlobe.gui, view);
             window.view = view;
             window.itowns = itowns;

--- a/packages/Main/src/Core/MainLoop.ts
+++ b/packages/Main/src/Core/MainLoop.ts
@@ -13,21 +13,21 @@ export const RENDERING_SCHEDULED = 1;
  */
 export const MAIN_LOOP_EVENTS = {
     /** Fired at the start of the update */
-    UPDATE_START: 'update_start',
+    UPDATE_START: 'update_start' as const,
     /** Fired before the camera update */
-    BEFORE_CAMERA_UPDATE: 'before_camera_update',
+    BEFORE_CAMERA_UPDATE: 'before_camera_update' as const,
     /** Fired after the camera update */
-    AFTER_CAMERA_UPDATE: 'after_camera_update',
+    AFTER_CAMERA_UPDATE: 'after_camera_update' as const,
     /** Fired before the layer update */
-    BEFORE_LAYER_UPDATE: 'before_layer_update',
+    BEFORE_LAYER_UPDATE: 'before_layer_update' as const,
     /** Fired after the layer update */
-    AFTER_LAYER_UPDATE: 'after_layer_update',
+    AFTER_LAYER_UPDATE: 'after_layer_update' as const,
     /** Fired before the render */
-    BEFORE_RENDER: 'before_render',
+    BEFORE_RENDER: 'before_render' as const,
     /** Fired after the render */
-    AFTER_RENDER: 'after_render',
+    AFTER_RENDER: 'after_render' as const,
     /** Fired at the end of the update */
-    UPDATE_END: 'update_end',
+    UPDATE_END: 'update_end' as const,
 };
 
 type Context = {

--- a/packages/Main/src/Core/MainLoop.ts
+++ b/packages/Main/src/Core/MainLoop.ts
@@ -131,7 +131,7 @@ class MainLoop extends EventDispatcher<MainLoopEvents> {
                 document.title += ' ⌛';
             }
 
-            // TODO Fix asynchronization between xr and MainLoop render loops.
+            // TODO: Fix asynchronization between xr and MainLoop render loops.
             // WebGLRenderer#setAnimationLoop must be used for WebXR projects.
             // (see WebXR#initializeWebXR).
             if (!this.gfxEngine.renderer.xr.isPresenting) {
@@ -254,8 +254,7 @@ class MainLoop extends EventDispatcher<MainLoopEvents> {
     private _renderView(view: View, dt: number) {
         view.execFrameRequesters(MAIN_LOOP_EVENTS.BEFORE_RENDER, dt, this._updateLoopRestarted);
 
-        if ('render' in view) {
-            // @ts-expect-error View isn't typed yet.
+        if (view.render) {
             view.render();
         } else {
             // use default rendering method

--- a/packages/Main/src/Core/MainLoop.ts
+++ b/packages/Main/src/Core/MainLoop.ts
@@ -91,7 +91,7 @@ function filterChangeSources(
     let fullUpdate = false;
     const filtered = new Set<UpdateSource>();
     updateSources.forEach((src) => {
-        if (src === geometryLayer || (src as ThreeCamera).isCamera) {
+        if (src === geometryLayer || 'isCamera' in src) {
             geometryLayer.info.clear();
             fullUpdate = true;
         } else if ((src as { layer: Layer }).layer === geometryLayer) {

--- a/packages/Main/src/Core/MainLoop.ts
+++ b/packages/Main/src/Core/MainLoop.ts
@@ -38,7 +38,7 @@ type Context = {
 };
 
 type UpdatableGeometryLayer<T> = GeometryLayer & {
-    update(context: Context, layer: Layer, node: T): Array<T> | undefined
+    update(context: Context, layer: Layer, node: T, parent?: T): Array<T> | undefined
 };
 
 function updateElements<T extends Object3D>(
@@ -67,8 +67,7 @@ function updateElements<T extends Object3D>(
                 // update attached layers
                 for (const attachedLayer of geometryLayer.attachedLayers) {
                     if (attachedLayer.ready) {
-                        // @ts-expect-error Updatable layer
-                        attachedLayer.update(context,
+                        (attachedLayer as UpdatableGeometryLayer<T>).update(context,
                             attachedLayer,
                             sub.elements[i],
                             sub.parent);

--- a/packages/Main/src/Core/MainLoop.ts
+++ b/packages/Main/src/Core/MainLoop.ts
@@ -1,8 +1,9 @@
-import { GeometryLayer, Layer, View } from 'Main';
-import { EventDispatcher, Object3D, Camera as ThreeCamera } from 'three';
-import Camera from 'Renderer/Camera';
-import c3DEngine from 'Renderer/c3DEngine';
-import Scheduler from './Scheduler/Scheduler';
+import type { GeometryLayer, Layer, View } from 'Main';
+import type { Object3D, Camera as ThreeCamera } from 'three';
+import { EventDispatcher } from 'three';
+import type Camera from 'Renderer/Camera';
+import type c3DEngine from 'Renderer/c3DEngine';
+import type Scheduler from './Scheduler/Scheduler';
 
 export const RENDERING_PAUSED = 0;
 export const RENDERING_SCHEDULED = 1;

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -485,7 +485,7 @@ class View extends THREE.EventDispatcher {
      * view.getLayers(layer => layer.isGeometryLayer);
      * // get one layer with id
      * view.getLayers(layer => layer.id === 'itt');
-     * @param {function(Layer):boolean} filter
+     * @param {function(Layer, Layer?):boolean} filter
      * @returns {Array<Layer>}
      */
     getLayers(filter) {

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -128,6 +128,7 @@ let id = 0;
  * @property {Camera} camera - itowns camera (that holds a threejs camera that is directly accessible with View.camera3D)
  * @property {THREE.Camera} camera3D - threejs camera that is stored in itowns camera
  * @property {THREE.WebGLRenderer} renderer - threejs webglrenderer rendering this view
+ * @property {undefined | function(): void} render - custom rendering callback
  */
 class View extends THREE.EventDispatcher {
     #layers = [];
@@ -186,6 +187,8 @@ class View extends THREE.EventDispatcher {
         }
 
         this.mainLoop = options.mainLoop || new MainLoop(new Scheduler(), engine);
+        /** @type undefined | function(): void */
+        this.render = undefined;
 
         this.scene = options.scene3D || new THREE.Scene();
         if (!options.scene3D) {

--- a/packages/Main/src/Layer/GeometryLayer.js
+++ b/packages/Main/src/Layer/GeometryLayer.js
@@ -142,10 +142,14 @@ class GeometryLayer extends Layer {
     // object to update for attached layer.
     // See 3dtilesLayer or PotreeLayer for examples.
     // eslint-disable-next-line arrow-body-style
+    /**
+     * @param {THREE.Object3D} obj
+     * @returns { { elements: THREE.Object3D[], parent: THREE.Object3D } }
+     */
     getObjectToUpdateForAttachedLayers(obj) {
         if (obj.parent && obj.material) {
             return {
-                element: obj,
+                elements: [obj],
                 parent: obj.parent,
             };
         }
@@ -153,7 +157,7 @@ class GeometryLayer extends Layer {
 
     // Placeholder
     // eslint-disable-next-line
-    postUpdate() {}
+    postUpdate() { }
 
     // Placeholder
     // eslint-disable-next-line

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -321,7 +321,7 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
         // slide 17
         context.camera.preSSE =
             context.camera.height /
-                (2 * Math.tan(THREE.MathUtils.degToRad(context.camera.camera3D.fov) * 0.5));
+            (2 * Math.tan(THREE.MathUtils.degToRad(context.camera.camera3D.fov) * 0.5));
 
         if (this.material) {
             this.material.visible = this.visible;
@@ -519,12 +519,12 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
             const p = meta.parent;
             if (p && p.obj) {
                 return {
-                    element: meta.obj,
+                    elements: [meta.obj],
                     parent: p.obj,
                 };
             } else {
                 return {
-                    element: meta.obj,
+                    elements: [meta.obj],
                 };
             }
         }

--- a/packages/Main/test/unit/potree2layerparsing.js
+++ b/packages/Main/test/unit/potree2layerparsing.js
@@ -278,7 +278,7 @@ describe('getObjectToUpdateForAttachedLayers', function () {
         const meta = {
             obj: 'a',
         };
-        assert.equal(Potree2Layer.prototype.getObjectToUpdateForAttachedLayers(meta).element, 'a');
+        assert.equal(Potree2Layer.prototype.getObjectToUpdateForAttachedLayers(meta).elements[0], 'a');
     });
     it('should correctly return the element and its parent', function () {
         const meta = {
@@ -288,7 +288,7 @@ describe('getObjectToUpdateForAttachedLayers', function () {
             },
         };
         const result = Potree2Layer.prototype.getObjectToUpdateForAttachedLayers(meta);
-        assert.equal(result.element, 'a');
+        assert.equal(result.elements[0], 'a');
         assert.equal(result.parent, 'b');
     });
 });

--- a/packages/Main/test/unit/potreelayerparsing.js
+++ b/packages/Main/test/unit/potreelayerparsing.js
@@ -151,7 +151,7 @@ describe('getObjectToUpdateForAttachedLayers', function () {
         const meta = {
             obj: 'a',
         };
-        assert.equal(PotreeLayer.prototype.getObjectToUpdateForAttachedLayers(meta).element, 'a');
+        assert.equal(PotreeLayer.prototype.getObjectToUpdateForAttachedLayers(meta).elements[0], 'a');
     });
     it('should correctly return the element and its parent', function () {
         const meta = {
@@ -161,7 +161,7 @@ describe('getObjectToUpdateForAttachedLayers', function () {
             },
         };
         const result = PotreeLayer.prototype.getObjectToUpdateForAttachedLayers(meta);
-        assert.equal(result.element, 'a');
+        assert.equal(result.elements[0], 'a');
         assert.equal(result.parent, 'b');
     });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Migrates MainLoop to TypeScript and cleans up some of the outdated and/or unused code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Part of the project-wide migration to TypeScript, I needed this file's migration to happen for other PRs I'm working on.