### PR TITLE
fix: demo not served in production environment

### DIFF
--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -11,6 +11,7 @@
             {
                 "imports": {
                     "itowns": "../../dist/itowns.js",
+                    "demo": "../../dist/demo.js",
                     "three": "https://unpkg.com/three@0.182.0/build/three.module.js",
                     "three/addons/": "https://unpkg.com/three@0.182.0/examples/jsm/",
                     "OrbitControls": "https://unpkg.com/three@0.182.0/examples/jsm/controls/OrbitControls.js"
@@ -51,7 +52,7 @@
         <script type="module">
             import * as THREE from "three";
             import * as itowns from "itowns";
-            import { SceneTransitionUtils, SceneRepository, Config } from "../../dist/demo.js";
+            import { SceneTransitionUtils, SceneRepository, Config } from "demo";
 
             Config.basePath = window.location.href.startsWith("about:srcdoc")
                 ? "/examples"

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -101,6 +101,10 @@ module.exports = () => {
             itowns: [
                 './packages/Main/src/MainBundle.js',
             ],
+            demo: {
+                import: './examples/demo/src/index.ts',
+                dependOn: 'itowns',
+            },
         },
         output: {
             ...sharedConfig.output,
@@ -119,6 +123,10 @@ module.exports = () => {
             itowns: [
                 './packages/Main/src/Main.js',
             ],
+            demo: {
+                import: './examples/demo/src/index.ts',
+                dependOn: 'itowns',
+            },
         },
         output: {
             ...sharedConfig.output,
@@ -163,28 +171,9 @@ module.exports = () => {
         ],
     };
 
-    const configServe = {
-        ...configESM,
-        entry: {
-            ...configESM.entry,
-            demo: {
-                import: './examples/demo/src/index.ts',
-                dependOn: 'itowns',
-            },
-        },
-        plugins: [
-            new ESLintPlugin({
-                files: include,
-                configType: 'eslintrc',
-            }),
-        ],
-        experiments: {
-            outputModule: true,
-        },
-    };
 
     if (process.env.WEBPACK_SERVE) {
-        configServe.devServer = {
+        configESM.devServer = {
             hot: false,
             devMiddleware: {
                 publicPath: '/dist/',
@@ -204,7 +193,7 @@ module.exports = () => {
             },
         };
 
-        return [configServe];
+        return [configESM];
     } else {
         return [configESM, configUMD];
     }


### PR DESCRIPTION
## Description
Fix webpack config so demo is always served.

## Motivation and Context
Fix for issue #2757, webpack only served iTowns demo (#2653) in local. This PR fixes the configuration to serve it constantly.