### PR TITLE
fix(types): Fix types output location

### DIFF
--- a/packages/Main/tsconfig.json
+++ b/packages/Main/tsconfig.json
@@ -6,7 +6,7 @@
         "declaration": true,
         "emitDeclarationOnly": true,
         "outDir": "lib",
-        "rootDir": ".",
+        "rootDir": "src",
         "baseUrl": "src"
     }
 }


### PR DESCRIPTION
## Motivation and Context
Output types location was wrong, typescript with eslint cannot correctly find the types.

In `packages/Main/tsconfig.json`, “rootDir”: “.” told TypeScript that the source root was the directory containing the entire package. Since the source files were located in `src/`, TypeScript preserved this subpath in the output, generating `lib/src/Main.d.ts` instead of the `lib/Main.d.ts` expected by the exports field in `package.json`.

## Screenshots (if appropriate)
Wihout the fix, types are located in `npm_modules/itowns/lib/src`.
<img width="569" height="800" alt="Capture d’écran 2026-04-05 à 11 56 20" src="https://github.com/user-attachments/assets/eaa4a392-1d42-43c7-ac6f-5e35d0ccc84b" />

So the linter doesn't understand correctly the type :
<img width="528" height="116" alt="Capture d’écran 2026-04-05 à 11 59 34" src="https://github.com/user-attachments/assets/e2215759-41a5-4ed4-bc14-e84f8f8a56dc" />

With the fix types are near the js files and linter understand correctly the type : 
<img width="436" height="644" alt="Capture d’écran 2026-04-05 à 12 00 14" src="https://github.com/user-attachments/assets/9a86199d-5a64-4d1b-a2ea-8fcf06c907b9" />

