### PR TITLE
feat: replace shaders with TSL equivalent

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "proj4": "^2.20.4",
     "puppeteer": "^24.37.3",
     "sinon": "^21.0.1",
-    "three": "^0.182.0",
+    "three": "mrdoob/three.js#dev",
     "tsc-alias": "^1.8.16",
     "typescript": "^5.9.3",
     "undici": "^7.22.0",

--- a/packages/Geographic/package.json
+++ b/packages/Geographic/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "proj4": ">=2.20.0",
-    "three": ">=0.182.0"
+    "three": "mrdoob/three.js#dev"
   },
   "homepage": "https://itowns.github.io/"
 }

--- a/packages/Main/package.json
+++ b/packages/Main/package.json
@@ -73,5 +73,9 @@
     "proj4": "^2.20.4",
     "three": "mrdoob/three.js#dev"
   },
+  "devDependencies": {
+    "chalk": "^5.4.1",
+    "copyfiles": "^2.4.1"
+  },
   "homepage": "https://itowns.github.io/"
 }

--- a/packages/Main/package.json
+++ b/packages/Main/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "postprocessing": "6.38.2",
     "proj4": "^2.20.4",
-    "three": "^0.182.0"
+    "three": "mrdoob/three.js#dev"
   },
   "homepage": "https://itowns.github.io/"
 }

--- a/packages/Main/src/Main.js
+++ b/packages/Main/src/Main.js
@@ -19,6 +19,7 @@ export { default as ObjectRemovalHelper } from 'Process/ObjectRemovalHelper';
 export { updateLayeredMaterialNodeImagery, updateLayeredMaterialNodeElevation } from 'Process/LayeredMaterialNodeProcessing';
 export { default as OrientedImageCamera } from 'Renderer/OrientedImageCamera';
 export { default as PointsMaterial, PNTS_MODE, PNTS_SHAPE, PNTS_SIZE_MODE, ClassificationScheme } from 'Renderer/PointsMaterial';
+export { default as PointsMaterialTsl } from 'Renderer/PointsMaterialTsl';
 export { default as GlobeControls } from 'Controls/GlobeControls';
 export { default as FlyControls } from 'Controls/FlyControls';
 export { default as FirstPersonControls } from 'Controls/FirstPersonControls';

--- a/packages/Main/src/Renderer/PointsMaterialTsl.ts
+++ b/packages/Main/src/Renderer/PointsMaterialTsl.ts
@@ -7,7 +7,7 @@ const enum RenderMode {
     COLOR,
     CLASSIFICATION,
     RETURN_COUNT,
-};
+}
 
 export default class PointsMaterialTsl extends wgpu.SpriteNodeMaterial {
     constructor(attributes: Record<string, THREE.TypedArray>, public renderMode: RenderMode) {
@@ -20,19 +20,19 @@ export default class PointsMaterialTsl extends wgpu.SpriteNodeMaterial {
         }
 
         const positionAttribute = new wgpu.InstancedBufferAttribute(attributes.positions as Float32Array, 3);
-        positionAttribute.name = "positionAttribute";
+        positionAttribute.name = 'positionAttribute';
         const position = tsl.instancedBufferAttribute(positionAttribute);
 
-        const colorAttribute = tsl.instancedBufferAttribute(new wgpu.InstancedBufferAttribute(attributes.colors as Uint8Array, 4)).setName("colorAttribute").div(255).setName("colorFinal");
+        const colorAttribute = tsl.instancedBufferAttribute(new wgpu.InstancedBufferAttribute(attributes.colors as Uint8Array, 4)).setName('colorAttribute').div(255).setName('colorFinal');
         const classificationAttribute = classification_coloring(
             tsl.instancedBufferAttribute(
-                new wgpu.InstancedBufferAttribute(attributes.Classification as Uint16Array, 1)
-            ).setName("classificationAttribute")
+                new wgpu.InstancedBufferAttribute(attributes.Classification as Uint16Array, 1),
+            ).setName('classificationAttribute'),
         );
-        const returnCountAttribute = tsl.instancedBufferAttribute(new wgpu.InstancedBufferAttribute(attributes.NumberOfReturns as Uint16Array, 1)).setName("returnCountAttribute").toFloat();
+        const returnCountAttribute = tsl.instancedBufferAttribute(new wgpu.InstancedBufferAttribute(attributes.NumberOfReturns as Uint16Array, 1)).setName('returnCountAttribute').toFloat();
 
         renderMode = RenderMode.CLASSIFICATION;
-        let color = [colorAttribute, classificationAttribute, returnCountAttribute][renderMode];
+        const color = [colorAttribute, classificationAttribute, returnCountAttribute][renderMode];
 
         super({
             positionNode: position,
@@ -41,6 +41,6 @@ export default class PointsMaterialTsl extends wgpu.SpriteNodeMaterial {
             scaleNode: tsl.float(0.0008),
             vertexColors: true,
             sizeAttenuation: false,
-        })
+        });
     }
 }

