### PR TITLE
[Refactor] Point Cloud Nodes -> homogeneisation

### DIFF
--- a/examples/copc_3d_loader.html
+++ b/examples/copc_3d_loader.html
@@ -49,6 +49,7 @@
             import * as itowns from 'itowns';
             import * as debug from 'debug';
             import * as itowns_widgets from 'itowns_widgets';
+            import { zoomToLayerGlobe } from './jsm/PointCloudHelper.js';
 
             var debugGui = new lil();
             var viewerDiv = document.getElementById('viewerDiv');
@@ -89,16 +90,8 @@
             loadCopc(url, options);
 
             function onLayerReady() {
-                var lookAt = layer.root.clampOBB.position;
-                var coordLookAt = new itowns.Coordinates(view.referenceCrs).setFromVector3(lookAt);
-
-                var size = new THREE.Vector3();
-                layer.root.voxelOBB.box3D.getSize(size);
-
-                view.controls.lookAtCoordinate({
-                    coord: coordLookAt,
-                    range: 2 * size.length(),
-                }, false);
+                zoomToLayerGlobe(view, layer);
+                debug.PointCloudDebug.initTools(view, layer, debugGui);
             }
 
             function loadCopc(url, options) {
@@ -129,9 +122,6 @@
                 layer = new itowns.CopcLayer('COPC', config);
 
                 itowns.View.prototype.addLayer.call(view, layer).then(onLayerReady);
-
-                layer.whenReady
-                    .then(() => debug.PointCloudDebug.initTools(view, layer, debugGui));
             }
 
             const loadUrlBtn = document.getElementById('loadUrlBtn');

--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -79,7 +79,7 @@
             }
 
             function onLayerReady() {
-                var lookAt = layer.root.origin.toVector3();
+                var lookAt = layer.root.clampOBB.position;
 
                 const size = new THREE.Vector3();
                 layer.root.voxelOBB.box3D.getSize(size);

--- a/examples/copc_simple_loader.html
+++ b/examples/copc_simple_loader.html
@@ -50,6 +50,7 @@
             import * as itowns from 'itowns';
             import * as debug from 'debug';
             import * as itowns_widgets from 'itowns_widgets';
+            import { zoomToLayer } from './jsm/PointCloudHelper.js';
 
             let layer; // COPCLayer
 
@@ -79,24 +80,10 @@
             }
 
             function onLayerReady() {
-                var lookAt = layer.root.clampOBB.position;
+                zoomToLayer(view, layer);
 
-                const size = new THREE.Vector3();
-                layer.root.voxelOBB.box3D.getSize(size);
-
-                controls.groundLevel = layer.minElevationRange;
-                var corner = new THREE.Vector3(...layer.source.header.min);
-                var position = corner.clone().add(
-                    size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
-                );
-
-                const camera = view.camera.camera3D;
-                camera.far = 10.0 * size.length();
-                camera.position.copy(position);
-                camera.lookAt(lookAt);
-                camera.updateProjectionMatrix();
-
-                view.notifyChange(camera);
+                // add GUI
+                debug.PointCloudDebug.initTools(view, layer, gui)
             }
 
             function loadCopc(url, options) {
@@ -125,8 +112,6 @@
                     }
                     layer = new itowns.CopcLayer('COPC', config);
                     view.addLayer(layer).then(onLayerReady);
-                    layer.whenReady
-                        .then(() => debug.PointCloudDebug.initTools(view, layer, gui));
                 })
             }
 

--- a/examples/entwine_3d_loader.html
+++ b/examples/entwine_3d_loader.html
@@ -90,7 +90,8 @@
 
             var eptLayer;
             function onLayerReady() {
-                var lookAt = eptLayer.root.origin;
+                var lookAt = new itowns.Coordinates(view.referenceCrs)
+                    .setFromVector3(eptLayer.root.clampOBB.center);
 
                 var size = new THREE.Vector3();
                 eptLayer.root.voxelOBB.box3D.getSize(size);

--- a/examples/entwine_3d_loader.html
+++ b/examples/entwine_3d_loader.html
@@ -50,6 +50,7 @@
             import * as itowns from 'itowns';
             import * as debug from 'debug';
             import * as itowns_widgets from 'itowns_widgets';
+            import { zoomToLayerGlobe } from './jsm/PointCloudHelper.js';
 
             var debugGui = new lil();
             var viewerDiv = document.getElementById('viewerDiv');
@@ -90,16 +91,8 @@
 
             var eptLayer;
             function onLayerReady() {
-                var lookAt = new itowns.Coordinates(view.referenceCrs)
-                    .setFromVector3(eptLayer.root.clampOBB.center);
-
-                var size = new THREE.Vector3();
-                eptLayer.root.voxelOBB.box3D.getSize(size);
-
-                view.controls.lookAtCoordinate({
-                    coord: lookAt,
-                    range: 2 * size.length(),
-                }, false);
+                zoomToLayerGlobe(view, eptLayer);
+                debug.PointCloudDebug.initTools(view, eptLayer, debugGui);
             }
 
             function loadEPT(url, options) {
@@ -126,9 +119,6 @@
                 eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', config);
 
                 itowns.View.prototype.addLayer.call(view, eptLayer).then(onLayerReady);
-
-                eptLayer.whenReady
-                    .then(() => debug.PointCloudDebug.initTools(view, eptLayer, debugGui));
             }
 
             const loadUrlBtn = document.getElementById('loadUrlBtn');

--- a/examples/entwine_3d_loader.html
+++ b/examples/entwine_3d_loader.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Itowns - Entwine 3D loader</title>
+        <title>iTowns - Entwine 3D loader</title>
 
         <script type="importmap">
         {
@@ -86,7 +86,7 @@
                 options[k] = isNaN(parseFloat(v, 10)) ? v : parseFloat(v, 10);
             }
 
-            loadEPT(url);
+            loadEPT(url, options);
 
             var eptLayer;
             function onLayerReady() {
@@ -102,7 +102,7 @@
                 }, false);
             }
 
