### PR TITLE
(Fix): node OBBes computation

### DIFF
--- a/packages/Geographic/src/Coordinates.ts
+++ b/packages/Geographic/src/Coordinates.ts
@@ -1,12 +1,10 @@
 import { Vector3, type Vector3Like, type Matrix4, MathUtils } from 'three';
-import proj4, { type Converter } from 'proj4';
 import Ellipsoid from './Ellipsoid';
 import * as CRS from './Crs';
 
 import type { ProjectionLike } from './Crs';
 
 const ellipsoid = /* @__PURE__ */ new Ellipsoid();
-const projectionCache: Record<string, Record<string, Converter>> = {};
 
 const v0 = /* @__PURE__ */ new Vector3();
 const v1 = /* @__PURE__ */ new Vector3();
@@ -19,18 +17,6 @@ export interface CoordinatesLike {
     readonly x: number;
     readonly y: number;
     readonly z: number;
-}
-
-function proj4cache(crsIn: ProjectionLike, crsOut: ProjectionLike): Converter {
-    if (!projectionCache[crsIn]) {
-        projectionCache[crsIn] = {};
-    }
-
-    if (!projectionCache[crsIn][crsOut]) {
-        projectionCache[crsIn][crsOut] = proj4(crsIn, crsOut);
-    }
-
-    return projectionCache[crsIn][crsOut];
 }
 
 /**
@@ -348,7 +334,7 @@ class Coordinates {
                 this.y = MathUtils.clamp(this.y, -89.999999, 89.999999);
             }
 
-            target.setFromArray(proj4cache(this.crs, crs)
+            target.setFromArray(CRS.transform(this.crs, crs)
                 .forward([this.x, this.y, this.z]));
         }
 

--- a/packages/Geographic/src/Crs.ts
+++ b/packages/Geographic/src/Crs.ts
@@ -1,4 +1,5 @@
 import proj4 from 'proj4';
+import type { Converter } from 'proj4';
 import type { ProjectionDefinition } from 'proj4/dist/lib/defs';
 
 type proj4Def = {
@@ -23,6 +24,19 @@ proj4.defs('WGS84').axis = 'neu';
  * [`proj4.defs`](https://github.com/proj4js/proj4js#named-projections).
  */
 export type ProjectionLike = string;
