### PR TITLE
fix(VpcLayer): fix root Node OBB calculation with huge extent

### DIFF
--- a/packages/Main/src/Layer/VpcLayer.js
+++ b/packages/Main/src/Layer/VpcLayer.js
@@ -75,9 +75,11 @@ class VpcLayer extends PointCloudLayer {
             const boundsConforming = this.source.boundsConforming;
             this.root = new PointCloudNode(-1, 0);
             this.root.source = this.source;
+            this.root.voxelKey = 'vpcRoot';
 
-            this.root.voxelOBB.setFromArray(boundsConforming).projOBB(this.source.crs, this.crs);
-            this.root.clampOBB.copy(this.root.voxelOBB).clampZ(this.source.zmin, this.source.zmax);
+            // We don't have acces to the VoxelOBB in vpcLayer (and it won't have any sens to calculate it)
+            this.root.clampOBB.setFromArray(boundsConforming).projOBB(this.source.crs, this.crs);
+
             this.object3d.add(this.root.clampOBB);
             this.root.clampOBB.updateMatrixWorld(true);
 

--- a/packages/Main/src/Renderer/OBB.ts
+++ b/packages/Main/src/Renderer/OBB.ts
@@ -220,11 +220,14 @@ class OBB extends THREE.Object3D {
         if (isGeocentric) {
             const coordOrigin = new Coordinates(crsOut).setFromArray(origin);
             quaternion = OrientationUtils.quaternionFromCRSToCRS(crsOut, crsIn)(coordOrigin);
+            // add the middle top for the curvature
+            corners.push(...forward([(min.x + max.x) * 0.5, (min.y + max.y) * 0.5, max.z]));
         }
 
         // project corners in local referentiel
         const cornersLocal = [];
-        for (let i = 0; i < 24; i += 3) {
+        const nbCorner = corners.length;
+        for (let i = 0; i < nbCorner; i += 3) {
             const cornerLocal = new THREE.Vector3(
                 corners[i] - origin[0],
                 corners[i + 1] - origin[1],


### PR DESCRIPTION
With the VPC Layer including more and more data, the extent start to grow big enough for the approximation on which the curvature of the Earth is negligeable doesn't apply anymore. The rootOBB start to be completly wrong.

Thus to prevent this approximation, we add the middle point of the extent to the Bbox calculation.
