### PR TITLE
fix(PointCloud): flickering and matrixInverse.copy()

### DIFF
--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -7,7 +7,6 @@ import Picking from 'Core/Picking';
 import type PointCloudNode from 'Core/PointCloudNode';
 
 const point = new THREE.Vector3();
-const matrix4 = new THREE.Matrix4();
 
 export interface PointCloudSource {
     /** The minimal value for elevation (read from the metadata). */
@@ -399,7 +398,7 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
                     // be added nor cleaned
                     this.group.add(elt.obj);
                     elt.obj.updateMatrixWorld(true);
-                    elt.obj.matrixWorldInverse = matrix4.copy(elt.obj.matrixWorld).invert();
+                    elt.obj.matrixWorldInverse = elt.obj.matrixWorld.clone().invert();
                     context.view.notifyChange(this);
                     this.dispatchEvent({ type: 'load-model', scene: pts, tile: elt });
                 }).catch((err: { isCancelledCommandException: boolean }) => {
@@ -442,7 +441,6 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
             if (!object3d.parent) {
                 this.obbes.add(object3d);
                 object3d.updateMatrixWorld(true);
-                object3d.matrixWorldInverse = matrix4.copy(object3d.matrixWorld).invert();
             }
         }
 

--- a/packages/Main/src/Renderer/OBB.ts
+++ b/packages/Main/src/Renderer/OBB.ts
@@ -39,7 +39,7 @@ class OBB extends THREE.Object3D {
         max = new THREE.Vector3(-Infinity, -Infinity, -Infinity),
     ) {
         super();
-        this.natBox = new THREE.Box3(min.clone(), max.clone());
+        this.natBox = new THREE.Box3(min, max);
         this.box3D = this.natBox.clone();
         this.z = { min: 0, max: 0, scale: 1.0, delta: 0 };
         this.matrixWorldInverse = this.matrixWorld.clone().invert();
@@ -57,7 +57,7 @@ class OBB extends THREE.Object3D {
         const matrixWorldInverseNeedsUpdate = this.matrixAutoUpdate || this.matrixWorldNeedsUpdate;
         super.updateMatrixWorld(force);
         if (matrixWorldInverseNeedsUpdate || force) {
-            this.matrixWorldInverse = this.matrixWorld.clone().invert();
+            this.matrixWorldInverse.copy(this.matrixWorld).invert();
         }
     }
 
@@ -172,13 +172,13 @@ class OBB extends THREE.Object3D {
 
     setFromBox3(box3: THREE.Box3) {
         this.natBox.copy(box3);
-        this.box3D = this.natBox.clone();
+        this.box3D.copy(this.natBox);
         return this;
     }
 
     setFromArray(array: number[]) {
         this.natBox.setFromArray(array);
-        this.box3D = this.natBox.clone();
+        this.box3D.copy(this.natBox);
         return this;
     }
 


### PR DESCRIPTION
The previous PR #2733 refactoring PointCloudLayer code induced a light regression:
A flmickering appeared during the panning of PointCloudData visualization with a non orthographic view.
This PR corect that regression.