### PR TITLE
fix(rendering): add SunLightLayer only if explicitly enabled in options

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -81,7 +81,7 @@
             const isEmbedded = window.self !== window.top;
 
             window.gui = new dat.GUI();
-            
+
 
             // ---- Create a GlobeView ----
 
@@ -97,6 +97,7 @@
             // Create a GlobeView
             const view = new GlobeView(viewerDiv, placement, {
                 realisticLighting: true,
+                withSunLightLayer: true,
                 shadows: true,
                 controls: {
                     minDistance: 100,

--- a/examples/demo/src/Views/View3D.ts
+++ b/examples/demo/src/Views/View3D.ts
@@ -30,6 +30,7 @@ class View3D extends View {
             placement,
             {
                 realisticLighting: true,
+                withSunLightLayer: true,
             },
         );
 

--- a/examples/mars.html
+++ b/examples/mars.html
@@ -62,6 +62,7 @@
                     scaleDepth: 0.38,
                 },
                 realisticLighting: true,
+                withSunLightLayer: true,
             });
             setupLoadingScreen(viewerDiv, view);
 

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -50,6 +50,7 @@
             // Create a GlobeView
             const view = new itowns.GlobeView(viewerDiv, placement, {
                 realisticLighting: true,
+                withSunLightLayer: true,
             });
 
             // Setup loading screen and debug menu

--- a/examples/view_3d_mns_map.html
+++ b/examples/view_3d_mns_map.html
@@ -57,6 +57,7 @@
             // Create a GlobeView
             const view = new itowns.GlobeView(viewerDiv, placement, {
                 realisticLighting: true,
+                withSunLightLayer: true,
             });
 
             // Setup loading screen and debug menu

