### PR TITLE
fix(Picking): use full scene for rendering to buffer

### DIFF
--- a/packages/Main/src/Core/Picking.js
+++ b/packages/Main/src/Core/Picking.js
@@ -234,7 +234,7 @@ export default {
             height: 1 + radius * 2,
         };
         const pixels = view.mainLoop.gfxEngine.renderViewToBuffer(
-            { scene: object, camera: view.camera },
+            { scene: view.scene, camera: view.camera },
             zone);
 
         const clearColor = new THREE.Color();


### PR DESCRIPTION
## Description
Use the full scene for the rendering used in the picking

## Motivation and Context
Currently the rendering is done with only the selected object. So there is no light associated, then the rendering is completely black.

cf https://github.com/iTowns/itowns/issues/2678

The full scene includes the light. Then the `intersect` is still done with only the object 


