### PR TITLE
fix(demo): relative paths changing under certain serving conditions

### DIFF
--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -6,36 +6,38 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <!-- both itowns paths for webpack and local build -->
-        <script type="importmap">
-            {
-                "imports": {
-                    "itowns": "../../dist/itowns.js",
-                    "demo": "../../dist/demo.js",
-                    "three": "https://unpkg.com/three@0.182.0/build/three.module.js",
-                    "three/addons/": "https://unpkg.com/three@0.182.0/examples/jsm/",
-                    "OrbitControls": "https://unpkg.com/three@0.182.0/examples/jsm/controls/OrbitControls.js"
-                }
-            }
-        </script>
         <script>
-            function loadCss(url) {
-                const link = document.createElement("link");
-                link.rel = "stylesheet";
-                link.type = "text/css";
-                link.href = url;
-                document.head.appendChild(link);
-            }
+            (function () {
+                // escape iframe to retrieve the correct URL
+                const here = (window.location.href.indexOf("about:srcdoc") === 0)
+                    ? window.parent.location.href
+                    : window.location.href;
+                const idx = here.lastIndexOf("/examples/");
+                const rootURL = idx >= 0
+                    ? here.slice(0, idx + 1)
+                    : new URL("./", here).href;
 
-            const basePath = window.location.href.startsWith("about:srcdoc")
-                ? "/examples"
-                : "..";
-
-            loadCss(`${basePath}/css/example.css`);
-            loadCss(`${basePath}/css/widgets.css`);
-            loadCss(`${basePath}/demo/css/demo.css`);
-            loadCss(`${basePath}/css/LoadingScreen.css`);
+                document.write('<base href="' + rootURL + '">');
+                window.__itownsRoot = rootURL;
+            })();
         </script>
+
+        <script type="importmap">
+        {
+            "imports": {
+                "itowns": "./dist/itowns.js",
+                "demo": "./dist/demo.js",
+                "three": "https://unpkg.com/three@0.182.0/build/three.module.js",
+                "three/addons/": "https://unpkg.com/three@0.182.0/examples/jsm/",
+                "OrbitControls": "https://unpkg.com/three@0.182.0/examples/jsm/controls/OrbitControls.js"
+            }
+        }
+        </script>
+
+        <link rel="stylesheet" href="examples/css/example.css">
+        <link rel="stylesheet" href="examples/css/widgets.css">
+        <link rel="stylesheet" href="examples/demo/css/demo.css">
+        <link rel="stylesheet" href="examples/css/LoadingScreen.css">
     </head>
     <body>
         <div id="demoUI">
@@ -54,9 +56,7 @@
             import * as itowns from "itowns";
             import { SceneTransitionUtils, SceneRepository, Config } from "demo";
 
-            Config.basePath = window.location.href.startsWith("about:srcdoc")
-                ? "/examples"
-                : "..";
+            Config.basePath = window.__itownsRoot + "examples";
 
             const resetSceneButton = document.getElementById("resetScene");
             const hardResetSceneButton =

--- a/examples/index.html
+++ b/examples/index.html
@@ -275,7 +275,7 @@
          */
         function cacheExample(slug) {
             const src = isLocal
-                ? `${new URL(baseURI).origin}/examples/${slug}.html`
+                ? new URL(slug + ".html", baseURI).href
                 : `https://raw.githubusercontent.com/itowns/itowns/refs/heads/master/examples/${slug}.html`;
             return fetch(src)
                 .then((response) => response.text())


### PR DESCRIPTION
## Description
Fix relative paths for the demo in iTowns' examples page.

Paths that worked :
- `[...]/demo/index.html` : "../examples.css" & "./assets/..." & "../../dist/itowns.js"
- local `/examples/?#demo/index` : "/examples/examples.css" & "/examples/demo/assets/..." & "../../dist/itowns.js"
- hosted `/itowns/dev/examples/?#demo/index` : "./examples.css" & "./demo/assets" & "../dist/itowns.js"

The fix consists at finding the root of `/examples` to use as a base in all cases.

## Motivation and Context
Relative paths from direct access (demo/index.html), local examples page access (examples/?#demo/index) and hosted access (itowns/dev/examples/?#demo/index) vary and caused errors when hosted that weren't visible when served locally.
