### PR TITLE
fix(pointcloud): Fix pointcloud debugBoxes

### DIFF
--- a/packages/Debug/src/PointCloudDebug.js
+++ b/packages/Debug/src/PointCloudDebug.js
@@ -328,7 +328,7 @@ export default {
 
         const debugBoxes = new PointCloudDebug();
         debugBoxes.init(layer);
-        view.scene.add(debugBoxes.group);
+        layer.object3d.add(debugBoxes.group);
 
         debugUI.add(debugBoxes, 'displayVoxelBounds').name('Node OBB (voxel)').onChange(() => {
             view.notifyChange(layer, true);


### PR DESCRIPTION
## Motivation and Context
In my [exemple](https://github.com/bloc-in-bloc/itowns/blob/f/hackathon2/examples/demo_hackathon_orvault_planarView.html) I use a custom object placement with PlanarView.
So I can't see debug boxes because boxes was added to the scene and not related to the layer object.

## Screenshots (if appropriate)
Before the fix
<img width="1438" height="869" alt="Capture d’écran 2026-05-20 à 14 29 46" src="https://github.com/user-attachments/assets/8dbacc38-60c0-47bb-9f6c-c0a44d0855eb" />

After the fix
<img width="1641" height="881" alt="Capture d’écran 2026-05-20 à 14 30 32" src="https://github.com/user-attachments/assets/61ecd072-614d-40a4-b0e7-6f3140b67fb5" />
