### PR TITLE
Feat/ogc3dtiles style pre sky

### DIFF
--- a/examples/3DTiles-11-styling.html
+++ b/examples/3DTiles-11-styling.html
@@ -1,0 +1,386 @@
+<html>
+   <head>
+        <title>Itowns - 3D Tiles styling</title>
+
+        <script type="importmap">
+        {
+            "imports": {
+                "itowns": "../dist/itowns.js",
+                "debug": "../dist/debug.js",
+                "dat": "https://unpkg.com/dat.gui@0.7.9/build/dat.gui.module.js",
+                "GuiTools": "./jsm/GUI/GuiTools.js",
+                "LoadingScreen": "./jsm/GUI/LoadingScreen.js",
+                "itowns_widgets": "../dist/itowns_widgets.js",
+                "three": "https://unpkg.com/three@0.170.0/build/three.module.js",
+                "three/addons/": "https://unpkg.com/three@0.170.0/examples/jsm/"
+            }
+        }
+        </script>
+
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <link rel="stylesheet" type="text/css" href="css/example.css">
+        <link rel="stylesheet" type="text/css" href="css/LoadingScreen.css">
+
+        <style type="text/css">
+            #description {
+                z-index: 2;
+                left: 10px;
+                max-width: 420px;
+            }
+
+            #description .marg {
+                margin: 10px;
+            }
+
+            /* ---- tileset input ---- */
+            #tileset-input-row {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                margin: 6px 0 4px 0;
+            }
+
+            #tileset-url {
+                flex: 1;
+                min-width: 0;
+                font-size: 11px;
+                padding: 2px 4px;
+                height: 22px;
+                box-sizing: border-box;
+            }
+
+            #load-btn {
+                flex-shrink: 0;
+                font-size: 12px;
+                padding: 2px 6px;
+                height: 22px;
+                cursor: pointer;
+            }
+
+            /* ---- feature color panel ---- */
+            .color-row {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                margin-bottom: 4px;
+                font-size: 12px;
+            }
+
+            .color-row label {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .color-row input[type="color"] {
+                width: 30px;
+                height: 22px;
+                padding: 0;
+                border: 1px solid #999;
+                cursor: pointer;
+                background: none;
+            }
+
+            .color-reset-btn {
+                font-size: 11px;
+                padding: 3px 10px;
+                margin-bottom: 6px;
+                cursor: pointer;
+            }
+        </style>
+
+    </head>
+    <body>
+        <div id="viewerDiv"></div>
+        <div id="description">
+            <b>Tileset</b>
+            <div id="tileset-input-row">
+                <input type="text" id="tileset-url" placeholder="Enter tileset URL" />
+                <button id="load-btn">Load</button>
+            </div>
+            <hr />
+            <p><b>Feature Colors</b></p>
+            <div id="featureColors" class="marg">
+                <em>Load a tileset to see feature types</em>
+            </div>
+        </div>
+
+
+        <script type="module">
+            import * as THREE from 'three';
+            import setupLoadingScreen from 'LoadingScreen';
+            import * as itowns from 'itowns';
+            import * as debug from 'debug';
+
+            import {
+                AmbientLight,
+                PMREMGenerator,
+            } from 'three';
+            import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+            import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+            import {
+                zoomToLayer,
+            } from './jsm/OGC3DTilesHelper.js';
+
+            const {
+                TMSSource, WMTSSource, OGC3DTilesSource,
+                ColorLayer, ElevationLayer, OGC3DTilesLayer, PNTS_SIZE_MODE,
+                GlobeView, Coordinates, Fetcher,
+            } = itowns;
+
+            // ── Current layer state ───────────────────────────────────────────────────
+            let currentLayer = null;
+            let layerCounter = 0;
+
+            const uri = new URL(location);
+
+            // ── GlobeView ─────────────────────────────────────────────────────────────
+
+            const placement = {
+                coord: new Coordinates('EPSG:4326', 2.351323, 48.856712),
+                range: 12500000,
+            };
+
+            const viewerDiv = document.getElementById('viewerDiv');
+
+            const view = new GlobeView(viewerDiv, placement, {
+                controls: { minDistance: 100 },
+            });
+
+            itowns.enableDracoLoader('./libs/draco/');
+            itowns.enableKtx2Loader('./lib/basis/', view.renderer);
+            itowns.enableMeshoptDecoder(MeshoptDecoder);
+
+            const light = new AmbientLight(0x404040, 40);
+            view.scene.add(light);
+
+            const environment = new RoomEnvironment();
+            const pmremGenerator = new PMREMGenerator(view.renderer);
+            view.scene.environment = pmremGenerator.fromScene(environment).texture;
+            pmremGenerator.dispose();
+
+            setupLoadingScreen(viewerDiv, view);
+
+            // ── Basemap ───────────────────────────────────────────────────────────────
+
+            Fetcher.json('./layers/JSONLayers/OPENSM.json').then((config) => {
+                const colorLayer = new ColorLayer('Ortho', {
+                    ...config,
+                    source: new TMSSource(config.source),
+                });
+                view.addLayer(colorLayer);
+            });
+
+            function addElevationLayerFromConfig(config) {
+                config.source = new itowns.WMTSSource(config.source);
+                var elevationLayer = new itowns.ElevationLayer(config.id, config);
+                view.addLayer(elevationLayer);
+            }
+            itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
+            itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
+
+            // ── Load / remove tileset ─────────────────────────────────────────────────
+
+            function removeCurrentLayer() {
+                if (!currentLayer) return;
+                try { view.removeLayer(currentLayer.layerId); } catch {}
+                try { currentLayer.layer.delete(); } catch {}
+                currentLayer = null;
+                document.getElementById('featureColors').innerHTML =
+                    '<em>Load a tileset to see feature types</em>';
+            }
+
+            function loadTileset(url) {
+                removeCurrentLayer();
+
+                const layerId = '3DTiles_' + (++layerCounter);
+
+                const source = new OGC3DTilesSource({ url });
+
+                const layer = new OGC3DTilesLayer(layerId, {
+                    source,
+                    pntsSizeMode: PNTS_SIZE_MODE.ATTENUATED,
+                });
+
+                // ── Feature Colors ───────────────────────────────────────
+                const typeColors = new Map();
+                const originalColors = new Map();
+                let rebuildTimer = null;
+                const featureColorsDiv = document.getElementById('featureColors');
+
+                function getFeatureType(feature) {
+                    let type;
+                    if (feature.userData?.CityObjectType) {
+                        type = feature.userData.CityObjectType;
+                    } else {
+                        try {
+                            const bt = feature.getInfo?.()?.batchTable;
+                            if (bt) {
+                                type = bt.surface_type || bt.CityObjectType || bt.type;
+                            }
+                        } catch {}
+                    }
+                    if (!type) return 'Unknown';
+                    if (type === 'BuildingPart') return 'Building';
+                    return type;
+                }
+
+                function applyTypeColors() {
+                    if (typeColors.size === 0) {
+                        layer.style = null;
+                    } else {
+                        layer.style = {
+                            fill: {
+                                color: (feature) => {
+                                    const t = getFeatureType(feature);
+                                    return typeColors.get(t) || originalColors.get(t) || '#ffffff';
+                                },
+                                opacity: 1.0,
+                            },
+                        };
+                    }
+                    view.notifyChange();
+                }
+
+                function getColorForType(typeName) {
+                    for (const [, featuresMap] of layer._tileFeatures) {
+                        for (const [, feature] of featuresMap) {
+                            if (getFeatureType(feature) !== typeName) continue;
+                            const geom = feature.object3d.geometry;
+                            const colorAttr = geom?.getAttribute('color');
+                            if (colorAttr && feature.groups?.length) {
+                                const indexAttr = geom.getIndex();
+                                const startIdx = feature.groups[0].start;
+                                const vertexIdx = indexAttr ? indexAttr.getX(startIdx) : startIdx;
+                                const r = colorAttr.getX(vertexIdx);
+                                const g = colorAttr.getY(vertexIdx);
+                                const b = colorAttr.getZ(vertexIdx);
+                                const c = new THREE.Color(r, g, b);
+                                return '#' + c.getHexString();
+                            }
+                        }
+                    }
+                    return '#ffffff';
+                }
+
+                const knownTypes = new Set();
+
+                function rebuildColorList() {
+                    const types = new Set();
+                    for (const [, featuresMap] of layer._tileFeatures) {
+                        for (const [, feature] of featuresMap) {
+                            types.add(getFeatureType(feature));
+                        }
+                    }
+
+                    if (types.size === 0) {
+                        featureColorsDiv.innerHTML = '<em>No features loaded</em>';
+                        knownTypes.clear();
+                        return;
+                    }
+
+                    const newTypes = [...types].filter(t => !knownTypes.has(t)).sort();
+                    if (newTypes.length === 0) return;
+
+                    if (knownTypes.size === 0) {
+                        featureColorsDiv.innerHTML = '';
+                        const resetBtn = document.createElement('button');
+                        resetBtn.className = 'color-reset-btn';
+                        resetBtn.textContent = 'Reset All';
+                        resetBtn.addEventListener('click', () => {
+                            typeColors.clear();
+                            originalColors.clear();
+                            knownTypes.clear();
+                            rebuildColorList();
+                            applyTypeColors();
+                        });
+                        featureColorsDiv.appendChild(resetBtn);
+                    }
+
+                    for (const typeName of newTypes) {
+                        knownTypes.add(typeName);
+
+                        if (!originalColors.has(typeName)) {
+                            originalColors.set(typeName, getColorForType(typeName));
+                        }
+
+                        const row = document.createElement('div');
+                        row.className = 'color-row';
+
+                        const lbl = document.createElement('label');
+                        lbl.textContent = typeName;
+                        lbl.title = typeName;
+
+                        const picker = document.createElement('input');
+                        picker.type = 'color';
+                        picker.value = typeColors.get(typeName) || originalColors.get(typeName);
+                        picker.title = 'Click to open color picker';
+
+                        function onPickerChange() {
+                            typeColors.set(typeName, picker.value);
+                            applyTypeColors();
+                        }
+                        picker.addEventListener('change', onPickerChange);
+
+                        row.appendChild(lbl);
+                        row.appendChild(picker);
+                        featureColorsDiv.appendChild(row);
+                    }
+                }
+
+                layer.addEventListener('load-model', () => {
+                    clearTimeout(rebuildTimer);
+                    rebuildTimer = setTimeout(rebuildColorList, 500);
+                });
+
+                currentLayer = { layerId, layer, url };
+
+                view.addLayer(layer).then((_layer) => {
+                    zoomToLayer(view, _layer);
+                });
+
+                // Update URL bar
+                uri.searchParams.set('3dtiles', url);
+                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
+            }
+
+            // ── UI wiring ─────────────────────────────────────────────────────────────
+
+            const urlInput = document.getElementById('tileset-url');
+            const loadBtn = document.getElementById('load-btn');
+
+            loadBtn.addEventListener('click', () => {
+                const u = urlInput.value.trim();
+                if (u) loadTileset(u);
+            });
+
+            urlInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    const u = urlInput.value.trim();
+                    if (u) loadTileset(u);
+                }
+            });
+
+            // ── Expose globals ────────────────────────────────────────────────────────
+
+            window.view = view;
+            window.itowns = itowns;
+            window.THREE = THREE;
+
+            // ── Load URL from query string ────────────────────────────────────────────
+
+            (function loadFromQueryString() {
+                const passedUrl = uri.searchParams.get('3dtiles');
+                if (passedUrl) {
+                    urlInput.value = passedUrl;
+                    loadTileset(passedUrl);
+                }
+            })();
+
+        </script>
+    </body>
+</html>

