### PR TITLE
fix(cog): Fix fallback texture format

### DIFF
--- a/packages/Main/src/Parser/CogParser.ts
+++ b/packages/Main/src/Parser/CogParser.ts
@@ -1,6 +1,6 @@
 import {
     DataTexture,
-    RedFormat,
+    RGBAFormat,
     Vector2,
 } from 'three';
 
@@ -111,10 +111,10 @@ async function parse(data: any, options: any) {
             + ` properties to at least ${extent.zoom + 1}.`,
         );
         texture = <TextureWithExtent> new DataTexture(
-            new Uint8Array(tileRasterDimensions.x * tileRasterDimensions.y),
+            new Uint8Array(1),
             tileRasterDimensions.x,
             tileRasterDimensions.y,
-            RedFormat,
+            RGBAFormat,
         );
     } else {
         texture = <TextureWithExtent> await overview.extractTexture({

--- a/packages/Main/test/unit/cog.js
+++ b/packages/Main/test/unit/cog.js
@@ -5,7 +5,6 @@ import { CRS, Extent } from '@itowns/geographic';
 
 import {
     UnsignedByteType,
-    RedFormat,
     RGBAFormat,
 } from 'three';
 
@@ -146,7 +145,7 @@ describe('CogParser', function () {
         );
         assert.equal(texture.source.data.width, 256);
         assert.equal(texture.source.data.height, 256);
-        assert.equal(texture.format, RedFormat);
+        assert.equal(texture.format, RGBAFormat);
     });
 });
 


### PR DESCRIPTION
## Description
When I hide the background map I see some black tiles (instead of blue tiles).
In COGParser the fallback texture must be transparent (quick fix).

But maybe it will need some deep optimization :
- Why tiles outside COG extent are affected by parse function from COGParser ? Wouldn't that make more sense if only tiles included in the extent computed from COGSource would be affected by parse funtion in COGParser ?

You can test our use case : https://github.com/bloc-in-bloc/itowns/blob/f/geotiff-big-extent-planarView/examples/demo_hackathon_orvault_planarView.html

## Screenshots (if appropriate)

If I hide map, I see geotiff but tiles outside geotiff extent is black.
<img width="1699" height="941" alt="without-fix" src="https://github.com/user-attachments/assets/fe6505ff-ea65-4a85-9e77-8138f83a4981" />

With the fix, if I hide map, tiles outside geotiff extent now look great (default blue color)
<img width="1575" height="939" alt="with-transparent-fallback-texture" src="https://github.com/user-attachments/assets/4a7f5c09-4f35-4f5b-b20d-cea5f9b05980" />
