### PR TITLE
Dynamic far rework

### DIFF
--- a/examples/view_multiglobe.html
+++ b/examples/view_multiglobe.html
@@ -113,6 +113,10 @@
                 object3ds[0].updateMatrixWorld(true);
                 object3ds[1].updateMatrixWorld(true);
 
+                view.dispatchEvent({
+                    type: itowns.VIEW_EVENTS.CAMERA_MOVED,
+                });
+
                 if (t < 1) {
                     // animation is not finished, schedule a new view update
                     view.notifyChange(cameraThree);
@@ -153,6 +157,9 @@
                     geo.altitude *= 1.1;
                 }
                 cameraThree.position.copy(geo.as('EPSG:4978'));
+                view.dispatchEvent({
+                    type: itowns.VIEW_EVENTS.CAMERA_MOVED,
+                });
                 view.notifyChange(cameraThree);
             };
             viewerDiv.addEventListener('DOMMouseScroll', onMouseWheel);

--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -4,19 +4,6 @@ import { ellipsoidSizes } from '@itowns/geographic';
 import { globalExtentTMS, schemeTiles } from 'Core/Tile/TileGrid';
 import { GlobeTileBuilder } from 'Core/Prefab/Globe/GlobeTileBuilder';
 
-// matrix to convert sphere to ellipsoid
-const worldToScaledEllipsoid = new THREE.Matrix4();
-// camera's position in worldToScaledEllipsoid system
-const cameraPosition = new THREE.Vector3();
-let magnitudeSquared = 0.0;
-let useFarCulling = false;
-let horizonDistance = 0.0;
-
-// vectors for operation purpose
-const cullingPoint = new THREE.Vector3();
-const cameraForward = new THREE.Vector3();
-const cameraToPoint = new THREE.Vector3();
-
 /**
  * @property {boolean} isGlobeLayer - Used to checkout whether this layer is a
  * GlobeLayer. Default is true. You should not change this, as it is used
@@ -79,6 +66,19 @@ class GlobeLayer extends TiledGeometryLayer {
         this.minSubdivisionLevel = minSubdivisionLevel;
         this.maxSubdivisionLevel = maxSubdivisionLevel;
 
+        // matrix to convert sphere to ellipsoid
+        this._worldToScaledEllipsoid = new THREE.Matrix4();
+        // camera's position in worldToScaledEllipsoid system
+        this._cameraPosition = new THREE.Vector3();
+        this._magnitudeSquared = 0.0;
+        this._useFarCulling = false;
+        this._horizonDistance = 0.0;
+
+        // vectors for operation purpose
+        this._cullingPoint = new THREE.Vector3();
+        this._cameraForward = new THREE.Vector3();
+        this._cameraToPoint = new THREE.Vector3();
+
         this.extent = this.schemeTile[0].clone();
 
         for (let i = 1; i < this.schemeTile.length; i++) {
@@ -89,8 +89,8 @@ class GlobeLayer extends TiledGeometryLayer {
         //    https://cesiumjs.org/2013/04/25/Horizon-culling/
         // This method assumes that the globe is a unit sphere at 0,0,0 so
         // we setup a world-to-scaled-ellipsoid matrix4
-        worldToScaledEllipsoid.copy(this.object3d.matrixWorld).invert();
-        worldToScaledEllipsoid.premultiply(
+        this._worldToScaledEllipsoid.copy(this.object3d.matrixWorld).invert();
+        this._worldToScaledEllipsoid.premultiply(
             new THREE.Matrix4().makeScale(
                 1 / ellipsoidSizes.x,
                 1 / ellipsoidSizes.y,
@@ -98,14 +98,14 @@ class GlobeLayer extends TiledGeometryLayer {
     }
 
     preUpdate(context, changeSources) {
-        useFarCulling = context.view.horizonScaleFactor < 1;
-        if (!useFarCulling) {
+        this._useFarCulling = context.view.horizonScaleFactor < 1;
+        if (!this._useFarCulling) {
             // pre-horizon culling
-            cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(worldToScaledEllipsoid);
-            magnitudeSquared = cameraPosition.lengthSq() - 1.0;
+            this._cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(this._worldToScaledEllipsoid);
+            this._magnitudeSquared = this._cameraPosition.lengthSq() - 1.0;
         } else {
             // pre-far culling
-            horizonDistance = context.view.horizonDistance;
+            this._horizonDistance = context.view.horizonDistance;
         }
         return super.preUpdate(context, changeSources);
     }
@@ -130,39 +130,39 @@ class GlobeLayer extends TiledGeometryLayer {
             return false;
         }
 
-        if (useFarCulling) {
-            return GlobeLayer.farCulling(node, camera);
+        if (this._useFarCulling) {
+            return this.farCulling(node, camera);
         } else {
-            return GlobeLayer.horizonCulling(node.horizonCullingPointElevationScaled);
+            return this.horizonCulling(node.horizonCullingPointElevationScaled);
         }
     }
 
-    static horizonCulling(point) {
+    horizonCulling(point) {
         // see https://cesiumjs.org/2013/04/25/Horizon-culling/
-        cullingPoint.copy(point).applyMatrix4(worldToScaledEllipsoid);
-        cullingPoint.sub(cameraPosition);
+        this._cullingPoint.copy(point).applyMatrix4(this._worldToScaledEllipsoid);
+        this._cullingPoint.sub(this._cameraPosition);
 
-        const vtMagnitudeSquared = cullingPoint.lengthSq();
-        const dot = -cullingPoint.dot(cameraPosition);
-        const isOccluded = magnitudeSquared < 0 ? dot > 0
-            : magnitudeSquared < dot && magnitudeSquared < ((dot * dot) / vtMagnitudeSquared);
+        const vtMagnitudeSquared = this._cullingPoint.lengthSq();
+        const dot = -this._cullingPoint.dot(this._cameraPosition);
+        const isOccluded = this._magnitudeSquared < 0 ? dot > 0
+            : this._magnitudeSquared < dot && this._magnitudeSquared < ((dot * dot) / vtMagnitudeSquared);
 
         return isOccluded;
     }
 
-    static farCulling(node, camera) {
+    farCulling(node, camera) {
         // Transform bounding sphere center from local to world space.
-        cullingPoint.copy(node.boundingSphere.center).applyMatrix4(node.matrixWorld);
+        this._cullingPoint.copy(node.boundingSphere.center).applyMatrix4(node.matrixWorld);
 
         // Camera forward direction in world space.
-        camera.camera3D.getWorldDirection(cameraForward);
+        camera.camera3D.getWorldDirection(this._cameraForward);
 
         // Project the vector camera -> sphere center onto the camera axis.
-        cameraToPoint.subVectors(cullingPoint, camera.camera3D.position);
-        const projectedDistance = cameraToPoint.dot(cameraForward);
+        this._cameraToPoint.subVectors(this._cullingPoint, camera.camera3D.position);
+        const projectedDistance = this._cameraToPoint.dot(this._cameraForward);
 
         // Cull only if the whole bounding sphere is beyond the far plane.
-        return projectedDistance - node.boundingSphere.radius > horizonDistance;
+        return projectedDistance - node.boundingSphere.radius > this._horizonDistance;
     }
 
     computeTileZoomFromDistanceCamera(distance, camera) {

--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -170,6 +170,23 @@ class GlobeLayer extends TiledGeometryLayer {
         return projectedDistance - worldSpaceSphereRadius > this._horizonDistance;
     }
 
+    pointCulling(point, camera) {
+        if (!point) {
+            return false;
+        }
+
+        if (this._useFarCulling) {
+            // Project the vector camera -> sphere center onto the camera axis.
+            this._cameraToPoint.subVectors(point, camera.camera3D.position);
+            const projectedDistance = this._cameraToPoint.dot(this._cameraForward);
+
+            // Cull if distance to point is larger than the horizon distance.
+            return projectedDistance > this._horizonDistance;
+        }
+
+        return this.horizonCulling(point);
+    }
+
     computeTileZoomFromDistanceCamera(distance, camera) {
         const preSinus =
             this.sizeDiagonalTexture * (this.sseSubdivisionThreshold * 0.5) / camera._preSSE / ellipsoidSizes.x;

--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -106,6 +106,8 @@ class GlobeLayer extends TiledGeometryLayer {
         } else {
             // pre-far culling
             this._horizonDistance = context.view.horizonDistance;
+            // Store camera forward direction in world space.
+            context.camera.camera3D.getWorldDirection(this._cameraForward);
         }
         return super.preUpdate(context, changeSources);
     }
@@ -153,9 +155,6 @@ class GlobeLayer extends TiledGeometryLayer {
     farCulling(node, camera) {
         // Transform bounding sphere center from local to world space.
         this._cullingPoint.copy(node.boundingSphere.center).applyMatrix4(node.matrixWorld);
-
-        // Camera forward direction in world space.
-        camera.camera3D.getWorldDirection(this._cameraForward);
 
         // Project the vector camera -> sphere center onto the camera axis.
         this._cameraToPoint.subVectors(this._cullingPoint, camera.camera3D.position);

--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -98,7 +98,7 @@ class GlobeLayer extends TiledGeometryLayer {
     }
 
     preUpdate(context, changeSources) {
-        this._useFarCulling = context.view.horizonScaleFactor < 1;
+        this._useFarCulling = context.view.dynamicCameraNearFar && context.view.horizonScaleFactor < 1;
         if (!this._useFarCulling) {
             // pre-horizon culling
             this._cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(this._worldToScaledEllipsoid);

--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -9,9 +9,13 @@ const worldToScaledEllipsoid = new THREE.Matrix4();
 // camera's position in worldToScaledEllipsoid system
 const cameraPosition = new THREE.Vector3();
 let magnitudeSquared = 0.0;
+let useFarCulling = false;
+let horizonDistance = 0.0;
 
 // vectors for operation purpose
-const scaledHorizonCullingPoint = new THREE.Vector3();
+const cullingPoint = new THREE.Vector3();
+const cameraForward = new THREE.Vector3();
+const cameraToPoint = new THREE.Vector3();
 
 /**
  * @property {boolean} isGlobeLayer - Used to checkout whether this layer is a
@@ -94,10 +98,15 @@ class GlobeLayer extends TiledGeometryLayer {
     }
 
     preUpdate(context, changeSources) {
-        // pre-horizon culling
-        cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(worldToScaledEllipsoid);
-        magnitudeSquared = cameraPosition.lengthSq() - 1.0;
-
+        useFarCulling = context.view.horizonScaleFactor < 1;
+        if (!useFarCulling) {
+            // pre-horizon culling
+            cameraPosition.copy(context.camera.camera3D.position).applyMatrix4(worldToScaledEllipsoid);
+            magnitudeSquared = cameraPosition.lengthSq() - 1.0;
+        } else {
+            // pre-far culling
+            horizonDistance = context.view.horizonDistance;
+        }
         return super.preUpdate(context, changeSources);
     }
 
@@ -121,19 +130,39 @@ class GlobeLayer extends TiledGeometryLayer {
             return false;
         }
 
-        return GlobeLayer.horizonCulling(node.horizonCullingPointElevationScaled);
+        if (useFarCulling) {
+            return GlobeLayer.farCulling(node, camera);
+        } else {
+            return GlobeLayer.horizonCulling(node.horizonCullingPointElevationScaled);
+        }
     }
 
     static horizonCulling(point) {
         // see https://cesiumjs.org/2013/04/25/Horizon-culling/
-        scaledHorizonCullingPoint.copy(point).applyMatrix4(worldToScaledEllipsoid);
-        scaledHorizonCullingPoint.sub(cameraPosition);
+        cullingPoint.copy(point).applyMatrix4(worldToScaledEllipsoid);
+        cullingPoint.sub(cameraPosition);
 
-        const vtMagnitudeSquared = scaledHorizonCullingPoint.lengthSq();
-        const dot = -scaledHorizonCullingPoint.dot(cameraPosition);
-        const isOccluded = magnitudeSquared < 0 ? dot > 0 : magnitudeSquared < dot && magnitudeSquared < ((dot * dot) / vtMagnitudeSquared);
+        const vtMagnitudeSquared = cullingPoint.lengthSq();
+        const dot = -cullingPoint.dot(cameraPosition);
+        const isOccluded = magnitudeSquared < 0 ? dot > 0
+            : magnitudeSquared < dot && magnitudeSquared < ((dot * dot) / vtMagnitudeSquared);
 
         return isOccluded;
+    }
+
+    static farCulling(node, camera) {
+        // Transform bounding sphere center from local to world space.
+        cullingPoint.copy(node.boundingSphere.center).applyMatrix4(node.matrixWorld);
+
+        // Camera forward direction in world space.
+        camera.camera3D.getWorldDirection(cameraForward);
+
+        // Project the vector camera -> sphere center onto the camera axis.
+        cameraToPoint.subVectors(cullingPoint, camera.camera3D.position);
+        const projectedDistance = cameraToPoint.dot(cameraForward);
+
+        // Cull only if the whole bounding sphere is beyond the far plane.
+        return projectedDistance - node.boundingSphere.radius > horizonDistance;
     }
 
     computeTileZoomFromDistanceCamera(distance, camera) {

--- a/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
+++ b/packages/Main/src/Core/Prefab/Globe/GlobeLayer.js
@@ -160,8 +160,14 @@ class GlobeLayer extends TiledGeometryLayer {
         this._cameraToPoint.subVectors(this._cullingPoint, camera.camera3D.position);
         const projectedDistance = this._cameraToPoint.dot(this._cameraForward);
 
+        // Convert the node bounding sphere radius from local space to world space.
+        // We use the largest world scale axis to stay conservative with non-uniform scaling
+        // and avoid over-culling.
+        const maxWorldScale = node.matrixWorld.getMaxScaleOnAxis();
+        const worldSpaceSphereRadius = node.boundingSphere.radius * maxWorldScale;
+
         // Cull only if the whole bounding sphere is beyond the far plane.
-        return projectedDistance - node.boundingSphere.radius > this._horizonDistance;
+        return projectedDistance - worldSpaceSphereRadius > this._horizonDistance;
     }
 
     computeTileZoomFromDistanceCamera(distance, camera) {

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -80,8 +80,11 @@ class GlobeView extends View {
      * @param {Function} [options.webXR.callback] - WebXR rendering callback.
      * @param {boolean} [options.webXR.controllers] - Enable the webXR controllers handling.
      * @param {boolean} [options.dynamicCameraNearFar=true] - The camera's near and far are automatically adjusted.
-     * @param {number} [options.farFactor=20] - Controls how far the camera can see.
-     * The maximum view distance is this factor times the camera's altitude (above sea level).
+     * @param {number} [options.farFactor=0.3] - Controls the far plane distance at low altitudes.
+     * Value between 0 and 1. Lower values reduce far distance near the ground. At higher altitudes,
+     * far distance transitions to full horizon distance.
+     * @param {number} [options.maxFarAltitude=50000] - the altitude at which the horizon is fully visible (meters).
+     * @param {number} [options.minFarDistance=5000] - the minimum horizon distance (meters).
      * @param {number} [options.fogSpread=0.5] - Proportion of the visible depth range that contains fog.
      * Between 0 and 1.
      * @param {boolean} [options.realisticLighting=false] - Enable realistic lighting.
@@ -98,11 +101,20 @@ class GlobeView extends View {
 
         this.camera3D.near = Math.max(15.0, 0.000002352 * ellipsoidSizes.x);
         this.camera3D.far = ellipsoidSizes.x * 10;
+
+        this.farFactor = options.farFactor ?? 0.3;
+        this.maxFarAltitude = options.maxFarAltitude ?? 80000;
+        this.minFarDistance = options.minFarDistance ?? 10000;
+
         const tileLayer = new GlobeLayer('globe', options.object3d, options);
         this.mainLoop.gfxEngine.label2dRenderer.infoTileLayer = tileLayer.info;
 
         this.addLayer(tileLayer);
         this.tileLayer = tileLayer;
+
+        this.horizonScaleFactor = 1;
+        this.horizonDistance = null;
+        this.globeRadiusMin = Math.min(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z);
 
         if (!placement.isExtent) {
             placement.coord = placement.coord || new Coordinates('EPSG:4326', 0, 0);
@@ -110,9 +122,6 @@ class GlobeView extends View {
             placement.heading = placement.heading || 0;
             placement.range = placement.range || ellipsoidSizes.x * 2.0;
         }
-
-        this.farFactor = options.farFactor ?? 40;
-        this.fogSpread = options.fogSpread ?? 0.5;
 
         if (options.noControls) {
             CameraUtils.transformCameraToLookAtTarget(this, this.camera3D, placement);
@@ -123,36 +132,10 @@ class GlobeView extends View {
             this.controls = new GlobeControls(this, placement, options.controls);
             this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
 
-            const globeRadiusMin = Math.min(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z);
-
             if (options.dynamicCameraNearFar || options.dynamicCameraNearFar === undefined) {
-                this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, () => {
-                    // update camera's near and far
-                    const originToCamSq = this.camera3D.position.lengthSq();
-
-                    // maximum possible distance from ground to camera
-                    const camCoordinates = new Coordinates(this.referenceCrs)
-                        .setFromVector3(this.camera3D.position);
-                    camCoordinates.as(this.tileLayer.extent.crs, camCoordinates);
-                    const camToSeaLevel = camCoordinates.z;
-
-                    const camToGroundDistMin = camToSeaLevel - View.ALTITUDE_MAX;
-                    this.camera3D.near = Math.max(1, camToGroundDistMin * this.fovDepthFactor);
-
-                    // distance from camera to the horizon
-                    const horizonDist = Math.sqrt(Math.max(0, originToCamSq - globeRadiusMin * globeRadiusMin));
-
-                    this.camera3D.far = Math.min(this.farFactor * camToSeaLevel, horizonDist);
-                    this.camera3D.updateProjectionMatrix();
-
-                    const fog = this.scene.fog;
-                    if (!fog) { return; }
-                    fog.far = this.camera3D.far;
-                    fog.near = fog.far - this.fogSpread * (fog.far - this.camera3D.near);
-                });
+                this.addEventListener(VIEW_EVENTS.INITIALIZED, () => this.updateDynamicNearFar());
+                this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, () => this.updateDynamicNearFar());
             }
-
-            this.scene.fog = new THREE.Fog(0xe2edff, 1, 1000); // default fog
         }
 
         // GlobeView needs this.camera.resize to set perpsective matrix camera
@@ -178,6 +161,73 @@ class GlobeView extends View {
         if (options.shadows === true) {
             this.shadows = true;
         }
+    }
+
+    updateDynamicNearFar() {
+        // maximum possible distance from ground to camera
+        const camToSeaLevel = new Coordinates(this.referenceCrs)
+            .setFromVector3(this.camera3D.position)
+            .as(this.tileLayer.extent.crs)
+            .z;
+
+        this.horizonScaleFactor = this.computeHorizonScaleFactor(camToSeaLevel);
+        this.horizonDistance = this.computeHorizonDistance(camToSeaLevel);
+
+        this.camera3D.near = this.computeCameraNear(camToSeaLevel);
+        this.camera3D.far = this.computeCameraFar(camToSeaLevel);
+
+        this.camera3D.updateProjectionMatrix();
+    }
+
+    /**
+     * This factor scales down the visible horizon at low altitudes based on farFactor and maxFarAltitude.
+     * farFactor sets its minimum at sea level and maxFarAltitude the altitude at which the horizon is fully visible.
+     * @param {number} altitude - Camera altitude above sea level in meters
+     * @returns {number} Scale factor between farFactor and 1
+     */
+    computeHorizonScaleFactor(altitude) {
+        if (this.farFactor === 1 || altitude >= this.maxFarAltitude) {
+            return 1;
+        }
+        if (altitude < 0) {
+            return this.farFactor;
+        }
+
+        // Normalize altitude, 0 at maxFarAltitude, 1 at sea level
+        const t = altitude / this.maxFarAltitude;
+        // Linear interpolation between farFactor and 1
+        return this.farFactor + t * (1 - this.farFactor);
+    }
+
+    computeHorizonDistance(altitude) {
+        const R = this.globeRadiusMin;
+        const h = Math.max(0, altitude);
+
+        // Approximate horizon distance: sqrt(h² + 2*R*h)
+        const horizonDistance = Math.sqrt(h * h + 2 * R * h);
+
+        // Reduced horizon distance considering scale factor
+        const reducedHorizonDist = horizonDistance * this.horizonScaleFactor;
+
+        // Ensuring horizon distance is not less than the minimum far distance
+        return Math.max(this.minFarDistance, reducedHorizonDist);
+    }
+
+    computeCameraNear(altitude) {
+        const camToGroundDistMin = altitude - View.ALTITUDE_MAX;
+        return Math.max(1, camToGroundDistMin * this.fovDepthFactor);
+    }
+
+    computeCameraFar() {
+        // Three-geospatial aerial-perspective is not working well with a close camera far-plane.
+        // Disabling dynamic camera far when realistic lighting is enabled
+        // Tiles will, however, still be culled at this.horizonDistance if farFactor is less than 1
+        if (this.horizonScaleFactor >= 1 || this.skyManager?.enabled) {
+            // Setting far plane behind the globe
+            return this.camera3D.position.length() + this.globeRadiusMin;
+        }
+
+        return this.horizonDistance;
     }
 
     /**

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -56,6 +56,8 @@ export const GLOBE_VIEW_EVENTS = {
     COLOR_LAYERS_ORDER_CHANGED: VIEW_EVENTS.COLOR_LAYERS_ORDER_CHANGED,
 };
 
+const camToSeaLevel = new Coordinates('EPSG:4978');
+
 class GlobeView extends View {
     /**
      * Creates a view of a globe.
@@ -163,16 +165,16 @@ class GlobeView extends View {
 
     updateDynamicNearFar() {
         // maximum possible distance from ground to camera
-        const camToSeaLevel = new Coordinates(this.referenceCrs)
+        const camToSeaLevelDist = camToSeaLevel
             .setFromVector3(this.camera3D.position)
             .as(this.tileLayer.extent.crs)
             .z;
 
-        this.horizonScaleFactor = this.computeHorizonScaleFactor(camToSeaLevel);
-        this.horizonDistance = this.computeHorizonDistance(camToSeaLevel);
+        this.horizonScaleFactor = this.computeHorizonScaleFactor(camToSeaLevelDist);
+        this.horizonDistance = this.computeHorizonDistance(camToSeaLevelDist);
 
-        this.camera3D.near = this.computeCameraNear(camToSeaLevel);
-        this.camera3D.far = this.computeCameraFar(camToSeaLevel);
+        this.camera3D.near = this.computeCameraNear(camToSeaLevelDist);
+        this.camera3D.far = this.computeCameraFar(camToSeaLevelDist);
 
         this.camera3D.updateProjectionMatrix();
     }

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -81,6 +81,7 @@ class GlobeView extends View {
      * enable WebXR to switch on VR visualization.
      * @param {Function} [options.webXR.callback] - WebXR rendering callback.
      * @param {boolean} [options.webXR.controllers] - Enable the webXR controllers handling.
+     * @param {boolean} [options.dynamicCameraNearFar=true] - The camera's near and far are automatically adjusted.
      * @param {number} [options.farFactor=0.3] - Controls the far plane distance at low altitudes.
      * Value between 0 and 1. Lower values reduce far distance near the ground. At higher altitudes,
      * far distance transitions to full horizon distance.

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -189,11 +189,12 @@ class GlobeView extends View {
         if (this.farFactor === 1 || altitude >= this.maxFarAltitude) {
             return 1;
         }
+        // Keep farFactor constant under the sea level
         if (altitude < 0) {
             return this.farFactor;
         }
 
-        // Normalize altitude, 0 at maxFarAltitude, 1 at sea level
+        // Normalize altitude, 1 at maxFarAltitude, 0 at sea level
         const t = altitude / this.maxFarAltitude;
         // Linear interpolation between farFactor and 1
         return this.farFactor + t * (1 - this.farFactor);

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -99,8 +99,11 @@ class GlobeView extends View {
         super('EPSG:4978', viewerDiv, options);
         this.isGlobeView = true;
 
-        this.camera3D.near = Math.max(15.0, 0.000002352 * ellipsoidSizes.x);
-        this.camera3D.far = ellipsoidSizes.x * 10;
+        this.altitude = 10000000;
+        this.DEFAULT_NEAR = Math.max(15.0, 0.000002352 * ellipsoidSizes.x);
+        this.camera3D.near = this.DEFAULT_NEAR;
+        this.DEFAULT_FAR = ellipsoidSizes.x * 10;
+        this.camera3D.far = this.DEFAULT_FAR;
 
         this.farFactor = options.farFactor ?? 0.3;
         this.maxFarAltitude = options.maxFarAltitude ?? 80000;
@@ -112,9 +115,10 @@ class GlobeView extends View {
         this.addLayer(tileLayer);
         this.tileLayer = tileLayer;
 
+        this.dynamicCameraNearFar = options.dynamicCameraNearFar ?? true;
         this.horizonScaleFactor = 1;
         this.horizonDistance = null;
-        this.globeRadiusMin = Math.min(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z);
+        this.globeRadiusMax = Math.max(ellipsoidSizes.x, ellipsoidSizes.y, ellipsoidSizes.z);
 
         if (!placement.isExtent) {
             placement.coord = placement.coord || new Coordinates('EPSG:4326', 0, 0);
@@ -125,18 +129,13 @@ class GlobeView extends View {
 
         if (options.noControls) {
             CameraUtils.transformCameraToLookAtTarget(this, this.camera3D, placement);
-
-            // In this case, since the camera's near and far properties aren't
-            // dynamically computed, the default fog won't be adapted, so don't enable it
         } else {
             this.controls = new GlobeControls(this, placement, options.controls);
             this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
-
-            if (options.dynamicCameraNearFar !== false) {
-                this.addEventListener(VIEW_EVENTS.INITIALIZED, () => this.updateDynamicNearFar());
-                this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, () => this.updateDynamicNearFar());
-            }
         }
+
+        this.addEventListener(VIEW_EVENTS.INITIALIZED, () => this.updateAltitudeAndClipping());
+        this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, () => this.updateAltitudeAndClipping());
 
         // GlobeView needs this.camera.resize to set perpsective matrix camera
         this.camera.resize(viewerDiv.clientWidth, viewerDiv.clientHeight);
@@ -163,18 +162,17 @@ class GlobeView extends View {
         }
     }
 
-    updateDynamicNearFar() {
+    updateAltitudeAndClipping() {
         // maximum possible distance from ground to camera
-        const camToSeaLevelDist = camToSeaLevel
+        this.altitude = camToSeaLevel
             .setFromVector3(this.camera3D.position)
             .as(this.tileLayer.extent.crs)
             .z;
 
-        this.horizonScaleFactor = this.computeHorizonScaleFactor(camToSeaLevelDist);
-        this.horizonDistance = this.computeHorizonDistance(camToSeaLevelDist);
-
-        this.camera3D.near = this.computeCameraNear(camToSeaLevelDist);
-        this.camera3D.far = this.computeCameraFar(camToSeaLevelDist);
+        this.horizonScaleFactor = this.computeHorizonScaleFactor();
+        this.horizonDistance = this.computeHorizonDistance();
+        this.camera3D.near = this.computeCameraNear();
+        this.camera3D.far = this.computeCameraFar();
 
         this.camera3D.updateProjectionMatrix();
     }
@@ -182,27 +180,29 @@ class GlobeView extends View {
     /**
      * This factor scales down the visible horizon at low altitudes based on farFactor and maxFarAltitude.
      * farFactor sets its minimum at sea level and maxFarAltitude the altitude at which the horizon is fully visible.
-     * @param {number} altitude - Camera altitude above sea level in meters
      * @returns {number} Scale factor between farFactor and 1
      */