--- a/examples/3DTiles-11-styling.html
+++ b/examples/3DTiles-11-styling.html
@@ -135,6 +135,7 @@
             // ── Current layer state ───────────────────────────────────────────────────
             let currentLayer = null;
             let layerCounter = 0;
+            let rebuildTimer = null;
 
             const uri = new URL(location);
 
@@ -187,8 +188,10 @@
 
             function removeCurrentLayer() {
                 if (!currentLayer) return;
-                try { view.removeLayer(currentLayer.layerId); } catch {}
-                try { currentLayer.layer.delete(); } catch {}
+                clearTimeout(rebuildTimer);
+                rebuildTimer = null;
+                try { view.removeLayer(currentLayer.layerId); } catch (e) { console.warn('removeLayer:', e); }
+                try { currentLayer.layer.delete(); } catch (e) { console.warn('layer.delete:', e); }
                 currentLayer = null;
                 document.getElementById('featureColors').innerHTML =
                     '<em>Load a tileset to see feature types</em>';
@@ -209,7 +212,6 @@
                 // ── Feature Colors ───────────────────────────────────────
                 const typeColors = new Map();
                 const originalColors = new Map();
-                let rebuildTimer = null;
                 const featureColorsDiv = document.getElementById('featureColors');
 
                 function getFeatureType(feature) {
@@ -222,9 +224,10 @@
                             if (bt) {
                                 type = bt.surface_type || bt.CityObjectType || bt.type;
                             }
-                        } catch {}
+                        } catch (e) { console.warn('getFeatureType batch table lookup:', e); }
                     }
                     if (!type) return 'Unknown';
+                    type = type.replace(/\0/g, '');
                     if (type === 'BuildingPart') return 'Building';
                     return type;
                 }

--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -1,5 +1,5 @@
 <html>
-   <head>
+    <head>
         <title>Itowns - 3D Tiles loader</title>
 
         <script type="importmap">
@@ -27,7 +27,6 @@
             #description {
                 z-index: 2;
                 left: 10px;
-                max-width: 420px;
             }
 
             #featureInfoText {
@@ -37,131 +36,19 @@
             #description .marg {
                 margin: 10px;
             }
