### PR TITLE
fix(geotiff): Fix geotiff sample

### DIFF
--- a/examples/source_file_cog.html
+++ b/examples/source_file_cog.html
@@ -34,10 +34,10 @@
     </head>
     <body>
         <div id="description">
-            <form>Specify the URL of a COG to load:
+            <div>Specify the URL of a COG to load:
                 <input type="text" id="cog_url" />
                 <button id="readCOGURLButton">Load</button>
-            </form>
+            </div>
             <button id="loadRGBSampleButton">Load RGB sample</button>
         </div>
 


### PR DESCRIPTION
## Motivation and Context
Since 4933b31137e88637df01163acfdc5acbfc16b7e9 it caused a bug in `source_file_cog.html`.
A button in a form reload all the page and break webpack dynamic import.
We must don't use form and must use div.

## Screenshots (if appropriate)
<img width="1130" height="63" alt="image" src="https://github.com/user-attachments/assets/c110a8d8-e534-4f7c-873c-d45e98af9fe7" />
