### PR TITLE
fix(CogSource): add zoom property and check in extentInsideLimit

### DIFF
--- a/packages/Main/src/Source/CogSource.ts
+++ b/packages/Main/src/Source/CogSource.ts
@@ -25,6 +25,13 @@ type CogSourceConfig = {
      * An optional decoder pool to use when extracting data from a COG image.
      */
     pool?: GeoTIFF.Pool;
+    /**
+     * Zoom level bounds for this source. Limits which tile zoom levels will
+     * request data from this COG. Required when used as an ElevationLayer
+     * source, since the tile system reads `source.zoom.max` to determine
+     * maximum subdivision depth.
+     */
+    zoom?: { min: number, max: number };
     [key: string]: any;  // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
@@ -61,6 +68,7 @@ class CogSource extends Source {
     defaultAlpha: number;
     resampleMethod: string;
     pool: GeoTIFF.Pool;
+    zoom: { min: number, max: number };
 
     /**
      * @param config - Source configuration.
@@ -70,6 +78,7 @@ class CogSource extends Source {
             pool = new GeoTIFF.Pool(),
             defaultAlpha = 255,
             resampleMethod = 'nearest',
+            zoom = { min: 0, max: Infinity },
             ...sourceConfig
         } = config;
 
@@ -83,6 +92,7 @@ class CogSource extends Source {
         this.defaultAlpha = defaultAlpha;
         this.pool = pool;
         this.resampleMethod = resampleMethod;
+        this.zoom = zoom;
 
         this.overviews = [];
 
@@ -126,8 +136,9 @@ class CogSource extends Source {
             });
     }
 
-    extentInsideLimit(extent: Extent) {
-        return this.extent.intersectsExtent(extent);
+    extentInsideLimit(extent: Extent, zoom: number) {
+        return zoom >= this.zoom.min && zoom <= this.zoom.max
+            && this.extent.intersectsExtent(extent);
     }
 
     urlFromExtent() {


### PR DESCRIPTION
Again all AI generated (below this sentence), but this is a simple and quite focused fix that allows using CogSource for elevation.


CogSource was missing the `zoom` property that all other Source subclasses set (TMSSource, WMTSSource, WMSSource, FileSource, WFSSource). This caused a crash in TiledGeometryLayer.preUpdate when CogSource was used as an ElevationLayer source, because the tile system reads `source.zoom.max` to determine maximum subdivision depth.

Additionally, `extentInsideLimit` was not checking the zoom parameter, causing the source to claim data availability at all zoom levels regardless of configuration.

Changes:
- Add `zoom` to CogSourceConfig type (default: { min: 0, max: Infinity })
- Add `zoom` class property and initialize from config in constructor
- Update `extentInsideLimit` to check zoom bounds, matching the contract used by other Source subclasses

## Before contributing

Read [CONTRIBUTING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) and [CODING.md](https://github.com/iTowns/itowns/blob/master/CONTRIBUTING.md) to apply `iTowns` conventions on PRs, Git history and code.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->

## Screenshots (if appropriate)