-            function loadEPT(url) {
+            function loadEPT(url, options) {
                 if(!url) return;
                 document.getElementById('share').innerHTML = '<a href="' +
                     location.href.replace(location.search, '?ept=' + url) +
@@ -117,10 +117,13 @@
                     eptLayer.delete();
                 }
 
-                eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', {
+                const config = {
                     source: eptSource,
                     crs: view.referenceCrs,
-                });
+                    ...options,
+                };
+
+                eptLayer = new itowns.EntwinePointTileLayer('Entwine Point Tile', config);
 
                 itowns.View.prototype.addLayer.call(view, eptLayer).then(onLayerReady);
 

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Itowns - Entwine simple loader</title>
+        <title>iTowns - Entwine simple loader</title>
 
         <script type="importmap">
         {

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -92,7 +92,9 @@
             }
 
             function onLayerReady() {
-                var lookAt = eptLayer.root.origin.toVector3();
+                var lookAt = new itowns.Coordinates(view.referenceCrs)
+                    .setFromVector3(eptLayer.root.clampOBB.center)
+                    .toVector3();
 
                 var size = new THREE.Vector3();
                 eptLayer.root.voxelOBB.box3D.getSize(size);

--- a/examples/entwine_simple_loader.html
+++ b/examples/entwine_simple_loader.html
@@ -45,6 +45,7 @@
             import * as itowns from 'itowns';
             import * as debug from 'debug';
             import * as itowns_widgets from 'itowns_widgets';
+            import { zoomToLayer } from './jsm/PointCloudHelper.js';
 
             itowns.CRS.defs('EPSG:3946', '+proj=lcc +lat_0=46 +lon_0=3 +lat_1=45.25 +lat_2=46.75 +x_0=1700000 +y_0=5200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
 
@@ -92,25 +93,7 @@
             }
 
             function onLayerReady() {
-                var lookAt = new itowns.Coordinates(view.referenceCrs)
-                    .setFromVector3(eptLayer.root.clampOBB.center)
-                    .toVector3();
-
-                var size = new THREE.Vector3();
-                eptLayer.root.voxelOBB.box3D.getSize(size);
-                view.camera3D.far = 2.0 * size.length();
-
-                controls.groundLevel = eptLayer.minElevationRange;
-                var corner = new THREE.Vector3(...eptLayer.source.boundsConforming.slice(0, 3));
-                var position = corner.clone().add(
-                    size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
-                );
-
-                view.camera3D.position.copy(position);
-                view.camera3D.lookAt(lookAt);
-                view.camera3D.updateProjectionMatrix();
-
-                view.notifyChange(view.camera3D);
+                zoomToLayer(view, eptLayer);
 
                 // add GUI
                 debug.PointCloudDebug.initTools(view, eptLayer, debugGui)

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -57,6 +57,7 @@
                 import * as itowns from 'itowns';
                 import * as debug from 'debug';
                 import * as itowns_widgets from 'itowns_widgets';
+                import { zoomToLayer } from './jsm/PointCloudHelper.js';
 
                 var potreeLayer;
                 var oldPostUpdate;
@@ -119,33 +120,9 @@
                 }
                 view.domElement.addEventListener('dblclick', dblClickHandler);
 
-                function placeCamera(position, lookAt) {
-                    view.camera3D.position.copy(position);
-                    view.camera3D.lookAt(lookAt);
-                    view.camera3D.updateProjectionMatrix();
-
-                    view.notifyChange(view.camera3D);
-                }
-
                 // add potreeLayer to scene
                 function onLayerReady() {
-                    var lookAt = new itowns.Coordinates(view.referenceCrs)
-                        .setFromVector3(potreeLayer.root.clampOBB.center)
-                        .toVector3();
-
-                    var size = new THREE.Vector3();
-                    potreeLayer.root.voxelOBB.box3D.getSize(size);
-
-                    lookAt.z = potreeLayer.root.voxelOBB.box3D.min.z;
-
-                    view.camera3D.far = 5.0 * size.length();
-
-                    var corner = new THREE.Vector3(...potreeLayer.source.boundsConforming.slice(0, 3));
-                    var position = corner.clone().add(
-                        size.multiply({ x: 0, y: 0, z: (size.x / size.z) })
-                    );
-
-                    placeCamera(position, lookAt);
+                    zoomToLayer(view, potreeLayer);
 
                     debug.PointCloudDebug.initTools(view, potreeLayer, debugGui);
 

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -127,7 +127,9 @@
 
                 // add potreeLayer to scene
                 function onLayerReady() {
-                    var lookAt = potreeLayer.root.origin.toVector3();
+                    var lookAt = new itowns.Coordinates(view.referenceCrs)
+                        .setFromVector3(potreeLayer.root.clampOBB.center)
+                        .toVector3();
 
                     var size = new THREE.Vector3();
                     potreeLayer.root.voxelOBB.box3D.getSize(size);

--- a/examples/potree_25d_map.html
+++ b/examples/potree_25d_map.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Point Cloud Viewer</title>
+        <title>iTowns - Potree simple loader</title>
 
         <script type="importmap">
         {
@@ -80,6 +80,8 @@
                 */
 
                 itowns.CRS.defs("EPSG:25831","+proj=utm +zone=31 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs");
+
+                const name = 'Sagrada Familia';
                 const url = 'https://betaserver.icgc.cat/potree12/resources/pointclouds/templesagradafamilia/cloud.js';
                 const crs = 'EPSG:25831';
 
@@ -99,7 +101,7 @@
                     crs,
                 });
 
-                potreeLayer = new itowns.PotreeLayer('eglise_saint_blaise_arles', {
+                potreeLayer = new itowns.PotreeLayer(name, {
                     source: potreeSource,
                 });
 

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -53,6 +53,7 @@
             import * as itowns from 'itowns';
             import * as debug from 'debug';
             import * as itowns_widgets from 'itowns_widgets';
+            import { zoomToLayerGlobe } from './jsm/PointCloudHelper.js';
 
             var potreeLayer;
             var oldPostUpdate;
@@ -106,17 +107,7 @@
 
             // add potreeLayer to scene
             function onLayerReady() {
-                var lookAt = potreeLayer.root.clampOBB.position;
-
-                var coordLookAt = new itowns.Coordinates(view.referenceCrs).setFromVector3(lookAt);
-
-                var size = new THREE.Vector3();
-                potreeLayer.root.voxelOBB.box3D.getSize(size);
-
-                view.controls.lookAtCoordinate({
-                    coord: coordLookAt,
-                    range: 2 * size.length(),
-                }, false);
+                zoomToLayerGlobe(view, potreeLayer);
 
                 // add GUI
                 debug.PointCloudDebug.initTools(view, potreeLayer, debugGui);

--- a/examples/potree_3d_map.html
+++ b/examples/potree_3d_map.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Point Cloud on globe</title>
+        <title>iTowns - Potree 3d loader</title>
 
         <script type="importmap">
         {
@@ -90,7 +90,7 @@
             */
 
             itowns.CRS.defs("EPSG:25831","+proj=utm +zone=31 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs");
-            name = 'TempleSagradaFamilia';
+            name = 'Sagrada Familia';
             const url = 'https://betaserver.icgc.cat/potree12/resources/pointclouds/templesagradafamilia/cloud.js';
             const crs = 'EPSG:25831';
 
@@ -112,8 +112,6 @@
 
                 var size = new THREE.Vector3();
                 potreeLayer.root.voxelOBB.box3D.getSize(size);
-
-                console.log(coordLookAt);
 
                 view.controls.lookAtCoordinate({
                     coord: coordLookAt,

--- a/examples/vpc_3d_loader.html
+++ b/examples/vpc_3d_loader.html
@@ -77,7 +77,7 @@
 
             var vpcLayer;
             function onLayerReady() {
-                var lookAt = vpcLayer.root.origin;
+                var lookAt = new itowns.Coordinates(vpcLayer.crs).setFromVector3(vpcLayer.root.clampOBB.position);
                 var size = new THREE.Vector3();
                 vpcLayer.root.voxelOBB.box3D.getSize(size);
 

--- a/examples/vpc_simple_loader.html
+++ b/examples/vpc_simple_loader.html
@@ -80,7 +80,7 @@
             var vpcLayer, vpcSource;
 
             function onLayerReady() {
-                var lookAt = vpcLayer.root.origin.toVector3();
+                var lookAt = vpcLayer.root.clampOBB.position;
 
                 var size = new THREE.Vector3();
                 vpcLayer.root.voxelOBB.box3D.getSize(size);

--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -127,6 +127,7 @@ class DebugLayer extends GeometryLayer {
         this.update = debugIdUpdate;
         this.isDebugLayer = true;
         this.layer = options.layer;
+        this.layer.object3d.add(this.object3d);
     }
 
     preUpdate(context, sources) {

--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -49,79 +49,50 @@ function setupControllerVisibily(gui, displayMode, sizeMode) {
     }
 }
 
-/**
- * Generate the position array of the bbox corner form the bbox
- * Adapted from THREE.BoxHelper.js
- * https://github.com/mrdoob/three.js/blob/master/src/helpers/BoxHelper.js
- *
- * @param {THREE.box3} bbox - Box3 of the node
- * @returns {array}
- */
-function getCornerPosition(bbox) {
-    const array =  new Float32Array(8 * 3);
-
-    const min = bbox.min;
-    const max = bbox.max;
-
-    /*
-      5____4
-    1/___0/|
-    | 6__|_7
-    2/___3/
-
-    0: max.x, max.y, max.z
-    1: min.x, max.y, max.z
-    2: min.x, min.y, max.z
-    3: max.x, min.y, max.z
-    4: max.x, max.y, min.z
-    5: min.x, max.y, min.z
-    6: min.x, min.y, min.z
-    7: max.x, min.y, min.z
-    */
-    array[0] = max.x; array[1] = max.y; array[2] = max.z;
-    array[3] = min.x; array[4] = max.y; array[5] = max.z;
-    array[6] = min.x; array[7] = min.y; array[8] = max.z;
-    array[9] = max.x; array[10] = min.y; array[11] = max.z;
-    array[12] = max.x; array[13] = max.y; array[14] = min.z;
-    array[15] = min.x; array[16] = max.y; array[17] = min.z;
-    array[18] = min.x; array[19] = min.y; array[20] = min.z;
-    array[21] = max.x; array[22] = min.y; array[23] = min.z;
-    return array;
-}
-
 const red =  new THREE.Color(0xff0000);
+// const blue =  new THREE.Color(0x0000ff);
+const yellow =  new THREE.Color(0xffff00);
 function debugIdUpdate(context, layer, node) {
     // filtering helper attached to node with the current debug layer
     if (!node.link) {
         node.link = {};
     }
+
     let helper = node.link[layer.id];
+
     if (node.visible) {
         if (!helper) {
             helper = new THREE.Group();
+            helper.name = 'helper';
 
-            // node obbes
+            // node OBBes
             const obbHelper = new OBBHelper(node.clampOBB, node.voxelKey, red);
             obbHelper.layer = layer;
+
             helper.add(obbHelper);
 
-            // point data boxes (in local ref)
-            const tightboxHelper = new THREE.BoxHelper(undefined, 0x0000ff);
+            // point data OBBes
+            const pointsOBBes = new THREE.Group();
+            pointsOBBes.name = 'tightBBox';
             if (node.obj) {
-                tightboxHelper.geometry.attributes.position.array = getCornerPosition(node.obj.geometry.boundingBox);
-                tightboxHelper.applyMatrix4(node.obj.matrixWorld);
-                node.obj.tightboxHelper = tightboxHelper;
-                helper.add(tightboxHelper);
-                tightboxHelper.updateMatrixWorld(true);
+                const pointsOBB = {
+                    position: node.obj.position.clone(),
+                    quaternion: node.obj.quaternion.clone(),
+                    box3D: node.obj.geometry.boundingBox.clone(),
+                };
+                const pointsOBBHelper = new OBBHelper(pointsOBB, node.voxelKey, yellow);
+                helper.add(pointsOBBHelper);
             } else if (node.promise) {
                 // TODO rethink architecture of node.obj/node.promise ?
                 node.promise.then(() => {
                     if (node.obj) {
-                        tightboxHelper.geometry.attributes.position.array = getCornerPosition(node.obj.geometry.boundingBox);
-                        tightboxHelper.applyMatrix4(node.obj.matrixWorld);
-                        node.obj.tightboxHelper = tightboxHelper;
-                        helper.add(tightboxHelper);
-                        tightboxHelper.updateMatrixWorld(true);
+                        const pointsOBB = {
+                            position: node.obj.position.clone(),
+                            quaternion: node.obj.quaternion.clone(),
+                            box3D: node.obj.geometry.boundingBox.clone(),
+                        };
+                        const pointsOBBHelper = new OBBHelper(pointsOBB, node.voxelKey, yellow);
+                        helper.add(pointsOBBHelper);
                     }
                 });
             }
@@ -132,6 +103,7 @@ function debugIdUpdate(context, layer, node) {
         }
 
         layer.object3d.add(helper);
+        helper.updateMatrixWorld(true);
 
         if (node.children && node.children.length) {
             if (node.sse >= 1) {

--- a/packages/Main/src/Core/EntwinePointTileNode.ts
+++ b/packages/Main/src/Core/EntwinePointTileNode.ts
@@ -38,7 +38,7 @@ class EntwinePointTileNode extends LasNodeBase {
         depth: number,
         x: number, y: number, z: number,
         source: EntwinePointTileSource,
-        numPoints: number = 0,
+        numPoints: number,
         crs: string,
     ) {
         super(depth, x, y, z, source, numPoints, crs);
@@ -57,7 +57,8 @@ class EntwinePointTileNode extends LasNodeBase {
     override async loadOctree(): Promise<void> {
         const hierarchyUrl = `${this.source.url}/ept-hierarchy/${this.voxelKey}.json`;
         const hierarchy =
-        await Fetcher.json(hierarchyUrl, this.networkOptions) as Record<string, number>;
+            await Fetcher.json(hierarchyUrl, this.networkOptions) as Record<string, number>;
+
         this.numPoints = hierarchy[this.voxelKey];
 
         const stack = [];

--- a/packages/Main/src/Core/LasNodeBase.ts
+++ b/packages/Main/src/Core/LasNodeBase.ts
@@ -28,7 +28,7 @@ abstract class LasNodeBase extends PointCloudNode {
     constructor(depth: number,
         x: number, y: number, z: number,
         source: PointCloudSource,
-        numPoints: number = 0,
+        numPoints: number,
         crs: string,
     ) {
         super(depth, numPoints);

--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -1,7 +1,5 @@
 import * as THREE from 'three';
 import OBB from 'Renderer/OBB';
-import proj4 from 'proj4';
-import { CRS, OrientationUtils, Coordinates } from '@itowns/geographic';
 
 export interface PointCloudSource {
     spacing: number;
@@ -41,9 +39,6 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
     promise: Promise<unknown> | null;
     obj: THREE.Points | undefined;
 
-    private _origin: Coordinates | undefined;
-    private _rotation: THREE.Quaternion | undefined;
-
     constructor(depth: number, numPoints: number) {
         super();
 
@@ -72,33 +67,6 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
 
     get pointSpacing(): number {
         return this.source.spacing / 2 ** this.depth;
-    }
-
-    // the origin is the center of the clamped OBB projected
-    // on the z=O local plan, in the world referential.
-    get origin(): Coordinates {
-        if (this._origin != undefined) { return this._origin; }
-        const center = this.clampOBB.center;
-        const centerCrsIn = CRS.transform(this.crs, this.source.crs).forward(center);
-        this._origin =  new Coordinates(this.crs)
-            .setFromArray(
-                CRS.transform(this.source.crs, this.crs)
-                    .forward([centerCrsIn.x, centerCrsIn.y, 0]));
-        return this._origin;
-    }
-
-    /**
-     * get the rotation between the local referentiel and
-     * the geocentrique one (if appliable).
-     */
-    get rotation(): THREE.Quaternion {
-        if (this._rotation != undefined) { return this._rotation; }
-        this._rotation = new THREE.Quaternion();
-        if (proj4.defs(this.crs).projName === 'geocent') {
-            this._rotation =
-                OrientationUtils.quaternionFromCRSToCRS(this.crs, this.source.crs)(this.origin);
-        }
-        return this._rotation;
     }
 
     async load(): Promise<THREE.BufferGeometry> {

--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -21,7 +21,8 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
 
     depth: number;
 
-    /** The number of points in this node. */
+    /** The number of points in this node.
+     * '-1' is the node has been loaded yet */
     numPoints: number;
     /** The children nodes of this node. */
     children: this[];
@@ -43,7 +44,7 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
     private _origin: Coordinates | undefined;
     private _rotation: THREE.Quaternion | undefined;
 
-    constructor(depth: number, numPoints = 0) {
+    constructor(depth: number, numPoints: number) {
         super();
 
         this.depth = depth;
@@ -95,13 +96,12 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
         this._rotation = new THREE.Quaternion();
         if (proj4.defs(this.crs).projName === 'geocent') {
             this._rotation =
-            OrientationUtils.quaternionFromCRSToCRS(this.crs, this.source.crs)(this.origin);
+                OrientationUtils.quaternionFromCRSToCRS(this.crs, this.source.crs)(this.origin);
         }
         return this._rotation;
     }
 
     async load(): Promise<THREE.BufferGeometry> {
-        // Query octree/HRC if we don't have children yet.
         if (!this.octreeIsLoaded) {
             await this.loadOctree();
         }

--- a/packages/Main/src/Core/Potree2Node.ts
+++ b/packages/Main/src/Core/Potree2Node.ts
@@ -61,7 +61,7 @@ class Potree2Node extends PotreeNodeBase {
     constructor(
         depth: number,
         index: number,
-        numPoints = 0,
+        numPoints: number,
         childrenBitField = 0,
         source: Potree2Source,
         crs: string,

--- a/packages/Main/src/Core/Potree2Node.ts
+++ b/packages/Main/src/Core/Potree2Node.ts
@@ -34,7 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 import type Potree2Source from 'Source/Potree2Source';
-import type { BufferGeometry } from 'three';
 import PotreeNodeBase from 'Core/PotreeNodeBase';
 
 const NODE_TYPE = {
@@ -48,9 +47,6 @@ type NodeType = typeof NODE_TYPE[keyof typeof NODE_TYPE];
 class Potree2Node extends PotreeNodeBase {
     source: Potree2Source;
 
-    loaded: boolean;
-    loading: boolean;
-
     // Properties initialized after loading hierarchy
     byteOffset!: bigint;
     byteSize!: bigint;
@@ -62,15 +58,12 @@ class Potree2Node extends PotreeNodeBase {
         depth: number,
         index: number,
         numPoints: number,
-        childrenBitField = 0,
+        childrenBitField: number | undefined,
         source: Potree2Source,
         crs: string,
     ) {
         super(depth, index, numPoints, childrenBitField, source, crs);
         this.source = source;
-
-        this.loaded = false;
-        this.loading = false;
     }
 
     override get url(): string {
@@ -103,26 +96,13 @@ class Potree2Node extends PotreeNodeBase {
         return networkOptions;
     }
 
-    override async load(): Promise<BufferGeometry> {
-        return super.load()
-            .then((data) => {
-                this.loaded = true;
-                this.loading = false;
-                return data;
-            });
-    }
-
     override loadOctree(): Promise<void> {
-        if (this.loaded || this.loading) {
-            return Promise.resolve();
-        }
-        this.loading = true;
-        return (this.nodeType === NODE_TYPE.PROXY) ? this.loadHierarchy() : Promise.resolve();
+        return this.loadHierarchy();
     }
 
     async loadHierarchy(): Promise<void> {
         const hierarchyUrl = `${this.baseurl}/hierarchy.bin`;
-        const buffer = await this.fetcher(hierarchyUrl, this.networkOptions);
+        const buffer = await this.fetcher(hierarchyUrl);
         this.parseHierarchy(buffer);
     }
 
@@ -150,6 +130,7 @@ class Potree2Node extends PotreeNodeBase {
                 current.byteOffset = byteOffset;
                 current.byteSize = byteSize;
                 current.numPoints = numPoints;
+                current.childrenBitField = childMask;
             } else if (type === NODE_TYPE.PROXY) {
                 // load proxy
                 current.hierarchyByteOffset = byteOffset;
@@ -160,10 +141,11 @@ class Potree2Node extends PotreeNodeBase {
                 current.byteOffset = byteOffset;
                 current.byteSize = byteSize;
                 current.numPoints = numPoints;
+                current.childrenBitField = childMask;
             }
 
             if (current.byteSize === 0n) {
-                // workaround for issue potree/potree#1125
+                // workaround for issue potree/potree/issues/1125
                 // some inner nodes erroneously report >0 points even though
                 // have 0 points however, they still report a byteSize of 0,
                 // so based on that we now set node.numPoints to 0.
@@ -184,7 +166,7 @@ class Potree2Node extends PotreeNodeBase {
                 }
 
                 const child = new Potree2Node(
-                    current.depth + 1, childIndex, numPoints, childMask, this.source, this.crs);
+                    current.depth + 1, childIndex, -1, undefined, this.source, this.crs);
                 current.add(child, childIndex);
                 stack.push(child);
             }

--- a/packages/Main/src/Core/Potree2Node.ts
+++ b/packages/Main/src/Core/Potree2Node.ts
@@ -50,8 +50,6 @@ class Potree2Node extends PotreeNodeBase {
     // Properties initialized after loading hierarchy
     byteOffset!: bigint;
     byteSize!: bigint;
-    hierarchyByteOffset!: bigint;
-    hierarchyByteSize!: bigint;
     nodeType!: NodeType;
 
     constructor(
@@ -71,14 +69,8 @@ class Potree2Node extends PotreeNodeBase {
     }
 
     override get networkOptions(): RequestInit {
-        let byteOffset = this.byteOffset;
-        let byteSize = this.byteSize;
-        if (this.nodeType === NODE_TYPE.PROXY) {
-            byteOffset = this.hierarchyByteOffset;
-            byteSize = this.hierarchyByteSize;
-        }
-        const first = byteOffset;
-        const last = first + byteSize - 1n;
+        const first = this.byteOffset;
+        const last = first + this.byteSize - 1n;
 
         // When we specify 'multipart/byteranges' on headers request it triggers
         // a preflight request. Currently github doesn't support it https://github.com/orgs/community/discussions/24659
@@ -122,24 +114,18 @@ class Potree2Node extends PotreeNodeBase {
             const type = view.getUint8(offset + 0) as NodeType;
             const childMask = view.getUint8(offset + 1);
             const numPoints = view.getUint32(offset + 2, true);
-            const byteOffset = view.getBigInt64(offset + 6, true);
-            const byteSize = view.getBigInt64(offset + 14, true);
+
+            current.byteOffset = view.getBigInt64(offset + 6, true);
+            current.byteSize = view.getBigInt64(offset + 14, true);
 
             if (current.nodeType === NODE_TYPE.PROXY) {
                 // replace proxy with real node
-                current.byteOffset = byteOffset;
-                current.byteSize = byteSize;
                 current.numPoints = numPoints;
                 current.childrenBitField = childMask;
             } else if (type === NODE_TYPE.PROXY) {
                 // load proxy
-                current.hierarchyByteOffset = byteOffset;
-                current.hierarchyByteSize = byteSize;
-                current.numPoints = numPoints;
             } else {
                 // load real node
-                current.byteOffset = byteOffset;
-                current.byteSize = byteSize;
                 current.numPoints = numPoints;
                 current.childrenBitField = childMask;
             }

--- a/packages/Main/src/Core/PotreeNode.ts
+++ b/packages/Main/src/Core/PotreeNode.ts
@@ -8,7 +8,7 @@ class PotreeNode extends PotreeNodeBase {
     constructor(
         depth: number,
         index: number,
-        numPoints = 0,
+        numPoints: number,
         childrenBitField = 0,
         source: PotreeSource,
         crs: string,
@@ -46,7 +46,7 @@ class PotreeNode extends PotreeNodeBase {
                 // does snode have a #indexChild child ?
                 if (snode.childrenBitField & (1 << indexChild) && (offset + 5) <= blob.byteLength) {
                     const childrenBitField = view.getUint8(offset); offset += 1;
-                    const numPoints = view.getUint32(offset, true) || this.numPoints; offset += 4;
+                    const numPoints = view.getUint32(offset, true); offset += 4;
                     const child = new PotreeNode(
                         snode.depth + 1, indexChild,
                         numPoints, childrenBitField, this.source, this.crs);

--- a/packages/Main/src/Core/PotreeNode.ts
+++ b/packages/Main/src/Core/PotreeNode.ts
@@ -1,5 +1,4 @@
-import * as THREE from 'three';
-import PotreeNodeBase, { computeChildBBox } from 'Core/PotreeNodeBase';
+import PotreeNodeBase from 'Core/PotreeNodeBase';
 import type PotreeSource from 'Source/PotreeSource';
 
 class PotreeNode extends PotreeNodeBase {
@@ -26,8 +25,6 @@ class PotreeNode extends PotreeNodeBase {
     }
 
     override async loadOctree(): Promise<void> {
-        this.offsetBBox = new THREE.Box3()
-            .setFromArray(this.source.boundsConforming);// Only for Potree1
         const octreeUrl = `${this.baseurl}/${this.hierarchyKey}.${this.source.extensionOctree}`;
         const blob = await this.fetcher(octreeUrl);
 
@@ -57,7 +54,6 @@ class PotreeNode extends PotreeNodeBase {
 
                     snode.add(child, indexChild);
                     // For Potree1 Parser
-                    child.offsetBBox = computeChildBBox(child.parent!.offsetBBox!, indexChild);
                     if ((child.depth % this.source.hierarchyStepSize) == 0) {
                         child.baseurl = `${this.baseurl}/${child.hierarchyKey.substring(1)}`;
                     } else {

--- a/packages/Main/src/Core/PotreeNodeBase.ts
+++ b/packages/Main/src/Core/PotreeNodeBase.ts
@@ -59,7 +59,7 @@ export abstract class PotreeNodeBase extends PointCloudNode {
     constructor(
         depth: number,
         index: number,
-        numPoints = 0,
+        numPoints: number,
         childrenBitField = 0,
         source: { baseurl: string },
         crs: string,

--- a/packages/Main/src/Core/PotreeNodeBase.ts
+++ b/packages/Main/src/Core/PotreeNodeBase.ts
@@ -51,7 +51,6 @@ export abstract class PotreeNodeBase extends PointCloudNode {
 
     childrenBitField: number | undefined;
     baseurl: string;
-    offsetBBox?: Box3;
     crs: string;
 
     private _hierarchyKey: string | undefined;
@@ -98,8 +97,8 @@ export abstract class PotreeNodeBase extends PointCloudNode {
     }
 
     override createChildAABB(childNode: this, childIndex: number): void {
-        childNode.voxelOBB.copy(this.voxelOBB);
-        childNode.voxelOBB.box3D = computeChildBBox(this.voxelOBB.box3D, childIndex);
+        const childVoxelBBox = computeChildBBox(this.voxelOBB.natBox, childIndex);
+        childNode.voxelOBB.setFromBox3(childVoxelBBox).projOBB(this.source.crs, this.crs);
 
         childNode.clampOBB.copy(childNode.voxelOBB);
         childNode.clampOBB.clampZ(this.source.zmin, this.source.zmax);

--- a/packages/Main/src/Core/PotreeNodeBase.ts
+++ b/packages/Main/src/Core/PotreeNodeBase.ts
@@ -49,7 +49,7 @@ export function computeChildBBox(voxelBBox: Box3, childIndex: number) {
 export abstract class PotreeNodeBase extends PointCloudNode {
     index: number;
 
-    childrenBitField: number;
+    childrenBitField: number | undefined;
     baseurl: string;
     offsetBBox?: Box3;
     crs: string;
@@ -60,7 +60,7 @@ export abstract class PotreeNodeBase extends PointCloudNode {
         depth: number,
         index: number,
         numPoints: number,
-        childrenBitField = 0,
+        childrenBitField: number | undefined,
         source: { baseurl: string },
         crs: string,
     ) {
@@ -76,7 +76,7 @@ export abstract class PotreeNodeBase extends PointCloudNode {
     }
 
     override get octreeIsLoaded(): boolean {
-        return !(this.childrenBitField && this.children.length === 0);
+        return !(this.childrenBitField !== 0 && this.children.length === 0);
     }
 
     override get id(): string {
@@ -93,8 +93,8 @@ export abstract class PotreeNodeBase extends PointCloudNode {
         return this._hierarchyKey;
     }
 
-    override fetcher(url: string, networkOptions: RequestInit): Promise<ArrayBuffer> {
-        return this.source.fetcher(url, networkOptions);
+    override fetcher(url: string): Promise<ArrayBuffer> {
+        return this.source.fetcher(url, this.networkOptions);
     }
 
     override createChildAABB(childNode: this, childIndex: number): void {

--- a/packages/Main/src/Layer/CopcLayer.ts
+++ b/packages/Main/src/Layer/CopcLayer.ts
@@ -37,7 +37,7 @@ class CopcLayer extends PointCloudLayer {
         this.isCopcLayer = true;
         this.source = config.source;
 
-        const loadOctree = this.source.whenReady.then((source) => {
+        const setRootNode = this.source.whenReady.then((source) => {
             this.setElevationRange();
 
             const { cube, rootHierarchyPage } = source.info;
@@ -49,10 +49,10 @@ class CopcLayer extends PointCloudLayer {
             this.obbes.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
-            return this.root.loadOctree();
+            return this.root;
         });
 
-        this._promises.push(loadOctree);
+        this._promises.push(setRootNode);
     }
 }
 

--- a/packages/Main/src/Layer/EntwinePointTileLayer.ts
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.ts
@@ -41,7 +41,7 @@ class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
 
         this.isEntwinePointTileLayer = true;
 
-        const loadOctree = this.source.whenReady.then((source) => {
+        const setRootNode = this.source.whenReady.then((source) => {
             this.setElevationRange();
 
             const { bounds } = source;
@@ -53,10 +53,10 @@ class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
             this.obbes.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
-            return this.root.loadOctree();
+            return this.root;
         });
 
-        this._promises.push(loadOctree);
+        this._promises.push(setRootNode);
     }
 }
 

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -356,7 +356,7 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
      */
     loadData(
         elt: PointCloudNode, context: Context, layer: this, distanceToCamera: number,
-    ): [] | PointCloudNode[] {
+    ): void {
         elt.notVisibleSince = undefined;
 
         // only load geometry if this elements has points
@@ -382,6 +382,7 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
                 }).then((pts: THREE.Points) => {
                     elt.obj = pts;
                     elt.obj.visible = false;
+
                     // make sure to add it here, otherwise it might never
                     // be added nor cleaned
                     this.group.add(elt.obj);
@@ -398,24 +399,6 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
                 });
             }
         }
-
-        if (elt.children && elt.children.length) {
-            elt.sse = computeScreenSpaceError(
-                context,
-                layer.pointSize,
-                elt.pointSpacing,
-                distanceToCamera,
-            ) / this.sseThreshold;
-            if (elt.sse >= 1) {
-                return elt.children;
-            } else {
-                for (const child of elt.children) {
-                    markForDeletion(child);
-                }
-                return [];
-            }
-        }
-        return [];
     }
 
     /**
@@ -460,7 +443,26 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
 
         const distanceToCamera = bbox.distanceToPoint(point);
 
-        return this.loadData(elt, context, layer, distanceToCamera);
+        this.loadData(elt, context, layer, distanceToCamera);
+
+        if (elt.children && elt.children.length) {
+            elt.sse = computeScreenSpaceError(
+                context,
+                layer.pointSize,
+                elt.pointSpacing,
+                distanceToCamera,
+            ) / this.sseThreshold;
+            if (elt.sse >= 1) {
+                return elt.children;
+            } else {
+                for (const child of elt.children) {
+                    markForDeletion(child);
+                }
+                return [];
+            }
+        }
+
+        return [];
     }
 
     postUpdate() {

--- a/packages/Main/src/Layer/Potree2Layer.ts
+++ b/packages/Main/src/Layer/Potree2Layer.ts
@@ -81,7 +81,7 @@ class Potree2Layer extends PointCloudLayer<Potree2Source> {
 
         this.isPotree2Layer = true;
 
-        const loadOctree = this.source.whenReady.then((metadata) => {
+        const setRootNode =  this.source.whenReady.then((metadata) => {
             this.metadata = metadata;
 
             const normal = Array.isArray(metadata.attributes) &&
@@ -109,10 +109,10 @@ class Potree2Layer extends PointCloudLayer<Potree2Source> {
 
             this.root = root;
 
-            return this.root.loadOctree();
+            return this.root;
         });
 
-        this._promises.push(loadOctree);
+        this._promises.push(setRootNode);
     }
 }
 

--- a/packages/Main/src/Layer/Potree2Layer.ts
+++ b/packages/Main/src/Layer/Potree2Layer.ts
@@ -102,9 +102,7 @@ class Potree2Layer extends PointCloudLayer<Potree2Source> {
             this.obbes.add(root.clampOBB);
             root.clampOBB.updateMatrixWorld(true);
 
-            root.nodeType = 2;
-            root.hierarchyByteOffset = 0n;
-            root.hierarchyByteSize = BigInt(hierarchy.firstChunkSize);
+            root.byteSize = BigInt(hierarchy.firstChunkSize);
             root.byteOffset = 0n;
 
             this.root = root;

--- a/packages/Main/src/Layer/PotreeLayer.ts
+++ b/packages/Main/src/Layer/PotreeLayer.ts
@@ -45,7 +45,7 @@ class PotreeLayer extends PointCloudLayer<PotreeSource> {
 
         this.isPotreeLayer = true;
 
-        const loadOctree = this.source.whenReady.then((cloud) => {
+        const setRootNode =  this.source.whenReady.then((cloud) => {
             const normal = Array.isArray(cloud.pointAttributes) &&
                 cloud.pointAttributes.find((elem: string) => elem.startsWith('NORMAL'));
             if (normal) {
@@ -64,10 +64,10 @@ class PotreeLayer extends PointCloudLayer<PotreeSource> {
             this.obbes.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
-            return this.root.loadOctree();
+            return this.root;
         });
 
-        this._promises.push(loadOctree);
+        this._promises.push(setRootNode);
     }
 }
 

--- a/packages/Main/src/Loader/LASLoader.js
+++ b/packages/Main/src/Loader/LASLoader.js
@@ -117,7 +117,12 @@ class LASLoader {
             getColor(i);
         }
 
-        return { attributes, box: box.toJSON() };
+        const userData = {
+            boundingBox: box.toJSON(),
+            position: origin.toArray(),
+            quaternion: quaternion.toJSON(),
+        };
+        return { attributes, userData };
     }
 
     /**
@@ -181,11 +186,7 @@ class LASLoader {
         const eb = ebVlr && Las.ExtraBytes.parse(await Las.Vlr.fetch(getter, ebVlr));
 
         const view = Las.View.create(pointData, header, eb);
-
-        return {
-            ...this._parseView(view, options),
-            header,
-        };
+        return this._parseView(view, options);
     }
 }
 

--- a/packages/Main/src/Parser/LASParser.js
+++ b/packages/Main/src/Parser/LASParser.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { spawn, Thread, Transfer } from 'threads';
-import proj4 from 'proj4';
-import { OrientationUtils, Coordinates } from '@itowns/geographic';
+import { CRS, OrientationUtils, Coordinates } from '@itowns/geographic';
 import { LASAttributes } from 'Loader/LASConstant';
 
 let _lazPerf;
@@ -35,11 +34,11 @@ async function parse(data, options, type = 'parseFile') {
         colorDepth: source.colorDepth,
         in: {
             crs: source.crs,
-            projDefs: proj4.defs(source.crs),
+            projDefs: CRS.defs(source.crs),
         },
         out: {
             crs: options.in.crs, // move crs to out ?
-            projDefs: proj4.defs(options.in.crs),
+            projDefs: CRS.defs(options.in.crs),
             origin: centerZ0,
             rotation: quaternion.toArray(),
         },
@@ -75,14 +74,14 @@ function buildBufferGeometry(attributes) {
 
 // get the projection of a point at Z=0
 function projZ0(center, crsIn, crsOut) {
-    const centerCrsIn = proj4(crsOut, crsIn).forward(center);
-    const centerZ0 = proj4(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
+    const centerCrsIn = CRS.transform(crsOut, crsIn).forward(center);
+    const centerZ0 = CRS.transform(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
     return centerZ0;
 }
 
 function getQuaternion(origin, crsIn, crsOut) {
     let quaternion = new THREE.Quaternion();
-    if (proj4.defs(crsOut).projName === 'geocent') {
+    if (CRS.defs(crsOut).projName === 'geocent') {
         const coord = new Coordinates(crsOut).setFromArray(origin);
         quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coord);
     }

--- a/packages/Main/src/Parser/LASParser.js
+++ b/packages/Main/src/Parser/LASParser.js
@@ -21,69 +21,62 @@ async function loader() {
     return _thread;
 }
 
-async function parse(data, options, type = 'parseFile') {
-    const lasLoader = await loader();
+function commonOptions(options) {
     const source = options.in.source;
-
-    const center = new Coordinates(options.in.crs)
-        .setFromVector3(options.in.clampOBB.center);
-    const centerZ0 = projZ0(center, source.crs, options.in.crs);
-    const quaternion = getQuaternion(centerZ0, source.crs, options.in.crs);
-
-    const config = {
+    return {
+        crs: {
+            in: source.crs,
+            out: options.in.crs,
+        },
+        matrixWorld: options.in.clampOBB.matrix,
         colorDepth: source.colorDepth,
-        in: {
-            crs: source.crs,
-            projDefs: CRS.defs(source.crs),
-        },
-        out: {
-            crs: options.in.crs, // move crs to out ?
-            projDefs: CRS.defs(options.in.crs),
-            origin: centerZ0,
-            rotation: quaternion.toArray(),
-        },
     };
-
-    if (type === 'parseChunk') {
-        config.pointCount = options.in.numPoints;
-        config.header = source.header;
-        config.eb = source.eb;
-    }
-
-    const parsedData = await lasLoader[type](Transfer(data), config);
-
-    const geometry = buildBufferGeometry(parsedData.attributes);
-    geometry.boundingBox = new THREE.Box3().fromJSON(parsedData.box);
-    // geometry.userData.header = parsedData.header;
-    geometry.userData.position = new Coordinates(options.in.crs).setFromArray(centerZ0);
-    geometry.userData.quaternion = quaternion.clone().invert();
-
-    return geometry;
 }
 
-function buildBufferGeometry(attributes) {
+async function parse(data, options, type = 'parseFile') {
+    const centerZ0 = new Coordinates(options.crs.out).setFromVector3(
+        new THREE.Vector3().applyMatrix4(options.matrixWorld),
+    );
+    const quaternion = getQuaternion(centerZ0, options.crs.in, options.crs.out);
+
+    options.in = {
+        crs: options.crs.in,
+        projDefs: CRS.defs(options.crs.in),
+    };
+    options.out = {
+        crs: options.crs.out,
+        projDefs: CRS.defs(options.crs.out),
+        origin: centerZ0.toArray(),
+        rotation: quaternion.toArray(),
+    };
+
+    const lasLoader = await loader();
+    const parsedData = await lasLoader[type](Transfer(data), options);
+
+    return buildBufferGeometry(parsedData);
+}
+
+function buildBufferGeometry(parsedData) {
     const geometry = new THREE.BufferGeometry();
+
+    const { attributes, userData } = parsedData;
 
     Object.keys(attributes).forEach((attributeName) => {
         const { bufferName, size, normalized  } = LASAttributes.find(a => a.name === attributeName);
         geometry.setAttribute(bufferName, new THREE.BufferAttribute(attributes[attributeName], size || 1, normalized));
     });
 
-    return geometry;
-}
+    geometry.boundingBox = new THREE.Box3().fromJSON(userData.boundingBox);
+    geometry.userData.position = userData.position;
+    geometry.userData.quaternion = userData.quaternion;
 
-// get the projection of a point at Z=0
-function projZ0(center, crsIn, crsOut) {
-    const centerCrsIn = CRS.transform(crsOut, crsIn).forward(center);
-    const centerZ0 = CRS.transform(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
-    return centerZ0;
+    return geometry;
 }
 
 function getQuaternion(origin, crsIn, crsOut) {
     let quaternion = new THREE.Quaternion();
     if (CRS.defs(crsOut).projName === 'geocent') {
-        const coord = new Coordinates(crsOut).setFromArray(origin);
-        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coord);
+        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(origin);
     }
     return quaternion;
 }
@@ -142,7 +135,17 @@ export default {
      * `THREE.BufferGeometry`.
      */
     async parseChunk(data, options = {}) {
-        const geometry = await parse(data, options, 'parseChunk');
+        const source = options.in.source;
+        const config = {
+            pointCount: options.in.numPoints,
+            header: source.header,
+            eb: source.eb,
+        };
+
+        const geometry = await parse(data, {
+            ...commonOptions(options),
+            ...config,
+        }, 'parseChunk');
         return geometry;
     },
 
@@ -171,7 +174,9 @@ export default {
             console.warn("Warning: options 'skip' not supported anymore");
         }
 
-        const geometry = await parse(data, options, 'parseFile');
+        const geometry = await parse(data, {
+            ...commonOptions(options),
+        }, 'parseFile');
         return geometry;
     },
 };

--- a/packages/Main/src/Parser/Potree2BinParser.js
+++ b/packages/Main/src/Parser/Potree2BinParser.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { spawn, Thread, Transfer } from 'threads';
 import proj4 from 'proj4';
+import { OrientationUtils, Coordinates } from '@itowns/geographic';
 
 let _thread;
 
@@ -20,6 +21,55 @@ async function loader() {
 
 function decoder(w, metadata) {
     return metadata.encoding === 'BROTLI' ? w.parseBrotli : w.parse;
+}
+
+// get the projection of a point at Z=0
+function projZ0(center, crsIn, crsOut) {
+    const centerCrsIn = proj4(crsOut, crsIn).forward(center);
+    const centerZ0 = proj4(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
+    return centerZ0;
+}
+
+function getQuaternion(origin, crsIn, crsOut) {
+    let quaternion = new THREE.Quaternion();
+    if (proj4.defs(crsOut).projName === 'geocent') {
+        const coord = new Coordinates(crsOut).setFromArray(origin);
+        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coord);
+    }
+    return quaternion;
+}
+
+function buildBufferGeometry(attributeBuffers) {
+    const geometry = new THREE.BufferGeometry();
+    Object.keys(attributeBuffers).forEach((attributeName) => {
+        const buffer = attributeBuffers[attributeName].buffer;
+
+        if (attributeName === 'position') {
+            geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(buffer), 3));
+        } else if (attributeName === 'rgba') {
+            geometry.setAttribute('color', new THREE.BufferAttribute(new Uint8Array(buffer), 4, true));
+        } else if (attributeName === 'NORMAL') {
+            geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(buffer), 3));
+        } else if (attributeName === 'INDICES') {
+            const bufferAttribute = new THREE.BufferAttribute(new Uint8Array(buffer), 4);
+            bufferAttribute.normalized = true;
+            geometry.setAttribute('indices', bufferAttribute);
+        } else {
+            const bufferAttribute = new THREE.BufferAttribute(new Float32Array(buffer), 1);
+
+            const batchAttribute = attributeBuffers[attributeName].attribute;
+            bufferAttribute.potree = {
+                offset: attributeBuffers[attributeName].offset,
+                scale: attributeBuffers[attributeName].scale,
+                preciseBuffer: attributeBuffers[attributeName].preciseBuffer,
+                range: batchAttribute.range,
+            };
+
+            geometry.setAttribute(attributeName, bufferAttribute);
+        }
+    });
+
+    return geometry;
 }
 
 export default {
@@ -44,24 +94,28 @@ export default {
      * @return {Promise} - a promise that resolves with a THREE.BufferGeometry.
      */
     parse: async function parse(buffer, options) {
+        const potreeLoader = await loader();
         const source = options.in.source;
+
         const metadata = source.metadata;
-        const pointAttributes = source.pointAttributes;
         const scale = metadata.scale;
+        const offset = metadata.offset;
+
+        const pointAttributes = source.pointAttributes;
+
         const box = options.in.voxelOBB.box3D;
         const min = box.min;
         const size = box.max.clone().sub(box.min);
         const max = box.max;
-        const offset = metadata.offset;
+
         const numPoints = options.in.numPoints;
 
-        const potreeLoader = await loader();
-        const decode = decoder(potreeLoader, metadata);
+        const center = new Coordinates(options.in.crs)
+            .setFromVector3(options.in.clampOBB.center);
+        const centerZ0 = projZ0(center, source.crs, options.in.crs);
+        const quaternion = getQuaternion(centerZ0, source.crs, options.in.crs);
 
-        const origin = options.in.origin;
-        const quaternion = options.in.rotation;
-
-        const data = await decode(Transfer(buffer), {
+        const config = {
             in: {
                 crs: source.crs,
                 projDefs: proj4.defs(source.crs),
@@ -69,7 +123,7 @@ export default {
             out: {
                 crs: options.in.crs,
                 projDefs: proj4.defs(options.in.crs),
-                origin: origin.toArray(),
+                origin: centerZ0,
                 rotation: quaternion.toArray(),
             },
             pointAttributes,
@@ -79,39 +133,16 @@ export default {
             size,
             offset,
             numPoints,
-        });
+        };
 
-        const buffers = data.attributeBuffers;
-        const geometry = new THREE.BufferGeometry();
-        Object.keys(buffers).forEach((property) => {
-            const buffer = buffers[property].buffer;
+        const decode = decoder(potreeLoader, metadata);
+        const parsedData = await decode(Transfer(buffer), config);
 
-            if (property === 'position') {
-                geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(buffer), 3));
-            } else if (property === 'rgba') {
-                geometry.setAttribute('color', new THREE.BufferAttribute(new Uint8Array(buffer), 4, true));
-            } else if (property === 'NORMAL') {
-                geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(buffer), 3));
-            } else if (property === 'INDICES') {
-                const bufferAttribute = new THREE.BufferAttribute(new Uint8Array(buffer), 4);
-                bufferAttribute.normalized = true;
-                geometry.setAttribute('indices', bufferAttribute);
-            } else {
-                const bufferAttribute = new THREE.BufferAttribute(new Float32Array(buffer), 1);
-
-                const batchAttribute = buffers[property].attribute;
-                bufferAttribute.potree = {
-                    offset: buffers[property].offset,
-                    scale: buffers[property].scale,
-                    preciseBuffer: buffers[property].preciseBuffer,
-                    range: batchAttribute.range,
-                };
-
-                geometry.setAttribute(property, bufferAttribute);
-            }
-        });
+        const geometry = buildBufferGeometry(parsedData.attributeBuffers);
 
         geometry.computeBoundingBox();
+        geometry.userData.position = new Coordinates(options.in.crs).setFromArray(centerZ0);
+        geometry.userData.quaternion = quaternion.clone().invert();
 
         return geometry;
     },

--- a/packages/Main/src/Parser/Potree2BinParser.js
+++ b/packages/Main/src/Parser/Potree2BinParser.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { spawn, Thread, Transfer } from 'threads';
-import proj4 from 'proj4';
-import { OrientationUtils, Coordinates } from '@itowns/geographic';
+import { CRS, OrientationUtils, Coordinates } from '@itowns/geographic';
 
 let _thread;
 
@@ -23,18 +22,10 @@ function decoder(w, metadata) {
     return metadata.encoding === 'BROTLI' ? w.parseBrotli : w.parse;
 }
 
-// get the projection of a point at Z=0
-function projZ0(center, crsIn, crsOut) {
-    const centerCrsIn = proj4(crsOut, crsIn).forward(center);
-    const centerZ0 = proj4(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
-    return centerZ0;
-}
-
 function getQuaternion(origin, crsIn, crsOut) {
     let quaternion = new THREE.Quaternion();
-    if (proj4.defs(crsOut).projName === 'geocent') {
-        const coord = new Coordinates(crsOut).setFromArray(origin);
-        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coord);
+    if (CRS.defs(crsOut).projName === 'geocent') {
+        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(origin);
     }
     return quaternion;
 }
@@ -103,34 +94,27 @@ export default {
 
         const pointAttributes = source.pointAttributes;
 
-        const box = options.in.voxelOBB.box3D;
-        const min = box.min;
-        const size = box.max.clone().sub(box.min);
-        const max = box.max;
-
         const numPoints = options.in.numPoints;
 
-        const center = new Coordinates(options.in.crs)
-            .setFromVector3(options.in.clampOBB.center);
-        const centerZ0 = projZ0(center, source.crs, options.in.crs);
+        const centerZ0 = new Coordinates(options.in.crs).setFromVector3(
+            new THREE.Vector3().applyMatrix4(options.in.clampOBB.matrix),
+        );
+
         const quaternion = getQuaternion(centerZ0, source.crs, options.in.crs);
 
         const config = {
             in: {
                 crs: source.crs,
-                projDefs: proj4.defs(source.crs),
+                projDefs: CRS.defs(source.crs),
             },
             out: {
                 crs: options.in.crs,
-                projDefs: proj4.defs(options.in.crs),
-                origin: centerZ0,
+                projDefs: CRS.defs(options.in.crs),
+                origin: centerZ0.toArray(),
                 rotation: quaternion.toArray(),
             },
             pointAttributes,
             scale,
-            min,
-            max,
-            size,
             offset,
             numPoints,
         };
@@ -141,8 +125,8 @@ export default {
         const geometry = buildBufferGeometry(parsedData.attributeBuffers);
 
         geometry.computeBoundingBox();
-        geometry.userData.position = new Coordinates(options.in.crs).setFromArray(centerZ0);
-        geometry.userData.quaternion = quaternion.clone().invert();
+        geometry.userData.position = parsedData.userData.position;
+        geometry.userData.quaternion = parsedData.userData.quaternion;
 
         return geometry;
     },

--- a/packages/Main/src/Parser/PotreeBinParser.js
+++ b/packages/Main/src/Parser/PotreeBinParser.js
@@ -1,5 +1,6 @@
 import proj4 from 'proj4';
 import * as THREE from 'three';
+import { OrientationUtils, Coordinates } from '@itowns/geographic';
 
 // See the different constants holding ordinal, name, numElements, byteSize in PointAttributes.cpp in PotreeConverter
 // elementByteSize is byteSize / numElements
@@ -49,6 +50,22 @@ const POINT_ATTRIBUTES = {
         attributeName: 'normal',
     },
 };
+
+// get the projection of a point at Z=0
+function projZ0(center, crsIn, crsOut) {
+    const centerCrsIn = proj4(crsOut, crsIn).forward(center);
+    const centerZ0 = proj4(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
+    return centerZ0;
+}
+
+function getQuaternion(origin, crsIn, crsOut) {
+    let quaternion = new THREE.Quaternion();
+    if (proj4.defs(crsOut).projName === 'geocent') {
+        const coord = new Coordinates(crsOut).setFromArray(origin);
+        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coord);
+    }
+    return quaternion;
+}
 
 // Find a way to factor this methode between the different PointCloud Parser
 function _applyQuaternion(v, q) {
@@ -118,8 +135,11 @@ export default {
         const applyQuaternion = (source.crs !== options.in.crs) ?
             _applyQuaternion : (x => x);
 
-        const origin = options.in.origin.toArray();
-        const quaternion = options.in.rotation.toArray();
+        const center = new Coordinates(options.in.crs)
+            .setFromVector3(options.in.clampOBB.center);
+        const centerZ0 = projZ0(center, source.crs, options.in.crs);
+        const quaternion = getQuaternion(centerZ0, source.crs, options.in.crs);
+        const quaternionArr = quaternion.toArray();
 
         let pointByteSize = 0;
         for (const potreeName of pointAttributes) {
@@ -150,10 +170,10 @@ export default {
                     const [x, y, z] = forward(position);
 
                     const position2 = applyQuaternion([
-                        x - origin[0],
-                        y - origin[1],
-                        z - origin[2],
-                    ], quaternion);
+                        x - centerZ0[0],
+                        y - centerZ0[1],
+                        z - centerZ0[2],
+                    ], quaternionArr);
 
                     array[arrayOffset + 0] = position2[0];
                     array[arrayOffset + 1] = position2[1];
@@ -169,6 +189,8 @@ export default {
         }
 
         geometry.computeBoundingBox();
+        geometry.userData.position = new Coordinates(options.in.crs).setFromArray(centerZ0);
+        geometry.userData.quaternion = quaternion.clone().invert();
 
         return Promise.resolve(geometry);
     },

--- a/packages/Main/src/Parser/PotreeBinParser.js
+++ b/packages/Main/src/Parser/PotreeBinParser.js
@@ -110,8 +110,7 @@ export default {
         const scale = source.scale;
         const pointAttributes = source.pointAttributes;
 
-        // find a methode by recursion to get offset from the node id ?
-        const offset = options.in.offsetBBox.min.toArray();
+        const offset = options.in.voxelOBB.natBox.min.toArray();
 
         const forward = (source.crs !== options.in.crs) ?
             proj4(source.crs, options.in.crs).forward :

--- a/packages/Main/src/Parser/PotreeBinParser.js
+++ b/packages/Main/src/Parser/PotreeBinParser.js
@@ -1,6 +1,5 @@
-import proj4 from 'proj4';
 import * as THREE from 'three';
-import { OrientationUtils, Coordinates } from '@itowns/geographic';
+import { CRS, OrientationUtils, Coordinates } from '@itowns/geographic';
 
 // See the different constants holding ordinal, name, numElements, byteSize in PointAttributes.cpp in PotreeConverter
 // elementByteSize is byteSize / numElements
@@ -51,18 +50,10 @@ const POINT_ATTRIBUTES = {
     },
 };
 
-// get the projection of a point at Z=0
-function projZ0(center, crsIn, crsOut) {
-    const centerCrsIn = proj4(crsOut, crsIn).forward(center);
-    const centerZ0 = proj4(crsIn, crsOut).forward([centerCrsIn.x, centerCrsIn.y, 0]);
-    return centerZ0;
-}
-
 function getQuaternion(origin, crsIn, crsOut) {
     let quaternion = new THREE.Quaternion();
-    if (proj4.defs(crsOut).projName === 'geocent') {
-        const coord = new Coordinates(crsOut).setFromArray(origin);
-        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coord);
+    if (CRS.defs(crsOut).projName === 'geocent') {
+        quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(origin);
     }
     return quaternion;
 }
@@ -130,14 +121,14 @@ export default {
         const offset = options.in.voxelOBB.natBox.min.toArray();
 
         const forward = (source.crs !== options.in.crs) ?
-            proj4(source.crs, options.in.crs).forward :
+            CRS.transform(source.crs, options.in.crs).forward :
             (x => x);
         const applyQuaternion = (source.crs !== options.in.crs) ?
             _applyQuaternion : (x => x);
 
-        const center = new Coordinates(options.in.crs)
-            .setFromVector3(options.in.clampOBB.center);
-        const centerZ0 = projZ0(center, source.crs, options.in.crs);
+        const centerZ0 = new Coordinates(options.in.crs).setFromVector3(
+            new THREE.Vector3().applyMatrix4(options.in.clampOBB.matrix),
+        );
         const quaternion = getQuaternion(centerZ0, source.crs, options.in.crs);
         const quaternionArr = quaternion.toArray();
 
@@ -170,9 +161,9 @@ export default {
                     const [x, y, z] = forward(position);
 
                     const position2 = applyQuaternion([
-                        x - centerZ0[0],
-                        y - centerZ0[1],
-                        z - centerZ0[2],
+                        x - centerZ0.x,
+                        y - centerZ0.y,
+                        z - centerZ0.z,
                     ], quaternionArr);
 
                     array[arrayOffset + 0] = position2[0];
@@ -189,8 +180,8 @@ export default {
         }
 
         geometry.computeBoundingBox();
-        geometry.userData.position = new Coordinates(options.in.crs).setFromArray(centerZ0);
-        geometry.userData.quaternion = quaternion.clone().invert();
+        geometry.userData.position = centerZ0.toArray();
+        geometry.userData.quaternion = quaternion.toJSON();
 
         return Promise.resolve(geometry);
     },

--- a/packages/Main/src/Provider/PointCloudProvider.js
+++ b/packages/Main/src/Provider/PointCloudProvider.js
@@ -35,8 +35,8 @@ export default {
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            points.position.copy(geometry.userData.position);
-            points.quaternion.copy(geometry.userData.quaternion);
+            points.position.fromArray(geometry.userData.position);
+            points.quaternion.fromArray(geometry.userData.quaternion).invert();
             points.updateMatrix();
 
             points.layer = layer;

--- a/packages/Main/src/Provider/PointCloudProvider.js
+++ b/packages/Main/src/Provider/PointCloudProvider.js
@@ -35,9 +35,8 @@ export default {
             addPickingAttribute(points);
             points.frustumCulled = false;
             points.matrixAutoUpdate = false;
-            points.position.copy(node.origin);
-
-            points.quaternion.copy(node.rotation).invert();
+            points.position.copy(geometry.userData.position);
+            points.quaternion.copy(geometry.userData.quaternion);
             points.updateMatrix();
 
             points.layer = layer;

--- a/packages/Main/src/Renderer/OBB.ts
+++ b/packages/Main/src/Renderer/OBB.ts
@@ -6,9 +6,6 @@ import { CRS, Coordinates, OrientationUtils } from '@itowns/geographic';
 
 import type { Extent, ProjectionLike } from '@itowns/geographic';
 
-// import from OrientationUtils ?
-type QuaternionFunction = (coords: Coordinates, target?: THREE.Quaternion) => THREE.Quaternion;
-
 // get oriented bounding box of tile
 const builder = new GlobeTileBuilder({ uvCount: 1 });
 const size = new THREE.Vector3();
@@ -16,19 +13,6 @@ const dimension = new THREE.Vector2();
 const center = new THREE.Vector3();
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 let _obb: OBB;
-
-const orientUtilsCache: Record<ProjectionLike, Record<ProjectionLike, QuaternionFunction>> = {};
-function quaternionFromCRSToCRS(crsIn: ProjectionLike, crsOut: ProjectionLike): QuaternionFunction {
-    if (!orientUtilsCache[crsIn]) {
-        orientUtilsCache[crsIn] = {};
-    }
-
-    if (!orientUtilsCache[crsIn][crsOut]) {
-        orientUtilsCache[crsIn][crsOut] = OrientationUtils.quaternionFromCRSToCRS(crsIn, crsOut);
-    }
-
-    return orientUtilsCache[crsIn][crsOut];
-}
 
 // it could be considered to remove THREE.Object3D extend.
 /**
@@ -236,7 +220,7 @@ class OBB extends THREE.Object3D {
         let quaternion = new THREE.Quaternion();
         if (isGeocentric) {
             const coordOrigin = new Coordinates(crsOut).setFromArray(origin);
-            quaternion = quaternionFromCRSToCRS(crsOut, crsIn)(coordOrigin);
+            quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coordOrigin);
         }
 
         // project corners in local referentiel

--- a/packages/Main/src/Source/Potree2Source.ts
+++ b/packages/Main/src/Source/Potree2Source.ts
@@ -131,6 +131,8 @@ class Potree2Source extends Source {
     baseurl: string;
 
     // Properties initialized after fetching metadata
+    boundsConforming!: [number, number, number, number, number, number];
+    bounds!: [number, number, number, number, number, number];
     metadata!: Potree2Metadata;
     pointAttributes!: Potree2PointAttributes;
     zmin!: number;
@@ -308,6 +310,8 @@ class Potree2Source extends Source {
             Promise.resolve(source.metadata) :
             Fetcher.json(this.url, this.networkOptions) as Promise<Potree2Metadata>)
             .then((metadata) => {
+                const { boundingBox } = metadata;
+                this.bounds = [...boundingBox.min, ...boundingBox.max];
                 this.metadata = metadata;
                 this.pointAttributes = parseAttributes(metadata.attributes);
 

--- a/packages/Main/src/Source/PotreeSource.ts
+++ b/packages/Main/src/Source/PotreeSource.ts
@@ -44,6 +44,7 @@ class PotreeSource extends Source {
 
     // Properties initialized after fetching cloud file
     boundsConforming!: [number, number, number, number, number, number];
+    bounds!: [number, number, number, number, number, number];
     pointAttributes!: string[];
     baseurl!: string;
     scale!: number;
@@ -134,6 +135,8 @@ class PotreeSource extends Source {
                 Promise.resolve(source.cloud) :
             Fetcher.json(this.url, this.networkOptions) as Promise<PotreeCloud>)
             .then((cloud) => {
+                const { lx, ly, lz, ux, uy, uz } = cloud.boundingBox;
+                this.bounds = [lx, ly, lz, ux, uy, uz];
                 this.boundsConforming = [
                     cloud.tightBoundingBox.lx,
                     cloud.tightBoundingBox.ly,

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -83,7 +83,8 @@ describe('COPC', function () {
             root.children[2].children[1].add(new CopcNode(3, 1, 6, 7, 0, 1000, source, 10, crs));
         });
 
-        describe('finds the common ancestor of two nodes', () => {
+        describe.skip('finds the common ancestor of two nodes', () => {
+            // done in pointcloudnode.js
             let ancestor;
             it('cousins => grand parent', () => {
                 ancestor = root.children[2].children[1].children[0].findCommonAncestor(root.children[2].children[0].children[0]);

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -30,15 +30,24 @@ describe('COPC', function () {
     });
 
     describe('Copc Layer', function () {
+        let layer;
         it('instanciates a layer', (done) => {
-            const layer = new CopcLayer('copc', { source, crs: 'EPSG:4978' });
+            layer = new CopcLayer('copc', { source, crs: 'EPSG:4978' });
+            assert.ok(layer.isCopcLayer);
             layer.startup()
                 .then(() => {
                     assert.equal(source.zmin, source.header.min[2]);
                     assert.ok(layer.root.isCopcNode);
-                    assert.ok(layer.root.children.length > 0);
+                    // loadOctree() is now called during the load
+                    // assert.ok(layer.root.children.length > 0);
+                    assert.ok(layer.object3d.children.indexOf(layer.root.clampOBB) >= 0);
                     done();
                 }).catch(done);
+        });
+
+        it('loadOctree()', async function _it() {
+            await layer.root.loadOctree();
+            assert.ok(layer.root.children.length > 0);
         });
     });
 

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -34,13 +34,14 @@ describe('COPC', function () {
         it('instanciates a layer', (done) => {
             layer = new CopcLayer('copc', { source, crs: 'EPSG:4978' });
             assert.ok(layer.isCopcLayer);
-            layer.startup()
+            layer.startup();
+            layer.whenReady
                 .then(() => {
                     assert.equal(source.zmin, source.header.min[2]);
                     assert.ok(layer.root.isCopcNode);
                     // loadOctree() is now called during the load
                     // assert.ok(layer.root.children.length > 0);
-                    assert.ok(layer.object3d.children.indexOf(layer.root.clampOBB) >= 0);
+                    assert.ok(layer.obbes.children.indexOf(layer.root.clampOBB) >= 0);
                     done();
                 }).catch(done);
         });

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -178,7 +178,8 @@ describe('Entwine Point Tile', function () {
             });
         });
 
-        describe('finds the common ancestor of two nodes', () => {
+        describe.skip('finds the common ancestor of two nodes', () => {
+            // done in pointcloudnode.js
             let root;
             const crs = 'EPSG:4978';
             before('create octree', function () {

--- a/packages/Main/test/unit/lasparser.js
+++ b/packages/Main/test/unit/lasparser.js
@@ -2,9 +2,8 @@ import assert from 'assert';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import LASParser from 'Parser/LASParser';
 import Fetcher from 'Provider/Fetcher';
-import * as THREE from 'three';
 import proj4 from 'proj4';
-import { OrientationUtils, Coordinates } from '@itowns/geographic';
+import OBB from 'Renderer/OBB';
 import { compareWithEpsilon } from './utils';
 
 
@@ -34,10 +33,8 @@ describe('LASParser', function () {
     });
 
     describe('unit tests', function _describe() {
-        const epsilon = 0.1;
+        const epsilon = 0.01;
         LASParser.enableLazPerf('../../examples/libs/laz-perf');
-
-        const rotation = new THREE.Quaternion();
 
         afterEach(async function () {
             await LASParser.terminate();
@@ -45,60 +42,72 @@ describe('LASParser', function () {
 
         it('parses a las file to a THREE.BufferGeometry (with reprojection)', async function () {
             if (!lasData) { this.skip(); }
-            proj4.defs('EPSG:2994', '+proj=lcc +lat_0=41.75 +lon_0=-120.5 +lat_1=43 +lat_2=45.5 +x_0=399999.9999984 +y_0=0 +ellps=GRS80 +towgs84=-0.991,1.9072,0.5129,-1.25033e-07,-4.6785e-08,-5.6529e-08,0 +units=ft +no_defs +type=crs');
-            const coordinates = new Coordinates('EPSG:2994', -2505146.7021798044, -3847441.7959745415, 4412576.847879505);
-            const rotation = OrientationUtils.quaternionFromCRSToCRS('EPSG:2994', 'EPSG:4978')(coordinates);
+            proj4.defs('EPSG:2994', '+proj=lcc +lat_0=41.75 +lon_0=-120.5 +lat_1=43 +lat_2=45.5 +x_0=399999.9999984 +y_0=0 ' +
+                '+ellps=GRS80 +towgs84=-0.991,1.9072,0.5129,-1.25033e-07,-4.6785e-08,-5.6529e-08,0 +units=ft +no_defs +type=crs');
+
+            const boundsConforming = [
+                635616, 848977, 407,
+                638864, 853362, 536,
+            ];
+            const clampOBB = new OBB().setFromArray(boundsConforming);
+            clampOBB.projOBB('EPSG:2994', 'EPSG:4978');
+
+            const pointCount = 106;
 
             const options = {
                 in: {
                     source: {
                         crs: 'EPSG:2994',
                     },
+                    clampOBB,
                     crs: 'EPSG:4978',
-                    origin: coordinates,
-                    rotation,
                 },
             };
             const bufferGeometry = await LASParser.parse(lasData, options);
-            const header = bufferGeometry.userData.header;
-            assert.strictEqual(header.pointCount, 106);
-            assert.strictEqual(bufferGeometry.attributes.position.count, header.pointCount);
-            assert.strictEqual(bufferGeometry.attributes.intensity.count, header.pointCount);
-            assert.strictEqual(bufferGeometry.attributes.classification.count, header.pointCount);
+            assert.strictEqual(bufferGeometry.attributes.position.count, pointCount);
+            assert.strictEqual(bufferGeometry.attributes.intensity.count, pointCount);
+            assert.strictEqual(bufferGeometry.attributes.classification.count, pointCount);
             assert.strictEqual(bufferGeometry.attributes.color, undefined, 'bufferGeometry.attributes.color');
 
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z, -176.9, epsilon), 'bufferGeometry.boundingBox.min.z');
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z, 780.2, epsilon), 'bufferGeometry.boundingBox.max.z');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z, boundsConforming[2], epsilon * boundsConforming[2]), 'bufferGeometry.boundingBox.min.z');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z, boundsConforming[5], epsilon * boundsConforming[2]), 'bufferGeometry.boundingBox.max.z');
         });
 
         it('parses a laz file to a THREE.BufferGeometry', async function () {
             if (!lazV14Data) { this.skip(); }
-            const coordinates = new Coordinates('EPSG:3857', 746000, 6508000, 1000);
+            const boundsConforming = [
+                -8242746, 4966506, -50,
+                -8242446, 4966706, 50,
+            ];
+            const clampOBB = new OBB().setFromArray(boundsConforming);
+
+            const pointCount = 100000;
+
             const options = {
                 in: {
                     source: {
                         crs: 'EPSG:3857',
                     },
+                    clampOBB,
                     crs: 'EPSG:3857',
-                    origin: coordinates,
-                    rotation,
                 },
             };
             const bufferGeometry = await LASParser.parse(lazV14Data, options);
-            const header = bufferGeometry.userData.header;
 
-            assert.strictEqual(header.pointCount, 100000);
-            assert.strictEqual(bufferGeometry.attributes.position.count, header.pointCount);
-            assert.strictEqual(bufferGeometry.attributes.intensity.count, header.pointCount);
-            assert.strictEqual(bufferGeometry.attributes.classification.count, header.pointCount);
-            assert.strictEqual(bufferGeometry.attributes.color.count, header.pointCount);
+            const origin = bufferGeometry.userData.position;
 
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.x + coordinates.x, header.min[0], epsilon));
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.y + coordinates.y, header.min[1], epsilon));
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z + coordinates.z, header.min[2], epsilon));
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + coordinates.x, header.max[0], epsilon));
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + coordinates.y, header.max[1], epsilon));
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + coordinates.z, header.max[2], epsilon));
+
+            assert.strictEqual(bufferGeometry.attributes.position.count, pointCount);
+            assert.strictEqual(bufferGeometry.attributes.intensity.count, pointCount);
+            assert.strictEqual(bufferGeometry.attributes.classification.count, pointCount);
+            assert.strictEqual(bufferGeometry.attributes.color.count, pointCount);
+
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.x + origin.x, boundsConforming[0], epsilon), 'min.x');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.y + origin.y, boundsConforming[1], epsilon), 'min.y');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z + origin.z, boundsConforming[2], epsilon), 'min.z');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + origin.x, boundsConforming[3], epsilon), 'max.x');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + origin.y, boundsConforming[4], epsilon), 'max.y');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + origin.z, boundsConforming[5], epsilon), 'max.z');
         });
 
         it('parses a copc chunk to a THREE.BufferGeometry', async function _it() {
@@ -134,18 +143,18 @@ describe('LASParser', function () {
                 evlrOffset: 630520,
                 evlrCount: 1,
             };
-            const coordinates = new Coordinates('EPSG:3857', 746000, 6508000, 1000);
+
+            const clampOBB = new OBB().setFromArray([...header.min, ...header.max]);
             const options = {
                 in: {
                     source: {
                         crs: 'EPSG:3857',
                         header,
                     },
+                    clampOBB,
                     numPoints: header.pointCount,
                     // eb,
                     crs: 'EPSG:3857',
-                    origin: coordinates,
-                    rotation,
                 },
             };
             const bufferGeometry = await LASParser.parseChunk(copcData, options);

--- a/packages/Main/test/unit/lasparser.js
+++ b/packages/Main/test/unit/lasparser.js
@@ -102,12 +102,12 @@ describe('LASParser', function () {
             assert.strictEqual(bufferGeometry.attributes.classification.count, pointCount);
             assert.strictEqual(bufferGeometry.attributes.color.count, pointCount);
 
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.x + origin.x, boundsConforming[0], epsilon), 'min.x');
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.y + origin.y, boundsConforming[1], epsilon), 'min.y');
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z + origin.z, boundsConforming[2], epsilon), 'min.z');
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + origin.x, boundsConforming[3], epsilon), 'max.x');
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + origin.y, boundsConforming[4], epsilon), 'max.y');
-            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + origin.z, boundsConforming[5], epsilon), 'max.z');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.x + origin[0], boundsConforming[0], epsilon), 'min.x');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.y + origin[1], boundsConforming[1], epsilon), 'min.y');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.min.z + origin[2], boundsConforming[2], epsilon), 'min.z');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.x + origin[0], boundsConforming[3], epsilon), 'max.x');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.y + origin[1], boundsConforming[4], epsilon), 'max.y');
+            assert.ok(compareWithEpsilon(bufferGeometry.boundingBox.max.z + origin[2], boundsConforming[5], epsilon), 'max.z');
         });
 
         it('parses a copc chunk to a THREE.BufferGeometry', async function _it() {

--- a/packages/Main/test/unit/node/pointcloudnode.js
+++ b/packages/Main/test/unit/node/pointcloudnode.js
@@ -1,0 +1,130 @@
+import assert from 'assert';
+import PointCloudNode from 'Core/PointCloudNode';
+
+const crs = 'EPSG:4978';
+function newPtCloudNode(depth, numPoints, source) {
+    const node = new PointCloudNode(depth, numPoints);
+    node.source = source;// might be moved to constructor ?
+    node.crs = crs;// might be moved to constructor ?
+    return node;
+}
+
+function newPtCloudNodeWithID(depth, numPoints, source, id) {
+    const node = new PointCloudNode(depth, numPoints, source);
+    node.id = id;
+    node.createChildAABB = () => {};
+    return node;
+}
+
+describe('Point Cloud Node', function () {
+    const bounds = [0, 0, 0, 10, 10, 10];
+    const zmin = 1;
+    const zmax = 9;
+    const source = {
+        spacing: 10,
+        crs,
+        bounds,
+        zmin,
+        zmax,
+    };
+
+    describe('constructor', () => {
+        it('instanciate a node', () => {
+            const depth = 2;
+            const numPoints = 5000;
+            const node = newPtCloudNode(depth, numPoints, source);
+            assert.equal(node.pointSpacing, source.spacing / 2 ** depth);
+        });
+    });
+
+    describe('getters', () => {
+        let root;
+        before('instanciate a root node', function () {
+            root = newPtCloudNode(0, 0, source);
+        });
+
+        it('get pointSpacing', () => {
+            assert.equal(root.pointSpacing, source.spacing);
+        });
+    });
+
+    describe('methods', () => {
+        let root;
+        let child;
+        before('instanciate nodes', function () {
+            root = newPtCloudNode(0, 0, source);
+            root.createChildAABB = () => {};
+            child = newPtCloudNode(1, 0, source);
+        });
+
+        it('add()', () => {
+            root.add(child);
+            assert.equal(root.children.length, 1);
+            assert.deepStrictEqual(child.parent, root);
+        });
+
+        it('load()', async () => {
+            // will be rewrite as load will be refactor
+            root.octreeIsLoaded = true;// to be replace later on
+            root.fetcher = () => Promise.resolve('fetched');
+            source.parser = buffer => Promise.resolve(`${buffer ? `${buffer} and ` : ''}parsed`);
+            const data = await root.load();
+            assert.equal(data, 'fetched and parsed');
+        });
+
+        describe('findCommonAncestor()', () => {
+            let root;
+            before('instantiate the nodes', function () {
+                const source = {
+                    url: 'http://server.geo',
+                    extension: 'laz',
+                    bounds: [1000, 1000, 1000, 0, 0, 0],
+                };
+
+                root = newPtCloudNodeWithID(0, 4000, source, '0000');
+
+                root.add(newPtCloudNodeWithID(1, 3000, source, '1000'));
+                root.add(newPtCloudNodeWithID(1, 3000, source, '1001'));
+                root.add(newPtCloudNodeWithID(1, 3000, source, '1011'));
+
+                root.children[0].add(newPtCloudNodeWithID(2, 2000, source, '2000'));
+                root.children[0].add(newPtCloudNodeWithID(2, 2000, source, '2010'));
+                root.children[1].add(newPtCloudNodeWithID(2, 2000, source, '2013'));
+                root.children[2].add(newPtCloudNodeWithID(2, 2000, source, '2022'));
+                root.children[2].add(newPtCloudNodeWithID(2, 2000, source, '2033'));
+
+                root.children[0].children[0].add(newPtCloudNodeWithID(3, 2000, source, '3000'));
+                root.children[0].children[0].add(newPtCloudNodeWithID(3, 2000, source, '3010'));
+                root.children[1].children[0].add(newPtCloudNodeWithID(3, 2000, source, '3027'));
+                root.children[2].children[0].add(newPtCloudNodeWithID(3, 2000, source, '3054'));
+                root.children[2].children[1].add(newPtCloudNodeWithID(3, 0, source, '3167'));
+            });
+
+            let ancestor;
+            it('cousins => grand parent', () => {
+                ancestor = root.children[2].children[1].children[0].findCommonAncestor(root.children[2].children[0].children[0]);
+                assert.deepStrictEqual(ancestor, root.children[2]);
+            });
+
+            it('brothers => parent', () => {
+                ancestor = root.children[0].children[0].children[0].findCommonAncestor(root.children[0].children[0].children[1]);
+                assert.deepStrictEqual(ancestor, root.children[0].children[0]);
+            });
+
+            it('grand child and grand grand child => root', () => {
+                ancestor = root.children[0].children[1].findCommonAncestor(root.children[2].children[1].children[0]);
+                assert.deepStrictEqual(ancestor, root);
+            });
+
+            it('parent and child => parent', () => {
+                ancestor = root.children[1].findCommonAncestor(root.children[1].children[0].children[0]);
+                assert.deepStrictEqual(ancestor, root.children[1]);
+            });
+
+            it('child and parent => parent', () => {
+                ancestor = root.children[2].children[0].findCommonAncestor(root.children[2]);
+                assert.deepStrictEqual(ancestor, root.children[2]);
+            });
+        });
+    });
+});

--- a/packages/Main/test/unit/nodes.js
+++ b/packages/Main/test/unit/nodes.js
@@ -1,0 +1,6 @@
+import './node/pointcloudnode';
+
+// import './node/entwinenode';
+// import './node/copcnode';
+// import './node/potreenode';
+// import './node/potree2node';

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -101,8 +101,10 @@ describe('Potree', function () {
                 View.prototype.addLayer.call(viewer, potreeLayer)
                     .then(() => {
                         context.camera.camera3D.updateMatrixWorld();
-                        assert.equal(potreeLayer.root.children.length, 6);
-                        potreeLayer.obbes.visible = true;
+                        // loadOctree() is now called during the load
+                        // assert.equal(potreeLayer.root.children.length, 6);
+                        assert.ok(potreeLayer.root instanceof PotreeNode);
+                        assert.ok(potreeLayer.object3d.children.indexOf(potreeLayer.root.clampOBB) >= 0);
                         done();
                     }).catch(done);
             });

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -104,7 +104,7 @@ describe('Potree', function () {
                         // loadOctree() is now called during the load
                         // assert.equal(potreeLayer.root.children.length, 6);
                         assert.ok(potreeLayer.root instanceof PotreeNode);
-                        assert.ok(potreeLayer.object3d.children.indexOf(potreeLayer.root.clampOBB) >= 0);
+                        assert.ok(potreeLayer.obbes.children.indexOf(potreeLayer.root.clampOBB) >= 0);
                         done();
                     }).catch(done);
             });
@@ -130,38 +130,40 @@ describe('Potree', function () {
         });
 
         describe('potree Node', function () {
+            const crs = 'EPSG:4326';
             const numPoints = 1000;
             const childrenBitField = 5;
             let root;
 
             it('instance', function (done) {
-                root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource);
+                root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource, crs);
                 assert.equal(root.numPoints, numPoints);
                 assert.equal(root.childrenBitField, childrenBitField);
                 done();
             });
 
             it('construct a correct URL', function () {
+                const source = {
+                    baseurl,
+                    bounds: [0, 0, 0, 100, 100, 100],
+                    crs,
+                };
+                root.voxelOBB.setFromArray(source.bounds);
+
                 const indexChild = 7;
                 const indexGChild = 3;
-                const extension = 'bin';
-                const nodeChild = new PotreeNode(1, indexChild, 0, 0, {
-                    baseurl,
-                    extension,
-                });
-                const nodeGChild = new PotreeNode(2, indexGChild, 0, 0, {
-                    baseurl,
-                    extension,
-                });
+                const nodeChild = new PotreeNode(1, indexChild, 0, 0, source, crs);
+                const nodeGChild = new PotreeNode(2, indexGChild, 0, 0, source, crs);
                 object3d.add(root.clampOBB);
                 root.add(nodeChild);
                 nodeChild.add(nodeGChild);
 
-                assert.equal(nodeGChild.url, `${baseurl}/r${indexChild}${indexGChild}.${extension}`);
+                assert.equal(nodeGChild.url, `${baseurl}/r${indexChild}${indexGChild}.bin`);
             });
 
             it('load octree', function (done) {
-                const root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource);
+                const root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource, crs);
+                root.voxelOBB.setFromArray(potreeSource.bounds);
                 object3d.add(root.clampOBB);
                 root.loadOctree()
                     .then(() => {
@@ -171,7 +173,8 @@ describe('Potree', function () {
             });
 
             it('load child node', function (done) {
-                const root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource, 'EPSG:4978');
+                const root = new PotreeNode(0, -1, numPoints, childrenBitField, potreeSource, crs);
+                root.voxelOBB.setFromArray(potreeSource.bounds);
                 object3d.add(root.clampOBB);
                 root.loadOctree()
                     .then(() => root.children[0].load()

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -59,8 +59,10 @@ describe('Potree2', function () {
         View.prototype.addLayer.call(viewer, potree2Layer)
             .then(() => {
                 context.camera.camera3D.updateMatrixWorld();
-                assert.equal(potree2Layer.root.children.length, 6);
-                potree2Layer.obbes.visible = true;
+                // loadOctree() is now called during the load
+                // assert.equal(potree2Layer.root.children.length, 6);
+                assert.ok(potree2Layer.root instanceof Potree2Node);
+                assert.ok(potree2Layer.object3d.children.indexOf(potree2Layer.root.clampOBB) >= 0);
                 done();
             }).catch(done);
     });

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -62,7 +62,7 @@ describe('Potree2', function () {
                 // loadOctree() is now called during the load
                 // assert.equal(potree2Layer.root.children.length, 6);
                 assert.ok(potree2Layer.root instanceof Potree2Node);
-                assert.ok(potree2Layer.object3d.children.indexOf(potree2Layer.root.clampOBB) >= 0);
+                assert.ok(potree2Layer.obbes.children.indexOf(potree2Layer.root.clampOBB) >= 0);
                 done();
             }).catch(done);
     });
@@ -87,18 +87,20 @@ describe('Potree2', function () {
     });
 
     describe('potree2 Node', function () {
+        const crs = 'EPSG:4326';
         const numPoints = 1000;
         const childrenBitField = 5;
 
         it('instance', function (done) {
-            const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source);
+            const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source, crs);
             assert.equal(root.numPoints, numPoints);
             assert.equal(root.childrenBitField, childrenBitField);
             done();
         });
 
         it('load octree', function (done) {
-            const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source);
+            const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source, crs);
+            root.voxelOBB.setFromArray(potree2Source.bounds);
             object3d.add(root.clampOBB);
             root.byteOffset = 0n;
             root.byteSize = 12650n;
@@ -110,7 +112,8 @@ describe('Potree2', function () {
         });
 
         it('load child node', function (done) {
-            const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source, 'EPSG:4978');
+            const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source, crs);
+            root.voxelOBB.setFromArray(potree2Source.bounds);
             object3d.add(root.clampOBB);
             root.byteOffset = 0n;
             root.byteSize = 12650n;

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -92,7 +92,6 @@ describe('Potree2', function () {
 
         it('instance', function (done) {
             const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source);
-            root.nodeType = 2;
             assert.equal(root.numPoints, numPoints);
             assert.equal(root.childrenBitField, childrenBitField);
             done();
@@ -101,9 +100,8 @@ describe('Potree2', function () {
         it('load octree', function (done) {
             const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source);
             object3d.add(root.clampOBB);
-            root.nodeType = 2;
-            root.hierarchyByteOffset = 0n;
-            root.hierarchyByteSize = 12650n;
+            root.byteOffset = 0n;
+            root.byteSize = 12650n;
             root.loadOctree()
                 .then(() => {
                     assert.equal(root.children.length, 6);
@@ -114,9 +112,8 @@ describe('Potree2', function () {
         it('load child node', function (done) {
             const root = new Potree2Node(0, -1, numPoints, childrenBitField, potree2Source, 'EPSG:4978');
             object3d.add(root.clampOBB);
-            root.nodeType = 2;
-            root.hierarchyByteOffset = 0n;
-            root.hierarchyByteSize = 12650n;
+            root.byteOffset = 0n;
+            root.byteSize = 12650n;
             root.loadOctree()
                 .then(() => root.children[0].load()
                     .then(() => {

--- a/packages/Main/test/unit/potree2BinParser.js
+++ b/packages/Main/test/unit/potree2BinParser.js
@@ -1,16 +1,22 @@
-import { Coordinates } from '@itowns/geographic';
 import assert from 'assert';
 import Potree2BinParser from 'Parser/Potree2BinParser';
 import * as THREE from 'three';
 
 describe('Potree2BinParser', function () {
+    const crs = 'EPSG:3857';
     it('should correctly parse position buffer', function (done) {
-        const nbPoints = 12;
-        const buffer = new ArrayBuffer(nbPoints * 4 * 3);
+        const nbPoints = 10;
+        const spatialDim = 3;// x, y, z
+        const bufferDim = 4;// int32
+        const buffer = new ArrayBuffer(nbPoints * bufferDim * spatialDim);
         const dv = new DataView(buffer);
-        for (let i = 0; i < nbPoints * 3; i++) {
-            dv.setInt32(i * 4, i * 2, true);
+        for (let i = 0; i < nbPoints; i++) {
+            dv.setInt32((i * spatialDim + 0) * bufferDim, i * 2, true);
+            dv.setInt32((i * spatialDim + 1) * bufferDim, i * 2, true);
+            dv.setInt32((i * spatialDim + 2) * bufferDim, i * 2, true);
         }
+
+        const valPositionMax = (nbPoints - 1) * 2;
 
         const options = {
             in: {
@@ -35,15 +41,16 @@ describe('Potree2BinParser', function () {
                         }],
                         vectors: [],
                     },
-                    crs: 'EPSG:4978',
+                    crs,
                 },
                 voxelOBB: {
-                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
+                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
+                },
+                clampOBB: {
+                    center: new THREE.Vector3(valPositionMax * 0.5, valPositionMax * 0.5, valPositionMax * 0.5),
                 },
                 numPoints: nbPoints,
-                crs: 'EPSG:4978',
-                origin: new Coordinates('EPSG:4978', 0, 0, 0),
-                rotation: new THREE.Quaternion(),
+                crs,
             },
         };
 
@@ -51,10 +58,11 @@ describe('Potree2BinParser', function () {
             .then((geometry) => {
                 const posAttr = geometry.getAttribute('position');
                 assert.equal(posAttr.itemSize, 3);
+                const origin = geometry.userData.position;
                 assert.ok(posAttr.array instanceof Float32Array);
                 assert.equal(posAttr.array.length, nbPoints * 3);
-                assert.equal(posAttr.array[0], 0);
-                assert.equal(posAttr.array[11], 22);
+                assert.equal(posAttr.array[0], -origin.x);// x of the 1st point
+                assert.equal(posAttr.array[14], 8);// z of the 5th point
                 done();
             })
             .catch(done);
@@ -68,9 +76,9 @@ describe('Potree2BinParser', function () {
         const dv = new DataView(buffer);
         for (let i = 0; i < numPoints; i++) {
             // position
-            dv.setInt32(i * numbyte + 0, 3 * i, true);
-            dv.setInt32(i * numbyte + 4, 3 * i + 1, true);
-            dv.setInt32(i * numbyte + 8, 3 * i + 2, true);
+            dv.setInt32(i * numbyte + 0, 2 * i + 1, true);// to avoid 0 for the deepStrictEqual
+            dv.setInt32(i * numbyte + 4, 2 * i + 1, true);
+            dv.setInt32(i * numbyte + 8, 2 * i + 1, true);
             // intensity
             dv.setInt16(i * numbyte + 12, 100 + i, true);
             // color
@@ -80,6 +88,8 @@ describe('Potree2BinParser', function () {
             // classification
             dv.setUint8(i * numbyte + 20, i * 3);
         }
+
+        const valPositionMax = numPoints * 2 - 1;
 
         const options = {
             in: {
@@ -137,15 +147,16 @@ describe('Potree2BinParser', function () {
                         }],
                         vectors: [],
                     },
-                    crs: 'EPSG:4978',
+                    crs,
                 },
                 voxelOBB: {
-                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 1, 1)),
+                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
+                },
+                clampOBB: {
+                    center: new THREE.Vector3(),
                 },
                 numPoints,
-                crs: 'EPSG:4978',
-                origin: new Coordinates('EPSG:4978', 0, 0, 0),
-                rotation: new THREE.Quaternion(),
+                crs,
             },
         };
 
@@ -159,10 +170,12 @@ describe('Potree2BinParser', function () {
 
                 // check position buffer
                 assert.equal(posAttr.itemSize, 3);
-                assert.deepStrictEqual(posAttr.array, Float32Array.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14));
+                assert.deepStrictEqual(posAttr.array,
+                    Float32Array.of(1, 1, 1, 3, 3, 3, 5, 5, 5, 7, 7, 7, 9, 9, 9),
+                    'positions');
                 // check intensity
                 assert.equal(intensityAttr.itemSize, 1);
-                assert.deepStrictEqual(intensityAttr.potree.preciseBuffer, Uint16Array.of(100, 101, 102, 103, 104));
+                assert.deepStrictEqual(intensityAttr.potree.preciseBuffer, Uint16Array.of(100, 101, 102, 103, 104), 'intensity');
                 // check colors
                 assert.equal(colorAttr.itemSize, 4);
                 assert.deepStrictEqual(colorAttr.array, Uint8Array.of(

--- a/packages/Main/test/unit/potree2BinParser.js
+++ b/packages/Main/test/unit/potree2BinParser.js
@@ -16,8 +16,6 @@ describe('Potree2BinParser', function () {
             dv.setInt32((i * spatialDim + 2) * bufferDim, i * 2, true);
         }
 
-        const valPositionMax = (nbPoints - 1) * 2;
-
         const options = {
             in: {
                 source: {
@@ -43,11 +41,8 @@ describe('Potree2BinParser', function () {
                     },
                     crs,
                 },
-                voxelOBB: {
-                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
-                },
                 clampOBB: {
-                    center: new THREE.Vector3(valPositionMax * 0.5, valPositionMax * 0.5, valPositionMax * 0.5),
+                    matrix: new THREE.Matrix4(),
                 },
                 numPoints: nbPoints,
                 crs,
@@ -61,7 +56,7 @@ describe('Potree2BinParser', function () {
                 const origin = geometry.userData.position;
                 assert.ok(posAttr.array instanceof Float32Array);
                 assert.equal(posAttr.array.length, nbPoints * 3);
-                assert.equal(posAttr.array[0], -origin.x);// x of the 1st point
+                assert.equal(posAttr.array[0], -origin[0], '1st point x value');// x of the 1st point
                 assert.equal(posAttr.array[14], 8);// z of the 5th point
                 done();
             })
@@ -88,8 +83,6 @@ describe('Potree2BinParser', function () {
             // classification
             dv.setUint8(i * numbyte + 20, i * 3);
         }
-
-        const valPositionMax = numPoints * 2 - 1;
 
         const options = {
             in: {
@@ -149,11 +142,8 @@ describe('Potree2BinParser', function () {
                     },
                     crs,
                 },
-                voxelOBB: {
-                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
-                },
                 clampOBB: {
-                    center: new THREE.Vector3(),
+                    matrix: new THREE.Matrix4(),
                 },
                 numPoints,
                 crs,

--- a/packages/Main/test/unit/potree2layerprocessing.js
+++ b/packages/Main/test/unit/potree2layerprocessing.js
@@ -4,8 +4,9 @@ import Potree2Layer from 'Layer/Potree2Layer';
 import Potree2Node from 'Core/Potree2Node';
 
 describe('preUpdate Potree2Layer', function () {
+    const crs = 'EPSG:4326';
     const context = { camera: { height: 1, camera3D: { fov: 1 } } };
-    const source = { baseurl: 'server.geo' };
+    const source = { baseurl: 'server.geo', crs };
     const layer = {
         id: 'a',
         source,
@@ -13,41 +14,41 @@ describe('preUpdate Potree2Layer', function () {
         object3d: new Group(),
     };
     before('create octree', () => {
-        layer.root = new Potree2Node(0, -1, 4000, 0, source);
+        layer.root = new Potree2Node(0, -1, 4000, 0, source, crs);
         layer.object3d.add(layer.root.clampOBB);
-        layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+        layer.root.voxelOBB.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
-        layer.root.add(new Potree2Node(1, 0, 3000, 0, source), 1);
+        layer.root.add(new Potree2Node(1, 0, 3000, 0, source, crs), 1);
         layer.root.children[0].obj = { layer, isPoints: true };
-        layer.root.add(new Potree2Node(1, 1, 3000, 0, source), 2);
+        layer.root.add(new Potree2Node(1, 1, 3000, 0, source, crs), 2);
         layer.root.children[1].obj = { layer, isPoints: true };
-        layer.root.add(new Potree2Node(1, 2, 3000, 0, source), 3);
+        layer.root.add(new Potree2Node(1, 2, 3000, 0, source, crs), 3);
         layer.root.children[2].obj = { layer, isPoints: true };
 
-        layer.root.children[0].add(new Potree2Node(2, 0, 2000, 0, source), 1);
+        layer.root.children[0].add(new Potree2Node(2, 0, 2000, 0, source, crs), 1);
         layer.root.children[0].children[0].obj = { layer, isPoints: true };
-        layer.root.children[0].add(new Potree2Node(2, 1, 2000, 0, source), 2);
+        layer.root.children[0].add(new Potree2Node(2, 1, 2000, 0, source, crs), 2);
         layer.root.children[0].children[1].obj = { layer, isPoints: true };
-        layer.root.children[1].add(new Potree2Node(2, 2, 2000, 0, source), 1);
+        layer.root.children[1].add(new Potree2Node(2, 2, 2000, 0, source, crs), 1);
         layer.root.children[1].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].add(new Potree2Node(2, 3, 2000, 0, source), 2);
+        layer.root.children[2].add(new Potree2Node(2, 3, 2000, 0, source, crs), 2);
         layer.root.children[2].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].add(new Potree2Node(2, 4, 2000, 0, source), 3);
+        layer.root.children[2].add(new Potree2Node(2, 4, 2000, 0, source, crs), 3);
         layer.root.children[2].children[1].obj = { layer, isPoints: true };
 
-        layer.root.children[0].children[0].add(new Potree2Node(3, 0, 1000, 0, source), 1);
+        layer.root.children[0].children[0].add(new Potree2Node(3, 0, 1000, 0, source, crs), 1);
         layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
-        layer.root.children[0].children[0].add(new Potree2Node(3, 1, 1000, 0, source), 5);
+        layer.root.children[0].children[0].add(new Potree2Node(3, 1, 1000, 0, source, crs), 5);
         layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
-        layer.root.children[0].children[1].add(new Potree2Node(3, 2, 1000, 0, source), 4);
+        layer.root.children[0].children[1].add(new Potree2Node(3, 2, 1000, 0, source, crs), 4);
         layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new Potree2Node(3, 3, 1000, 0, source), 1);
+        layer.root.children[2].children[1].add(new Potree2Node(3, 3, 1000, 0, source, crs), 1);
         layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new Potree2Node(3, 4, 1000, 0, source), 2);
+        layer.root.children[2].children[1].add(new Potree2Node(3, 4, 1000, 0, source, crs), 2);
         layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new Potree2Node(3, 5, 1000, 0, source), 3);
+        layer.root.children[2].children[1].add(new Potree2Node(3, 5, 1000, 0, source, crs), 3);
         layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new Potree2Node(3, 6, 1000, 0, source), 4);
+        layer.root.children[2].children[1].add(new Potree2Node(3, 6, 1000, 0, source, crs), 4);
         layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
     });
 

--- a/packages/Main/test/unit/potreeBinParser.js
+++ b/packages/Main/test/unit/potreeBinParser.js
@@ -27,11 +27,10 @@ describe('PotreeBinParser', function () {
                 },
                 crs,
                 voxelOBB: {
-                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
                     natBox: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
                 },
                 clampOBB: {
-                    center: new THREE.Vector3(valPositionMax * 0.5, valPositionMax * 0.5, valPositionMax * 0.5),
+                    matrix: new THREE.Matrix4(),
                 },
             },
         };
@@ -43,10 +42,10 @@ describe('PotreeBinParser', function () {
                 assert.ok(posAttr.array instanceof Float32Array);
                 const origin = geom.userData.position;
                 assert.equal(posAttr.array.length, nbPoints * spatialDim);
-                assert.equal(posAttr.array[0], 0 - origin.x);
-                assert.equal(posAttr.array[2], 0 - origin.z);
-                assert.equal(posAttr.array[33], valPositionMax - origin.x);
-                assert.equal(posAttr.array[35], valPositionMax - origin.z);
+                assert.equal(posAttr.array[0], 0 - origin[0]);
+                assert.equal(posAttr.array[2], 0 - origin[2]);
+                assert.equal(posAttr.array[33], valPositionMax - origin[0]);
+                assert.equal(posAttr.array[35], valPositionMax - origin[2]);
                 done();
             })
             .catch(done);
@@ -85,11 +84,10 @@ describe('PotreeBinParser', function () {
                 },
                 crs,
                 voxelOBB: {
-                    box3D: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
                     natBox: new THREE.Box3(new THREE.Vector3(0, 0, 0), new THREE.Vector3(valPositionMax, valPositionMax, valPositionMax)),
                 },
                 clampOBB: {
-                    center: new THREE.Vector3(),
+                    matrix: new THREE.Matrix4(),
                 },
             },
         };

--- a/packages/Main/test/unit/potreelayerprocessing.js
+++ b/packages/Main/test/unit/potreelayerprocessing.js
@@ -4,8 +4,9 @@ import PotreeLayer from 'Layer/PotreeLayer';
 import PotreeNode from 'Core/PotreeNode';
 
 describe('preUpdate PotreeLayer', function () {
+    const crs = 'EPSG:4326';
     const context = { camera: { height: 1, camera3D: { fov: 1 } } };
-    const source = { baseurl: 'server.geo' };
+    const source = { baseurl: 'server.geo', crs };
     const layer = {
         id: 'a',
         source,
@@ -13,41 +14,41 @@ describe('preUpdate PotreeLayer', function () {
         object3d: new Group(),
     };
     before('create octree', () => {
-        layer.root = new PotreeNode(0, -1, 4000, 0, source);
+        layer.root = new PotreeNode(0, -1, 4000, 0, source, crs);
         layer.object3d.add(layer.root.clampOBB);
-        layer.root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
+        layer.root.voxelOBB.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
-        layer.root.add(new PotreeNode(1, 0, 3000, 0, source), 1);
+        layer.root.add(new PotreeNode(1, 0, 3000, 0, source, crs), 1);
         layer.root.children[0].obj = { layer, isPoints: true };
-        layer.root.add(new PotreeNode(1, 1, 3000, 0, source), 2);
+        layer.root.add(new PotreeNode(1, 1, 3000, 0, source, crs), 2);
         layer.root.children[1].obj = { layer, isPoints: true };
-        layer.root.add(new PotreeNode(1, 2, 3000, 0, source), 3);
+        layer.root.add(new PotreeNode(1, 2, 3000, 0, source, crs), 3);
         layer.root.children[2].obj = { layer, isPoints: true };
 
-        layer.root.children[0].add(new PotreeNode(2, 0, 2000, 0, source), 1);
+        layer.root.children[0].add(new PotreeNode(2, 0, 2000, 0, source, crs), 1);
         layer.root.children[0].children[0].obj = { layer, isPoints: true };
-        layer.root.children[0].add(new PotreeNode(2, 1, 2000, 0, source), 2);
+        layer.root.children[0].add(new PotreeNode(2, 1, 2000, 0, source, crs), 2);
         layer.root.children[0].children[1].obj = { layer, isPoints: true };
-        layer.root.children[1].add(new PotreeNode(2, 2, 2000, 0, source), 1);
+        layer.root.children[1].add(new PotreeNode(2, 2, 2000, 0, source, crs), 1);
         layer.root.children[1].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].add(new PotreeNode(2, 3, 2000, 0, source), 2);
+        layer.root.children[2].add(new PotreeNode(2, 3, 2000, 0, source, crs), 2);
         layer.root.children[2].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].add(new PotreeNode(2, 4, 2000, 0, source), 3);
+        layer.root.children[2].add(new PotreeNode(2, 4, 2000, 0, source, crs), 3);
         layer.root.children[2].children[1].obj = { layer, isPoints: true };
 
-        layer.root.children[0].children[0].add(new PotreeNode(3, 0, 1000, 0, source), 1);
+        layer.root.children[0].children[0].add(new PotreeNode(3, 0, 1000, 0, source, crs), 1);
         layer.root.children[0].children[0].children[0].obj = { layer, isPoints: true };
-        layer.root.children[0].children[0].add(new PotreeNode(3, 1, 1000, 0, source), 5);
+        layer.root.children[0].children[0].add(new PotreeNode(3, 1, 1000, 0, source, crs), 5);
         layer.root.children[0].children[0].children[1].obj = { layer, isPoints: true };
-        layer.root.children[0].children[1].add(new PotreeNode(3, 2, 1000, 0, source), 4);
+        layer.root.children[0].children[1].add(new PotreeNode(3, 2, 1000, 0, source, crs), 4);
         layer.root.children[0].children[1].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new PotreeNode(3, 3, 1000, 0, source), 1);
+        layer.root.children[2].children[1].add(new PotreeNode(3, 3, 1000, 0, source, crs), 1);
         layer.root.children[2].children[1].children[0].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new PotreeNode(3, 4, 1000, 0, source), 2);
+        layer.root.children[2].children[1].add(new PotreeNode(3, 4, 1000, 0, source, crs), 2);
         layer.root.children[2].children[1].children[1].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new PotreeNode(3, 5, 1000, 0, source), 3);
+        layer.root.children[2].children[1].add(new PotreeNode(3, 5, 1000, 0, source, crs), 3);
         layer.root.children[2].children[1].children[2].obj = { layer, isPoints: true };
-        layer.root.children[2].children[1].add(new PotreeNode(3, 6, 1000, 0, source), 4);
+        layer.root.children[2].children[1].add(new PotreeNode(3, 6, 1000, 0, source, crs), 4);
         layer.root.children[2].children[1].children[3].obj = { layer, isPoints: true };
     });
 


### PR DESCRIPTION
Light refactorisation of Point Cloud Node and fix.

- PointCloudDebug : 
  - remove BoxHelper to only use OBBHelper
  - fix a bug linked with custom projection
- PointCloud refactor
  - remove all pointNumber Default value (and keep -1 when node is not loaded yet)
  - load Octree in node only
- refactorisation of Potree and Potree2 and fix for potree
- Proposal of a new structure for PointCloudNode test:
  - add a pointcloudnode.js test file
  - move node test from generic PointCloudType files to their own pointCloudNode files
  - regroup them all in a folder node
  
  
  
  The commit with the Potree2 Arene data will be removed, but I let it for test on Potree2 if needed
