### PR TITLE
fix(geographic): Fix geographic index types generation

### DIFF
--- a/packages/Geographic/package.json
+++ b/packages/Geographic/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "lib/index.js",
   "exports": {
-    "types": "./src/index.ts",
+    "types": "./lib/index.d.ts",
     "default": "./lib/index.js"
   },
-  "types": "./src/index.ts",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "build": "",
     "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"test/**/*.js\"",

--- a/packages/Geographic/tsconfig.json
+++ b/packages/Geographic/tsconfig.json
@@ -3,7 +3,7 @@
     "include": [ "src/index.ts" ],
     "exclude": [ "lib" ],
     "compilerOptions": {
-        "declaration": false,
+        "declaration": true,
         "outDir": "lib"
     }
 }


### PR DESCRIPTION
## Description
It seems index types generation of Geographic package is missing and wrong.

## Motivation and Context
When I compile my project with typescript, it check `node_modules/@itowns/geographic/src/Ellipsoid.ts` because package.json in `@itowns/geographic` contains `/src/index.ts` types.

## Screenshots (if appropriate)
<img width="1141" height="123" alt="Capture d’écran 2026-04-10 à 16 44 31" src="https://github.com/user-attachments/assets/f15b6b87-d783-40a9-aac0-13a7fbb2e06d" />
