### PR TITLE
[Fix] vpc layer and custom referentiel

### DIFF
--- a/packages/Main/src/Layer/VpcLayer.js
+++ b/packages/Main/src/Layer/VpcLayer.js
@@ -75,7 +75,6 @@ class VpcLayer extends PointCloudLayer {
             this.root.source = this.source;
             this.root.crs = this.crs;
             this.root.setOBBes(boundsConforming.slice(0, 3), boundsConforming.slice(3, 6));
-
             this.object3d.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
@@ -103,7 +102,6 @@ class VpcLayer extends PointCloudLayer {
                 mockSubRoot.load = promisedRoot.then(root => root.load());
 
                 mockSubRoot.setOBBes(boundsConforming.slice(0, 3), boundsConforming.slice(3, 6));
-
                 this.object3d.add(mockSubRoot.clampOBB);
                 mockSubRoot.clampOBB.updateMatrixWorld(true);
 


### PR DESCRIPTION
Follwing the PR #2656 vpcLayer aren't well displayed anymore du to oversights.

vpcLayer add several layer of 'root' node and they need all to be added to the layer.object3d.