### PR TITLE
fix(scheduler): use different URI construct due to non-standard webpack handling

### DIFF
--- a/packages/Main/src/Core/Scheduler/Scheduler.js
+++ b/packages/Main/src/Core/Scheduler/Scheduler.js
@@ -155,7 +155,7 @@ Scheduler.prototype.execute = function execute(command) {
     // parse host
     const layer = command.layer;
     const host = layer.source && layer.source.url && layer.source.url !== 'none' ?
-        new URL(URLBuilder.subDomains(layer.source.url), import.meta.url).host : undefined;
+        new URL(URLBuilder.subDomains(layer.source.url), document.baseURI).host : undefined;
 
     command.promise = new Promise((resolve, reject) => {
         command.resolve = resolve;


### PR DESCRIPTION
## Description

This fix was initially in #2702 but extracted it as its own commit. This reverts to initial fix proposed in https://github.com/iTowns/itowns/pull/2590 since recent versions of webpack are non-standard compliant is their handling of import.meta.url. It treats import.meta.url as a file:// URL scheme and new URL(..., import.meta.url) as some sort of modules import...