--- a/packages/Main/src/Core/Prefab/Globe/SkyManager.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyManager.ts
@@ -94,7 +94,8 @@ class SkyManager {
         if (!this.enabled) { return; }
 
         // sunLightLayer necessarily exists if SkyManager was created.
-        const sunDirection = this.view.sunLightLayer!.sunDirection;
+        if (!this.view.sunLightLayer) { return; }
+        const sunDirection = this.view.sunLightLayer.sunDirection;
         const moonDirection = new THREE.Vector3();
         getMoonDirectionECEF(this.view.date, moonDirection);
 
@@ -140,7 +141,8 @@ class SkyManager {
     private _setState(on: boolean) {
         // Realistic rendering requires a dimmer sunlight.
         // sunLightLayer necessarily exists if SkyManager was created.
-        this.view.sunLightLayer!.sunLight.intensity *= on ? 0.1 : 10;
+        if (!this.view.sunLightLayer) { return; }
+        this.view.sunLightLayer.sunLight.intensity *= on ? 0.1 : 10;
         this.sky.visible = on;
         this.skyLight.visible = on;
         this.effectPass.enabled = on;

--- a/packages/Main/src/Core/Prefab/Globe/SkyManager.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyManager.ts
@@ -93,7 +93,8 @@ class SkyManager {
         const camera = this.view.camera3D as THREE.PerspectiveCamera | THREE.OrthographicCamera;
         if (!this.enabled) { return; }
 
-        const sunDirection = this.view.sunLightLayer.sunDirection;
+        // sunLightLayer necessarily exists if SkyManager was created.
+        const sunDirection = this.view.sunLightLayer!.sunDirection;
         const moonDirection = new THREE.Vector3();
         getMoonDirectionECEF(this.view.date, moonDirection);
 
@@ -137,8 +138,9 @@ class SkyManager {
     }
 
     private _setState(on: boolean) {
-        // Realistic rendering requires a dimmer sunlight
-        this.view.sunLightLayer.sunLight.intensity *= on ? 0.1 : 10;
+        // Realistic rendering requires a dimmer sunlight.
+        // sunLightLayer necessarily exists if SkyManager was created.
+        this.view.sunLightLayer!.sunLight.intensity *= on ? 0.1 : 10;
         this.sky.visible = on;
         this.skyLight.visible = on;
         this.effectPass.enabled = on;

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -84,9 +84,13 @@ class GlobeView extends View {
      * The maximum view distance is this factor times the camera's altitude (above sea level).
      * @param {number} [options.fogSpread=0.5] - Proportion of the visible depth range that contains fog.
      * Between 0 and 1.
+     * @param {boolean} [options.withSunLightLayer=false] - Create and add a SunLightLayer.
+     * If true, it can later be switched by setting this.sunLightLayer.visible to true/false.
+     * If false, it will be impossible to enable it later on.
      * @param {boolean} [options.realisticLighting=false] - Enable realistic lighting.
      * If true, it can later be switched by setting this.skyManager.enabled to true/false.
      * If false, it will be impossible to enable it later on.
+     * Can only be enabled if withSunLightLayer was also enabled.
      * @param {boolean} [options.shadows=false] - Enable shadow map rendering. Can be toggled
      * later via `this.shadows`.
      */
@@ -164,13 +168,20 @@ class GlobeView extends View {
         }
 
         this.date = new Date(); // now
+        const withSunLightLayer = options.withSunLightLayer === true;
 
         // Sunlight and shadow layer
-        this.sunLightLayer = new SunLightLayer(this);
-        this.addLayer(this.sunLightLayer);
+        if (withSunLightLayer) {
+            this.sunLightLayer = new SunLightLayer(this);
+            this.addLayer(this.sunLightLayer);
+        }
 
         if (options.realisticLighting === true) {
-            this.skyManager = new SkyManager(this);
+            if (withSunLightLayer) {
+                this.skyManager = new SkyManager(this);
+            } else {
+                console.error('Realistic lighting cannot be enabled without sunlight layer option');
+            }
         }
 
         this.renderer.shadowMap.enabled = true;
@@ -229,10 +240,11 @@ class GlobeView extends View {
      * @type {boolean}
      */
     get shadows() {
-        return this.sunLightLayer.castShadow;
+        return this.sunLightLayer?.castShadow ?? false;
     }
 
     set shadows(value) {
+        if (!this.sunLightLayer) { return; }
         if (this.sunLightLayer.castShadow == value) { return; }
         this.sunLightLayer.castShadow = value;
         this.notifyChange(this.camera3D);

--- a/packages/Main/test/unit/globeview.js
+++ b/packages/Main/test/unit/globeview.js
@@ -17,6 +17,7 @@ describe('GlobeView', function () {
     const viewer = new GlobeView(renderer.domElement, placement, {
         renderer,
         realisticLighting: true,
+        withSunLightLayer: true,
     });
     const pickedPosition = new THREE.Vector3();
     pickedPosition.copy(viewer.camera.position());


### PR DESCRIPTION
## Description
Add an option in `GlobeView` to decide whether to add a `SunLightLayer`.
Set it to false by default to recreate the default behavior in cases where a sunlight is not needed.

## Motivation and Context
The unconditional creation of a Sunlight layer in  https://github.com/iTowns/itowns/pull/2691 modified the default lighting of the scenes by creating a directional sunlight. As a result, the globe views always had a bright side and a dark side, instead of being uniformly lit.
For example, the default placement of potree_3d_map example was completely in the dark.

## Technical decisions
To avoid blocking the upcoming release, provide a minimal viable solution, i.e. the additional option creates and adds a `SunLightLayer` **only during initialization**. If it is not created during initialization, it therefore cannot be enabled afterward.

**An alternative** is to always create it but make it “invisible” immediately afterward if the configuration option is not enabled. In that case, it could be enabled/disabled afterward, but the downside is that a `SunLightLayer` would always be created, even in examples where it is not needed.

**A long-term solution** could of course combine both advantages (creation only upon first activation + ability to modify it afterward), but I do not consider that a minimal solution, and it requires discussions to decide on architectural specifications.