### PR TITLE
chore: fix incorrect version bumping

### DIFF
--- a/config/version.mjs
+++ b/config/version.mjs
@@ -31,7 +31,7 @@ try {
 
 if (npm_config_git_tag_version === 'false') {
     try {
-        execSync('git add packages/**/package.json changelog.md', {
+        execSync('git add packages/**/package.json examples/demo/package.json changelog.md', {
             stdio: 'inherit'
         });
     } catch (error) {

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@itowns/demo",
-  "version": "0.1.0",
+  "version": "2.46.0",
   "description": "Itowns Demo",
   "type": "module",
   "scripts": {
     "build": "",
     "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
     "transpile": "tsc && cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir dist --extensions .js,.ts",
-    "watch": "npm run transpile -- --watch"
+    "watch": "npm run transpile -- --watch",
+    "version": "cross-env-shell npm pkg set dependencies.itowns=^$npm_package_version"
   },
   "files": [
     "src"

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "examples/demo": {
       "name": "@itowns/demo",
-      "version": "0.1.0",
+      "version": "2.46.0",
       "license": "(CECILL-B OR MIT)",
       "dependencies": {
         "itowns": "^2.46.0"

--- a/packages/Debug/package.json
+++ b/packages/Debug/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
     "transpile": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib --extensions .js,.ts",
     "watch": "npm run transpile -- --watch",
-    "version": "cross-env-shell npm install @itowns/geographic@$npm_package_version itowns@$npm_package_version"
+    "version": "cross-env-shell npm pkg set dependencies.@itowns/geographic=^$npm_package_version dependencies.itowns=^$npm_package_version"
   },
   "files": [
     "*.md",

--- a/packages/Main/package.json
+++ b/packages/Main/package.json
@@ -24,7 +24,7 @@
     "postpublish": "node clean.cjs",
     "publish-latest": "npm publish --access public --tag=latest --provenance",
     "publish-next": "npm publish --access public --tag=next --provenance",
-    "version": "cross-env-shell npm install @itowns/geographic@$npm_package_version && node scripts/version.mjs"
+    "version": "cross-env-shell npm pkg set dependencies.@itowns/geographic=^$npm_package_version && node scripts/version.mjs"
   },
   "c8": {
     "exclude": [

--- a/packages/Widgets/package.json
+++ b/packages/Widgets/package.json
@@ -14,7 +14,7 @@
     "transpileOnly": "cross-env BABEL_DISABLE_CACHE=1 babel src --out-dir lib --extensions .js,.ts",
     "transpile": "npm run transpileOnly && npm run copy_transpile",
     "watch": "npm run transpileOnly -- --watch",
-    "version": "cross-env-shell npm install @itowns/geographic@$npm_package_version itowns@$npm_package_version"
+    "version": "cross-env-shell npm pkg set dependencies.@itowns/geographic=^$npm_package_version dependencies.itowns=^$npm_package_version"
   },
   "files": [
     "*.md",


### PR DESCRIPTION
## Description

The `version` lifecycle scripts in sub-packages (including the demo) were running `npm install <workspace>@$version` during version bumps. This installed copies from the npm registry into each package's own `node_modules`, shadowing the root-level workspace symlinks and causing stale dependency versions to be locked in `package-lock.json`.

This PR replaces all `npm install` calls with `npm pkg set` which only updates the version in sub-packages `package.json` without touching `package-lock.json` (and `node_modules`), letting the root `package.json` updates the `package-lock.json`.

## Testing

Run `npm run publish-next`, this shall run until credentials are asked.