### PR TITLE
(Feat) TMSSource remove the extras $ in url param

### DIFF
--- a/docs/tutorials/3DTiles-point-cloud-pnts.md
+++ b/docs/tutorials/3DTiles-point-cloud-pnts.md
@@ -53,7 +53,7 @@ var orthoSource = new itowns.TMSSource({
     crs: "EPSG:3857",
     isInverted: true,
     format: "image/png",
-    url: "https://maps.pole-emploi.fr/styles/klokantech-basic/${z}/${x}/${y}.png",
+    url: "https://maps.pole-emploi.fr/styles/klokantech-basic/{z}/{x}/{y}.png",
     attribution: {
         name:"OpenStreetMap",
         url: "http://www.openstreetmap.org/"
@@ -210,7 +210,7 @@ The full code to achieve this result is:
                 crs: "EPSG:3857",
                 isInverted: true,
                 format: "image/png",
-                url: "https://maps.pole-emploi.fr/styles/klokantech-basic/${z}/${x}/${y}.png",
+                url: "https://maps.pole-emploi.fr/styles/klokantech-basic/{z}/{x}/{y}.png",
                 attribution: {
                     name:"OpenStreetMap",
                     url: "http://www.openstreetmap.org/"

--- a/examples/customColorLayerEffect.html
+++ b/examples/customColorLayerEffect.html
@@ -119,7 +119,7 @@
                 crs: 'EPSG:3857',
                 isInverted: true,
                 format: 'image/png',
-                url: 'https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/${z}/${x}/${y}.jpg',
+                url: 'https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/{z}/{x}/{y}.jpg',
                 tileMatrixSet: 'PM'
             });
 

--- a/examples/layers/JSONLayers/DARK.json
+++ b/examples/layers/JSONLayers/DARK.json
@@ -4,7 +4,7 @@
         "crs": "EPSG:3857",
 	    "networkOptions": { "crossOrigin" : "anonymous" },
         "format": "image/png",
-        "url": "http://a.basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png",
+        "url": "http://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
     	"attribution": {
     		"name":"CARTO",
     		"url": "https://carto.com/"

--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -4,7 +4,7 @@
         "crs": "EPSG:3857",
         "isInverted": true,
         "format": "image/png",
-        "url": "https://maps.pole-emploi.fr/styles/klokantech-basic/${z}/${x}/${y}.png",
+        "url": "https://maps.pole-emploi.fr/styles/klokantech-basic/{z}/{x}/{y}.png",
         "attribution": {
             "name":"OpenStreetMap",
             "url": "http://www.openstreetmap.org/"

--- a/examples/mars.html
+++ b/examples/mars.html
@@ -69,8 +69,8 @@
             var tmsMarsSource = new itowns.TMSSource({
                     // crs: 'EPSG:104905',
                     crs: 'EPSG:4326',
-                    url: 'https://trek.nasa.gov/tiles/Mars/EQ/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0/default/default028mm/${z}/${y}/${x}.jpg',
-                    // url : 'https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0//default/default028mm/${z}/${y}/${x}.jpg',
+                    url: 'https://trek.nasa.gov/tiles/Mars/EQ/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0/default/default028mm/{z}/{y}/{x}.jpg',
+                    // url : 'https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0//default/default028mm/{z}/${y}/{x}.jpg',
                     zoom: { min: 0, max: 9 },
                 })
 
@@ -89,7 +89,7 @@
                 source: new itowns.TMSSource({
                     // crs: 'EPSG:104905',
                     crs: 'EPSG:4326',
-                    url : 'https://api.nasa.gov/mars-wmts/catalog/Mars_MGS_MOLA_DEM_mosaic_global_463m_8/1.0.0//default/default028mm/${z}/${y}/${x}.png',
+                    url : 'https://api.nasa.gov/mars-wmts/catalog/Mars_MGS_MOLA_DEM_mosaic_global_463m_8/1.0.0//default/default028mm/{z}/{y}/{x}.png',
                     zoom: { min: 0, max: 5 },
                 }),
             });

--- a/examples/plugins_pyramidal_tiff.html
+++ b/examples/plugins_pyramidal_tiff.html
@@ -53,7 +53,7 @@
 
             // Add one imagery layer to the scene, read from TIFFs.
             var tiffSource = new itowns.TMSSource({
-                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/geoid/localcolors/tiff/${z}/localcolors_${x}_${y}.tif',
+                url: 'https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/master/geoid/localcolors/tiff/{z}/localcolors_{x}_{y}.tif',
                 tileMatrixSet: 'WGS84G',
                 crs: 'EPSG:4326',
                 parser: TIFFParser.parse,

--- a/examples/source_file_geojson_raster_2.html
+++ b/examples/source_file_geojson_raster_2.html
@@ -71,7 +71,7 @@
             // -> TMS imagery source
             var opensmSource = new itowns.TMSSource({
                 isInverted: true,
-                url: 'https://tile.openstreetmap.org/${z}/${x}/${y}.png',
+                url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 networkOptions: { crossOrigin: 'anonymous' },
                 extent,
                 crs: 'EPSG:3857',

--- a/examples/view_2d_map.html
+++ b/examples/view_2d_map.html
@@ -64,8 +64,7 @@
             // Add a TMS imagery source
             var opensmSource = new itowns.TMSSource({
                 isInverted: true,
-                // eslint-disable-next-line no-template-curly-in-string
-                url: 'https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/${z}/${x}/${y}.jpg',
+                url: 'https://watercolormaps.collection.cooperhewitt.org/tile/watercolor/{z}/{x}/{y}.jpg',
                 networkOptions: { crossOrigin: 'anonymous' },
                 extent,
                 crs: 'EPSG:3857',

--- a/packages/Main/src/Provider/URLBuilder.js
+++ b/packages/Main/src/Provider/URLBuilder.js
@@ -5,7 +5,7 @@ let subDomainsCount = 0;
  * @returns {string}
  */
 function subDomains(url) {
-    const subDomainsPtrn = /\$\{u:([\w-_.|]+)\}/.exec(url);
+    const subDomainsPtrn = /\$\{u:([\w\-.|]+)\}/.exec(url);
 
     if (!subDomainsPtrn) {
         return url;
@@ -23,7 +23,7 @@ function subDomains(url) {
  * In an url, it is also possible to specify subdomains alternatives using the
  * `${u:a|b|c}` pattern, by separating differents options using `|`. It will go
  * through the following alternative each time (no random). For example
- * `https://${u:xyz.org|yzx.org|zxy.org}/${z}/${x}/${y}.png`
+ * `https://${u:xyz.org|yzx.org|zxy.org}/{z}/{x}/{y}.png`
  *
  * @module URLBuilder
  */
@@ -36,9 +36,9 @@ export default {
      * The source object needs to have an url property, which should have some
      * specific strings that will be replaced by coordinates.
      * <ul>
-     * <li>`${x}` or `%COL` will be replaced by `coords.col`</li>
-     * <li>`${y}` or `%ROW` will be replaced by `coords.row`</li>
-     * <li>`${z}` or `%TILEMATRIX` will be replaced by `coords.zoom`</li>
+     * <li>`{x}` or `%COL` will be replaced by `coords.col`</li>
+     * <li>`{y}` or `%ROW` will be replaced by `coords.row`</li>
+     * <li>`{z}` or `%TILEMATRIX` will be replaced by `coords.zoom`</li>
      * </ul>
      *
      * @example
@@ -51,7 +51,7 @@ export default {
      *
      * @example
      * coords = new Extent('TMS', 15, 2142, 3412);
-     * source.url = 'http://server.geo/tms/${z}/${y}/${x}.jpg';
+     * source.url = 'http://server.geo/tms/{z}/{y}/{x}.jpg';
      * url = URLBuilder.xyz(coords, source);
      *
      * // The resulting url is:
@@ -68,9 +68,10 @@ export default {
      * @returns {string} the formed url
      */
     xyz: function xyz(coords, source) {
-        return subDomains(source.url.replace(/(\$\{z\}|%TILEMATRIX)/, source.tileMatrixCallback(coords.zoom))
-            .replace(/(\$\{y\}|%ROW)/, coords.row)
-            .replace(/(\$\{x\}|%COL)/, coords.col));
+        return subDomains(source.url)
+            .replace(/(\{z\}|%TILEMATRIX)/, source.tileMatrixCallback(coords.zoom))
+            .replace(/(\{y\}|%ROW)/, coords.row)
+            .replace(/(\{x\}|%COL)/, coords.col);
     },
 
     /**
@@ -117,7 +118,8 @@ export default {
         const n = bbox.north.toFixed(precision);
 
         let bboxInUnit = source.axisOrder || 'wsen';
-        bboxInUnit = bboxInUnit.replace('w', `${w},`)
+        bboxInUnit = bboxInUnit
+            .replace('w', `${w},`)
             .replace('s', `${s},`)
             .replace('e', `${e},`)
             .replace('n', `${n},`)

--- a/packages/Main/src/Source/TMSSource.js
+++ b/packages/Main/src/Source/TMSSource.js
@@ -36,7 +36,7 @@ import { TileMatrixSetLimits } from 'Core/Tile/Tile';
  * // Create the source
  * const tmsSource = new itowns.TMSSource({
  *     format: 'image/png',
- *     url: 'http://osm.io/styles/${z}/${x}/${y}.png',
+ *     url: 'http://osm.io/styles/{z}/{x}/{y}.png',
  *     attribution: {
  *         name: 'OpenStreetMap',
  *         url: 'http://www.openstreetmap.org/',
@@ -55,7 +55,7 @@ import { TileMatrixSetLimits } from 'Core/Tile/Tile';
  * @example <caption><b>Source from Mapbox server :</b></caption>
  * // Create the source
  * const orthoSource = new itowns.TMSSource({
- *     url: 'https://api.mapbox.com/v4/mapbox.satellite/${z}/${x}/${y}.jpg?access_token=' + accessToken,
+ *     url: 'https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.jpg?access_token=' + accessToken,
  *     crs: 'EPSG:3857',
  * };
  *
@@ -74,6 +74,12 @@ class TMSSource extends Source {
      */
     constructor(source) {
         source.format = source.format || 'image/png';
+
+        if (source.url && source.url.search(/(\$\{x\}|\$\{y\}|\$\{z\})/) >= 0) {
+            console.warn("Deprecated usage of '$' before {x}, {y} and {z} in url.");
+            source.url = source.url
+                .replace(/(\$\{x\})|(\$\{y\})|(\$\{z\})/g, corr => corr.substring(1));
+        }
 
         super(source);
 

--- a/packages/Main/src/Source/VectorTilesSource.js
+++ b/packages/Main/src/Source/VectorTilesSource.js
@@ -5,10 +5,6 @@ import URLBuilder from 'Provider/URLBuilder';
 import Fetcher from 'Provider/Fetcher';
 import urlParser from 'Parser/MapBoxUrlParser';
 
-function toTMSUrl(url) {
-    return url.replace(/\{/g, '${');
-}
-
 function mergeCollections(collections) {
     const collection = collections[0];
     collections.forEach((col, index) => {
@@ -139,17 +135,17 @@ class VectorTilesSource extends TMSSource {
                         return Fetcher.json(urlSource, this.networkOptions).then((tileJSON) => {
                             if (tileJSON.tiles[0]) {
                                 tileJSON.tiles[0] = decodeURIComponent(new URL(tileJSON.tiles[0], urlSource).toString());
-                                return toTMSUrl(tileJSON.tiles[0]);
+                                return tileJSON.tiles[0];
                             }
                         });
                     } else if (sourceVT.tiles) {
-                        return Promise.resolve(toTMSUrl(sourceVT.tiles[0]));
+                        return Promise.resolve(sourceVT.tiles[0]);
                     }
                     return Promise.reject();
                 });
                 return Promise.all(TMSUrlList);
             }
-            return (Promise.resolve([toTMSUrl(this.url)]));
+            return (Promise.resolve([this.url]));
         }).then((TMSUrlList) => {
             this.urls = Array.from(new Set(TMSUrlList));
         });

--- a/packages/Main/test/unit/provider_url.js
+++ b/packages/Main/test/unit/provider_url.js
@@ -7,9 +7,9 @@ import Tile from 'Core/Tile/Tile';
 describe('URL creations', function () {
     const layer = { tileMatrixCallback: (zoomLevel => zoomLevel) };
 
-    it('should correctly replace ${x}, ${y} and ${z} by 359, 512 and 10', function () {
+    it('should correctly replace {x}, {y} and {z} by 359, 512 and 10', function () {
         const coords = new Tile('EPSG:4857', 10, 512, 359);
-        layer.url = 'http://server.geo/tms/${z}/${y}/${x}.jpg';
+        layer.url = 'http://server.geo/tms/{z}/{y}/{x}.jpg';
         const result = URLBuilder.xyz(coords, layer);
         assert.equal(result, 'http://server.geo/tms/10/512/359.jpg');
     });

--- a/packages/Main/test/unit/source/tmssource.js
+++ b/packages/Main/test/unit/source/tmssource.js
@@ -3,21 +3,46 @@ import TMSSource from 'Source/TMSSource';
 import Tile from 'Core/Tile/Tile';
 
 describe('TMSSource', function () {
-    const paramsTMS = {
-        url: 'http://',
-        crs: 'EPSG:3857',
-        tileMatrixSetLimits: {
-            5: { minTileRow: 0, maxTileRow: 32, minTileCol: 0, maxTileCol: 32 },
-        },
-    };
+    let source;
 
-    it('should instance and use TMSSource', function () {
-        const source = new TMSSource(paramsTMS);
-        source.onLayerAdded({ out: { crs: 'EPSG:4326' } });
-        const extent = new Tile('TMS:3857', 5, 0, 0);
-        assert.ok(source.isTMSSource);
-        assert.ok(source.urlFromExtent(extent));
-        assert.ok(source.hasData(extent, extent.zoom));
+    describe('instantiation', function () {
+        // eslint-disable-next-line no-template-curly-in-string
+        const urlDeprecated = 'http://${z}/${y}/${x}';
+        const url = 'http://{z}/{y}/{x}';
+        const crs = 'EPSG:3857';
+        const tileMatrixSetLimits = {
+            5: { minTileRow: 0, maxTileRow: 32, minTileCol: 0, maxTileCol: 32 },
+        };
+
+        it('without url', function () {
+            assert.throws(() => new TMSSource({ url, tileMatrixSetLimits }), { message: 'New TMSSource/WMTSSource: crs is required' });
+        });
+
+        it('with deprecated url', function () {
+            source = new TMSSource({ url: urlDeprecated, crs, tileMatrixSetLimits });
+            assert.ok(source.isTMSSource);
+            assert.equal(source.url, url);
+        });
+
+        it('with url', function () {
+            source = new TMSSource({ url, crs, tileMatrixSetLimits });
+            assert.ok(source.isTMSSource);
+            assert.deepStrictEqual(source.zoom, { min: 5, max: 5 });
+        });
+    });
+
+    describe('methods', function () {
+        const zoom = 5;
+        const row = 3;
+        const col = 2;
+        const extent = new Tile('TMS:3857', zoom, row, col);
+        it('urlFromExtent', function () {
+            assert.equal(source.urlFromExtent(extent), `http://${zoom}/${row}/${col}`);
+        });
+
+        it('hasData', function () {
+            assert.ok(source.hasData(extent, extent.zoom));
+        });
     });
 });
 

--- a/packages/Main/test/unit/vectortiles.js
+++ b/packages/Main/test/unit/vectortiles.js
@@ -118,8 +118,7 @@ describe('VectorTilesSource', function () {
         });
         source.whenReady.then(() => {
             assert.equal(source.urls.length, 1);
-            // eslint-disable-next-line no-template-curly-in-string
-            assert.ok(source.urls.includes('http://server.geo/${z}/${x}/${y}.pbf'));
+            assert.ok(source.urls.includes('http://server.geo/{z}/{x}/{y}.pbf'));
             done();
         })
             .catch(done);
@@ -345,10 +344,8 @@ describe('VectorTilesSource', function () {
             source.whenReady
                 .then(() => {
                     assert.equal(source.urls.length, 2);
-                    // eslint-disable-next-line no-template-curly-in-string
-                    assert.ok(source.urls.includes('http://server.geo/${z}/${x}/${y}.pbf'));
-                    // eslint-disable-next-line no-template-curly-in-string
-                    assert.ok(source.urls.includes('http://server2.geo/${z}/${x}/${y}.pbf'));
+                    assert.ok(source.urls.includes('http://server.geo/{z}/{x}/{y}.pbf'));
+                    assert.ok(source.urls.includes('http://server2.geo/{z}/{x}/{y}.pbf'));
                     done();
                 })
                 .catch(done);
@@ -372,8 +369,7 @@ describe('VectorTilesSource', function () {
             source.whenReady
                 .then(() => {
                     assert.equal(source.urls.length, 1);
-                    // eslint-disable-next-line no-template-curly-in-string
-                    assert.ok(source.urls.includes('http://server.geo/${z}/${x}/${y}.pbf'));
+                    assert.ok(source.urls.includes('http://server.geo/{z}/{x}/{y}.pbf'));
                     done();
                 })
                 .catch(done);


### PR DESCRIPTION
Modification of url parameter in TMSSource to be similar as what is used in the VectorTile format:
Removal the unecessary '$' before {x}, {y} and {z}.

Allows a simplification of the VectorTileSource by removing the toTMSUrl() function.

This PR removes all references to ${z}, ${y}, ${x} in documentation and examples.