-    computeHorizonScaleFactor(altitude) {
-        if (this.farFactor === 1 || altitude >= this.maxFarAltitude) {
+    computeHorizonScaleFactor() {
+        if (!this.dynamicCameraNearFar
+            || this.skyManager?.enabled // Realistic lighting needs full horizon (no scale-down) for aerial perspective
+            || this.farFactor === 1
+            || this.altitude >= this.maxFarAltitude) {
             return 1;
         }
         // Keep farFactor constant under the sea level
-        if (altitude < 0) {
+        if (this.altitude < 0) {
             return this.farFactor;
         }
 
         // Normalize altitude, 1 at maxFarAltitude, 0 at sea level
-        const t = altitude / this.maxFarAltitude;
+        const t = this.altitude / this.maxFarAltitude;
         // Linear interpolation between farFactor and 1
         return this.farFactor + t * (1 - this.farFactor);
     }
 
-    computeHorizonDistance(altitude) {
-        const R = this.globeRadiusMin;
-        const h = Math.max(0, altitude);
+    computeHorizonDistance() {
+        const R = this.globeRadiusMax;
+        const h = Math.max(0, this.altitude);
 
         // Approximate horizon distance: sqrt(h² + 2*R*h)
         const horizonDistance = Math.sqrt(h * h + 2 * R * h);
@@ -214,18 +214,25 @@ class GlobeView extends View {
         return Math.max(this.minFarDistance, reducedHorizonDist);
     }
 
-    computeCameraNear(altitude) {
-        const camToGroundDistMin = altitude - View.ALTITUDE_MAX;
+    computeCameraNear() {
+        if (!this.dynamicCameraNearFar) {
+            return this.DEFAULT_NEAR;
+        }
+
+        const camToGroundDistMin = this.altitude - View.ALTITUDE_MAX * this.getMaxElevationScale();
         return Math.max(1, camToGroundDistMin * this.fovDepthFactor);
     }
 
     computeCameraFar() {
+        if (!this.dynamicCameraNearFar) {
+            return this.DEFAULT_FAR;
+        }
+
         // Three-geospatial aerial-perspective is not working well with a close camera far-plane.
         // Disabling dynamic camera far when realistic lighting is enabled
-        // Tiles will, however, still be culled at this.horizonDistance if farFactor is less than 1
         if (this.horizonScaleFactor >= 1 || this.skyManager?.enabled) {
             // Setting far plane behind the globe
-            return this.camera3D.position.length() + this.globeRadiusMin;
+            return this.camera3D.position.length() + this.globeRadiusMax;
         }
 
         return this.horizonDistance;

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -79,13 +79,11 @@ class GlobeView extends View {
      * enable WebXR to switch on VR visualization.
      * @param {Function} [options.webXR.callback] - WebXR rendering callback.
      * @param {boolean} [options.webXR.controllers] - Enable the webXR controllers handling.
-     * @param {boolean} [options.dynamicCameraNearFar=true] - The camera's near and far are automatically adjusted.
      * @param {number} [options.farFactor=0.3] - Controls the far plane distance at low altitudes.
      * Value between 0 and 1. Lower values reduce far distance near the ground. At higher altitudes,
      * far distance transitions to full horizon distance.
-     * @param {number} [options.maxFarAltitude=50000] - the altitude at which the horizon is fully visible (meters).
-     * @param {number} [options.minFarDistance=5000] - the minimum horizon distance (meters).
-     * @param {number} [options.fogSpread=0.5] - Proportion of the visible depth range that contains fog.
+     * @param {number} [options.maxFarAltitude=80000] - the altitude at which the horizon is fully visible (meters).
+     * @param {number} [options.minFarDistance=10000] - the minimum horizon distance (meters).
      * Between 0 and 1.
      * @param {boolean} [options.realisticLighting=false] - Enable realistic lighting.
      * If true, it can later be switched by setting this.skyManager.enabled to true/false.

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -132,7 +132,7 @@ class GlobeView extends View {
             this.controls = new GlobeControls(this, placement, options.controls);
             this.controls.handleCollision = typeof (options.handleCollision) !== 'undefined' ? options.handleCollision : true;
 
-            if (options.dynamicCameraNearFar || options.dynamicCameraNearFar === undefined) {
+            if (options.dynamicCameraNearFar !== false) {
                 this.addEventListener(VIEW_EVENTS.INITIALIZED, () => this.updateDynamicNearFar());
                 this.addEventListener(VIEW_EVENTS.CAMERA_MOVED, () => this.updateDynamicNearFar());
             }

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -86,7 +86,6 @@ class GlobeView extends View {
      * far distance transitions to full horizon distance.
      * @param {number} [options.maxFarAltitude=80000] - the altitude at which the horizon is fully visible (meters).
      * @param {number} [options.minFarDistance=10000] - the minimum horizon distance (meters).
-     * Between 0 and 1.
      * @param {boolean} [options.realisticLighting=false] - Enable realistic lighting.
      * If true, it can later be switched by setting this.skyManager.enabled to true/false.
      * If false, it will be impossible to enable it later on.

--- a/packages/Main/src/Core/Prefab/PlanarView.js
+++ b/packages/Main/src/Core/Prefab/PlanarView.js
@@ -80,7 +80,7 @@ class PlanarView extends View {
                 }
                 const maxDist = Math.sqrt(maxDistSq);
 
-                const camToGroundDistMin = this.camera3D.position.z - View.ALTITUDE_MAX;
+                const camToGroundDistMin = this.camera3D.position.z - View.ALTITUDE_MAX * this.getMaxElevationScale();
                 this.camera3D.near = Math.max(1, camToGroundDistMin * this.fovDepthFactor);
 
                 const boxBottomToCam = camPos.z - box.min.z;

--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -135,7 +135,7 @@ class View extends THREE.EventDispatcher {
     #pixelDepthBuffer = new Uint8Array(4);
     #fullSizeDepthBuffer;
 
-    static ALTITUDE_MAX = 100000; // more than 10 times altitude of Mount Everest
+    static ALTITUDE_MAX = 10000; // more than Mount Everest
 
     /**
      * Constructs an Itowns View instance
@@ -519,6 +519,11 @@ class View extends THREE.EventDispatcher {
 
     getLayerById(layerId) {
         return this.getLayers(l => l.id === layerId)[0];
+    }
+
+    getMaxElevationScale() {
+        return this.getLayers(layer => layer.isElevationLayer)
+            .reduce((max, layer) => Math.max(max, layer.scale), 1.0);
     }
 
     /**

--- a/packages/Main/src/Layer/TiledGeometryLayer.js
+++ b/packages/Main/src/Layer/TiledGeometryLayer.js
@@ -374,6 +374,11 @@ class TiledGeometryLayer extends GeometryLayer {
         return !camera.isBox3Visible(node.obb.box3D, node.matrixWorld);
     }
 
+
+    pointCulling() {
+        return false;
+    }
+
     /**
      * Tell if a node has enough elevation or color textures to subdivide.
      * Subdivision is prevented if:

--- a/packages/Main/src/Renderer/Label2DRenderer.js
+++ b/packages/Main/src/Renderer/Label2DRenderer.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import GlobeLayer from 'Core/Prefab/Globe/GlobeLayer';
 
 function isIntersectedOrOverlaped(a, b) {
     return !(a.left > b.right || a.right < b.left
@@ -132,7 +131,8 @@ class Label2DRenderer {
     }
 
     render(scene, camera) {
-        const labelLayers = this.infoTileLayer && this.infoTileLayer.layer.attachedLayers.filter(l => l.isLabelLayer && l.visible);
+        const tileLayer = this.infoTileLayer?.layer;
+        const labelLayers = tileLayer?.attachedLayers.filter(l => l.isLabelLayer && l.visible) || [];
         if (labelLayers.length == 0) { return; }
         this.grid.reset();
 
@@ -146,7 +146,7 @@ class Label2DRenderer {
                         (label) => {
                             labelsNode.updatePosition(label);
 
-                            this.culling(label, camera);
+                            this.culling(label, camera, tileLayer);
                         });
                     labelsNode.domElements.labels.show();
                     labelsNode.needsUpdate = false;
@@ -180,13 +180,13 @@ class Label2DRenderer {
         });
     }
 
-    culling(label, camera) {
+    culling(label, camera, tileLayer) {
         label.getWorldPosition(worldPosition);
         // Check if the frustum contains tle label
         if (!frustum.containsPoint(worldPosition.applyMatrix4(camera.matrixWorldInverse)) ||
         // Check if globe horizon culls the label
         // Do some horizon culling (if possible) if the tiles level is small enough.
-            (label.horizonCullingPoint && GlobeLayer.horizonCulling(label.horizonCullingPoint))
+            (label.horizonCullingPoint && tileLayer.pointCulling(label.horizonCullingPoint, camera))
             // Why do we might need this part ?
             // || // Check if content isn't present in visible labels
             // this.grid.visible.some((l) => {


### PR DESCRIPTION
## Description
I am assessing issues pointed out by @gchoqueux about horizon clipping with the dynamic near / far option enabled.
For now, this work only targets GlobeView and GlobeLayer.
It would be nice to have a uniform 'dynamic far' api for both of them in the end. I suggest merging this PR first and then later making something more uniform with planar view.

Fixes #2619

### New far computation
I implemented a new far computation method that applies a varying factor to horizon distance instead of aplying a linear coefficient to camera sea level altitude. This looks more natural near the ground.
It has 3 parameters : 
- farFactor - Value between 0 and 1. Lower values reduce far distance near the ground. It is the lowest factor applied to the real horizon distance, at sea level. For instance, a factor of 0.3 will induce a far distance corresponding to 30% of real horizon distance when camera is at sea level (if minimum distance mentionned bellow allows it)
- maxFarAltitude - the altitude at which the horizon is fully visible (meters).
- minFarDistance - the minimum horizon distance (meters). This is prevents shrinking too much the horizon bellow a decent value, 10 km here. 

This method is not mathematicaly perfect, as it is scaling horizon distance in spherical unit earth referencial, then re-multiplying it by max globe radius. It won't exactly match culled horizon distance. But this seemed sufficient to me, horizon culling being quite conservative.

<img width="1158" height="636" alt="549534485-4422008f-bdd6-4823-b82c-27a0703fe3b9" src="https://github.com/user-attachments/assets/e2ae09f9-0cda-4bcc-b164-02c7a9cf66ab" />
<img width="937" height="632" alt="image" src="https://github.com/user-attachments/assets/f7233de5-abf6-46dc-98c4-dc2636dc0963" />

### Culling tiles at the reduced horizon distance
The dynamic far distance was not related to horizon culling in Globe layer. This meant that textures would still be downloaded while the related tile was not rendered. The new farCulling method from `GlobeView` simply cull tiles based on the horizonDistance instead of horizon computation.

### Setting far at a fixed distance in two conditions
I am setting far distance as the furthest point on the globe (on the other side) in two situations : 
- When camera altitude is above maxFarAltitude. This removes the fog while keeping a close-enough distance to benefit from depth-buffer resolution.
- When RealisticLighting is enabled. For now, at the far plane, it seems that three-geospatial is having issues identifying what is background. The geometries very close to the far plane are not processed the same by aerial perspective and this create a visual artifact. Aerial perspective is already strong enough to hide tile culling. This still imply to render more tiles. This can be removed when fixing this artifact issue. 

<img width="812" height="365" alt="image" src="https://github.com/user-attachments/assets/a316e2c3-0457-47cd-b71c-5c8851322d96" />
