### PR TITLE
fix(export): Add missing export

### DIFF
--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -38,6 +38,8 @@ export { default as Capabilities } from 'Core/System/Capabilities';
 export { CAMERA_TYPE } from 'Renderer/Camera';
 export { default as OBB } from 'Renderer/OBB';
 
+export { default as PointCloudNode } from 'Core/PointCloudNode';
+
 // Internal itowns format
 export { default as Feature, FeatureCollection, FeatureGeometry, FEATURE_TYPES } from 'Core/Feature';
 export { default as Style } from 'Core/Style';


### PR DESCRIPTION
## Motivation and Context

In typescript implementation, I need to access PointCloudNode from itowns but export is missing.

```typescript
import type { PointCloudNode } from "itowns";
```

I also added all the missing Node class exports in `Main.js`
