### PR TITLE
fix(cog): Fix fallback texture size

### DIFF
--- a/packages/Main/src/Parser/CogParser.ts
+++ b/packages/Main/src/Parser/CogParser.ts
@@ -111,9 +111,9 @@ async function parse(data: any, options: any) {
             + ` properties to at least ${extent.zoom + 1}.`,
         );
         texture = <TextureWithExtent> new DataTexture(
-            new Uint8Array(1),
-            1,
-            1,
+            new Uint8Array(tileRasterDimensions.x * tileRasterDimensions.y),
+            tileRasterDimensions.x,
+            tileRasterDimensions.y,
             RedFormat,
         );
     } else {

--- a/packages/Main/test/unit/cog.js
+++ b/packages/Main/test/unit/cog.js
@@ -144,8 +144,8 @@ describe('CogParser', function () {
                 extent: targetExtent,
             },
         );
-        assert.equal(texture.source.data.width, 1);
-        assert.equal(texture.source.data.height, 1);
+        assert.equal(texture.source.data.width, 256);
+        assert.equal(texture.source.data.height, 256);
         assert.equal(texture.format, RedFormat);
     });
 });


### PR DESCRIPTION
## Description
Fix for #2716

The old code created a 1×1-pixel fallback texture (new Uint8Array(1), 1, 1), whereas normal textures are 256×256. In LayeredMaterial.ts, all textures in the same tile set must have the same dimensions. When some tiles have a 256×256 texture and others have a 1×1 texture, the validation fails and displays the error.