+
+const proj4Cache: Record<string, Record<string, Converter>> = {};
+export function transform(crsIn: ProjectionLike, crsOut: ProjectionLike): Converter {
+    if (!proj4Cache[crsIn]) {
+        proj4Cache[crsIn] = {};
+    }
+
+    if (!proj4Cache[crsIn][crsOut]) {
+        proj4Cache[crsIn][crsOut] = proj4(crsIn, crsOut);
+    }
+
+    return proj4Cache[crsIn][crsOut];
+}
 
 function isString(s: unknown): s is string {
     return typeof s === 'string' || s instanceof String;

--- a/packages/Geographic/src/Crs.ts
+++ b/packages/Geographic/src/Crs.ts
@@ -23,6 +23,7 @@ proj4.defs('WGS84').axis = 'neu';
  * projection definition previously defined with
  * [`proj4.defs`](https://github.com/proj4js/proj4js#named-projections).
  */
+// TODO Unify with OrientationUtils.js
 export type ProjectionLike = string;
 
 const proj4Cache: Record<string, Record<string, Converter>> = {};
@@ -223,7 +224,7 @@ export async function fromEPSG(crs: string): Promise<ProjectionDefinition> {
     return proj4.defs(crs);
 }
 
-export function defsFromWkt(wkt: string) {
+export function defsFromWkt(wkt: string): string {
     proj4.defs('unknown', wkt);
     const proj4Defs = proj4.defs as unknown as proj4Def;
     let projCS;
@@ -233,7 +234,7 @@ export function defsFromWkt(wkt: string) {
     } else {
         projCS = proj4Defs('unknown');
     }
-    const crsAlias = projCS.title || projCS.name || 'EPSG:XXXX';
+    const crsAlias = (projCS.title || projCS.name || 'EPSG:XXXX');
     if (!(crsAlias in proj4.defs)) {
         proj4.defs(crsAlias, projCS);
     }

--- a/packages/Geographic/src/OrientationUtils.ts
+++ b/packages/Geographic/src/OrientationUtils.ts
@@ -32,6 +32,7 @@ type Attitude = Partial<EulerAngles> | Partial<PhotogrammetryAngles>;
 
 type QuaternionFunction = (coords: Coordinates, target?: Quaternion) => Quaternion;
 
+// To unify with Crs.js ProjectionLike type ?
 type ProjectionLike = ProjectionDefinition | string;
 type LCCProjection = { long0: number, lat0: number };
 type TMercProjection = { a: number, b: number, e?: number, long0: number };

--- a/packages/Main/src/Core/LasNodeBase.ts
+++ b/packages/Main/src/Core/LasNodeBase.ts
@@ -96,15 +96,7 @@ abstract class LasNodeBase extends PointCloudNode {
 
         // get a clamped bbox from the voxel bbox
         childNode.clampOBB.copy(childNode.voxelOBB);
-
-        const childClampBBox = childNode.clampOBB.box3D;
-
-        if (childClampBBox.min.z < this.source.zmax) {
-            childClampBBox.max.z = Math.min(childClampBBox.max.z, this.source.zmax);
-        }
-        if (childClampBBox.max.z > this.source.zmin) {
-            childClampBBox.min.z = Math.max(childClampBBox.min.z, this.source.zmin);
-        }
+        childNode.clampOBB.clampZ(this.source.zmin, this.source.zmax);
 
         (this.clampOBB.parent as Group).add(childNode.clampOBB);
         childNode.clampOBB.updateMatrixWorld(true);

--- a/packages/Main/src/Core/LasNodeBase.ts
+++ b/packages/Main/src/Core/LasNodeBase.ts
@@ -69,9 +69,8 @@ abstract class LasNodeBase extends PointCloudNode {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     override createChildAABB(childNode: this, _indexChild: number): void {
         // initialize the child node obb
-        childNode.voxelOBB.copy(this.voxelOBB);
-        const voxelBBox = this.voxelOBB.box3D;
-        const childVoxelBBox = childNode.voxelOBB.box3D;
+        const voxelBBox = this.voxelOBB.natBox;
+        const childVoxelBBox = voxelBBox.clone();
 
         // factor to apply, based on the depth difference (can be > 1)
         const f = 2 ** (childNode.depth - this.depth);
@@ -94,9 +93,10 @@ abstract class LasNodeBase extends PointCloudNode {
         // use the size computed above to set the max
         childVoxelBBox.max.copy(childVoxelBBox.min).add(size);
 
+        childNode.voxelOBB.setFromBox3(childVoxelBBox).projOBB(this.source.crs, this.crs);
+
         // get a clamped bbox from the voxel bbox
-        childNode.clampOBB.copy(childNode.voxelOBB);
-        childNode.clampOBB.clampZ(this.source.zmin, this.source.zmax);
+        childNode.clampOBB.copy(childNode.voxelOBB).clampZ(this.source.zmin, this.source.zmax);
 
         (this.clampOBB.parent as Group).add(childNode.clampOBB);
         childNode.clampOBB.updateMatrixWorld(true);

--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import OBB from 'Renderer/OBB';
 import proj4 from 'proj4';
-import { OrientationUtils, Coordinates } from '@itowns/geographic';
+import { CRS, OrientationUtils, Coordinates } from '@itowns/geographic';
 
 export interface PointCloudSource {
     spacing: number;
@@ -78,10 +78,11 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
     get origin(): Coordinates {
         if (this._origin != undefined) { return this._origin; }
         const center = this.clampOBB.center;
-        const centerCrsIn = proj4(this.crs, this.source.crs).forward(center);
+        const centerCrsIn = CRS.transform(this.crs, this.source.crs).forward(center);
         this._origin =  new Coordinates(this.crs)
             .setFromArray(
-                proj4(this.source.crs, this.crs).forward([centerCrsIn.x, centerCrsIn.y, 0]));
+                CRS.transform(this.source.crs, this.crs)
+                    .forward([centerCrsIn.x, centerCrsIn.y, 0]));
         return this._origin;
     }
 

--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -40,7 +40,6 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
     promise: Promise<unknown> | null;
     obj: THREE.Points | undefined;
 
-    private _center: Coordinates | undefined;
     private _origin: Coordinates | undefined;
     private _rotation: THREE.Quaternion | undefined;
 
@@ -74,21 +73,12 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
         return this.source.spacing / 2 ** this.depth;
     }
 
-    // get the center of the node i.e. the center of the bounding box.
-    get center(): Coordinates {
-        if (this._center != undefined) { return this._center; }
-        const centerBbox = new THREE.Vector3();
-        this.voxelOBB.box3D.getCenter(centerBbox);
-        this._center =  new Coordinates(this.crs)
-            .setFromVector3(centerBbox.applyMatrix4(this.clampOBB.matrix));
-        return this._center;
-    }
-
-    // the origin is the center of the bounding box projected
+    // the origin is the center of the clamped OBB projected
     // on the z=O local plan, in the world referential.
     get origin(): Coordinates {
         if (this._origin != undefined) { return this._origin; }
-        const centerCrsIn = proj4(this.crs, this.source.crs).forward(this.center);
+        const center = this.clampOBB.center;
+        const centerCrsIn = proj4(this.crs, this.source.crs).forward(center);
         this._origin =  new Coordinates(this.crs)
             .setFromArray(
                 proj4(this.source.crs, this.crs).forward([centerCrsIn.x, centerCrsIn.y, 0]));

--- a/packages/Main/src/Core/PointCloudNode.ts
+++ b/packages/Main/src/Core/PointCloudNode.ts
@@ -13,8 +13,6 @@ export interface PointCloudSource {
     networkOptions: RequestInit;
 }
 
-type ExtentedOBB = OBB & { matrixWorldInverse: THREE.Matrix4 };
-
 abstract class PointCloudNode extends THREE.EventDispatcher {
     /** The crs of the node. */
     abstract crs: string;
@@ -30,9 +28,9 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
     parent: this | undefined;
 
     /** The node cubique obb. */
-    voxelOBB: ExtentedOBB;
+    voxelOBB: OBB;
     /** The cubique obb clamped to zmin and zmax. */
-    clampOBB: ExtentedOBB;
+    clampOBB: OBB;
 
     // Properties used internally by PointCloud layer
     visible: boolean;
@@ -56,8 +54,8 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
         this.children = [];
         this.parent = undefined;
 
-        this.voxelOBB = new OBB() as ExtentedOBB;
-        this.clampOBB = new OBB() as ExtentedOBB;
+        this.voxelOBB = new OBB();
+        this.clampOBB = new OBB();
         this.sse = -1;
 
         this.visible = false;
@@ -120,77 +118,6 @@ abstract class PointCloudNode extends THREE.EventDispatcher {
             .then(file => this.source.parser(file, {
                 in: this,
             }));
-    }
-
-    setOBBes(min: number[], max: number[]): void {
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const root = this;
-        const crs = {
-            in: root.source.crs,
-            out: this.crs,
-        };
-        const zmin = root.source.zmin;
-        const zmax = root.source.zmax;
-
-        let forward = (x: [number, number, number]) => x;
-        if (crs.in !== crs.out) {
-            try {
-                forward = proj4(crs.in, crs.out).forward;
-            } catch (err) {
-                throw new Error(`${err} is not defined in proj4`);
-            }
-        }
-
-        const corners = [
-            ...forward([max[0], max[1], max[2]]),
-            ...forward([min[0], max[1], max[2]]),
-            ...forward([min[0], min[1], max[2]]),
-            ...forward([max[0], min[1], max[2]]),
-            ...forward([max[0], max[1], min[2]]),
-            ...forward([min[0], max[1], min[2]]),
-            ...forward([min[0], min[1], min[2]]),
-            ...forward([max[0], min[1], min[2]]),
-        ];
-
-        // get center of box at altitude Z=0 and project it in view crs;
-        const origin = forward([(min[0] + max[0]) * 0.5, (min[1] + max[1]) * 0.5, 0]);
-
-        // get LocalRotation
-        const isGeocentric = proj4.defs(crs.out).projName === 'geocent';
-        let rotation = new THREE.Quaternion();
-        if (isGeocentric) {
-            const coordOrigin = new Coordinates(crs.out).setFromArray(origin);
-            rotation = OrientationUtils.quaternionFromCRSToCRS(crs.out, crs.in)(coordOrigin);
-        }
-
-        // project corners in local referentiel
-        const cornersLocal = [];
-        for (let i = 0; i < 24; i += 3) {
-            const cornerLocal = new THREE.Vector3(
-                corners[i] - origin[0],
-                corners[i + 1] - origin[1],
-                corners[i + 2] - origin[2],
-            );
-            cornerLocal.applyQuaternion(rotation);
-            cornersLocal.push(...cornerLocal.toArray());
-        }
-
-        // get the bbox containing all cornersLocal => the bboxLocal
-        root.voxelOBB.box3D.setFromArray(cornersLocal);
-        root.voxelOBB.position.set(...origin);
-        root.voxelOBB.quaternion.copy(rotation).invert();
-
-        root.voxelOBB.updateMatrix();
-
-        root.clampOBB.copy(root.voxelOBB);
-
-        const clampBBox = root.clampOBB.box3D;
-        if (clampBBox.min.z < zmax) {
-            clampBBox.max.z = Math.min(clampBBox.max.z, zmax);
-        }
-        if (clampBBox.max.z > zmin) {
-            clampBBox.min.z = Math.max(clampBBox.min.z, zmin);
-        }
     }
 
     add(node: this, indexChild: number): void {

--- a/packages/Main/src/Core/PotreeNodeBase.ts
+++ b/packages/Main/src/Core/PotreeNodeBase.ts
@@ -102,14 +102,7 @@ export abstract class PotreeNodeBase extends PointCloudNode {
         childNode.voxelOBB.box3D = computeChildBBox(this.voxelOBB.box3D, childIndex);
 
         childNode.clampOBB.copy(childNode.voxelOBB);
-        const childClampBBox = childNode.clampOBB.box3D;
-
-        if (childClampBBox.min.z < this.source.zmax) {
-            childClampBBox.max.z = Math.min(childClampBBox.max.z, this.source.zmax);
-        }
-        if (childClampBBox.max.z > this.source.zmin) {
-            childClampBBox.min.z = Math.max(childClampBBox.min.z, this.source.zmin);
-        }
+        childNode.clampOBB.clampZ(this.source.zmin, this.source.zmax);
 
         (this.clampOBB.parent as Group).add(childNode.clampOBB);
         childNode.clampOBB.updateMatrixWorld(true);

--- a/packages/Main/src/Layer/CopcLayer.ts
+++ b/packages/Main/src/Layer/CopcLayer.ts
@@ -46,7 +46,7 @@ class CopcLayer extends PointCloudLayer {
             this.root.voxelOBB.setFromArray(cube).projOBB(source.crs, this.crs);
             this.root.clampOBB.copy(this.root.voxelOBB).clampZ(source.zmin, source.zmax);
 
-            this.object3d.add(this.root.clampOBB);
+            this.obbes.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
             return this.root.loadOctree();

--- a/packages/Main/src/Layer/CopcLayer.ts
+++ b/packages/Main/src/Layer/CopcLayer.ts
@@ -40,10 +40,11 @@ class CopcLayer extends PointCloudLayer {
         const loadOctree = this.source.whenReady.then((source) => {
             this.setElevationRange();
 
-            const { rootHierarchyPage, cube } = source.info;
+            const { cube, rootHierarchyPage } = source.info;
             const { pageOffset, pageLength } = rootHierarchyPage;
             this.root = new CopcNode(0, 0, 0, 0, pageOffset, pageLength, source, -1, this.crs);
-            this.root.setOBBes(cube.slice(0, 3), cube.slice(3, 6));
+            this.root.voxelOBB.setFromArray(cube).projOBB(source.crs, this.crs);
+            this.root.clampOBB.copy(this.root.voxelOBB).clampZ(source.zmin, source.zmax);
 
             this.object3d.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);

--- a/packages/Main/src/Layer/EntwinePointTileLayer.ts
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.ts
@@ -50,7 +50,7 @@ class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
             this.root.voxelOBB.setFromArray(bounds).projOBB(source.crs, this.crs);
             this.root.clampOBB.copy(this.root.voxelOBB).clampZ(source.zmin, source.zmax);
 
-            this.object3d.add(this.root.clampOBB);
+            this.obbes.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
             return this.root.loadOctree();

--- a/packages/Main/src/Layer/EntwinePointTileLayer.ts
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.ts
@@ -46,6 +46,7 @@ class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
 
             const { bounds } = source;
             this.root = new EntwinePointTileNode(0, 0, 0, 0, source, -1, this.crs);
+
             this.root.voxelOBB.setFromArray(bounds).projOBB(source.crs, this.crs);
             this.root.clampOBB.copy(this.root.voxelOBB).clampZ(source.zmin, source.zmax);
 

--- a/packages/Main/src/Layer/EntwinePointTileLayer.ts
+++ b/packages/Main/src/Layer/EntwinePointTileLayer.ts
@@ -41,12 +41,13 @@ class EntwinePointTileLayer extends PointCloudLayer<EntwinePointTileSource> {
 
         this.isEntwinePointTileLayer = true;
 
-        const loadOctree = this.source.whenReady.then(() => {
+        const loadOctree = this.source.whenReady.then((source) => {
             this.setElevationRange();
 
-            this.root = new EntwinePointTileNode(0, 0, 0, 0, this.source, -1, this.crs);
-            const { bounds } = this.source;
-            this.root.setOBBes(bounds.slice(0, 3), bounds.slice(3, 6));
+            const { bounds } = source;
+            this.root = new EntwinePointTileNode(0, 0, 0, 0, source, -1, this.crs);
+            this.root.voxelOBB.setFromArray(bounds).projOBB(source.crs, this.crs);
+            this.root.clampOBB.copy(this.root.voxelOBB).clampZ(source.zmin, source.zmax);
 
             this.object3d.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -22,7 +22,6 @@ export interface PointCloudLayerParameters {
     source: PointCloudSource;
     object3d?: THREE.Group;
     group?: THREE.Group;
-    bboxes?: THREE.Group;
     octreeDepthLimit?: number;
     pointBudget?: number;
     pointSize?: number;
@@ -172,10 +171,10 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
     readonly group: THREE.Group;
 
     /**
-     * Container group for the points bounding boxes.
+     * Container group for the oriented points bounding boxes.
      * Add this to the three.js scene in order to render it.
      */
-    readonly bboxes: THREE.Group;
+    readonly obbes: THREE.Group;
 
     /**
      * Maximum depth to which points will be loaded and rendered.
@@ -246,7 +245,6 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
         const {
             object3d = new THREE.Group(),
             group = new THREE.Group(),
-            bboxes = new THREE.Group(),
             octreeDepthLimit = -1,
             pointBudget = 2000000,
             pointSize = 2,
@@ -271,10 +269,10 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
         this.group.name = 'points';
         this.object3d.add(this.group);
 
-        this.bboxes = bboxes;
-        this.bboxes.name = 'bboxes';
-        this.bboxes.visible = false;
-        this.object3d.add(this.bboxes);
+        this.obbes = new THREE.Group();
+        this.obbes.name = 'obbes';
+        this.obbes.visible = false;
+        this.object3d.add(this.obbes);
 
         this.group.updateMatrixWorld();
 

--- a/packages/Main/src/Layer/Potree2Layer.ts
+++ b/packages/Main/src/Layer/Potree2Layer.ts
@@ -93,9 +93,12 @@ class Potree2Layer extends PointCloudLayer<Potree2Source> {
 
             this.setElevationRange();
 
-            const root = new Potree2Node(0, -1, 0, 0, this.source, this.crs);
             const { boundingBox, hierarchy } = metadata;
-            root.setOBBes(boundingBox.min, boundingBox.max);
+            const bounds = [...boundingBox.min, ...boundingBox.max];
+            const root = new Potree2Node(0, 0, -1, undefined, this.source, this.crs);
+            root.voxelOBB.setFromArray(bounds).projOBB(this.source.crs, this.crs);
+            root.clampOBB.copy(root.voxelOBB).clampZ(this.source.zmin, this.source.zmax);
+
             this.object3d.add(root.clampOBB);
             root.clampOBB.updateMatrixWorld(true);
 

--- a/packages/Main/src/Layer/Potree2Layer.ts
+++ b/packages/Main/src/Layer/Potree2Layer.ts
@@ -99,7 +99,7 @@ class Potree2Layer extends PointCloudLayer<Potree2Source> {
             root.voxelOBB.setFromArray(bounds).projOBB(this.source.crs, this.crs);
             root.clampOBB.copy(root.voxelOBB).clampZ(this.source.zmin, this.source.zmax);
 
-            this.object3d.add(root.clampOBB);
+            this.obbes.add(root.clampOBB);
             root.clampOBB.updateMatrixWorld(true);
 
             root.nodeType = 2;

--- a/packages/Main/src/Layer/PotreeLayer.ts
+++ b/packages/Main/src/Layer/PotreeLayer.ts
@@ -61,7 +61,7 @@ class PotreeLayer extends PointCloudLayer<PotreeSource> {
             this.root.voxelOBB.setFromArray(bounds).projOBB(this.source.crs, this.crs);
             this.root.clampOBB.copy(this.root.voxelOBB).clampZ(this.source.zmin, this.source.zmax);
 
-            this.object3d.add(this.root.clampOBB);
+            this.obbes.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 
             return this.root.loadOctree();

--- a/packages/Main/src/Layer/PotreeLayer.ts
+++ b/packages/Main/src/Layer/PotreeLayer.ts
@@ -55,10 +55,11 @@ class PotreeLayer extends PointCloudLayer<PotreeSource> {
 
             this.setElevationRange();
 
-            this.root = new PotreeNode(0, -1, 0, 0, this.source, this.crs);
-            const { boundingBox } = cloud;
-            this.root.setOBBes([boundingBox.lx, boundingBox.ly, boundingBox.lz],
-                [boundingBox.ux, boundingBox.uy, boundingBox.uz]);
+            const { lx, ly, lz, ux, uy, uz } = cloud.boundingBox;
+            const bounds = [lx, ly, lz, ux, uy, uz];
+            this.root = new PotreeNode(0, 0, -1, undefined, this.source, this.crs);
+            this.root.voxelOBB.setFromArray(bounds).projOBB(this.source.crs, this.crs);
+            this.root.clampOBB.copy(this.root.voxelOBB).clampZ(this.source.zmin, this.source.zmax);
 
             this.object3d.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);

--- a/packages/Main/src/Renderer/OBB.ts
+++ b/packages/Main/src/Renderer/OBB.ts
@@ -193,7 +193,7 @@ class OBB extends THREE.Object3D {
         let forward = ((coord: [number, number, number]) => coord);
         if (crsIn !== crsOut) {
             try {
-                forward = proj4(crsIn, crsOut).forward;
+                forward = CRS.transform(crsIn, crsOut).forward;
             } catch (err) {
                 throw new Error(`${err} is not defined in proj4`);
             }

--- a/packages/Main/src/Renderer/OBB.ts
+++ b/packages/Main/src/Renderer/OBB.ts
@@ -24,7 +24,7 @@ class OBB extends THREE.Object3D {
     z: { min: number, max: number, scale: number, delta: number };
 
     private _center: undefined | THREE.Vector3;
-    private _matrixWorldInverse: undefined | THREE.Matrix4;
+    private matrixWorldInverse: undefined | THREE.Matrix4;
 
     /**
      * @param min - (optional) A {@link THREE.Vector3} representing the lower
@@ -52,15 +52,12 @@ class OBB extends THREE.Object3D {
         return this._center;
     }
 
-    get matrixWorldInverse() {
-        if (this._matrixWorldInverse !== undefined) { return this._matrixWorldInverse; }
-        this._matrixWorldInverse = this.matrixWorld.clone().invert();
-        return this._matrixWorldInverse;
-    }
-
     override updateMatrixWorld(force?: boolean) {
-        this._matrixWorldInverse = undefined;
+        const matrixWorldInverseNeedsUpdate = this.matrixAutoUpdate || this.matrixWorldNeedsUpdate;
         super.updateMatrixWorld(force);
+        if (matrixWorldInverseNeedsUpdate || force) {
+            this.matrixWorldInverse = this.matrixWorld.clone().invert();
+        }
     }
 
     /**

--- a/packages/Main/src/Renderer/OBB.ts
+++ b/packages/Main/src/Renderer/OBB.ts
@@ -22,7 +22,9 @@ class OBB extends THREE.Object3D {
     box3D: THREE.Box3;
     natBox: THREE.Box3;
     z: { min: number, max: number, scale: number, delta: number };
-    _matrixWorldInverse: undefined | THREE.Matrix4;
+
+    private _center: undefined | THREE.Vector3;
+    private _matrixWorldInverse: undefined | THREE.Matrix4;
 
     /**
      * @param min - (optional) A {@link THREE.Vector3} representing the lower
@@ -42,10 +44,23 @@ class OBB extends THREE.Object3D {
         this.z = { min: 0, max: 0, scale: 1.0, delta: 0 };
     }
 
+    get center(): THREE.Vector3 {
+        if (this._center != undefined) { return this._center; }
+        const centerBbox = new THREE.Vector3();
+        this.box3D.getCenter(centerBbox);
+        this._center = centerBbox.applyMatrix4(this.matrix);
+        return this._center;
+    }
+
     get matrixWorldInverse() {
         if (this._matrixWorldInverse !== undefined) { return this._matrixWorldInverse; }
         this._matrixWorldInverse = this.matrixWorld.clone().invert();
         return this._matrixWorldInverse;
+    }
+
+    override updateMatrixWorld(force?: boolean) {
+        this._matrixWorldInverse = undefined;
+        super.updateMatrixWorld(force);
     }
 
     /**
@@ -228,6 +243,9 @@ class OBB extends THREE.Object3D {
 
         this.updateMatrix();
         this.updateMatrixWorld();
+
+        // reset center
+        this._center = undefined;
     }
     /**
      * Clamped the OBB on the z axes of the OBB.box3D.

--- a/packages/Main/test/unit/copc.js
+++ b/packages/Main/test/unit/copc.js
@@ -44,28 +44,33 @@ describe('COPC', function () {
 
     describe('COPC Node', function () {
         let root;
+        const crs = 'EPSG:4978';
         before('create octree', function () {
             const object3d = new Object3D();
-            const source = { url: 'http://server.geo', extension: 'laz' };
-            root = new CopcNode(0, 0, 0, 0, 0, 1000, source, 4000);
+            const source = {
+                url: 'http://server.geo',
+                extension: 'laz',
+                crs,
+            };
+            root = new CopcNode(0, 0, 0, 0, 0, 1000, source, 4000, crs);
             object3d.add(root.clampOBB);
             root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
 
-            root.add(new CopcNode(1, 0, 0, 0, 0, 1000, source, 3000));
-            root.add(new CopcNode(1, 0, 0, 1, 0, 1000, source, 3000));
-            root.add(new CopcNode(1, 0, 1, 1, 0, 1000, source, 3000));
+            root.add(new CopcNode(1, 0, 0, 0, 0, 1000, source, 3000, crs));
+            root.add(new CopcNode(1, 0, 0, 1, 0, 1000, source, 3000, crs));
+            root.add(new CopcNode(1, 0, 1, 1, 0, 1000, source, 3000, crs));
 
-            root.children[0].add(new CopcNode(2, 0, 0, 0, 0, 1000, source, 2000));
-            root.children[0].add(new CopcNode(2, 0, 1, 0, 0, 1000, source, 2000));
-            root.children[1].add(new CopcNode(2, 0, 1, 3, 0, 1000, source, 2000));
-            root.children[2].add(new CopcNode(2, 0, 2, 2, 0, 1000, source, 2000));
-            root.children[2].add(new CopcNode(2, 0, 3, 3, 0, 1000, source, 2000));
+            root.children[0].add(new CopcNode(2, 0, 0, 0, 0, 1000, source, 2000, crs));
+            root.children[0].add(new CopcNode(2, 0, 1, 0, 0, 1000, source, 2000, crs));
+            root.children[1].add(new CopcNode(2, 0, 1, 3, 0, 1000, source, 2000, crs));
+            root.children[2].add(new CopcNode(2, 0, 2, 2, 0, 1000, source, 2000, crs));
+            root.children[2].add(new CopcNode(2, 0, 3, 3, 0, 1000, source, 2000, crs));
 
-            root.children[0].children[0].add(new CopcNode(3, 0, 0, 0, 0, 1000, source, 1000));
-            root.children[0].children[0].add(new CopcNode(3, 0, 1, 0, 0, 1000, source, 1000));
-            root.children[1].children[0].add(new CopcNode(3, 0, 2, 7, 0, 1000, source, 1000));
-            root.children[2].children[0].add(new CopcNode(3, 0, 5, 4, 0, 1000, source, 1000));
-            root.children[2].children[1].add(new CopcNode(3, 1, 6, 7, 0, 1000, source));
+            root.children[0].children[0].add(new CopcNode(3, 0, 0, 0, 0, 1000, source, 1000, crs));
+            root.children[0].children[0].add(new CopcNode(3, 0, 1, 0, 0, 1000, source, 1000, crs));
+            root.children[1].children[0].add(new CopcNode(3, 0, 2, 7, 0, 1000, source, 1000, crs));
+            root.children[2].children[0].add(new CopcNode(3, 0, 5, 4, 0, 1000, source, 1000, crs));
+            root.children[2].children[1].add(new CopcNode(3, 1, 6, 7, 0, 1000, source, 10, crs));
         });
 
         describe('finds the common ancestor of two nodes', () => {

--- a/packages/Main/test/unit/entwine.js
+++ b/packages/Main/test/unit/entwine.js
@@ -180,27 +180,32 @@ describe('Entwine Point Tile', function () {
 
         describe('finds the common ancestor of two nodes', () => {
             let root;
+            const crs = 'EPSG:4978';
             before('create octree', function () {
-                const source = { url: 'http://server.geo', extension: 'laz' };
-                root = new EntwinePointTileNode(0, 0, 0, 0, source, 4000);
+                const source = {
+                    url: 'http://server.geo',
+                    extension: 'laz',
+                    crs,
+                };
+                root = new EntwinePointTileNode(0, 0, 0, 0, source, 4000, crs);
                 root.voxelOBB.box3D.setFromArray([1000, 1000, 1000, 0, 0, 0]);
                 object3d.add(root.clampOBB);
 
-                root.add(new EntwinePointTileNode(1, 0, 0, 0, source, 3000));
-                root.add(new EntwinePointTileNode(1, 0, 0, 1, source, 3000));
-                root.add(new EntwinePointTileNode(1, 0, 1, 1, source, 3000));
+                root.add(new EntwinePointTileNode(1, 0, 0, 0, source, 3000, crs));
+                root.add(new EntwinePointTileNode(1, 0, 0, 1, source, 3000, crs));
+                root.add(new EntwinePointTileNode(1, 0, 1, 1, source, 3000, crs));
 
-                root.children[0].add(new EntwinePointTileNode(2, 0, 0, 0, source, 2000));
-                root.children[0].add(new EntwinePointTileNode(2, 0, 1, 0, source, 2000));
-                root.children[1].add(new EntwinePointTileNode(2, 0, 1, 3, source, 2000));
-                root.children[2].add(new EntwinePointTileNode(2, 0, 2, 2, source, 2000));
-                root.children[2].add(new EntwinePointTileNode(2, 0, 3, 3, source, 2000));
+                root.children[0].add(new EntwinePointTileNode(2, 0, 0, 0, source, 2000, crs));
+                root.children[0].add(new EntwinePointTileNode(2, 0, 1, 0, source, 2000, crs));
+                root.children[1].add(new EntwinePointTileNode(2, 0, 1, 3, source, 2000, crs));
+                root.children[2].add(new EntwinePointTileNode(2, 0, 2, 2, source, 2000, crs));
+                root.children[2].add(new EntwinePointTileNode(2, 0, 3, 3, source, 2000, crs));
 
-                root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 0, 0, source, 1000));
-                root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 1, 0, source, 1000));
-                root.children[1].children[0].add(new EntwinePointTileNode(3, 0, 2, 7, source, 1000));
-                root.children[2].children[0].add(new EntwinePointTileNode(3, 0, 5, 4, source, 1000));
-                root.children[2].children[1].add(new EntwinePointTileNode(3, 1, 6, 7, source));
+                root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 0, 0, source, 1000, crs));
+                root.children[0].children[0].add(new EntwinePointTileNode(3, 0, 1, 0, source, 1000, crs));
+                root.children[1].children[0].add(new EntwinePointTileNode(3, 0, 2, 7, source, 1000, crs));
+                root.children[2].children[0].add(new EntwinePointTileNode(3, 0, 5, 4, source, 1000, crs));
+                root.children[2].children[1].add(new EntwinePointTileNode(3, 1, 6, 7, source, 10, crs));
             });
 
             let ancestor;

--- a/packages/Main/test/unit/potree.js
+++ b/packages/Main/test/unit/potree.js
@@ -102,7 +102,7 @@ describe('Potree', function () {
                     .then(() => {
                         context.camera.camera3D.updateMatrixWorld();
                         assert.equal(potreeLayer.root.children.length, 6);
-                        potreeLayer.bboxes.visible = true;
+                        potreeLayer.obbes.visible = true;
                         done();
                     }).catch(done);
             });

--- a/packages/Main/test/unit/potree2.js
+++ b/packages/Main/test/unit/potree2.js
@@ -60,7 +60,7 @@ describe('Potree2', function () {
             .then(() => {
                 context.camera.camera3D.updateMatrixWorld();
                 assert.equal(potree2Layer.root.children.length, 6);
-                potree2Layer.bboxes.visible = true;
+                potree2Layer.obbes.visible = true;
                 done();
             }).catch(done);
     });


### PR DESCRIPTION
Linked with issue #2694.

Currently done:
- The layer instanciate the root node and we compute the voxel OBB from bounds.
  - then we project that OBB and use the projection to compute all children OBB
  => the approximation of the subdivision of the projected OBB leads to a shift of the OBBes as noticed in the issus
  
This PR uses the OBB non projected to subdivise and compute the children OBB and projecte them.
