### PR TITLE
fix(examples): fix duplicating panel bug, sessionStorage bugs and responsive design

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -10,11 +10,6 @@
     --icon-filter: none;
     --dropdown-arrow: url(../images/dropdown_arrow.svg);
 }
-/*
-* {
-    box-sizing: border-box;
-}
-    */
 
 
 html.light {
@@ -207,6 +202,10 @@ p, h1, h2, h3, h4 {
     height: 1.7em;
     color: light-dark(#1565c1, #8CC1EE);
 } 
+
+.theme-toggle:hover {
+    transform: scale(130%);
+}
 
 
 /* SIDEBAR */
@@ -448,6 +447,8 @@ p, h1, h2, h3, h4 {
 
 .category-header h3 {
     font-weight: 400;
+    font-size: 1.3rem;
+
 }
 
 
@@ -489,11 +490,6 @@ p, h1, h2, h3, h4 {
     transition: transform 0.2s;
     height: 8em;
     padding: 0.5em 0.5em;   
-    /*
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
-    */
 }
 
 .example-item:hover {
@@ -538,40 +534,33 @@ p, h1, h2, h3, h4 {
 }
 
 
-/*
-.example-info {
-    flex: 1;         
-    min-width: 0;
-    display: block;   
-    overflow: hidden; 
-    padding: 0 15px;
-    gap: 0.5em;    
-    align-self: center; 
-}
-    */
-
 .example-title, .example-desc {
     margin: 0;
     padding: 0;
 }
 
-.example-title{
-    text-transform: uppercase;
-    font-size: 1.2em;
-    font-weight: 500;
-    color: light-dark(#3F4B5A, #BECDDF);
 
-    white-space: nowrap;     
-    overflow: hidden;        
+.example-title{    
+    text-transform: uppercase;
+    font-size: 1.3em;
+    font-weight: 600;
+    color: light-dark(#3F4B5A, #BECDDF);
+    
+    display: -webkit-box;
+    -webkit-line-clamp: 2;   
+    line-clamp: 2;
     text-overflow: ellipsis; 
-    display: block;   
+    -webkit-box-orient: vertical;
+    overflow: hidden;
     margin-bottom: 4px;
+    
 }
+
 
 
 .example-desc {
     font-size: 1.15em;
-    opacity: 80%;
+    opacity: 90%;
 
     display: -webkit-box;
     -webkit-line-clamp: 2;   
@@ -791,7 +780,7 @@ input:checked + .slider:before {
 
 }
 
-@media (width < 1100px) {
+@media (width < 1170px) {
     #editor-panel {
         display: none !important;
     }
@@ -841,7 +830,6 @@ input:checked + .slider:before {
     display: block;
     position: absolute;
     right: 135px;
-    bottom: 20;
     border: 2px solid black;
     border-top: none;
     text-align: center;
@@ -858,16 +846,3 @@ input:checked + .slider:before {
     -ms-user-select: none;
     user-select: none;
 }
-
-
-/* TEMPORARY - DEBUG */ 
-
-/*
-#example-list { outline: 2px solid red !important; }
-.category-content { outline: 2px solid green !important; }
-.example-item { outline: 2px solid blue !important; }
-.example-info { outline: 2px solid orange !important; }
-
-
-
-*/

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -10,6 +10,11 @@
     --icon-filter: none;
     --dropdown-arrow: url(../images/dropdown_arrow.svg);
 }
+/*
+* {
+    box-sizing: border-box;
+}
+    */
 
 
 html.light {
@@ -148,6 +153,7 @@ body {
 #editor-collapse:hover {
     opacity: 1 !important;
     transition-duration: 100ms;
+    background-color: light-dark(#e3e3e3,#2E3944);
 }
 
 #editor-collapse>img {
@@ -193,6 +199,8 @@ p, h1, h2, h3, h4 {
     z-index: 100;  
     cursor: pointer;
 }
+
+
 
 .theme-toggle svg {
     width: 1.7em;
@@ -297,6 +305,12 @@ p, h1, h2, h3, h4 {
     
     padding-top: 0.2em;
     padding-bottom: 0.2em;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;  
+    display: block;
+    padding-right: 3em
     
 }
 
@@ -407,6 +421,7 @@ p, h1, h2, h3, h4 {
     transition: grid-template-rows 0.3s ease-out;
     overflow: hidden;
     padding-left: 0.5em;
+    min-width: 0;
 }
 
 .category.collapsed .category-grid-wrapper {
@@ -427,6 +442,7 @@ p, h1, h2, h3, h4 {
     border-style: none;
     color: light-dark(#1565c1, #8CC1EE);
     border-radius: 0.5em;
+    cursor: pointer;
 }
 
 
@@ -456,6 +472,10 @@ p, h1, h2, h3, h4 {
     display: flex;
     flex-direction: column  ;
     gap: 1.3em;
+    
+    width: 100%;     
+    max-width: 100%;
+    
 }
 
 
@@ -469,6 +489,11 @@ p, h1, h2, h3, h4 {
     transition: transform 0.2s;
     height: 8em;
     padding: 0.5em 0.5em;   
+    /*
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    */
 }
 
 .example-item:hover {
@@ -476,9 +501,9 @@ p, h1, h2, h3, h4 {
 }
 
 
-.example-item:target {
-        background-color: light-dark(#e0effd, #09184B);
-outline: 0.2em solid light-dark(#5891d3, #70AEE5CC);
+.example-item:target,.example-item.active-example {
+    background-color: light-dark(#e0effd, #09184B);
+    outline: 0.2em solid light-dark(#5891d3, #70AEE5CC);
     outline-offset: -2px; 
 }
 
@@ -498,14 +523,32 @@ outline: 0.2em solid light-dark(#5891d3, #70AEE5CC);
     border-radius: 8px;
 }
 
+
 .example-info {
     display: flex;
     flex-direction: column; 
     justify-content: center;
     padding: 0px 15px;
-    gap: 1em;            
+    gap: 0.5em;            
     min-width: 0;
+    
+    flex: 1 1 0;
+    overflow: hidden;
+    
 }
+
+
+/*
+.example-info {
+    flex: 1;         
+    min-width: 0;
+    display: block;   
+    overflow: hidden; 
+    padding: 0 15px;
+    gap: 0.5em;    
+    align-self: center; 
+}
+    */
 
 .example-title, .example-desc {
     margin: 0;
@@ -517,12 +560,25 @@ outline: 0.2em solid light-dark(#5891d3, #70AEE5CC);
     font-size: 1.2em;
     font-weight: 500;
     color: light-dark(#3F4B5A, #BECDDF);
+
+    white-space: nowrap;     
+    overflow: hidden;        
+    text-overflow: ellipsis; 
+    display: block;   
+    margin-bottom: 4px;
 }
 
 
 .example-desc {
     font-size: 1.15em;
     opacity: 80%;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 2;   
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 hr {
@@ -802,3 +858,16 @@ input:checked + .slider:before {
     -ms-user-select: none;
     user-select: none;
 }
+
+
+/* TEMPORARY - DEBUG */ 
+
+/*
+#example-list { outline: 2px solid red !important; }
+.category-content { outline: 2px solid green !important; }
+.example-item { outline: 2px solid blue !important; }
+.example-info { outline: 2px solid orange !important; }
+
+
+
+*/

--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -165,7 +165,6 @@ body {
 
 
 
-
 body.manual-collapse #editor-panel {
     left: calc(-100% * 6 / 16);
 }
@@ -194,8 +193,6 @@ p, h1, h2, h3, h4 {
     z-index: 100;  
     cursor: pointer;
 }
-
-
 
 .theme-toggle svg {
     width: 1.7em;
@@ -497,7 +494,7 @@ p, h1, h2, h3, h4 {
 }
 
 
-.example-item:target,.example-item.active-example {
+.example-item:target, .example-item.active-example {
     background-color: light-dark(#e0effd, #09184B);
     outline: 0.2em solid light-dark(#5891d3, #70AEE5CC);
     outline-offset: -2px; 
@@ -557,7 +554,6 @@ p, h1, h2, h3, h4 {
 }
 
 
-
 .example-desc {
     font-size: 1.15em;
     opacity: 90%;
@@ -577,7 +573,6 @@ hr {
     margin: 2em auto;
     opacity: 20%;
 }
-
 
 
 
@@ -702,7 +697,6 @@ input:checked + .slider:before {
 
 
 
-
 #code-editor-wrapper {
     flex: 1;            
     display: flex;      
@@ -823,7 +817,6 @@ input:checked + .slider:before {
     user-select: none;
     z-index: 2 !important;
 }
-
 
 
 #divScaleWidget {

--- a/examples/index.html
+++ b/examples/index.html
@@ -293,13 +293,20 @@
         async function loadExample(slug) {
             updateCodePanelHeader(slug);
 
+            // set current example to active to update its appearance
+            document.querySelectorAll('.example-item').forEach(el => el.classList.remove('active-example'));
+            const targetItem = document.getElementById(slug);
+            if (targetItem) {
+                targetItem.classList.add('active-example');
+                targetItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            }
+
             const example = exampleCache[slug] ?? (await (() => {
                 codeEditor.setValue("Loading...");
                 return cacheExample(slug);
             })());
             codeEditor.setValue(example);
             window.location.hash = slug;
-            window.location.search = "";
             runCode();
             setTimeout(() => codeEditor.refresh(), 0);
         }
@@ -443,7 +450,7 @@
                 const target = isDev ? options[0] : options[1];
                 const current = isDev ? options[1] : options[0];
 
-                window.location.href = document.location.href.replace(current, target);
+                window.location.href = document.location.href.replace(current, target).replace("?","");
             } 
         });
 
@@ -575,18 +582,16 @@
                 .then(function _(config) {
                     examplesConfig = config;
                     initNavigation(config);
-                    
 
+                    const hash = window.location.hash.replace("#", "");
                     const localCode = sessionStorage.getItem("code");
 
                     if (!localCode || isLocal) {
-                        loadExample(
-                            window.location.hash.replace("#", "") ||
-                            "demo/index",
-                        );
+                        loadExample(hash || "demo/index");
                     }
                     else {
                         codeEditor.setValue(fromBase64(localCode));
+                        updateCodePanelHeader(hash);
                         runCode();
                     }
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -262,7 +262,12 @@
          */
         function runCode() {                
             const code = codeEditor.getValue();
+            const hash = window.location.hash.replace("#", "");
             sessionStorage.setItem("code", toBase64(code));
+
+            if (hash){
+                sessionStorage.setItem("exampleSlug", hash)
+            }
 
             iframe.srcdoc = code;
         }
@@ -270,8 +275,9 @@
         
 
         /** 
-         * Caches the code of the example associated with the given slug.
+         * Fetches and caches the code of the example associated with the given slug.
          * @param {string} slug - An example's slug
+         * @returns {Promise<string>} A promise that resolves to the source code of the example.
          */
         function cacheExample(slug) {
             const src = isLocal
@@ -285,12 +291,13 @@
                 });
         }   
                 
-
+            
         /** 
-         * Loads the example associated with the given slug.
+         * Loads the example associated with the given slug or the given code.
          * @param {string} slug - An example's slug 
+         * @param {string} [localCode=null] - An example's code
          */
-        async function loadExample(slug) {
+        async function loadExample(slug, localCode = null) {
             updateCodePanelHeader(slug);
 
             // set current example to active to update its appearance
@@ -301,11 +308,17 @@
                 targetItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
             }
 
-            const example = exampleCache[slug] ?? (await (() => {
-                codeEditor.setValue("Loading...");
-                return cacheExample(slug);
-            })());
-            codeEditor.setValue(example);
+            let code;
+            if (localCode != null) {
+                code = localCode;
+            } else {
+                code = exampleCache[slug] ?? (await (() => {
+                    codeEditor.setValue("Loading...");
+                    return cacheExample(slug);
+                })());
+            }
+
+            codeEditor.setValue(code);
             window.location.hash = slug;
             runCode();
             setTimeout(() => codeEditor.refresh(), 0);
@@ -585,14 +598,16 @@
 
                     const hash = window.location.hash.replace("#", "");
                     const localCode = sessionStorage.getItem("code");
+                    const localExampleSlug = sessionStorage.getItem("exampleSlug");
+                    const targetSlug = hash || "demo/index";
 
-                    if (!localCode || isLocal) {
-                        loadExample(hash || "demo/index");
+                    // if target slug corresponds to the saved example, load it
+                    if (localCode && targetSlug === localExampleSlug) {
+                        loadExample(targetSlug, fromBase64(localCode));
                     }
+                    // else, load the default example (current hash or fallback)
                     else {
-                        codeEditor.setValue(fromBase64(localCode));
-                        updateCodePanelHeader(hash);
-                        runCode();
+                        loadExample(targetSlug);
                     }
 
                     // staying on the same panel even when hard refreshing

--- a/examples/index.html
+++ b/examples/index.html
@@ -97,7 +97,7 @@
                 <button id="code-btn" class="sidebar-btn notalink" data-panel="code-panel" title="Code editor" aria-label="Open code editor">
                      <img src="images/code.svg" alt="Code editor" />
                 </button>
-                <a href="https://github.com/iTowns" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/iTowns/itowns" target="_blank" rel="noopener noreferrer">
                     <button id="github-btn" class="sidebar-btn" title="iTowns GitHub repository" type="button" aria-label="iTowns GitHub repository">
                             <img src="images/github.svg" alt="GitHub logo" />
                     </button>
@@ -122,7 +122,7 @@
                         <form id="search-container">
                             <input type="search" id="search-input" placeholder="Browse examples" autocomplete="off">
 
-                            <select id="category-selector">
+                            <select id="category-selector" aria-label="Filter by category">
                                 <!-- content added dynamically in JS --> 
                             </select>
                             
@@ -347,8 +347,15 @@
 
 
 
+        /** 
+         * Removes spaces and converts the given string to lowercase.
+         * @param {string} str - The string to clean
+         * @returns {string} The cleaned string
+         */
+        function clean(str) {
+            return str.replace(/\s+/g, '').toLowerCase();
+        }
 
-        const clean = (str) => str.replace(/\s+/g, '').toLowerCase();
 
         /** 
          * Displays or hides examples based on the user's text query and selected category.
@@ -430,28 +437,24 @@
         };
         
 
-        
-        // collapsing categories
+        // click on example and category collapsing
         exampleList.addEventListener('click', (event) => {
-            const header = event.target.closest('.category-header');
-            if (!header) return;
-
-            const parent = header.closest('.category');
-            parent.classList.toggle('collapsed');
-        });
-
-
-
-        // click on example
-        exampleList.addEventListener('click', (event) => {
+            // click on example
             const item = event.target.closest('.example-item');
-            if (!item) return;
-
-            const slug = item.dataset.slug;
-            loadExample(slug);
-            codeBtn.click(); 
+            if (item) {
+                const slug = item.dataset.slug;
+                loadExample(slug);
+                codeBtn.click(); 
+                return;
+            }
+            // category collapsing
+            const header = event.target.closest('.category-header');
+            if (header) {
+                const parent = header.closest('.category');
+                parent.classList.toggle('collapsed');
+                return;
+            }
         });
-
 
 
         // version switching 
@@ -466,7 +469,6 @@
                 window.location.href = document.location.href.replace(current, target).replace("?","");
             } 
         });
-
 
 
         themeInput.addEventListener("change", toggleTheme);


### PR DESCRIPTION
## Description
This PR adresses these issues: 
- Due to bad URL handling, by switching between the dev and the released version of the example page, one could infinitely duplicate the side panel listing the examples (on the released version).
- The sessionStorage management sometimes led to an example's code being displayed properly, but without its title and description, or a wrong one.
- On smaller screen sizes, the text in the example list was sometimes cut out.
- Some cursor:pointer were missing.

## Screenshots 
<img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/180f863e-158d-4a67-90ef-601503fa2b83" />
lol