### PR TITLE
fix(view): improve view disposal

### DIFF
--- a/packages/Main/src/Core/View.js
+++ b/packages/Main/src/Core/View.js
@@ -333,6 +333,8 @@ class View extends THREE.EventDispatcher {
         viewers.splice(id, 1);
         // Remove remaining objects in the scene (e.g. helpers, debug, etc.)
         this.scene.traverse(ObjectRemovalHelper.cleanup);
+        // Dispose the rendering engine (removes canvas and label2d from DOM, disposes WebGL renderer)
+        this.mainLoop.gfxEngine.dispose();
         this.dispatchEvent({ type: VIEW_EVENTS.DISPOSED });
         // remove alls events
         this.removeAllEvents();

--- a/packages/Main/src/Renderer/c3DEngine.js
+++ b/packages/Main/src/Renderer/c3DEngine.js
@@ -36,10 +36,12 @@ class c3DEngine {
         let renderer;
         let viewerDiv;
         if (rendererOrDiv.domElement) {
+            this._shouldDisposeRenderer = false; // don't dispose renderer if provided by the user
             renderer = rendererOrDiv;
             viewerDiv = renderer.domElement instanceof HTMLDivElement ?
                 renderer.domElement : renderer.domElement.parentElement;
         } else {
+            this._shouldDisposeRenderer = true;
             viewerDiv = rendererOrDiv;
         }
 
@@ -140,11 +142,13 @@ class c3DEngine {
     }
 
     dispose() {
-        this.renderer.domElement.parentElement?.removeChild(this.renderer.domElement);
         this.label2dRenderer.domElement.parentElement?.removeChild(this.label2dRenderer.domElement);
         this.fullSizeRenderTarget.dispose();
         this.composer.dispose();
-        this.renderer.dispose();
+        if (this._shouldDisposeRenderer) {
+            this.renderer.domElement.parentElement?.removeChild(this.renderer.domElement);
+            this.renderer.dispose();
+        }
     }
 
     getWindowSize() {

--- a/packages/Main/src/Renderer/c3DEngine.js
+++ b/packages/Main/src/Renderer/c3DEngine.js
@@ -139,6 +139,14 @@ class c3DEngine {
         });
     }
 
+    dispose() {
+        this.renderer.domElement.parentElement?.removeChild(this.renderer.domElement);
+        this.label2dRenderer.domElement.parentElement?.removeChild(this.label2dRenderer.domElement);
+        this.fullSizeRenderTarget.dispose();
+        this.composer.dispose();
+        this.renderer.dispose();
+    }
+
     getWindowSize() {
         return new THREE.Vector2(this.width, this.height);
     }

--- a/packages/Main/test/unit/bootstrap.js
+++ b/packages/Main/test/unit/bootstrap.js
@@ -122,6 +122,14 @@ class DOMElement {
         c.parentNode = this;
         this.children.push(c);
     }
+    removeChild(c) {
+        const idx = this.children.indexOf(c);
+        if (idx > -1) {
+            this.children.splice(idx, 1);
+        }
+        c.parentNode = null;
+        return c;
+    }
     append(c) { this.appendChild(c); }
     cloneNode() { return Object.create(this); }
     getBoundingClientRect() { return { x: 0, y: 0, width: this.width, height: this.height }; }
@@ -420,6 +428,7 @@ class Renderer {
     getDrawingBufferSize() { return new THREE.Vector2(4, 4); } // arbitrary size
     getClearAlpha() { return 1; }
     setClearAlpha() {}
+    dispose() {}
 }
 
 export default Renderer;


### PR DESCRIPTION
## Description

Remove all created dom elements and dispose all renderers when removing the view.

## Motivation and Context

While reviewing https://github.com/iTowns/itowns/pull/2745 , I tried to remove and recreate a view and the view creation failed (no error but nothing displayed. You can find a reprod attached: [view_2d_map.html](https://github.com/user-attachments/files/26700513/view_2d_map.html)