-
-            /* ---- tileset rows ---- */
-            #tilesets-container {
-                margin: 6px 0 4px 0;
-            }
-
-            .tileset-row {
-                display: flex;
-                align-items: center;
-                gap: 4px;
-                margin-bottom: 4px;
-            }
-
-            .layer-url {
-                flex: 1;
-                min-width: 0;
-                font-size: 11px;
-                padding: 2px 4px;
-                height: 22px;
-                box-sizing: border-box;
-            }
-
-            .load-btn, .remove-btn {
-                flex-shrink: 0;
-                font-size: 12px;
-                padding: 2px 6px;
-                height: 22px;
-                cursor: pointer;
-            }
-
-            .remove-btn {
-                color: #c00;
-                font-weight: bold;
-            }
-
-            #addTilesetBtn {
-                font-size: 12px;
-                padding: 2px 8px;
-                margin-bottom: 4px;
-                cursor: pointer;
-            }
-
-            /* ---- tooltip ---- */
-            #tooltip {
-                position: fixed;
-                left: 0;
-                top: 0;
-                background-color: rgba(0, 0, 0, 0.9);
-                color: white;
-                padding: 8px 12px;
-                border-radius: 4px;
-                font-size: 12px;
-                pointer-events: none;
-                z-index: 2147483647;
-                max-width: 400px;
-                max-height: 300px;
-                overflow-y: auto;
-                display: none;
-                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-            }
-
-            #tooltip.visible {
-                display: block !important;
-                visibility: visible !important;
-                opacity: 1 !important;
-            }
-
-            #tooltip .tooltip-content {
-                margin: 0;
-            }
-
-            /* ---- feature color panel ---- */
-            .color-row {
-                display: flex;
-                align-items: center;
-                gap: 6px;
-                margin-bottom: 4px;
-                font-size: 12px;
-            }
-
-            .color-row label {
-                flex: 1;
-                min-width: 0;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-
-            .color-row input[type="color"] {
-                width: 30px;
-                height: 22px;
-                padding: 0;
-                border: 1px solid #999;
-                cursor: pointer;
-                background: none;
-            }
-
-            .color-reset-btn {
-                font-size: 11px;
-                padding: 3px 10px;
-                margin-bottom: 6px;
-                cursor: pointer;
-            }
         </style>
 
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <div id="tooltip">
-            <div class="tooltip-content"></div>
-        </div>
-        <div id="description">
-            <b>Tilesets</b>
-            <div id="tilesets-container"></div>
-            <button id="addTilesetBtn">+ Add tileset</button>
+        <div id="description">Specify the URL of a tileset to load:
+            <input type="text" id="url" />
+            <button id="readURLButton">Load</button>
             <div class="marg">
                 <button id="loadLyonButton">Load Lyon 1 (Mesh)</button>
                 <button id="loadSeteButton">Load Sete (Point Cloud)</button>
                 <button id="loadLilleButton">Load Lille (Mesh)</button>
                 <div id="share"></div>
-            </div>
-            <hr />
-            <p><b>Feature Colors</b></p>
-            <div id="featureColors" class="marg">
-                <em>Load a tileset to see feature types</em>
             </div>
             <hr />
             <p id="featureInfoText" class="marg"><em>Display feature information by clicking on it</em></p>
@@ -188,9 +75,7 @@
             import {
                 zoomToLayer,
                 fillHTMLWithPickingInfo,
-                extractBuildingId,
             } from './jsm/OGC3DTilesHelper.js';
-            import { createHTMLListFromObject } from './jsm/GUI/GuiTools.js';
 
             const {
                 TMSSource, WMTSSource, OGC3DTilesSource,
@@ -198,45 +83,57 @@
                 GlobeView, Coordinates, Fetcher,
             } = itowns;
 
-            // ── Layer registry ────────────────────────────────────────────────────────
-            // layerRegistry: rowId → { layerId, layer, guiFolder, state }
-            const layerRegistry = new Map();
-            let layerCounter = 0;
-            let rowCounter    = 0;
+            window.layer = null; // 3D Tiles layer
 
             const uri = new URL(location);
 
             window.gui = new dat.GUI();
 
-            // ── GlobeView ─────────────────────────────────────────────────────────────
+            // ---- Create a GlobeView ----
 
+            // Define camera initial position
             const placement = {
                 coord: new Coordinates('EPSG:4326', 2.351323, 48.856712),
                 range: 12500000,
             };
 
+            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             const viewerDiv = document.getElementById('viewerDiv');
 
+            // Create a GlobeView
             const view = new GlobeView(viewerDiv, placement, {
-                controls: { minDistance: 100 },
+                controls: {
+                    minDistance: 100,
+                }
             });
 
+            // Enable various compression support for 3D Tiles tileset:
+            // - `KHR_draco_mesh_compression` mesh compression extension
+            // - `KHR_texture_basisu` texture compression extension
+            // - `EXT_meshopt_compression` data compression extension
             itowns.enableDracoLoader('./libs/draco/');
             itowns.enableKtx2Loader('./lib/basis/', view.renderer);
             itowns.enableMeshoptDecoder(MeshoptDecoder);
 
+            // Add ambient light to globally illuminates all objects
             const light = new AmbientLight(0x404040, 40);
             view.scene.add(light);
 
+            // Set the environment map for all physical materials in the scene.
+            // Otherwise, mesh with only diffuse colors will appear black.
             const environment = new RoomEnvironment();
             const pmremGenerator = new PMREMGenerator(view.renderer);
             view.scene.environment = pmremGenerator.fromScene(environment).texture;
             pmremGenerator.dispose();
 
+            // Setup loading screen
             setupLoadingScreen(viewerDiv, view);
 
-            // ── Basemap ───────────────────────────────────────────────────────────────
+            // ---- Add a basemap ----
 
+            // Add one imagery layer to the scene. This layer's properties are
+            // defined in a json file, but it cou   ld be defined as a plain js
+            // object. See `Layer` documentation for more info.
             Fetcher.json('./layers/JSONLayers/OPENSM.json').then((config) => {
                 const colorLayer = new ColorLayer('Ortho', {
                     ...config,
@@ -245,6 +142,10 @@
                 view.addLayer(colorLayer);
             });
 
+            // ---- Add 3D terrain ----
+
+            // Add two elevation layers: world terrain and a more precise terrain for france
+            // These will deform iTowns globe geometry to represent terrain elevation.
             function addElevationLayerFromConfig(config) {
                 config.source = new itowns.WMTSSource(config.source);
                 var elevationLayer = new itowns.ElevationLayer(config.id, config);
@@ -253,455 +154,105 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
 
-            // ── Helpers ───────────────────────────────────────────────────────────────
+            // ---------- 3D Tiles loading
 
-            /** Return a short label from a URL string (parent dir, or hostname). */
-            function shortName(url) {
-                try {
-                    const u = new URL(url);
-                    const parts = u.pathname.replace(/\/tileset\.json$/i, '').split('/').filter(Boolean);
-                    return parts[parts.length - 1] || u.hostname || url;
-                } catch {
-                    return url.split('/').filter(Boolean).pop() || url;
-                }
-            }
-
-            /** Push the current set of loaded URLs into the address bar. */
-            function syncUrlParams() {
-                uri.searchParams.delete('3dtiles');
-                for (const entry of layerRegistry.values()) {
-                    uri.searchParams.append('3dtiles', entry.url);
-                }
-                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
-            }
-
-            // ── Tileset rows (HTML) ───────────────────────────────────────────────────
-
-            /**
-             * Create a new URL-input row in the panel.
-             * If `url` is supplied the text field is pre-filled but not loaded yet.
-             */
-            function addTilesetRow(url = '') {
-                const rowId = ++rowCounter;
-
-                const row = document.createElement('div');
-                row.className = 'tileset-row';
-                row.dataset.rowId = rowId;
-
-                const urlInput = document.createElement('input');
-                urlInput.type = 'text';
-                urlInput.className = 'layer-url';
-                urlInput.placeholder = 'Enter tileset URL…';
-                urlInput.value = url;
-
-                const loadBtn = document.createElement('button');
-                loadBtn.className = 'load-btn';
-                loadBtn.textContent = 'Load';
-
-                const removeBtn = document.createElement('button');
-                removeBtn.className = 'remove-btn';
-                removeBtn.textContent = '×';
-                removeBtn.title = 'Remove this tileset';
-
-                row.appendChild(urlInput);
-                row.appendChild(loadBtn);
-                row.appendChild(removeBtn);
-                document.getElementById('tilesets-container').appendChild(row);
-
-                loadBtn.addEventListener('click', () => {
-                    const u = urlInput.value.trim();
-                    if (u) addTileset(rowId, u);
-                });
-
-                urlInput.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter') {
-                        const u = urlInput.value.trim();
-                        if (u) addTileset(rowId, u);
-                    }
-                });
-
-                removeBtn.addEventListener('click', () => removeTileset(rowId, row));
+            function readURL() {
+                const url = document.getElementById('url').value;
 
                 if (url) {
-                    addTileset(rowId, url);
+                    setUrl(url);
                 }
-
-                return row;
             }
 
-            // ── Load / remove tilesets ────────────────────────────────────────────────
+            function setUrl(url) {
+                if (!url) return;
 
-            /**
-             * Load a tileset URL and associate it with the given panel row.
-             * If the row already has a loaded layer, remove it first.
-             */
-            function addTileset(rowId, url) {
-                if (layerRegistry.has(rowId)) {
-                    _removeRegistryEntry(rowId);
-                }
+                const input_url = document.getElementById('url');
+                if (!input_url) return;
 
-                const layerId = '3DTiles_' + (++layerCounter);
+                uri.searchParams.set('3dtiles', url);
+                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
 
-                // Single-tileset mode: disable load buttons
-                document.getElementById('addTilesetBtn').disabled = true;
-                document.getElementById('loadLyonButton').disabled = true;
-                document.getElementById('loadSeteButton').disabled = true;
-                document.getElementById('loadLilleButton').disabled = true;
+                input_url.value = url;
+                load(url);
+            }
 
+
+            function load(url) {
                 const source = new OGC3DTilesSource({ url });
 
-                const layer = new OGC3DTilesLayer(layerId, {
+                if (window.layer) {
+                    gui.removeFolder('Layer 3DTiles');
+                    view.removeLayer('3DTiles');
+                    view.notifyChange();
+                    window.layer.delete();
+                }
+
+                window.layer = new OGC3DTilesLayer('3DTiles', {
                     source,
                     pntsSizeMode: PNTS_SIZE_MODE.ATTENUATED,
                 });
 
-                const state = { visible: true, opacity: 1.0 };
+                // Add an event for picking the 3D Tiles layer and displaying
+                // information about the picked feature in an html div
+                const pickingArgs = {
+                    htmlDiv: document.getElementById('featureInfo'),
+                    view,
+                    layer: window.layer,
+                };
 
-                const label = shortName(url) + ' (#' + layerCounter + ')';
-                const folder = window.gui.addFolder(label);
-
-                folder.add(state, 'visible').name('Visible').onChange(v => {
-                    layer.visible = v;
-                    view.notifyChange();
+                // Add the layer to our view
+                view.addLayer(window.layer).then((layer) => {
+                    zoomToLayer(view, layer);
+                    window.addEventListener('click',
+                        (event) => fillHTMLWithPickingInfo(event, pickingArgs), false);
                 });
 
-                folder.add(state, 'opacity', 0, 1, 0.01).name('Opacity').onChange(v => {
-                    layer.opacity = v;
-                    view.notifyChange();
-                });
-
-                folder.open();
-
-                // ── Feature Colors (in #description panel) ─────────────
-                const typeColors = new Map();
-                const originalColors = new Map();
-                let rebuildTimer = null;
-                const featureColorsDiv = document.getElementById('featureColors');
-
-                function getFeatureType(feature) {
-                    let type;
-                    if (feature.userData?.CityObjectType) {
-                        type = feature.userData.CityObjectType;
-                    } else {
-                        try {
-                            const bt = feature.getInfo?.()?.batchTable;
-                            if (bt) {
-                                type = bt.surface_type || bt.CityObjectType || bt.type;
-                            }
-                        } catch {}
-                    }
-                    if (!type) return 'Unknown';
-                    type = type.replace(/\0/g, '');
-                    // Group sub-types with their parent
-                    if (type === 'BuildingPart') return 'Building';
-                    return type;
-                }
-
-                function applyTypeColors() {
-                    if (typeColors.size === 0) {
-                        layer.style = null;
-                    } else {
-                        layer.style = {
-                            fill: {
-                                color: (feature) => {
-                                    const t = getFeatureType(feature);
-                                    return typeColors.get(t) || originalColors.get(t) || '#ffffff';
-                                },
-                                opacity: 1.0,
-                            },
-                        };
-                    }
-                    view.notifyChange();
-                }
-
-                function getColorForType(typeName) {
-                    for (const [, featuresMap] of layer._tileFeatures) {
-                        for (const [, feature] of featuresMap) {
-                            if (getFeatureType(feature) !== typeName) continue;
-                            const geom = feature.object3d.geometry;
-                            const colorAttr = geom?.getAttribute('color');
-                            if (colorAttr && feature.groups?.length) {
-                                // groups are in index-buffer space; look up actual vertex
-                                const indexAttr = geom.getIndex();
-                                const startIdx = feature.groups[0].start;
-                                const vertexIdx = indexAttr ? indexAttr.getX(startIdx) : startIdx;
-                                const r = colorAttr.getX(vertexIdx);
-                                const g = colorAttr.getY(vertexIdx);
-                                const b = colorAttr.getZ(vertexIdx);
-                                const c = new THREE.Color(r, g, b);
-                                return '#' + c.getHexString();
-                            }
-                        }
-                    }
-                    return '#ffffff';
-                }
-
-                // Track which types already have DOM rows to avoid
-                // destroying elements while the user interacts with them
-                const knownTypes = new Set();
-
-                function rebuildColorList() {
-                    const types = new Set();
-                    for (const [, featuresMap] of layer._tileFeatures) {
-                        for (const [, feature] of featuresMap) {
-                            types.add(getFeatureType(feature));
-                        }
-                    }
-
-                    if (types.size === 0) {
-                        featureColorsDiv.innerHTML = '<em>No features loaded</em>';
-                        knownTypes.clear();
-                        return;
-                    }
-
-                    // Only add new types; never destroy existing rows
-                    const newTypes = [...types].filter(t => !knownTypes.has(t)).sort();
-                    if (newTypes.length === 0) return;
-
-                    // Add Reset button on first population
-                    if (knownTypes.size === 0) {
-                        featureColorsDiv.innerHTML = '';
-                        const resetBtn = document.createElement('button');
-                        resetBtn.className = 'color-reset-btn';
-                        resetBtn.textContent = 'Reset All';
-                        resetBtn.addEventListener('click', () => {
-                            typeColors.clear();
-                            originalColors.clear();
-                            knownTypes.clear();
-                            rebuildColorList();
-                            applyTypeColors();
-                        });
-                        featureColorsDiv.appendChild(resetBtn);
-                    }
-
-                    for (const typeName of newTypes) {
-                        knownTypes.add(typeName);
-
-                        if (!originalColors.has(typeName)) {
-                            originalColors.set(typeName, getColorForType(typeName));
-                        }
-
-                        const row = document.createElement('div');
-                        row.className = 'color-row';
-
-                        const lbl = document.createElement('label');
-                        lbl.textContent = typeName;
-                        lbl.title = typeName;
-
-                        const picker = document.createElement('input');
-                        picker.type = 'color';
-                        picker.value = typeColors.get(typeName) || originalColors.get(typeName);
-                        picker.title = 'Click to open color picker';
-
-                        function onPickerChange() {
-                            typeColors.set(typeName, picker.value);
-                            applyTypeColors();
-                        }
-                        picker.addEventListener('change', onPickerChange);
-
-                        row.appendChild(lbl);
-                        row.appendChild(picker);
-                        featureColorsDiv.appendChild(row);
-                    }
-                }
-
-                layer.addEventListener('load-model', () => {
-                    clearTimeout(rebuildTimer);
-                    rebuildTimer = setTimeout(rebuildColorList, 500);
-                });
-
-                layerRegistry.set(rowId, { layerId, layer, guiFolder: folder, state, url });
-
-                view.addLayer(layer).then((_layer) => {
-                    zoomToLayer(view, _layer);
-                });
-
-                syncUrlParams();
+                window.layer.whenReady
+                    .then(() => debug.createOGC3DTilesDebugUI(gui, view, window.layer));
             }
-
-            /** Remove the loaded layer for rowId (but keep the HTML row). */
-            function _removeRegistryEntry(rowId) {
-                const entry = layerRegistry.get(rowId);
-                if (!entry) return;
-
-                try { window.gui.removeFolder(entry.guiFolder); } catch {}
-                try { view.removeLayer(entry.layerId); } catch {}
-                try { entry.layer.delete(); } catch {}
-
-                layerRegistry.delete(rowId);
-                syncUrlParams();
-
-                // Re-enable load buttons if no tilesets remain
-                if (layerRegistry.size === 0) {
-                    document.getElementById('addTilesetBtn').disabled = false;
-                    document.getElementById('loadLyonButton').disabled = false;
-                    document.getElementById('loadSeteButton').disabled = false;
-                    document.getElementById('loadLilleButton').disabled = false;
-                    document.getElementById('featureColors').innerHTML =
-                        '<em>Load a tileset to see feature types</em>';
-                }
-            }
-
-            /** Remove both the HTML row and its loaded layer. */
-            function removeTileset(rowId, rowEl) {
-                _removeRegistryEntry(rowId);
-                rowEl.remove();
-            }
-
-            // ── Preset buttons ────────────────────────────────────────────────────────
 
             function loadLyon() {
-                const row = addTilesetRow("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/refs/heads/master/3DTiles/lyon1-4978/tileset.json");
+                setUrl("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/refs/heads/master/3DTiles/lyon1-4978/tileset.json");
             }
 
             function loadSete() {
-                const row = addTilesetRow("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/pnts-sete-2021-0756_6256/tileset.json");
+                setUrl("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/pnts-sete-2021-0756_6256/tileset.json");
             }
 
             function loadLille() {
-                const row = addTilesetRow("https://webimaging.lillemetropole.fr/externe/maillage/2020_mel_5cm/tileset.json");
+                setUrl("https://webimaging.lillemetropole.fr/externe/maillage/2020_mel_5cm/tileset.json");
             }
 
-            document.getElementById('loadLyonButton').addEventListener('click', loadLyon);
-            document.getElementById('loadSeteButton').addEventListener('click', loadSete);
-            document.getElementById('loadLilleButton').addEventListener('click', loadLille);
-            document.getElementById('addTilesetBtn').addEventListener('click', () => addTilesetRow());
 
-            // ── Picking / feature info ────────────────────────────────────────────────
+            
 
-            // Click: fill the feature info panel from whichever layer is hit
-            window.addEventListener('click', (event) => {
-                const activeLayers = [...layerRegistry.values()].map(e => e.layer);
-                if (!activeLayers.length) return;
-                // Pick against all active layers; use the first hit
-                for (const layer of activeLayers) {
-                    const intersects = view.pickObjectsAt(event, 5, layer);
-                    if (intersects && intersects.length > 0) {
-                        fillHTMLWithPickingInfo(event, {
-                            htmlDiv: document.getElementById('featureInfo'),
-                            view,
-                            layer,
-                        });
-                        break;
-                    }
-                }
-            }, false);
+            const readUrlButton = document.getElementById('readURLButton');
+            
+            const loadLyonButton = document.getElementById('loadLyonButton');
+            const loadSeteButton = document.getElementById('loadSeteButton');
+            const loadLilleButton = document.getElementById('loadLilleButton');
 
-            // ── Tooltip ───────────────────────────────────────────────────────────────
+            loadLyonButton.addEventListener('click', loadLyon);
+            loadSeteButton.addEventListener('click', loadSete);
+            loadLilleButton.addEventListener('click', loadLille);
+            readUrlButton.addEventListener('click', readURL);
 
-            window.tooltipEnabled = false;
-
-            let tooltip = null;
-            let tooltipContent = null;
-
-            function initTooltip() {
-                tooltip = document.getElementById('tooltip');
-                tooltipContent = tooltip && tooltip.querySelector('.tooltip-content');
-                return !!(tooltip && tooltipContent);
-            }
-
-            setTimeout(initTooltip, 0);
-
-            function showTooltip(event, featureInfo) {
-                if (!window.tooltipEnabled || !tooltip || !tooltipContent) return;
-                if (!featureInfo || !featureInfo.hasChildNodes()) return;
-
-                while (tooltipContent.firstChild) tooltipContent.removeChild(tooltipContent.firstChild);
-                tooltipContent.appendChild(featureInfo.cloneNode(true));
-
-                tooltip.classList.add('visible');
-                tooltip.style.display = 'block';
-
-                const offset = 15;
-                let left = event.clientX + offset;
-                let top  = event.clientY + offset;
-                tooltip.style.left = `${left}px`;
-                tooltip.style.top  = `${top}px`;
-
-                void tooltip.offsetHeight;
-                const rect = tooltip.getBoundingClientRect();
-                if (rect.right  > window.innerWidth)  left = event.clientX - rect.width  - offset;
-                if (rect.bottom > window.innerHeight)  top  = event.clientY - rect.height - offset;
-                if (left < 0) left = offset;
-                if (top  < 0) top  = offset;
-                tooltip.style.left = `${left}px`;
-                tooltip.style.top  = `${top}px`;
-            }
-
-            function hideTooltip() {
-                if (!tooltip || !tooltipContent) return;
-                tooltip.classList.remove('visible');
-                tooltip.style.display = 'none';
-                while (tooltipContent.firstChild) tooltipContent.removeChild(tooltipContent.firstChild);
-            }
-
-            function onMouseMove(event) {
-                if (!window.tooltipEnabled) return;
-                if (!tooltip || !tooltipContent) { initTooltip(); hideTooltip(); return; }
-
-                const canvas = viewerDiv.querySelector('canvas');
-                const target = event.target;
-                const isOverViewer = target === canvas || target === viewerDiv || viewerDiv.contains(target);
-                if (!isOverViewer) { hideTooltip(); return; }
-
-                // Pick from all loaded layers; use first hit
-                const activeLayers = [...layerRegistry.values()].map(e => e.layer);
-                const pickEl = canvas || viewerDiv;
-                const pickRect = pickEl.getBoundingClientRect();
-                const viewCoords = { x: event.clientX - pickRect.left, y: event.clientY - pickRect.top };
-
-                for (const layer of activeLayers) {
-                    try {
-                        const intersects = view.pickObjectsAt(viewCoords, 5, layer);
-                        const closest = layer.getC3DTileFeatureFromIntersectsArray(intersects);
-                        if (closest) {
-                            const tempDiv = document.createElement('div');
-                            layer.getMetadataFromIntersections(intersects).then((meta) => {
-                                if (!window.tooltipEnabled) return;
-                                const buildingId = extractBuildingId(meta);
-                                if (buildingId != null) {
-                                    tempDiv.appendChild(createHTMLListFromObject({ BuildingId: buildingId }));
-                                } else {
-                                    tempDiv.appendChild(createHTMLListFromObject({
-                                        BuildingId: '(not in tile)',
-                                        batchId: closest.batchId ?? closest.batchid ?? '—',
-                                    }));
-                                }
-                                showTooltip(event, tempDiv);
-                            }).catch(() => {
-                                if (window.tooltipEnabled) {
-                                    tempDiv.appendChild(createHTMLListFromObject({
-                                        BuildingId: '(unavailable)',
-                                        batchId: closest.batchId ?? closest.batchid ?? '—',
-                                    }));
-                                    showTooltip(event, tempDiv);
-                                }
-                            });
-                            return;
-                        }
-                    } catch {}
-                }
-                hideTooltip();
-            }
-
-            viewerDiv.addEventListener('mousemove', onMouseMove, { passive: true });
-            viewerDiv.addEventListener('mouseleave', hideTooltip);
-            window.addEventListener('mousemove', onMouseMove, { passive: true });
-
-            // ── Expose globals ────────────────────────────────────────────────────────
-
-            window.layerRegistry = layerRegistry;
+            window.readURL = readURL;
+            window.loadLyon = loadLyon;
+            window.loadSete = loadSete;
+            window.loadLille = loadLille;
             window.view = view;
             window.itowns = itowns;
             window.THREE = THREE;
-            window.tooltipEnabled = false;
-
-            // ── Load URLs from query string ───────────────────────────────────────────
-
-            (function loadFromQueryString() {
-                const passedUrls = uri.searchParams.getAll('3dtiles');
-                passedUrls.forEach(u => { if (u) addTilesetRow(u); });
-            })();
+            
+            function loadPassedModel() {
+                const passedUrl = uri.searchParams.get('3dtiles');
+                if (passedUrl) {
+                    setUrl(passedUrl);
+                }
+            }
+            loadPassedModel();
 
         </script>
     </body>

--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -1,5 +1,5 @@
 <html>
-    <head>
+   <head>
         <title>Itowns - 3D Tiles loader</title>
 
         <script type="importmap">
@@ -27,6 +27,7 @@
             #description {
                 z-index: 2;
                 left: 10px;
+                max-width: 420px;
             }
 
             #featureInfoText {
@@ -36,19 +37,131 @@
             #description .marg {
                 margin: 10px;
             }
+
+            /* ---- tileset rows ---- */
+            #tilesets-container {
+                margin: 6px 0 4px 0;
+            }
+
+            .tileset-row {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                margin-bottom: 4px;
+            }
+
+            .layer-url {
+                flex: 1;
+                min-width: 0;
+                font-size: 11px;
+                padding: 2px 4px;
+                height: 22px;
+                box-sizing: border-box;
+            }
+
+            .load-btn, .remove-btn {
+                flex-shrink: 0;
+                font-size: 12px;
+                padding: 2px 6px;
+                height: 22px;
+                cursor: pointer;
+            }
+
+            .remove-btn {
+                color: #c00;
+                font-weight: bold;
+            }
+
+            #addTilesetBtn {
+                font-size: 12px;
+                padding: 2px 8px;
+                margin-bottom: 4px;
+                cursor: pointer;
+            }
+
+            /* ---- tooltip ---- */
+            #tooltip {
+                position: fixed;
+                left: 0;
+                top: 0;
+                background-color: rgba(0, 0, 0, 0.9);
+                color: white;
+                padding: 8px 12px;
+                border-radius: 4px;
+                font-size: 12px;
+                pointer-events: none;
+                z-index: 2147483647;
+                max-width: 400px;
+                max-height: 300px;
+                overflow-y: auto;
+                display: none;
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+            }
+
+            #tooltip.visible {
+                display: block !important;
+                visibility: visible !important;
+                opacity: 1 !important;
+            }
+
+            #tooltip .tooltip-content {
+                margin: 0;
+            }
+
+            /* ---- feature color panel ---- */
+            .color-row {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                margin-bottom: 4px;
+                font-size: 12px;
+            }
+
+            .color-row label {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .color-row input[type="color"] {
+                width: 30px;
+                height: 22px;
+                padding: 0;
+                border: 1px solid #999;
+                cursor: pointer;
+                background: none;
+            }
+
+            .color-reset-btn {
+                font-size: 11px;
+                padding: 3px 10px;
+                margin-bottom: 6px;
+                cursor: pointer;
+            }
         </style>
 
     </head>
     <body>
         <div id="viewerDiv"></div>
-        <div id="description">Specify the URL of a tileset to load:
-            <input type="text" id="url" />
-            <button id="readURLButton">Load</button>
+        <div id="tooltip">
+            <div class="tooltip-content"></div>
+        </div>
+        <div id="description">
+            <b>Tilesets</b>
+            <div id="tilesets-container"></div>
+            <button id="addTilesetBtn">+ Add tileset</button>
             <div class="marg">
                 <button id="loadLyonButton">Load Lyon 1 (Mesh)</button>
                 <button id="loadSeteButton">Load Sete (Point Cloud)</button>
                 <button id="loadLilleButton">Load Lille (Mesh)</button>
                 <div id="share"></div>
+            </div>
+            <hr />
+            <p><b>Feature Colors</b></p>
+            <div id="featureColors" class="marg">
+                <em>Load a tileset to see feature types</em>
             </div>
             <hr />
             <p id="featureInfoText" class="marg"><em>Display feature information by clicking on it</em></p>
@@ -75,7 +188,9 @@
             import {
                 zoomToLayer,
                 fillHTMLWithPickingInfo,
+                extractBuildingId,
             } from './jsm/OGC3DTilesHelper.js';
+            import { createHTMLListFromObject } from './jsm/GUI/GuiTools.js';
 
             const {
                 TMSSource, WMTSSource, OGC3DTilesSource,
@@ -83,57 +198,45 @@
                 GlobeView, Coordinates, Fetcher,
             } = itowns;
 
-            window.layer = null; // 3D Tiles layer
+            // ── Layer registry ────────────────────────────────────────────────────────
+            // layerRegistry: rowId → { layerId, layer, guiFolder, state }
+            const layerRegistry = new Map();
+            let layerCounter = 0;
+            let rowCounter    = 0;
 
             const uri = new URL(location);
 
             window.gui = new dat.GUI();
 
-            // ---- Create a GlobeView ----
+            // ── GlobeView ─────────────────────────────────────────────────────────────
 
-            // Define camera initial position
             const placement = {
                 coord: new Coordinates('EPSG:4326', 2.351323, 48.856712),
                 range: 12500000,
             };
 
-            // `viewerDiv` will contain iTowns' rendering area (`<canvas>`)
             const viewerDiv = document.getElementById('viewerDiv');
 
-            // Create a GlobeView
             const view = new GlobeView(viewerDiv, placement, {
-                controls: {
-                    minDistance: 100,
-                }
+                controls: { minDistance: 100 },
             });
 
-            // Enable various compression support for 3D Tiles tileset:
-            // - `KHR_draco_mesh_compression` mesh compression extension
-            // - `KHR_texture_basisu` texture compression extension
-            // - `EXT_meshopt_compression` data compression extension
             itowns.enableDracoLoader('./libs/draco/');
             itowns.enableKtx2Loader('./lib/basis/', view.renderer);
             itowns.enableMeshoptDecoder(MeshoptDecoder);
 
-            // Add ambient light to globally illuminates all objects
             const light = new AmbientLight(0x404040, 40);
             view.scene.add(light);
 
-            // Set the environment map for all physical materials in the scene.
-            // Otherwise, mesh with only diffuse colors will appear black.
             const environment = new RoomEnvironment();
             const pmremGenerator = new PMREMGenerator(view.renderer);
             view.scene.environment = pmremGenerator.fromScene(environment).texture;
             pmremGenerator.dispose();
 
-            // Setup loading screen
             setupLoadingScreen(viewerDiv, view);
 
-            // ---- Add a basemap ----
+            // ── Basemap ───────────────────────────────────────────────────────────────
 
-            // Add one imagery layer to the scene. This layer's properties are
-            // defined in a json file, but it cou   ld be defined as a plain js
-            // object. See `Layer` documentation for more info.
             Fetcher.json('./layers/JSONLayers/OPENSM.json').then((config) => {
                 const colorLayer = new ColorLayer('Ortho', {
                     ...config,
@@ -142,10 +245,6 @@
                 view.addLayer(colorLayer);
             });
 
-            // ---- Add 3D terrain ----
-
-            // Add two elevation layers: world terrain and a more precise terrain for france
-            // These will deform iTowns globe geometry to represent terrain elevation.
             function addElevationLayerFromConfig(config) {
                 config.source = new itowns.WMTSSource(config.source);
                 var elevationLayer = new itowns.ElevationLayer(config.id, config);
@@ -154,105 +253,455 @@
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json').then(addElevationLayerFromConfig);
             itowns.Fetcher.json('./layers/JSONLayers/WORLD_DTM.json').then(addElevationLayerFromConfig);
 
-            // ---------- 3D Tiles loading
+            // ── Helpers ───────────────────────────────────────────────────────────────
 
-            function readURL() {
-                const url = document.getElementById('url').value;
+            /** Return a short label from a URL string (parent dir, or hostname). */
+            function shortName(url) {
+                try {
+                    const u = new URL(url);
+                    const parts = u.pathname.replace(/\/tileset\.json$/i, '').split('/').filter(Boolean);
+                    return parts[parts.length - 1] || u.hostname || url;
+                } catch {
+                    return url.split('/').filter(Boolean).pop() || url;
+                }
+            }
+
+            /** Push the current set of loaded URLs into the address bar. */
+            function syncUrlParams() {
+                uri.searchParams.delete('3dtiles');
+                for (const entry of layerRegistry.values()) {
+                    uri.searchParams.append('3dtiles', entry.url);
+                }
+                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
+            }
+
+            // ── Tileset rows (HTML) ───────────────────────────────────────────────────
+
+            /**
+             * Create a new URL-input row in the panel.
+             * If `url` is supplied the text field is pre-filled but not loaded yet.
+             */
+            function addTilesetRow(url = '') {
+                const rowId = ++rowCounter;
+
+                const row = document.createElement('div');
+                row.className = 'tileset-row';
+                row.dataset.rowId = rowId;
+
+                const urlInput = document.createElement('input');
+                urlInput.type = 'text';
+                urlInput.className = 'layer-url';
+                urlInput.placeholder = 'Enter tileset URL…';
+                urlInput.value = url;
+
+                const loadBtn = document.createElement('button');
+                loadBtn.className = 'load-btn';
+                loadBtn.textContent = 'Load';
+
+                const removeBtn = document.createElement('button');
+                removeBtn.className = 'remove-btn';
+                removeBtn.textContent = '×';
+                removeBtn.title = 'Remove this tileset';
+
+                row.appendChild(urlInput);
+                row.appendChild(loadBtn);
+                row.appendChild(removeBtn);
+                document.getElementById('tilesets-container').appendChild(row);
+
+                loadBtn.addEventListener('click', () => {
+                    const u = urlInput.value.trim();
+                    if (u) addTileset(rowId, u);
+                });
+
+                urlInput.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        const u = urlInput.value.trim();
+                        if (u) addTileset(rowId, u);
+                    }
+                });
+
+                removeBtn.addEventListener('click', () => removeTileset(rowId, row));
 
                 if (url) {
-                    setUrl(url);
+                    addTileset(rowId, url);
                 }
+
+                return row;
             }
 
-            function setUrl(url) {
-                if (!url) return;
+            // ── Load / remove tilesets ────────────────────────────────────────────────
 
-                const input_url = document.getElementById('url');
-                if (!input_url) return;
+            /**
+             * Load a tileset URL and associate it with the given panel row.
+             * If the row already has a loaded layer, remove it first.
+             */
+            function addTileset(rowId, url) {
+                if (layerRegistry.has(rowId)) {
+                    _removeRegistryEntry(rowId);
+                }
 
-                uri.searchParams.set('3dtiles', url);
-                history.replaceState(null, null, `?${uri.searchParams.toString()}`);
+                const layerId = '3DTiles_' + (++layerCounter);
 
-                input_url.value = url;
-                load(url);
-            }
+                // Single-tileset mode: disable load buttons
+                document.getElementById('addTilesetBtn').disabled = true;
+                document.getElementById('loadLyonButton').disabled = true;
+                document.getElementById('loadSeteButton').disabled = true;
+                document.getElementById('loadLilleButton').disabled = true;
 
-
-            function load(url) {
                 const source = new OGC3DTilesSource({ url });
 
-                if (window.layer) {
-                    gui.removeFolder('Layer 3DTiles');
-                    view.removeLayer('3DTiles');
-                    view.notifyChange();
-                    window.layer.delete();
-                }
-
-                window.layer = new OGC3DTilesLayer('3DTiles', {
+                const layer = new OGC3DTilesLayer(layerId, {
                     source,
                     pntsSizeMode: PNTS_SIZE_MODE.ATTENUATED,
                 });
 
-                // Add an event for picking the 3D Tiles layer and displaying
-                // information about the picked feature in an html div
-                const pickingArgs = {
-                    htmlDiv: document.getElementById('featureInfo'),
-                    view,
-                    layer: window.layer,
-                };
+                const state = { visible: true, opacity: 1.0 };
 
-                // Add the layer to our view
-                view.addLayer(window.layer).then((layer) => {
-                    zoomToLayer(view, layer);
-                    window.addEventListener('click',
-                        (event) => fillHTMLWithPickingInfo(event, pickingArgs), false);
+                const label = shortName(url) + ' (#' + layerCounter + ')';
+                const folder = window.gui.addFolder(label);
+
+                folder.add(state, 'visible').name('Visible').onChange(v => {
+                    layer.visible = v;
+                    view.notifyChange();
                 });
 
-                window.layer.whenReady
-                    .then(() => debug.createOGC3DTilesDebugUI(gui, view, window.layer));
+                folder.add(state, 'opacity', 0, 1, 0.01).name('Opacity').onChange(v => {
+                    layer.opacity = v;
+                    view.notifyChange();
+                });
+
+                folder.open();
+
+                // ── Feature Colors (in #description panel) ─────────────
+                const typeColors = new Map();
+                const originalColors = new Map();
+                let rebuildTimer = null;
+                const featureColorsDiv = document.getElementById('featureColors');
+
+                function getFeatureType(feature) {
+                    let type;
+                    if (feature.userData?.CityObjectType) {
+                        type = feature.userData.CityObjectType;
+                    } else {
+                        try {
+                            const bt = feature.getInfo?.()?.batchTable;
+                            if (bt) {
+                                type = bt.surface_type || bt.CityObjectType || bt.type;
+                            }
+                        } catch {}
+                    }
+                    if (!type) return 'Unknown';
+                    type = type.replace(/\0/g, '');
+                    // Group sub-types with their parent
+                    if (type === 'BuildingPart') return 'Building';
+                    return type;
+                }
+
+                function applyTypeColors() {
+                    if (typeColors.size === 0) {
+                        layer.style = null;
+                    } else {
+                        layer.style = {
+                            fill: {
+                                color: (feature) => {
+                                    const t = getFeatureType(feature);
+                                    return typeColors.get(t) || originalColors.get(t) || '#ffffff';
+                                },
+                                opacity: 1.0,
+                            },
+                        };
+                    }
+                    view.notifyChange();
+                }
+
+                function getColorForType(typeName) {
+                    for (const [, featuresMap] of layer._tileFeatures) {
+                        for (const [, feature] of featuresMap) {
+                            if (getFeatureType(feature) !== typeName) continue;
+                            const geom = feature.object3d.geometry;
+                            const colorAttr = geom?.getAttribute('color');
+                            if (colorAttr && feature.groups?.length) {
+                                // groups are in index-buffer space; look up actual vertex
+                                const indexAttr = geom.getIndex();
+                                const startIdx = feature.groups[0].start;
+                                const vertexIdx = indexAttr ? indexAttr.getX(startIdx) : startIdx;
+                                const r = colorAttr.getX(vertexIdx);
+                                const g = colorAttr.getY(vertexIdx);
+                                const b = colorAttr.getZ(vertexIdx);
+                                const c = new THREE.Color(r, g, b);
+                                return '#' + c.getHexString();
+                            }
+                        }
+                    }
+                    return '#ffffff';
+                }
+
+                // Track which types already have DOM rows to avoid
+                // destroying elements while the user interacts with them
+                const knownTypes = new Set();
+
+                function rebuildColorList() {
+                    const types = new Set();
+                    for (const [, featuresMap] of layer._tileFeatures) {
+                        for (const [, feature] of featuresMap) {
+                            types.add(getFeatureType(feature));
+                        }
+                    }
+
+                    if (types.size === 0) {
+                        featureColorsDiv.innerHTML = '<em>No features loaded</em>';
+                        knownTypes.clear();
+                        return;
+                    }
+
+                    // Only add new types; never destroy existing rows
+                    const newTypes = [...types].filter(t => !knownTypes.has(t)).sort();
+                    if (newTypes.length === 0) return;
+
+                    // Add Reset button on first population
+                    if (knownTypes.size === 0) {
+                        featureColorsDiv.innerHTML = '';
+                        const resetBtn = document.createElement('button');
+                        resetBtn.className = 'color-reset-btn';
+                        resetBtn.textContent = 'Reset All';
+                        resetBtn.addEventListener('click', () => {
+                            typeColors.clear();
+                            originalColors.clear();
+                            knownTypes.clear();
+                            rebuildColorList();
+                            applyTypeColors();
+                        });
+                        featureColorsDiv.appendChild(resetBtn);
+                    }
+
+                    for (const typeName of newTypes) {
+                        knownTypes.add(typeName);
+
+                        if (!originalColors.has(typeName)) {
+                            originalColors.set(typeName, getColorForType(typeName));
+                        }
+
+                        const row = document.createElement('div');
+                        row.className = 'color-row';
+
+                        const lbl = document.createElement('label');
+                        lbl.textContent = typeName;
+                        lbl.title = typeName;
+
+                        const picker = document.createElement('input');
+                        picker.type = 'color';
+                        picker.value = typeColors.get(typeName) || originalColors.get(typeName);
+                        picker.title = 'Click to open color picker';
+
+                        function onPickerChange() {
+                            typeColors.set(typeName, picker.value);
+                            applyTypeColors();
+                        }
+                        picker.addEventListener('change', onPickerChange);
+
+                        row.appendChild(lbl);
+                        row.appendChild(picker);
+                        featureColorsDiv.appendChild(row);
+                    }
+                }
+
+                layer.addEventListener('load-model', () => {
+                    clearTimeout(rebuildTimer);
+                    rebuildTimer = setTimeout(rebuildColorList, 500);
+                });
+
+                layerRegistry.set(rowId, { layerId, layer, guiFolder: folder, state, url });
+
+                view.addLayer(layer).then((_layer) => {
+                    zoomToLayer(view, _layer);
+                });
+
+                syncUrlParams();
             }
 
+            /** Remove the loaded layer for rowId (but keep the HTML row). */
+            function _removeRegistryEntry(rowId) {
+                const entry = layerRegistry.get(rowId);
+                if (!entry) return;
+
+                try { window.gui.removeFolder(entry.guiFolder); } catch {}
+                try { view.removeLayer(entry.layerId); } catch {}
+                try { entry.layer.delete(); } catch {}
+
+                layerRegistry.delete(rowId);
+                syncUrlParams();
+
+                // Re-enable load buttons if no tilesets remain
+                if (layerRegistry.size === 0) {
+                    document.getElementById('addTilesetBtn').disabled = false;
+                    document.getElementById('loadLyonButton').disabled = false;
+                    document.getElementById('loadSeteButton').disabled = false;
+                    document.getElementById('loadLilleButton').disabled = false;
+                    document.getElementById('featureColors').innerHTML =
+                        '<em>Load a tileset to see feature types</em>';
+                }
+            }
+
+            /** Remove both the HTML row and its loaded layer. */
+            function removeTileset(rowId, rowEl) {
+                _removeRegistryEntry(rowId);
+                rowEl.remove();
+            }
+
+            // ── Preset buttons ────────────────────────────────────────────────────────
+
             function loadLyon() {
-                setUrl("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/refs/heads/master/3DTiles/lyon1-4978/tileset.json");
+                const row = addTilesetRow("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/refs/heads/master/3DTiles/lyon1-4978/tileset.json");
             }
 
             function loadSete() {
-                setUrl("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/pnts-sete-2021-0756_6256/tileset.json");
+                const row = addTilesetRow("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/pointclouds/pnts-sete-2021-0756_6256/tileset.json");
             }
 
             function loadLille() {
-                setUrl("https://webimaging.lillemetropole.fr/externe/maillage/2020_mel_5cm/tileset.json");
+                const row = addTilesetRow("https://webimaging.lillemetropole.fr/externe/maillage/2020_mel_5cm/tileset.json");
             }
 
+            document.getElementById('loadLyonButton').addEventListener('click', loadLyon);
+            document.getElementById('loadSeteButton').addEventListener('click', loadSete);
+            document.getElementById('loadLilleButton').addEventListener('click', loadLille);
+            document.getElementById('addTilesetBtn').addEventListener('click', () => addTilesetRow());
 
-            
+            // ── Picking / feature info ────────────────────────────────────────────────
 
-            const readUrlButton = document.getElementById('readURLButton');
-            
-            const loadLyonButton = document.getElementById('loadLyonButton');
-            const loadSeteButton = document.getElementById('loadSeteButton');
-            const loadLilleButton = document.getElementById('loadLilleButton');
+            // Click: fill the feature info panel from whichever layer is hit
+            window.addEventListener('click', (event) => {
+                const activeLayers = [...layerRegistry.values()].map(e => e.layer);
+                if (!activeLayers.length) return;
+                // Pick against all active layers; use the first hit
+                for (const layer of activeLayers) {
+                    const intersects = view.pickObjectsAt(event, 5, layer);
+                    if (intersects && intersects.length > 0) {
+                        fillHTMLWithPickingInfo(event, {
+                            htmlDiv: document.getElementById('featureInfo'),
+                            view,
+                            layer,
+                        });
+                        break;
+                    }
+                }
+            }, false);
 
-            loadLyonButton.addEventListener('click', loadLyon);
-            loadSeteButton.addEventListener('click', loadSete);
-            loadLilleButton.addEventListener('click', loadLille);
-            readUrlButton.addEventListener('click', readURL);
+            // ── Tooltip ───────────────────────────────────────────────────────────────
 
-            window.readURL = readURL;
-            window.loadLyon = loadLyon;
-            window.loadSete = loadSete;
-            window.loadLille = loadLille;
+            window.tooltipEnabled = false;
+
+            let tooltip = null;
+            let tooltipContent = null;
+
+            function initTooltip() {
+                tooltip = document.getElementById('tooltip');
+                tooltipContent = tooltip && tooltip.querySelector('.tooltip-content');
+                return !!(tooltip && tooltipContent);
+            }
+
+            setTimeout(initTooltip, 0);
+
+            function showTooltip(event, featureInfo) {
+                if (!window.tooltipEnabled || !tooltip || !tooltipContent) return;
+                if (!featureInfo || !featureInfo.hasChildNodes()) return;
+
+                while (tooltipContent.firstChild) tooltipContent.removeChild(tooltipContent.firstChild);
+                tooltipContent.appendChild(featureInfo.cloneNode(true));
+
+                tooltip.classList.add('visible');
+                tooltip.style.display = 'block';
+
+                const offset = 15;
+                let left = event.clientX + offset;
+                let top  = event.clientY + offset;
+                tooltip.style.left = `${left}px`;
+                tooltip.style.top  = `${top}px`;
+
+                void tooltip.offsetHeight;
+                const rect = tooltip.getBoundingClientRect();
+                if (rect.right  > window.innerWidth)  left = event.clientX - rect.width  - offset;
+                if (rect.bottom > window.innerHeight)  top  = event.clientY - rect.height - offset;
+                if (left < 0) left = offset;
+                if (top  < 0) top  = offset;
+                tooltip.style.left = `${left}px`;
+                tooltip.style.top  = `${top}px`;
+            }
+
+            function hideTooltip() {
+                if (!tooltip || !tooltipContent) return;
+                tooltip.classList.remove('visible');
+                tooltip.style.display = 'none';
+                while (tooltipContent.firstChild) tooltipContent.removeChild(tooltipContent.firstChild);
+            }
+
+            function onMouseMove(event) {
+                if (!window.tooltipEnabled) return;
+                if (!tooltip || !tooltipContent) { initTooltip(); hideTooltip(); return; }
+
+                const canvas = viewerDiv.querySelector('canvas');
+                const target = event.target;
+                const isOverViewer = target === canvas || target === viewerDiv || viewerDiv.contains(target);
+                if (!isOverViewer) { hideTooltip(); return; }
+
+                // Pick from all loaded layers; use first hit
+                const activeLayers = [...layerRegistry.values()].map(e => e.layer);
+                const pickEl = canvas || viewerDiv;
+                const pickRect = pickEl.getBoundingClientRect();
+                const viewCoords = { x: event.clientX - pickRect.left, y: event.clientY - pickRect.top };
+
+                for (const layer of activeLayers) {
+                    try {
+                        const intersects = view.pickObjectsAt(viewCoords, 5, layer);
+                        const closest = layer.getC3DTileFeatureFromIntersectsArray(intersects);
+                        if (closest) {
+                            const tempDiv = document.createElement('div');
+                            layer.getMetadataFromIntersections(intersects).then((meta) => {
+                                if (!window.tooltipEnabled) return;
+                                const buildingId = extractBuildingId(meta);
+                                if (buildingId != null) {
+                                    tempDiv.appendChild(createHTMLListFromObject({ BuildingId: buildingId }));
+                                } else {
+                                    tempDiv.appendChild(createHTMLListFromObject({
+                                        BuildingId: '(not in tile)',
+                                        batchId: closest.batchId ?? closest.batchid ?? '—',
+                                    }));
+                                }
+                                showTooltip(event, tempDiv);
+                            }).catch(() => {
+                                if (window.tooltipEnabled) {
+                                    tempDiv.appendChild(createHTMLListFromObject({
+                                        BuildingId: '(unavailable)',
+                                        batchId: closest.batchId ?? closest.batchid ?? '—',
+                                    }));
+                                    showTooltip(event, tempDiv);
+                                }
+                            });
+                            return;
+                        }
+                    } catch {}
+                }
+                hideTooltip();
+            }
+
+            viewerDiv.addEventListener('mousemove', onMouseMove, { passive: true });
+            viewerDiv.addEventListener('mouseleave', hideTooltip);
+            window.addEventListener('mousemove', onMouseMove, { passive: true });
+
+            // ── Expose globals ────────────────────────────────────────────────────────
+
+            window.layerRegistry = layerRegistry;
             window.view = view;
             window.itowns = itowns;
             window.THREE = THREE;
-            
-            function loadPassedModel() {
-                const passedUrl = uri.searchParams.get('3dtiles');
-                if (passedUrl) {
-                    setUrl(passedUrl);
-                }
-            }
-            loadPassedModel();
+            window.tooltipEnabled = false;
+
+            // ── Load URLs from query string ───────────────────────────────────────────
+
+            (function loadFromQueryString() {
+                const passedUrls = uri.searchParams.getAll('3dtiles');
+                passedUrls.forEach(u => { if (u) addTilesetRow(u); });
+            })();
 
         </script>
     </body>

--- a/examples/jsm/OGC3DTilesHelper.js
+++ b/examples/jsm/OGC3DTilesHelper.js
@@ -6,8 +6,27 @@ import { Coordinates, Extent, CameraUtils } from 'itowns';
 import { createHTMLListFromObject } from './GUI/GuiTools.js';
 
 /**
+ * Extract the CityJSON Building id from metadata returned by getMetadataFromIntersections.
+ * Prefer BuildingId (Tyler), then id. Returns the first non-null value found in the metadata array.
+ * @param {Array<Object>|null} metadata
+ * @returns {string|null}
+ */
+export function extractBuildingId(metadata) {
+    if (!Array.isArray(metadata)) { return null; }
+    for (const m of metadata) {
+        if (m && typeof m === 'object') {
+            if (m.BuildingId != null && m.BuildingId !== '') { return String(m.BuildingId); }
+            if (m.id != null && m.id !== '') { return String(m.id); }
+        }
+    }
+    return null;
+}
+
+/**
  * Function allowing picking on a given 3D tiles layer and filling an html div
- * with information on the picked feature.
+ * with information on the picked feature. Displays only the BuildingId (the id
+ * that links to the CityJSON building) when present, so users can report e.g.
+ * "Building 253 is missing a wall".
  * @param {MouseEvent} event
  * @param {Object} pickingArg
  * @param {HTMLDivElement} pickingArg.htmlDiv - div element which contains the
@@ -26,20 +45,37 @@ export function fillHTMLWithPickingInfo(event, pickingArg) {
 
     // Get intersected objects
     const intersects = view.pickObjectsAt(event, 5, layer);
-
-    // Get information from intersected objects (from the batch table and
-    // eventually the 3D Tiles extensions
     const closestC3DTileFeature =
         layer.getC3DTileFeatureFromIntersectsArray(intersects);
 
-    if (closestC3DTileFeature) {
-        // eslint-disable-next-line
-        htmlDiv.appendChild(createHTMLListFromObject(closestC3DTileFeature));
-    }
-
+    // Resolve metadata first; show only BuildingId when present (CityJSON building id)
     layer.getMetadataFromIntersections(intersects).then((metadata) => {
-        // eslint-disable-next-line
-        metadata?.forEach(m => htmlDiv.appendChild(createHTMLListFromObject(m)));
+        const buildingId = extractBuildingId(metadata);
+        if (buildingId != null) {
+            htmlDiv.appendChild(createHTMLListFromObject({ BuildingId: buildingId }));
+        } else {
+            // No BuildingId in tile (e.g. old tiles); show batchId as fallback with a note
+            const batchId = closestC3DTileFeature?.batchId ?? closestC3DTileFeature?.batchid ?? '—';
+            htmlDiv.appendChild(createHTMLListFromObject({
+                BuildingId: '(not in tile)',
+                batchId,
+                note: 'Tile has no BuildingId; batchId is the feature index in this tile.',
+            }));
+        }
+    }).catch((err) => {
+        console.warn('getMetadataFromIntersections failed (e.g. missing EXT_structural_metadata):', err?.message ?? err);
+        const i0 = intersects?.[0];
+        const batchId = closestC3DTileFeature?.batchId ?? closestC3DTileFeature?.batchid ?? '—';
+        const fallback = {
+            BuildingId: '(unavailable)',
+            note: 'Metadata unavailable (no property table or error)',
+            batchId,
+        };
+        if (i0?.distance != null) { fallback.distance = Number(i0.distance).toFixed(2); }
+        if (i0?.point) {
+            fallback.point = { x: i0.point.x?.toFixed(2), y: i0.point.y?.toFixed(2), z: i0.point.z?.toFixed(2) };
+        }
+        htmlDiv.appendChild(createHTMLListFromObject(fallback));
     });
 }
 

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -23,7 +23,6 @@ import PointsMaterial, {
     ClassificationScheme,
 } from 'Renderer/PointsMaterial';
 import { VIEW_EVENTS } from 'Core/View';
-// eslint-disable-next-line no-unused-vars
 import Style from 'Core/Style';
 import C3DTFeature from 'Core/3DTiles/C3DTFeature';
 import { optimizeGeometryGroups } from 'Utils/ThreeUtils';
@@ -785,7 +784,7 @@ class OGC3DTilesLayer extends GeometryLayer {
 
                     const color = new THREE.Color(this._style.fill.color);
                     const opacity = this._style.fill.opacity;
-                    const materialId = color.getHexString() + opacity;
+                    const materialId = `${color.getHexString()}_${opacity}`;
 
                     let material;
                     if (this._fillColorMaterials.has(materialId)) {
@@ -880,6 +879,7 @@ class OGC3DTilesLayer extends GeometryLayer {
         } else if (!value) {
             this._style = null;
             this._restoreOriginalMaterials();
+            return;
         } else {
             this._style = new Style(value);
         }

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -23,8 +23,24 @@ import PointsMaterial, {
     ClassificationScheme,
 } from 'Renderer/PointsMaterial';
 import { VIEW_EVENTS } from 'Core/View';
+// eslint-disable-next-line no-unused-vars
+import Style from 'Core/Style';
+import C3DTFeature from 'Core/3DTiles/C3DTFeature';
+import { optimizeGeometryGroups } from 'Utils/ThreeUtils';
 
 const _raycaster = new THREE.Raycaster();
+
+/**
+ * Returns the feature ID buffer attribute from a geometry, checking 3D Tiles
+ * 1.1 attribute names first, then falling back to 1.0.
+ * @param {THREE.BufferGeometry} geometry
+ * @returns {THREE.BufferAttribute|undefined}
+ */
+function getFeatureIdAttribute(geometry) {
+    return geometry?.getAttribute('_FEATURE_ID_0')
+        ?? geometry?.getAttribute('_feature_id_0')
+        ?? geometry?.getAttribute('_batchid');
+}
 
 // Stores lruCache, downloadQueue and parseQueue for each id of view {@link View}
 // every time a tileset has been added
@@ -430,6 +446,16 @@ class OGC3DTilesLayer extends GeometryLayer {
             this.sseThreshold = config.sseThreshold;
         }
 
+        // Per-feature styling state
+        /** @type {Map<THREE.Object3D, Map<number, C3DTFeature>>} */
+        this._tileFeatures = new Map();
+        /** @type {Map<string, THREE.Material>} */
+        this._fillColorMaterials = new Map();
+        /** @type {Style|null} */
+        this._style = null;
+        /** @type {Map<THREE.Object3D, Map<THREE.Mesh, THREE.Material>>} */
+        this._originalMaterials = new Map();
+
         // Used for custom schedule callbacks (VR)
         this.tasks = [];
         this.tilesSchedulingCB = (func) => {
@@ -524,7 +550,19 @@ class OGC3DTilesLayer extends GeometryLayer {
                 this._assignFinalMaterial(obj);
                 this._assignFinalAttributes(obj);
             });
+            try {
+                this._initFeatures(scene);
+                if (this._style) {
+                    this.updateStyle();
+                }
+            } catch (err) {
+                console.warn('[OGC3DTilesLayer] Feature init error:', err);
+            }
             view.notifyChange(this);
+        });
+
+        this.tilesRenderer.addEventListener('dispose-model', (e) => {
+            this._cleanupTileFeatures(e.scene);
         });
 
         this._setupCacheAndQueues(view);
@@ -586,6 +624,280 @@ class OGC3DTilesLayer extends GeometryLayer {
         }
     }
 
+    /**
+     * Initialize C3DTFeature objects from a loaded tile scene. Scans meshes
+     * for feature ID attributes (_FEATURE_ID_0 for 3D Tiles 1.1, _batchid
+     * for 1.0) and groups vertices by feature ID.
+     * @param {THREE.Object3D} scene - tile content root
+     * @private
+     */
+    _initFeatures(scene) {
+        const featuresMap = new Map();
+        const originalMats = new Map();
+
+        scene.traverse((child) => {
+            if (!child.isMesh) { return; }
+
+            const featureIdAttr = getFeatureIdAttribute(child.geometry);
+            if (!featureIdAttr) { return; }
+
+            // Save original material for later restore
+            originalMats.set(child, child.material);
+
+            const indexAttr = child.geometry.getIndex();
+
+            const registerGroup = (currentFeatureId, start, count) => {
+                if (featuresMap.has(currentFeatureId)) {
+                    featuresMap.get(currentFeatureId).groups.push({ start, count });
+                } else {
+                    const feature = new C3DTFeature(
+                        scene.uuid,
+                        currentFeatureId,
+                        [{ start, count }],
+                        {},
+                        child,
+                    );
+                    featuresMap.set(currentFeatureId, feature);
+                }
+            };
+
+            if (indexAttr) {
+                // Indexed geometry: groups must be in index-buffer space
+                // for addGroup() to work correctly.
+                const indexCount = indexAttr.count;
+                if (indexCount === 0) { return; }
+
+                let currentFeatureId = featureIdAttr.getX(indexAttr.getX(0));
+                let start = 0;
+                let count = 0;
+
+                for (let i = 0; i < indexCount; i++) {
+                    const vertexIdx = indexAttr.getX(i);
+                    const featureId = featureIdAttr.getX(vertexIdx);
+                    if (featureId !== currentFeatureId) {
+                        registerGroup(currentFeatureId, start, count);
+                        currentFeatureId = featureId;
+                        start = i;
+                        count = 0;
+                    }
+                    count++;
+                    if (i === indexCount - 1) {
+                        registerGroup(currentFeatureId, start, count);
+                    }
+                }
+            } else {
+                // Non-indexed geometry: groups in vertex space
+                const positionAttr = child.geometry.getAttribute('position');
+                const vertexCount = positionAttr.count;
+                if (vertexCount === 0) { return; }
+
+                let currentFeatureId = featureIdAttr.getX(0);
+                let start = 0;
+                let count = 0;
+
+                for (let i = 0; i < vertexCount; i++) {
+                    const featureId = featureIdAttr.getX(i);
+                    if (featureId !== currentFeatureId) {
+                        registerGroup(currentFeatureId, start, count);
+                        currentFeatureId = featureId;
+                        start = i;
+                        count = 0;
+                    }
+                    count++;
+                    if (i === vertexCount - 1) {
+                        registerGroup(currentFeatureId, start, count);
+                    }
+                }
+            }
+        });
+
+        if (featuresMap.size > 0) {
+            this._tileFeatures.set(scene, featuresMap);
+            this._originalMaterials.set(scene, originalMats);
+            this._populateFeatureMetadata(scene, featuresMap);
+        }
+    }
+
+    /**
+     * Populate C3DTFeature userData from EXT_structural_metadata property
+     * tables. This makes per-feature properties (e.g. CityObjectType)
+     * available in style callbacks via feature.userData.
+     * @param {THREE.Object3D} scene - tile content root
+     * @param {Map<number, C3DTFeature>} featuresMap - feature map
+     * @private
+     */
+    _populateFeatureMetadata(scene, featuresMap) {
+        scene.traverse((child) => {
+            if (!child.isMesh) { return; }
+
+            const { meshFeatures, structuralMetadata } = child.userData;
+            if (!meshFeatures || !structuralMetadata) { return; }
+
+            const featureInfo = meshFeatures.getFeatureInfo();
+            if (!featureInfo || featureInfo.length === 0) { return; }
+
+            const tableIndex = featureInfo[0].propertyTable;
+            if (tableIndex === undefined) { return; }
+
+            for (const [featureId, feature] of featuresMap) {
+                if (feature.object3d !== child) { continue; }
+
+                const data = structuralMetadata.getPropertyTableData(
+                    tableIndex, featureId,
+                );
+                if (data) {
+                    Object.assign(feature.userData, data);
+                }
+            }
+        });
+    }
+
+    /**
+     * Update style of the C3DTFeatures. Evaluates the style callbacks for each
+     * feature and assigns materials via geometry groups.
+     * @returns {boolean} true if style was applied, false otherwise
+     */
+    updateStyle() {
+        if (!this._style) {
+            return false;
+        }
+
+        const currentMaterials = [];
+
+        for (const [, featuresMap] of this._tileFeatures) {
+            // Group features by their object3d
+            const meshFeatures = new Map();
+            for (const [, feature] of featuresMap) {
+                if (!meshFeatures.has(feature.object3d)) {
+                    meshFeatures.set(feature.object3d, []);
+                }
+                meshFeatures.get(feature.object3d).push(feature);
+            }
+
+            for (const [object3d, features] of meshFeatures) {
+                object3d.geometry.clearGroups();
+                object3d.material = [];
+
+                for (const feature of features) {
+                    this._style.context.setGeometry({
+                        properties: feature,
+                    });
+
+                    const color = new THREE.Color(this._style.fill.color);
+                    const opacity = this._style.fill.opacity;
+                    const materialId = color.getHexString() + opacity;
+
+                    let material;
+                    if (this._fillColorMaterials.has(materialId)) {
+                        material = this._fillColorMaterials.get(materialId);
+                    } else {
+                        material = new THREE.MeshStandardMaterial({
+                            color,
+                            opacity,
+                            transparent: opacity < 1,
+                            alphaTest: 0.09,
+                        });
+                        this._fillColorMaterials.set(materialId, material);
+                    }
+
+                    // Find or add material in object3d.material array
+                    let materialIndex = object3d.material.indexOf(material);
+                    if (materialIndex < 0) {
+                        object3d.material.push(material);
+                        materialIndex = object3d.material.length - 1;
+                    }
+
+                    feature.groups.forEach((group) => {
+                        object3d.geometry.addGroup(
+                            group.start, group.count, materialIndex,
+                        );
+                    });
+                }
+
+                optimizeGeometryGroups(object3d);
+
+                // Record materials in use
+                if (Array.isArray(object3d.material)) {
+                    object3d.material.forEach((m) => {
+                        if (!currentMaterials.includes(m)) {
+                            currentMaterials.push(m);
+                        }
+                    });
+                } else if (!currentMaterials.includes(object3d.material)) {
+                    currentMaterials.push(object3d.material);
+                }
+            }
+        }
+
+        // Remove unused cached materials
+        for (const [id, material] of this._fillColorMaterials) {
+            if (!currentMaterials.includes(material)) {
+                material.dispose();
+                this._fillColorMaterials.delete(id);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Restore original materials on all styled meshes. Called when style is
+     * set to null.
+     * @private
+     */
+    _restoreOriginalMaterials() {
+        for (const [, originalMats] of this._originalMaterials) {
+            for (const [mesh, material] of originalMats) {
+                mesh.geometry.clearGroups();
+                mesh.material = material;
+            }
+        }
+
+        // Dispose all cached style materials
+        this._fillColorMaterials.forEach(m => m.dispose());
+        this._fillColorMaterials.clear();
+    }
+
+    /**
+     * Remove features and original materials for a disposed tile scene.
+     * @param {THREE.Object3D} scene - tile content root
+     * @private
+     */
+    _cleanupTileFeatures(scene) {
+        this._tileFeatures.delete(scene);
+        this._originalMaterials.delete(scene);
+    }
+
+    /**
+     * Sets the style for per-feature coloring. Accepts a Style instance, a
+     * plain object with fill.color / fill.opacity callbacks, or null to
+     * restore original materials.
+     * @param {Style|Object|null} value - the style to apply
+     */
+    set style(value) {
+        if (value instanceof Style) {
+            this._style = value;
+        } else if (!value) {
+            this._style = null;
+            this._restoreOriginalMaterials();
+        } else {
+            this._style = new Style(value);
+        }
+        this.updateStyle();
+    }
+
+    get style() {
+        return this._style;
+    }
+
+    /**
+     * Number of cached fill-color materials currently in use.
+     * @type {number}
+     */
+    get materialCount() {
+        return this._fillColorMaterials.size;
+    }
+
     handleTasks() {
         for (let t = 0, l = this.tasks.length; t < l; t++) {
             this.tasks[t]();
@@ -619,6 +931,12 @@ class OGC3DTilesLayer extends GeometryLayer {
         }
 
         this.tilesRenderer.dispose();
+
+        // Clean up styling state
+        this._tileFeatures.clear();
+        this._fillColorMaterials.forEach(m => m.dispose());
+        this._fillColorMaterials.clear();
+        this._originalMaterials.clear();
 
         // Clean up references
         this.tilesSchedulingCB = null;
@@ -662,24 +980,35 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         const { face, index, object, instanceId } = intersects[0];
 
+        const featureIdAttr = getFeatureIdAttribute(object.geometry);
+
         /** @type{number|null} */
         let batchId;
         if (object.isPoints && index != null) {
-            batchId = object.geometry.getAttribute('_batchid')?.getX(index) ?? index;
+            batchId = featureIdAttr?.getX(index) ?? index;
         } else if (object.isMesh && face) {
-            batchId = object.geometry.getAttribute('_batchid')?.getX(face.a) ?? instanceId;
+            batchId = featureIdAttr?.getX(face.a) ?? instanceId;
         }
 
         if (batchId === undefined) {
             return null;
         }
 
+        // Look up in feature map first (works for both 1.0 and 1.1)
+        for (const [, featuresMap] of this._tileFeatures) {
+            const feature = featuresMap.get(batchId);
+            if (feature && feature.object3d === object) {
+                return feature;
+            }
+        }
+
+        // Fall back to batch table lookup (original behavior)
         let tileObject = object;
-        while (!tileObject.batchTable) {
+        while (tileObject && !tileObject.batchTable) {
             tileObject = tileObject.parent;
         }
 
-        return tileObject.batchTable.getDataFromId(batchId);
+        return tileObject?.batchTable?.getDataFromId(batchId) ?? null;
     }
 
     /**

--- a/packages/Main/src/Utils/ThreeUtils.js
+++ b/packages/Main/src/Utils/ThreeUtils.js
@@ -90,10 +90,15 @@ export function optimizeGeometryGroups(object3D) {
             usedIndexMaterials.push(currentMaterialIndex);
             continue;
         } else {
-            // indeed same group merge with previous group
+            // Same materialIndex — only merge when the two groups are
+            // contiguous in vertex space.  Non-contiguous runs occur with
+            // per-feature styling when different feature types interleave.
             const previousGroup = object3D.geometry.groups[index + 1];
-            previousGroup.count += group.count; // previous group wrap the current one
-            object3D.geometry.groups.splice(index, 1); // remove group
+            if (group.start + group.count === previousGroup.start) {
+                previousGroup.start = group.start;
+                previousGroup.count += group.count;
+                object3D.geometry.groups.splice(index, 1);
+            }
         }
     }
 

--- a/packages/Main/test/unit/ogc3dtileslayer.js
+++ b/packages/Main/test/unit/ogc3dtileslayer.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import * as THREE from 'three';
 import OGC3DTilesSource from 'Source/OGC3DTilesSource';
 import OGC3DTilesLayer, {
     itownsGLTFLoader,
@@ -249,5 +250,146 @@ describe('OGC3DTilesLayer', function () {
         material.classificationTexture.userData.transparent = false;
         assert.equal(material.opacity, layer.opacity);
         assert.equal(material.transparent, layer.opacity < 1.0);
+    });
+
+    // Helper: create a mock tile scene with _FEATURE_ID_0 attribute (3D Tiles 1.1)
+    function createMockScene11(featureIds) {
+        const geometry = new THREE.BufferGeometry();
+        const positions = new Float32Array(featureIds.length * 3);
+        geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.setAttribute(
+            '_FEATURE_ID_0',
+            new THREE.BufferAttribute(new Uint16Array(featureIds), 1),
+        );
+
+        const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.isMesh = true;
+
+        const scene = new THREE.Group();
+        scene.add(mesh);
+        return { scene, mesh, material };
+    }
+
+    it('should initialize features from _FEATURE_ID_0 (3D Tiles 1.1)', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+        // 6 vertices: feature 0 (3 verts), feature 1 (2 verts), feature 2 (1 vert)
+        const { scene } = createMockScene11([0, 0, 0, 1, 1, 2]);
+
+        layer._initFeatures(scene);
+
+        assert.equal(layer._tileFeatures.size, 1);
+        const featuresMap = layer._tileFeatures.get(scene);
+        assert.ok(featuresMap);
+        assert.equal(featuresMap.size, 3);
+
+        const f0 = featuresMap.get(0);
+        assert.equal(f0.batchId, 0);
+        assert.deepEqual(f0.groups, [{ start: 0, count: 3 }]);
+
+        const f1 = featuresMap.get(1);
+        assert.equal(f1.batchId, 1);
+        assert.deepEqual(f1.groups, [{ start: 3, count: 2 }]);
+
+        const f2 = featuresMap.get(2);
+        assert.equal(f2.batchId, 2);
+        assert.deepEqual(f2.groups, [{ start: 5, count: 1 }]);
+    });
+
+    it('should initialize features from _batchid (3D Tiles 1.0 fallback)', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+
+        const geometry = new THREE.BufferGeometry();
+        const positions = new Float32Array(9); // 3 vertices
+        geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.setAttribute(
+            '_batchid',
+            new THREE.BufferAttribute(new Int32Array([5, 5, 7]), 1),
+        );
+
+        const material = new THREE.MeshStandardMaterial();
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.isMesh = true;
+
+        const scene = new THREE.Group();
+        scene.add(mesh);
+
+        layer._initFeatures(scene);
+
+        const featuresMap = layer._tileFeatures.get(scene);
+        assert.equal(featuresMap.size, 2);
+        assert.ok(featuresMap.has(5));
+        assert.ok(featuresMap.has(7));
+    });
+
+    it('should apply style to features and create materials', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+        const { scene } = createMockScene11([0, 0, 1, 1]);
+
+        layer._initFeatures(scene);
+
+        layer.style = {
+            fill: {
+                color: (feature) => {
+                    if (feature.batchId === 0) { return 'red'; }
+                    return 'blue';
+                },
+                opacity: 1.0,
+            },
+        };
+
+        // 2 distinct colors => 2 materials
+        assert.equal(layer.materialCount, 2);
+    });
+
+    it('should restore original materials when style is set to null', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+        const { scene, mesh, material: originalMaterial } = createMockScene11([0, 0, 1, 1]);
+
+        layer._initFeatures(scene);
+
+        // Apply style
+        layer.style = {
+            fill: {
+                color: 'red',
+                opacity: 1.0,
+            },
+        };
+
+        assert.notEqual(mesh.material, originalMaterial);
+
+        // Remove style
+        layer.style = null;
+
+        assert.equal(mesh.material, originalMaterial);
+        assert.equal(layer.materialCount, 0);
+    });
+
+    it('should clean up tile features on dispose', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+        const { scene } = createMockScene11([0, 0, 1, 1]);
+
+        layer._initFeatures(scene);
+        assert.equal(layer._tileFeatures.size, 1);
+
+        layer._cleanupTileFeatures(scene);
+        assert.equal(layer._tileFeatures.size, 0);
+    });
+
+    it('should pick features using _FEATURE_ID_0', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+        const { scene, mesh } = createMockScene11([0, 0, 0, 1, 1, 2]);
+
+        layer._initFeatures(scene);
+
+        // Simulate picking vertex at face.a = 4 (featureId = 1)
+        const intersects = [{
+            face: { a: 4, b: 5, c: 3 },
+            object: mesh,
+        }];
+
+        const result = layer.getC3DTileFeatureFromIntersectsArray(intersects);
+        assert.ok(result);
+        assert.equal(result.batchId, 1);
     });
 });

--- a/packages/Main/test/unit/ogc3dtileslayer.js
+++ b/packages/Main/test/unit/ogc3dtileslayer.js
@@ -322,6 +322,64 @@ describe('OGC3DTilesLayer', function () {
         assert.ok(featuresMap.has(7));
     });
 
+    // Helper: create a mock indexed tile scene with _FEATURE_ID_0
+    function createMockScene11Indexed(featureIds, indices) {
+        const geometry = new THREE.BufferGeometry();
+        const positions = new Float32Array(featureIds.length * 3);
+        geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.setAttribute(
+            '_FEATURE_ID_0',
+            new THREE.BufferAttribute(new Uint16Array(featureIds), 1),
+        );
+        geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(indices), 1));
+
+        const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.isMesh = true;
+
+        const scene = new THREE.Group();
+        scene.add(mesh);
+        return { scene, mesh, material };
+    }
+
+    it('should initialize features from indexed geometry', function () {
+        const layer = new OGC3DTilesLayer('3dtiles', { source });
+        // 4 vertices with feature IDs: [0, 0, 1, 1]
+        // Index buffer references them: [0, 1, 2,  2, 3, 0] (6 indices, 2 triangles)
+        // Indices 0-2 map to vertices 0,1,2 => feature IDs 0,0,1
+        //   index 0 -> vertex 0 -> fid 0
+        //   index 1 -> vertex 1 -> fid 0
+        //   index 2 -> vertex 2 -> fid 1 (different => split)
+        // Indices 3-5 map to vertices 2,3,0 => feature IDs 1,1,0
+        //   index 3 -> vertex 2 -> fid 1
+        //   index 4 -> vertex 3 -> fid 1
+        //   index 5 -> vertex 0 -> fid 0 (different => split)
+        const { scene } = createMockScene11Indexed(
+            [0, 0, 1, 1],
+            [0, 1, 2, 2, 3, 0],
+        );
+
+        layer._initFeatures(scene);
+
+        const featuresMap = layer._tileFeatures.get(scene);
+        assert.ok(featuresMap);
+        assert.equal(featuresMap.size, 2);
+
+        const f0 = featuresMap.get(0);
+        assert.equal(f0.batchId, 0);
+        // Feature 0 appears in two non-contiguous runs in the index buffer:
+        // indices [0,1] (start=0, count=2) and index [5] (start=5, count=1)
+        assert.deepEqual(f0.groups, [
+            { start: 0, count: 2 },
+            { start: 5, count: 1 },
+        ]);
+
+        const f1 = featuresMap.get(1);
+        assert.equal(f1.batchId, 1);
+        // Feature 1: indices [2,3,4] (start=2, count=3)
+        assert.deepEqual(f1.groups, [{ start: 2, count: 3 }]);
+    });
+
     it('should apply style to features and create materials', function () {
         const layer = new OGC3DTilesLayer('3dtiles', { source });
         const { scene } = createMockScene11([0, 0, 1, 1]);


### PR DESCRIPTION
Note: This branch is based on master prior to the sky/atmosphere rendering merge (66a44d49), which introduced a camera/zoom regression I encountered. The changes in this PR are independent of that feature and should rebase cleanly once the regression is addressed.

Also, you will see in commit messages that code is generated by AI.  however, I have made sure I understand the code and I have deliberately kept the code edits limited in scope to ease the work of reviewers.

**PR message generated by AI; lightly modified by me**

## Description

Add per-feature styling capability to `OGC3DTilesLayer`, enabling color assignment by feature type (e.g. Building, SolitaryVegetationObject).  The original intent was to provide interactive visual rendering for 3DTiles 1.1 but 3D Tiles 1.0 behavior should be preserved.

**New functionality in `OGC3DTilesLayer`:**
- Detect feature IDs from `_FEATURE_ID_0` (3D Tiles 1.1) with `_batchid` (1.0) fallback
- Handle both indexed and non-indexed geometries when building feature groups
- Populate per-feature metadata from `EXT_structural_metadata` property tables into `C3DTFeature.userData`
- Support dynamic style application and removal via `layer.style` setter, with material caching
- Cache and restore original materials when style is toggled off
- Clean up tile features on `dispose-model` events

**Bug fix in `optimizeGeometryGroups` (`ThreeUtils.js`):**
- Only merge geometry groups that are contiguous in vertex space. Previously, groups sharing a `materialIndex` were merged unconditionally, which produced wrong vertex ranges when features of the same type interleave in the buffer (e.g. Building, Vegetation, Building).

**Tests:**
- 7 new unit tests covering feature init (1.1 + 1.0 fallback), indexed geometry, style apply, style restore, cleanup, and picking

**Examples:**
- New `3DTiles-11-styling.html`: interactive per-type color picker for any tileset URL
- Updated `OGC3DTilesHelper.js`

## Motivation and Context

There was no built-in way to style individual features in `OGC3DTilesLayer` by semantic type. Users working with CityGML-derived 3D Tiles (Buildings, Vegetation, etc.) had no API to assign colors per feature category.

This change brings `OGC3DTilesLayer` closer to the per-feature styling capabilities already present in the vector layer pipeline, and makes the 3D Tiles 1.1 `EXT_structural_metadata` / `EXT_mesh_features` extensions usable for styling.

Tested on Chrome 134 / Windows 11 (WSL2) with 3D Tiles 1.1 tilesets containing `EXT_structural_metadata`.

## Screenshots 

screenshot of `3DTiles-11-styling.html` showing color pickers and styled features.
<img width="613" height="620" alt="pr-screenshot" src="https://github.com/user-attachments/assets/0c59c2a9-5827-4bfe-a513-a7615874d423" />
