### PR TITLE
fix(PlanarLayer): Delete extent from globalExtentTMS const (fix #2244)

### DIFF
--- a/packages/Main/src/Core/Prefab/Planar/PlanarLayer.js
+++ b/packages/Main/src/Core/Prefab/Planar/PlanarLayer.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 import TiledGeometryLayer from 'Layer/TiledGeometryLayer';
-import { globalExtentTMS } from 'Core/Tile/TileGrid';
+import { globalExtentTMS, globalDefaultExtentCRS } from 'Core/Tile/TileGrid';
 import { PlanarTileBuilder } from './PlanarTileBuilder';
 
 /**
@@ -55,6 +55,13 @@ class PlanarLayer extends TiledGeometryLayer {
 
         this.minSubdivisionLevel = minSubdivisionLevel;
         this.maxSubdivisionLevel = maxSubdivisionLevel;
+    }
+
+    delete(clearCache) {
+        super.delete(clearCache);
+        if (!globalDefaultExtentCRS.includes(this.extent.crs)) {
+            globalExtentTMS.delete(this.extent.crs);
+        }
     }
 }
 

--- a/packages/Main/src/Core/Tile/TileGrid.ts
+++ b/packages/Main/src/Core/Tile/TileGrid.ts
@@ -4,6 +4,7 @@ import { Extent } from '@itowns/geographic';
 const _countTiles = new THREE.Vector2();
 const _dim = new THREE.Vector2();
 
+export const globalDefaultExtentCRS = ['EPSG:4326', 'EPSG:3857'];
 export const globalExtentTMS: Map<string, Extent> = new Map();
 export const schemeTiles: Map<string, THREE.Vector2> = new Map();
 


### PR DESCRIPTION
## Description
Fix for #2244 

## Motivation and Context
It's to fix an old issue until the proposal https://github.com/iTowns/itowns/issues/2290 is implemented.
The quick fix is to remove CRS in globalExtentTMS const if it's not a default CRS added in the const in TileGrid.ts
