### PR TITLE
fix(PlanarLayer): Erase extent if already exist (fix #2244)

### DIFF
--- a/packages/Main/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/packages/Main/src/Core/Prefab/Planar/PlanarLayer.js
@@ -40,10 +40,8 @@ class PlanarLayer extends TiledGeometryLayer {
         } = config;
 
         const tileMatrixSets = [extent.crs];
-        if (!globalExtentTMS.get(extent.crs)) {
-            // Add new global extent for this new crs projection.
-            globalExtentTMS.set(extent.crs, extent);
-        }
+        // Add new global extent for this new crs projection.
+        globalExtentTMS.set(extent.crs, extent);
 
         const builder = new PlanarTileBuilder({ crs: extent.crs });
         super(id, object3d || new THREE.Group(), [extent], builder, {


### PR DESCRIPTION
## Description
Fix for #2244 

## Motivation and Context
It's to fix an old issue until the proposal #2290 is implemented.
The quick fix is to erase extent if it already exist in `globalExtentTMS` for a CRS.
So we can delete and create new PlanarLayer with larger extent and same CRS.