--- a/packages/Main/src/Renderer/PointsMaterialTsl.ts
+++ b/packages/Main/src/Renderer/PointsMaterialTsl.ts
@@ -1,0 +1,23 @@
+import * as THREE from 'three/webgpu';
+import { color, uv, Fn, uniform, float, int, defined, depth } from 'three/tsl';
+
+const pointsMaterialTsl = new THREE.PointsNodeMaterial();
+
+const diffuse = uniform(new THREE.Vector3()).setName('diffuse');
+const opacity = uniform(float(0)).setName('opacity');
+const gamma = uniform(float(0)).setName('gamma');
+const ambientBoost = uniform(float(0)).setName('ambientBoost');
+const picking = uniform(false).setName('picking');
+const shape = uniform(int(0)).setName('shape');
+
+const main = Fn(() => {
+    uv().sub(0.5).length().greaterThan(0.5)
+        .discard();
+    if (defined('USE_LOGARITHMIC_DEPTH_BUFFER')) {
+        depth.assign(viewZToLogarithmicDepth);
+    }
+});
+
+pointsMaterialTsl.colorNode = main();
+
+export default pointsMaterialTsl;

--- a/packages/Main/src/Renderer/PointsMaterialTsl.ts
+++ b/packages/Main/src/Renderer/PointsMaterialTsl.ts
@@ -1,23 +1,46 @@
-import * as THREE from 'three/webgpu';
-import { color, uv, Fn, uniform, float, int, defined, depth } from 'three/tsl';
+import * as THREE from 'three';
+import * as wgpu from 'three/webgpu';
+import * as tsl from 'three/tsl';
+// import { WebGLNodesHandler } from 'three/addons/tsl/WebGLNodesHandler.js';
 
-const pointsMaterialTsl = new THREE.PointsNodeMaterial();
+const enum RenderMode {
+    COLOR,
+    CLASSIFICATION,
+    RETURN_COUNT,
+};
 
-const diffuse = uniform(new THREE.Vector3()).setName('diffuse');
-const opacity = uniform(float(0)).setName('opacity');
-const gamma = uniform(float(0)).setName('gamma');
-const ambientBoost = uniform(float(0)).setName('ambientBoost');
-const picking = uniform(false).setName('picking');
-const shape = uniform(int(0)).setName('shape');
+export default class PointsMaterialTsl extends wgpu.SpriteNodeMaterial {
+    constructor(attributes: Record<string, THREE.TypedArray>, public renderMode: RenderMode) {
+        function classification_coloring(classif: wgpu.Node): wgpu.Node {
+            return tsl.array([
+                tsl.vec3(1, 0, 0),
+                tsl.vec3(0, 1, 0),
+                tsl.vec3(0, 0, 1),
+            ]).element(classif.mod(3));
+        }
 
-const main = Fn(() => {
-    uv().sub(0.5).length().greaterThan(0.5)
-        .discard();
-    if (defined('USE_LOGARITHMIC_DEPTH_BUFFER')) {
-        depth.assign(viewZToLogarithmicDepth);
+        const positionAttribute = new wgpu.InstancedBufferAttribute(attributes.positions as Float32Array, 3);
+        positionAttribute.name = "positionAttribute";
+        const position = tsl.instancedBufferAttribute(positionAttribute);
+
+        const colorAttribute = tsl.instancedBufferAttribute(new wgpu.InstancedBufferAttribute(attributes.colors as Uint8Array, 4)).setName("colorAttribute").div(255).setName("colorFinal");
+        const classificationAttribute = classification_coloring(
+            tsl.instancedBufferAttribute(
+                new wgpu.InstancedBufferAttribute(attributes.Classification as Uint16Array, 1)
+            ).setName("classificationAttribute")
+        );
+        const returnCountAttribute = tsl.instancedBufferAttribute(new wgpu.InstancedBufferAttribute(attributes.NumberOfReturns as Uint16Array, 1)).setName("returnCountAttribute").toFloat();
+
+        renderMode = RenderMode.CLASSIFICATION;
+        let color = [colorAttribute, classificationAttribute, returnCountAttribute][renderMode];
+
+        super({
+            positionNode: position,
+            opacityNode: tsl.shapeCircle(),
+            colorNode: color,
+            scaleNode: tsl.float(0.0008),
+            vertexColors: true,
+            sizeAttenuation: false,
+        })
     }
-});
-
-pointsMaterialTsl.colorNode = main();
-
-export default pointsMaterialTsl;
+}


### PR DESCRIPTION
> [!WARNING]
> Early draft, missing a lot of implementation. This is exploratory work largely meant for discussion rather than direct inclusion into iTowns.

## Description
<!--- Describe your changes in detail -->
Attempts to replace the different shaders used within iTowns with equivalent TSL variants to smoothen the addition of WebGPU support.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please also state your testing environment (browser, version and anything relevant) here -->
Maintaining two different versions of every shader in GLSL and WGSL would increase maintenance work to keep them coherent, not to mention the different features supported by WebGL and WebGPU. Having a single source of truth will help avoid this issue.
We also benefit from taking a good look at the shaders and what's really necessary, hopefully allowing us to make the shader code much simpler. 
> [!NOTE]
> It's important to keep in mind that TSL is still a nascent evolution of Three.js that will likely undergo significant changes over time, so its current shortcomings (like documentation and error reporting) will have been improved upon by the time we can fully transition to WebGPU being a primary target (if that day ever comes).
