### PR TITLE
SkyController: refactoring, new simple sky mode, improvements and bug fixes

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -200,29 +200,8 @@
                     .then(() => debug.createOGC3DTilesDebugUI(gui, view, window.layer));
             }
 
-            // ---------- DATE/TIME CONTROLS ----------
-
-            // Add date/time controls to adjust sun position
-            const dateFolder = gui.addFolder('Date/Time');
-            const date = view.date;
-            dateFolder.add(
-                { month: 1 + date.getMonth() }, 'month', 1, 12, 1
-            ).onChange((v) => {
-                date.setMonth(v - 1);
-                view.notifyChange(view.sunLightLayer);
-            }).name('month (1-12)');
-            dateFolder.add(
-                { hour: date.getHours() }, 'hour', 0, 24, 0.1
-            ).onChange((v) => {
-                const hours = Math.floor(v);
-                const minutes = (v - hours) * 60;
-                date.setHours(hours, minutes);
-                view.notifyChange(view.camera3D);
-            }).name('hour (24h)');
-
-            gui.add(view, 'realisticLighting').onChange((v) => {
-                view.realisticLighting = v;
-            });
+            // ---------- Realistic lighting & DATE/TIME CONTROLS ----------
+            debug.createRealisticLightingDebugUI(gui,view);
 
             function loadLyon() {
                 setUrl("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/refs/heads/master/3DTiles/lyon1-4978/tileset.json");
@@ -235,9 +214,6 @@
             function loadLille() {
                 setUrl("https://webimaging.lillemetropole.fr/externe/maillage/2020_mel_5cm/tileset.json");
             }
-
-
-
 
             const readUrlButton = document.getElementById('readURLButton');
 

--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -96,7 +96,6 @@
 
             // Create a GlobeView
             const view = new GlobeView(viewerDiv, placement, {
-                realisticLighting: true,
                 shadows: true,
                 controls: {
                     minDistance: 100,
@@ -220,6 +219,10 @@
                 date.setHours(hours, minutes);
                 view.notifyChange(view.camera3D);
             }).name('hour (24h)');
+
+            gui.add(view, 'realisticLighting').onChange((v) => {
+                view.realisticLighting = v;
+            });
 
             function loadLyon() {
                 setUrl("https://raw.githubusercontent.com/iTowns/iTowns2-sample-data/refs/heads/master/3DTiles/lyon1-4978/tileset.json");

--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -217,7 +217,7 @@
                 const hours = Math.floor(v);
                 const minutes = (v - hours) * 60;
                 date.setHours(hours, minutes);
-                view.notifyChange(view.sunLightLayer);
+                view.notifyChange(view.camera3D);
             }).name('hour (24h)');
 
             function loadLyon() {

--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -81,7 +81,7 @@
             const isEmbedded = window.self !== window.top;
 
             window.gui = new dat.GUI();
-            
+
 
             // ---- Create a GlobeView ----
 
@@ -179,6 +179,7 @@
                 window.layer = new OGC3DTilesLayer('3DTiles', {
                     source,
                     pntsSizeMode: PNTS_SIZE_MODE.ATTENUATED,
+                    sseThreshold: 2,
                 });
 
                 // Add an event for picking the 3D Tiles layer and displaying

--- a/examples/demo/src/Views/ImmersiveView.ts
+++ b/examples/demo/src/Views/ImmersiveView.ts
@@ -50,10 +50,8 @@ class ImmersiveView extends View {
         // @ts-expect-error camera3D updateProjectionMatrix method undefined
         this.view.camera3D.updateProjectionMatrix();
 
-        const view = this.view as itowns.GlobeView & { skyManager: { enabled: boolean } };
-        if (view.skyManager && view.skyManager.enabled) {
-            view.skyManager.enabled = false;
-        }
+        const view = this.view as itowns.GlobeView & { realisticLighting: boolean };
+        view.realisticLighting = false;
 
         setupLoadingScreen(this.viewerDiv, view);
 

--- a/examples/demo/src/Views/View3D.ts
+++ b/examples/demo/src/Views/View3D.ts
@@ -35,8 +35,8 @@ class View3D extends View {
         const view = this.view as itowns.GlobeView;
 
         this.atmosphereFrameRequester = () => {
-            if (view.skyManager) {
-                view.skyManager.enabled =
+            if (view.skyController) {
+                view.realisticLighting =
                     view.getDistanceFromCamera() > Config.ATMOSPHERE_THRESHOLD;
             }
         };

--- a/examples/mars.html
+++ b/examples/mars.html
@@ -33,6 +33,20 @@
             import * as THREE from 'three';
             import * as itowns from 'itowns';
             import * as debug from 'debug';
+
+            const marsRealisticParams = {
+                rayleighScattering: new THREE.Vector3(0.00199, 0.00092, 0.00045),
+                mieScattering: new THREE.Vector3(0.003, 0.002, 0.0015),
+                mieExtinction: new THREE.Vector3(0.0033, 0.0022, 0.00165),
+                miePhaseFunctionG: 0.7,
+            };
+
+            const marsSimpleParams = {
+                skyAltitude: 100000, // Closer to ground
+                skyColor: 0xd99b75, // Orange sky
+                fogColor: 0xd6ad9a, // Beige fog
+            }
+
             import * as itowns_widgets from 'itowns_widgets';
             // # Simple Globe viewer
             // Define initial camera position
@@ -51,18 +65,13 @@
 
             // Instanciate iTowns GlobeView*
             var view = new itowns.GlobeView(viewerDiv, placement, {
-                atmosphere: {
-                    Kr: 0.0025,
-                    Km: 0.0015,
-                    ESun: 15.0,
-                    g: -0.950,
-                    innerRadius: 6400000,
-                    outerRadius: 6600000,
-                    wavelength: [0.350, 0.470, 0.575],
-                    scaleDepth: 0.38,
-                },
+                realisticSky: marsRealisticParams,
+                simpleSky: marsSimpleParams,
                 realisticLighting: true,
+                farFactor: 0.6, // Less aggressive horizon scaling for this ellipsoid-based demo
             });
+
+            view.skyController.realisticSky.sky.material.moon = false;
             setupLoadingScreen(viewerDiv, view);
 
             // Add a tms imagery source
@@ -98,7 +107,7 @@
             var menuGlobe = new GuiTools('menuDiv', view);
 
             const cRL = menuGlobe.addGUI('RealisticLighting', true, function (v) {
-                view.skyManager.enabled = v;
+                view.realisticLighting = v;
             });
 
             debug.createTileDebugUI(menuGlobe.gui, view);

--- a/examples/mars.html
+++ b/examples/mars.html
@@ -106,10 +106,7 @@
 
             var menuGlobe = new GuiTools('menuDiv', view);
 
-            const cRL = menuGlobe.addGUI('RealisticLighting', true, function (v) {
-                view.realisticLighting = v;
-            });
-
+            debug.createRealisticLightingDebugUI(menuGlobe.gui, view);
             debug.createTileDebugUI(menuGlobe.gui, view);
             window.view = view;
             window.itowns = itowns;

--- a/examples/plugins_pyramidal_tiff.html
+++ b/examples/plugins_pyramidal_tiff.html
@@ -74,7 +74,6 @@
                 var layer = new itowns.ElevationLayer(config.id, config);
                 view.addLayer(layer).then(function _(layer) {
                     layer.scale = 10000;
-                    view.tileLayer.attachedLayers[0].visible = false;
                     menuGlobe.addLayerGUI(layer);
                     menuGlobe.elevationGui.open();
                     menuGlobe.elevationGui.__folders.GEOIDMNT.open();

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -49,7 +49,7 @@
 
             // Create a GlobeView
             const view = new itowns.GlobeView(viewerDiv, placement, {
-                realisticLighting: true,
+                realisticLighting: false,
             });
 
             // Setup loading screen and debug menu

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -143,12 +143,7 @@
             });
 
             // ---------- DEBUG TOOLS : ----------
-
-            // Toggle atmospheric lighting on/off.
-            const cRL = debugMenu.addGUI('RealisticLighting', !view.isDebugMode, function (v) {
-                view.realisticLighting = v;
-            });
-
+            debug.createRealisticLightingDebugUI(debugMenu.gui, view);
             debug.createTileDebugUI(debugMenu.gui, view);
 
             window.view = view;

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -146,15 +146,14 @@
 
             // ---------- DISPLAY ATMOSPHERIC LIGHTING : ----------
 
-            view.skyManager.enabled = !view.isDebugMode;
-
+            view.realisticLighting = !view.isDebugMode;
 
 
             // ---------- DEBUG TOOLS : ----------
 
             // Toggle atmospheric lighting on/off.
             const cRL = debugMenu.addGUI('RealisticLighting', !view.isDebugMode, function (v) {
-                view.skyManager.enabled = v;
+                view.realisticLighting = v;
             });
 
             debug.createTileDebugUI(debugMenu.gui, view);

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -143,7 +143,7 @@
             });
 
             // ---------- DEBUG TOOLS : ----------
-            debug.createRealisticLightingDebugUI(debugMenu.gui, view);
+            const cRL = debug.createRealisticLightingDebugUI(debugMenu.gui, view);
             debug.createTileDebugUI(debugMenu.gui, view);
 
             window.view = view;

--- a/examples/view_3d_map.html
+++ b/examples/view_3d_map.html
@@ -142,13 +142,6 @@
                 position: 'top-right',
             });
 
-
-
-            // ---------- DISPLAY ATMOSPHERIC LIGHTING : ----------
-
-            view.realisticLighting = !view.isDebugMode;
-
-
             // ---------- DEBUG TOOLS : ----------
 
             // Toggle atmospheric lighting on/off.

--- a/examples/view_3d_mns_map.html
+++ b/examples/view_3d_mns_map.html
@@ -150,7 +150,7 @@
 
             // ---------- DISPLAY ATMOSPHERIC LIGHTING : ----------
 
-            view.skyManager.enabled = !view.isDebugMode;
+            view.realisticLighting = !view.isDebugMode;
 
 
 
@@ -158,7 +158,7 @@
 
             // Toggle atmospheric lighting on/off.
             const cRL = debugMenu.addGUI('RealisticLighting', !view.isDebugMode, function (v) {
-                view.skyManager.enabled = v;
+                view.realisticLighting = v;
             });
 
             debug.createTileDebugUI(debugMenu.gui, view);

--- a/examples/view_3d_mns_map.html
+++ b/examples/view_3d_mns_map.html
@@ -157,9 +157,7 @@
             // ---------- DEBUG TOOLS : ----------
 
             // Toggle atmospheric lighting on/off.
-            const cRL = debugMenu.addGUI('RealisticLighting', !view.isDebugMode, function (v) {
-                view.realisticLighting = v;
-            });
+            debug.createRealisticLightingDebugUI(debugMenu.gui, view);
 
             debug.createTileDebugUI(debugMenu.gui, view);
 

--- a/packages/Debug/src/Debug.js
+++ b/packages/Debug/src/Debug.js
@@ -147,11 +147,6 @@ function Debug(view, datDebugTool, chartDivContainer) {
     debugCamera.updateProjectionMatrix();
     const g = view.mainLoop.gfxEngine;
     const r = g.renderer;
-    let fogDistance = 10e10;
-    const layerAtmosphere = view.getLayerById('atmosphere');
-    if (layerAtmosphere) {
-        fogDistance = layerAtmosphere.fog.distance;
-    }
     helper.visible = false;
     view.scene.add(helper);
 
@@ -161,12 +156,6 @@ function Debug(view, datDebugTool, chartDivContainer) {
     displayedTilesObbHelper.visible = false;
     view.scene.add(displayedTilesObb);
     view.scene.add(displayedTilesObbHelper);
-
-    function updateFogDistance(obj) {
-        if (obj.material && fogDistance) {
-            obj.material.setUniform('fogDistance', fogDistance);
-        }
-    }
 
     const clearColor = new Color();
     const lookAtCameraDebug = new Vector3();
@@ -207,13 +196,6 @@ function Debug(view, datDebugTool, chartDivContainer) {
             helper.update();
 
             debugCamera.updateProjectionMatrix();
-            if (layerAtmosphere) {
-                layerAtmosphere.object3d.visible = false;
-                fogDistance = 10e10;
-                for (const obj of tileLayer.level0Nodes) {
-                    obj.traverseVisible(updateFogDistance);
-                }
-            }
 
             const deltaY = state.displayCharts ? Math.round(parseFloat(chartDivContainer.style.height.replace('%', '')) * g.height / 100) + 3 : 0;
             helper.visible = true;
@@ -231,15 +213,6 @@ function Debug(view, datDebugTool, chartDivContainer) {
 
             helper.visible = false;
             displayedTilesObbHelper.visible = false;
-            if (layerAtmosphere) {
-                layerAtmosphere.object3d.visible = true;
-            }
-            if (layerAtmosphere) {
-                fogDistance = layerAtmosphere.fog.distance;
-                for (const obj of tileLayer.level0Nodes) {
-                    obj.traverseVisible(updateFogDistance);
-                }
-            }
         }
     }
 }

--- a/packages/Debug/src/Debug.js
+++ b/packages/Debug/src/Debug.js
@@ -195,6 +195,10 @@ function Debug(view, datDebugTool, chartDivContainer) {
 
             helper.update();
 
+            const distToTarget = debugCamera.position.distanceTo(lookAtCameraDebug);
+            debugCamera.near = distToTarget * 0.01;
+            debugCamera.far = distToTarget * 100;
+
             debugCamera.updateProjectionMatrix();
 
             const deltaY = state.displayCharts ? Math.round(parseFloat(chartDivContainer.style.height.replace('%', '')) * g.height / 100) + 3 : 0;
@@ -206,7 +210,17 @@ function Debug(view, datDebugTool, chartDivContainer) {
             r.setScissorTest(true);
             r.setClearColor(backgroundChartDiv);
             r.clear();
+
+            if (view.skyController) {
+                view.skyController.enabled = false;
+            }
+
             r.render(view.scene, debugCamera);
+
+            if (view.skyController) {
+                view.skyController.enabled = true;
+            }
+
             r.setScissorTest(false);
             r.setClearColor(clearColor);
             r.setViewport(0, 0, g.width, g.height);

--- a/packages/Debug/src/Debug.js
+++ b/packages/Debug/src/Debug.js
@@ -211,13 +211,14 @@ function Debug(view, datDebugTool, chartDivContainer) {
             r.setClearColor(backgroundChartDiv);
             r.clear();
 
-            if (view.skyController) {
+            const skyEnabled = view.skyController && view.skyController.enabled;
+            if (skyEnabled) {
                 view.skyController.enabled = false;
             }
 
             r.render(view.scene, debugCamera);
 
-            if (view.skyController) {
+            if (skyEnabled) {
                 view.skyController.enabled = true;
             }
 

--- a/packages/Debug/src/Main.js
+++ b/packages/Debug/src/Main.js
@@ -3,5 +3,6 @@ export { default as PointCloudDebug } from 'PointCloudDebug';
 export { default as createTileDebugUI } from 'TileDebug';
 export { default as create3dTilesDebugUI } from '3dTilesDebug';
 export { default as createOGC3DTilesDebugUI } from 'OGC3DTilesDebug';
+export { createRealisticLightingDebugUI, createDateTimeUI } from 'RealisticLightingDebug';
 export { default as GeometryDebug } from 'GeometryDebug';
 export { default as GuiTools } from 'GuiTools';

--- a/packages/Debug/src/RealisticLightingDebug.js
+++ b/packages/Debug/src/RealisticLightingDebug.js
@@ -1,0 +1,49 @@
+export function createRealisticLightingDebugUI(gui, view) {
+    if (view.realisticLighting === undefined) {
+        console.error('Failed to create realistic lighting debug UI. The view does not expose realisticLighting');
+        return;
+    }
+    if (view.skyController === undefined) {
+        console.error('Failed to create debug UI. The view does not expose skyController');
+        return;
+    }
+    const realisticLightingFolder = gui.addFolder('Realistic lighting');
+    const realisticLightingProperty = realisticLightingFolder.add(view, 'realisticLighting');
+    const forceDayTimeProperty = realisticLightingFolder.add(view.skyController, 'forceDaytime');
+    const dateTimeFolder = createDateTimeUI(realisticLightingFolder, view);
+
+    function toggleDateTimeFolder() {
+        if (!view.realisticLighting || view.skyController.forceDaytime) {
+            dateTimeFolder.hide();
+        } else {
+            dateTimeFolder.show();
+            dateTimeFolder.open();
+        }
+    }
+
+    toggleDateTimeFolder();
+    forceDayTimeProperty.onChange(() => toggleDateTimeFolder());
+    realisticLightingProperty.onChange(() => toggleDateTimeFolder());
+    return realisticLightingFolder;
+}
+
+export function createDateTimeUI(gui, view) {
+    const date = view.date;
+    const dateTimeFolder = gui.addFolder('Date/Time');
+    dateTimeFolder.add(
+        { month: 1 + date.getMonth() }, 'month', 1, 12, 1,
+    ).onChange((v) => {
+        date.setMonth(v - 1);
+        view.notifyChange(view.camera3D);
+    }).name('month (1-12)');
+
+    dateTimeFolder.add(
+        { hour: date.getHours() }, 'hour', 0, 24, 0.1,
+    ).onChange((v) => {
+        const hours = Math.floor(v);
+        const minutes = (v - hours) * 60;
+        date.setHours(hours, minutes);
+        view.notifyChange(view.camera3D);
+    }).name('hour (24h)');
+    return dateTimeFolder;
+}

--- a/packages/Main/src/Core/Prefab/Globe/HorizonGradient.ts
+++ b/packages/Main/src/Core/Prefab/Globe/HorizonGradient.ts
@@ -1,0 +1,101 @@
+import * as THREE from 'three';
+import { ellipsoidSizes } from '@itowns/geographic';
+import vertexShader from 'Core/Prefab/Globe/Shaders/HorizonGradientVS.glsl';
+import fragmentShader from 'Core/Prefab/Globe/Shaders/HorizonGradientFS.glsl';
+import GlobeView from 'Core/Prefab/GlobeView';
+
+const geodeticUp = new THREE.Vector3();
+
+/**
+ * Screen-space atmospheric horizon band rendered as a full-screen quad.
+ *
+ * This helper draws a soft gradient near the geometric horizon to visually
+ * blend ground fog into the sky.
+ *
+ * Notes:
+ * - Based on `ellipsoidSizes`.
+ * - It relies on scene fog color (`view.scene.fog`).
+ * - It is rendered late (`renderOrder = 999`) as a transparent pass.
+ */
+class HorizonGradient {
+    mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
+
+    constructor(scene: THREE.Scene) {
+        const material = new THREE.ShaderMaterial({
+            uniforms: {
+                fogColor: { value: new THREE.Color() },
+                groundColor: { value: new THREE.Color(0x000000) },
+                sinHorizon: { value: 0.0 },
+                bandHalfWidth: { value: 0.04 },
+                geodeticUp: { value: new THREE.Vector3() },
+                uProjectionMatrixInverse: { value: new THREE.Matrix4() },
+            },
+            vertexShader,
+            fragmentShader,
+            depthTest: true,
+            depthWrite: true,
+            transparent: true,
+            blending: THREE.NormalBlending,
+        });
+
+        this.mesh = new THREE.Mesh(
+            new THREE.PlaneGeometry(2, 2),
+            material,
+        );
+
+        this.mesh.frustumCulled = false;
+        this.mesh.renderOrder = 999;
+        this.mesh.onBeforeRender = (_renderer, _scene, camera) => {
+            material.uniforms.uProjectionMatrixInverse.value.copy(camera.projectionMatrixInverse);
+        };
+
+        scene.add(this.mesh);
+    }
+
+    /*
+     * Updates shader uniforms from the current globe camera and fog state.
+     */
+    update(view: GlobeView, fogSpreadValue: number) {
+        if (!this.mesh) { return; }
+
+        const fog = view.scene.fog as THREE.Fog | null;
+        if (!fog || !this.mesh.visible) { return; }
+
+        const uniforms = this.mesh.material.uniforms;
+        uniforms.fogColor.value.copy(fog.color);
+
+        // Geodetic surface normal: (x/a², y/a², z/b²) normalized
+        const pos = view.camera3D.position;
+        const a = ellipsoidSizes.x;
+        const b = ellipsoidSizes.z;
+        const a2 = a * a;
+        const b2 = b * b;
+        geodeticUp.set(pos.x / a2, pos.y / a2, pos.z / b2).normalize();
+
+        // Geodetic altitude: distance from camera to ellipsoid along the normal
+        const nx = geodeticUp.x;
+        const ny = geodeticUp.y;
+        const nz = geodeticUp.z;
+        const surfaceR = 1.0 / Math.sqrt((nx * nx + ny * ny) / a2 + (nz * nz) / b2);
+        const hGeo = Math.max(0, pos.dot(geodeticUp) - surfaceR);
+
+        // Depression angle from horizontal to the geometric horizon
+        uniforms.sinHorizon.value = -Math.sqrt(hGeo * (2 * surfaceR + hGeo)) / (surfaceR + hGeo);
+
+        // Band width scales with fog spread
+        // Scaling value was determined experimentally
+        uniforms.bandHalfWidth.value = fogSpreadValue * 0.08;
+
+        uniforms.geodeticUp.value.copy(geodeticUp);
+    }
+
+    get visible() {
+        return this.mesh.visible;
+    }
+
+    set visible(visible: boolean) {
+        this.mesh.visible = visible;
+    }
+}
+
+export default HorizonGradient;

--- a/packages/Main/src/Core/Prefab/Globe/ISkyStrategy.ts
+++ b/packages/Main/src/Core/Prefab/Globe/ISkyStrategy.ts
@@ -1,0 +1,7 @@
+interface ISkyStrategy {
+    enabled: boolean;
+    readonly ready: boolean;
+    update(): void;
+    dispose(): void;
+}
+export default ISkyStrategy;

--- a/packages/Main/src/Core/Prefab/Globe/RealisticSky.ts
+++ b/packages/Main/src/Core/Prefab/Globe/RealisticSky.ts
@@ -61,7 +61,7 @@ class RealisticSky implements ISkyStrategy {
         this.sky.visible = false;
         scene.add(this.sky);
 
-        // SkyLightProbe computes skyController irradiance of its position.
+        // SkyLightProbe computes sky irradiance of its position.
         this.skyLight = new SkyLightProbe();
         this.skyLight.intensity = 0.5;
         this.skyLight.position.copy(camera.position);

--- a/packages/Main/src/Core/Prefab/Globe/RealisticSky.ts
+++ b/packages/Main/src/Core/Prefab/Globe/RealisticSky.ts
@@ -5,7 +5,9 @@ import {
     SkyMaterial,
     getMoonDirectionECEF,
     PrecomputedTexturesGenerator,
+    AtmosphereParameters,
 } from '@takram/three-atmosphere';
+
 import {
     EffectPass,
     RenderPass,
@@ -16,84 +18,96 @@ import {
     EffectComposer,
 } from 'postprocessing';
 import GlobeView from 'Core/Prefab/GlobeView';
+import SunLightLayer from 'Layer/SunLightLayer';
+import ISkyStrategy from './ISkyStrategy';
 
-class SkyManager {
+export interface RealisticSkyParameters {
+    rayleighScattering: THREE.Vector3;
+    mieScattering: THREE.Vector3;
+    mieExtinction: THREE.Vector3;
+    miePhaseFunctionG: number;
+}
+
+class RealisticSky implements ISkyStrategy {
     sky: THREE.Mesh;
     skyLight: SkyLightProbe;
     aerialPerspective: AerialPerspectiveEffect;
+    renderPass: RenderPass;
     effectPass: EffectPass;
+    FXAAPass: EffectPass;
     scene: THREE.Scene;
     composer: EffectComposer;
-    fog: THREE.Fog;
     view: GlobeView;
+    sunLightLayer: SunLightLayer;
+    ready: boolean;
+    private _originalIntensity: number;
 
-    constructor(view: GlobeView) {
+    constructor(view: GlobeView, sunLightLayer: SunLightLayer, params?: RealisticSkyParameters) {
         this.view = view;
         const scene = view.scene;
         this.scene = scene;
         const camera = view.camera3D;
         const composer = view.mainLoop.gfxEngine.composer;
         this.composer = composer;
+        this.sunLightLayer = sunLightLayer;
+        this.ready = false;
+        this._originalIntensity = sunLightLayer.sunLight.intensity;
 
         // SkyMaterial disables projection.
         // Provide a plane that covers clip space.
         const skyMaterial = new SkyMaterial();
         this.sky = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), skyMaterial);
         this.sky.frustumCulled = false;
+        this.sky.visible = false;
         scene.add(this.sky);
 
-        // SkyLightProbe computes sky irradiance of its position.
+        // SkyLightProbe computes skyController irradiance of its position.
         this.skyLight = new SkyLightProbe();
         this.skyLight.intensity = 0.5;
         this.skyLight.position.copy(camera.position);
+        this.skyLight.visible = false;
         scene.add(this.skyLight);
 
         this.aerialPerspective = new AerialPerspectiveEffect(camera);
-        this.aerialPerspective.setSize(window.innerWidth, window.innerHeight);
 
-        const renderer = view.renderer;
-        renderer.toneMappingExposure = 10;
+        const rendererSize = new THREE.Vector2();
+        view.mainLoop.gfxEngine.renderer.getSize(rendererSize);
+        this.aerialPerspective.setSize(rendererSize.x, rendererSize.y);
 
-        composer.addPass(new RenderPass(scene, camera));
+        this.renderPass = new RenderPass(scene, camera);
         this.effectPass = new EffectPass(
             camera,
             this.aerialPerspective,
             new ToneMappingEffect({ mode: ToneMappingMode.AGX }),
         );
-        this.effectPass.enabled = false;
-        composer.addPass(this.effectPass);
-        composer.addPass(new EffectPass(camera, new FXAAEffect())); // anti-aliasing
+        this.FXAAPass = new EffectPass(camera, new FXAAEffect());
 
         // Generate precomputed textures.
+        const renderer = view.renderer;
         const generator = new PrecomputedTexturesGenerator(renderer);
-        generator.update().catch((error) => { console.error(error); });
 
-        const textures = generator.textures;
-        Object.assign(skyMaterial, textures);
-        this.skyLight.irradianceTexture = textures.irradianceTexture;
-        Object.assign(this.aerialPerspective, textures);
+        const atmosphereParams = params ? new AtmosphereParameters(params) : AtmosphereParameters.DEFAULT;
+        generator.update(atmosphereParams).then(() => {
+            const textures = generator.textures;
+            Object.assign(skyMaterial, textures);
+            this.skyLight.irradianceTexture = textures.irradianceTexture;
+            Object.assign(this.aerialPerspective, textures);
+            this.ready = true;
 
-        this.fog = scene.fog;
-
-        this._setState(true);
-
-        scene.onBeforeRender = () => {
-            // disable fog only during render
-            // to let its parameters be modified elsewhere
-            if (this.enabled) { this.scene.fog = null; }
-        };
-        scene.onAfterRender = () => {
-            if (this.enabled) { this.scene.fog = this.fog; }
-        };
-
-        this.composer.render();
+            // If already enabled, trigger an update now that textures are ready
+            if (this.enabled) {
+                this.update();
+                this.view.notifyChange(this.view.camera3D);
+                this.composer.render();
+            }
+        }).catch((error) => { console.error(error); });
     }
 
     update() {
         const camera = this.view.camera3D as THREE.PerspectiveCamera | THREE.OrthographicCamera;
-        if (!this.enabled) { return; }
+        if (!this.enabled || !this.ready) { return; }
 
-        const sunDirection = this.view.sunLightLayer.sunDirection;
+        const sunDirection = this.sunLightLayer.sunDirection;
         const moonDirection = new THREE.Vector3();
         getMoonDirectionECEF(this.view.date, moonDirection);
 
@@ -107,7 +121,7 @@ class SkyManager {
 
         // attenuate aerial perspective when far away.
         // value determined experimentally
-        this.aerialPerspective.blendMode.opacity.value = Math.max(1 - 2e-7 * camera.near, 0);
+        this.aerialPerspective.blendMode.opacity.value = Math.max(0.1 - 2e-8 * camera.near, 0.05);
 
         // The changes to the camera's near/far must be manually updated
         // to the uniforms used in post-processing effects
@@ -125,7 +139,7 @@ class SkyManager {
     }
 
     set enabled(on: boolean) {
-        if (this.enabled == on) { return; }
+        if (this.enabled === on) { return; }
         this._setState(on);
 
         // force internally calling state.buffers.color.setClear
@@ -133,16 +147,43 @@ class SkyManager {
         this.view.renderer.setClearAlpha(this.view.renderer.getClearAlpha());
 
         if (on) { this.update(); }
-        this.composer.render();
+    }
+
+    dispose() {
+        this._setState(false);
+
+        this.scene.remove(this.sky);
+        this.sky.geometry.dispose();
+        (this.sky.material as THREE.Material).dispose();
+
+        this.scene.remove(this.skyLight);
+
+        this.aerialPerspective.dispose();
+        this.renderPass.dispose();
+        this.effectPass.dispose();
+        this.FXAAPass.dispose();
     }
 
     private _setState(on: boolean) {
         // Realistic rendering requires a dimmer sunlight
-        this.view.sunLightLayer.sunLight.intensity *= on ? 0.1 : 10;
+        this.sunLightLayer.sunLight.intensity = on
+            ? this._originalIntensity * 0.1
+            : this._originalIntensity;
         this.sky.visible = on;
         this.skyLight.visible = on;
-        this.effectPass.enabled = on;
+
+        this.view.renderer.toneMappingExposure = on ? 10 : 1;
+
+        if (on) {
+            this.composer.addPass(this.renderPass);
+            this.composer.addPass(this.effectPass);
+            this.composer.addPass(this.FXAAPass);
+        } else {
+            this.composer.removePass(this.renderPass);
+            this.composer.removePass(this.effectPass);
+            this.composer.removePass(this.FXAAPass);
+        }
     }
 }
 
-export default SkyManager;
+export default RealisticSky;

--- a/packages/Main/src/Core/Prefab/Globe/RealisticSky.ts
+++ b/packages/Main/src/Core/Prefab/Globe/RealisticSky.ts
@@ -121,7 +121,7 @@ class RealisticSky implements ISkyStrategy {
 
         // attenuate aerial perspective when far away.
         // value determined experimentally
-        this.aerialPerspective.blendMode.opacity.value = Math.max(0.1 - 2e-8 * camera.near, 0.05);
+        this.aerialPerspective.blendMode.opacity.value = Math.max(0.3 - 2e-7 * camera.near, 0.05);
 
         // The changes to the camera's near/far must be manually updated
         // to the uniforms used in post-processing effects

--- a/packages/Main/src/Core/Prefab/Globe/Shaders/HorizonGradientFS.glsl
+++ b/packages/Main/src/Core/Prefab/Globe/Shaders/HorizonGradientFS.glsl
@@ -1,0 +1,23 @@
+uniform vec3  fogColor;
+uniform float sinHorizon;
+uniform float bandHalfWidth;
+uniform vec3  geodeticUp;
+
+varying vec3 vWorldDirection;
+
+vec3 linearToSRGB(vec3 c) {
+    return pow(c, vec3(1.0 / 2.2));
+}
+
+void main() {
+    gl_FragDepth = 1.0;
+    // Use the world-space ray direction computed in the vertex shader
+    vec3 worldRay = normalize(vWorldDirection);
+    // Elevation of ray relative to geodetic up (surface normal)
+    float sinElev = dot(worldRay, geodeticUp);
+    // Gaussian fade above horizon, constant fog below
+    float t = (sinElev - sinHorizon) / max(bandHalfWidth, 1e-4);
+    float alpha = t <= 0.0 ? 1.0 : exp(-0.5 * t * t);
+    if (alpha < 1e-3) discard;
+    gl_FragColor = vec4(linearToSRGB(fogColor), alpha);
+}

--- a/packages/Main/src/Core/Prefab/Globe/Shaders/HorizonGradientVS.glsl
+++ b/packages/Main/src/Core/Prefab/Globe/Shaders/HorizonGradientVS.glsl
@@ -1,0 +1,11 @@
+uniform mat4 uProjectionMatrixInverse;
+
+varying vec3 vWorldDirection;
+
+void main() {
+    vec4 clipPos = vec4(position.xy, 0.0, 1.0);
+    vec4 viewRay = uProjectionMatrixInverse * clipPos;
+    // viewMatrix is orthonormal, so inverse rotation = transpose
+    vWorldDirection = transpose(mat3(viewMatrix)) * viewRay.xyz;
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+}

--- a/packages/Main/src/Core/Prefab/Globe/SimpleSky.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SimpleSky.ts
@@ -38,7 +38,7 @@ class SimpleSky implements ISkyStrategy {
     readonly ready: boolean = true;
     private _enabled: boolean;
 
-    constructor(view: GlobeView, options : SimpleSkyParameters) {
+    constructor(view: GlobeView, options: SimpleSkyParameters) {
         const {
             fogSpread,
             skyAltitude,

--- a/packages/Main/src/Core/Prefab/Globe/SimpleSky.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SimpleSky.ts
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+import HorizonGradient from 'Core/Prefab/Globe/HorizonGradient';
+import GlobeView from 'Core/Prefab/GlobeView';
+import ISkyStrategy from './ISkyStrategy';
+
+const computedSkyColor = new THREE.Color();
+
+export interface SimpleSkyParameters {
+    fogSpread?: number;
+    skyAltitude?: number;
+    enabled?: boolean;
+    spaceColor?: THREE.ColorRepresentation;
+    skyColor?: THREE.ColorRepresentation;
+    fogColor?: THREE.ColorRepresentation;
+}
+
+const DEFAULT_OPTIONS = {
+    fogSpread: 0.4,
+    skyAltitude: 200000,
+    enabled: true,
+    spaceColor: 0x030508,
+    skyColor: 0xa3ceff,
+    fogColor: 0xe2edff,
+};
+
+/**
+ * Renders a simple sky representation with fog effects, atmospheric gradient, and color blending based on altitude,
+ * for a globe view.
+ */
+class SimpleSky implements ISkyStrategy {
+    view: GlobeView;
+    fogSpread: number;
+    skyAltitude: number;
+    spaceColor: THREE.Color;
+    skyColor: THREE.Color;
+    fogColor: THREE.Color;
+    horizonGradient: HorizonGradient;
+    readonly ready: boolean = true;
+    private _enabled: boolean;
+
+    constructor(view: GlobeView, options : SimpleSkyParameters) {
+        const {
+            fogSpread,
+            skyAltitude,
+            enabled,
+            spaceColor,
+            skyColor,
+            fogColor,
+        } = {
+            ...DEFAULT_OPTIONS,
+            ...options,
+        };
+
+        this.view = view;
+        this.fogSpread = fogSpread;
+        this.skyAltitude = skyAltitude;
+        this._enabled = enabled;
+        this.spaceColor = new THREE.Color(spaceColor);
+        this.skyColor = new THREE.Color(skyColor);
+        this.fogColor = new THREE.Color(fogColor);
+
+        this.horizonGradient = new HorizonGradient(view.scene);
+
+        if (this._enabled) {
+            this.update();
+        }
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    set enabled(on) {
+        if (this._enabled === on) { return; }
+        this._enabled = on;
+        this.horizonGradient.mesh.visible = on;
+        if (on) {
+            this.update();
+        } else {
+            this.view.scene.fog = null;
+        }
+    }
+
+    update() {
+        if (!this._enabled) { return; }
+        const altitude = this.view.altitude;
+        if (altitude == null) { return; }
+        this.updateFog(altitude);
+        this.updateSkyColor(altitude);
+        this.updateAtmosphericGradient(altitude);
+    }
+
+    updateFog(altitude: number) {
+        if (!this.view.cameraNear) {
+            return;
+        }
+
+        if (!this.view.scene.fog) {
+            this.view.scene.fog = new THREE.Fog(this.fogColor, 1, 1000);
+        }
+
+        const fog = this.view.scene.fog;
+        if (altitude >= this.skyAltitude) {
+            this.view.scene.fog = null;
+            return;
+        }
+
+        fog.far = this.view.horizonDistance;
+
+        const fogSpreadValue = this.computeFogSpread(altitude);
+        fog.near = fog.far - fogSpreadValue * (fog.far - this.view.cameraNear);
+    }
+
+    computeFogSpread(altitude: number) {
+        if (altitude < 0) {
+            return this.fogSpread;
+        }
+
+        // Normalize altitude, 0 at maxFarAltitude, 1 at sea level
+        const t = (this.skyAltitude - altitude) / this.skyAltitude;
+        // Linear interpolation between 0 and fogSpread
+        return this.fogSpread * t;
+    }
+
+    updateSkyColor(altitude: number) {
+        const renderer = this.view.mainLoop.gfxEngine.renderer;
+        renderer.setClearColor(this.computeSkyColor(altitude), renderer.getClearAlpha());
+    }
+
+    computeSkyColor(altitude: number) {
+        if (altitude < 0) {
+            return this.skyColor;
+        }
+
+        if (altitude >= this.skyAltitude) {
+            return this.spaceColor;
+        }
+
+        // Normalize altitude, 0 at skyAltitude, 1 at sea level
+        const t = (this.skyAltitude - altitude) / this.skyAltitude;
+        // Linear interpolation between spaceColor and skyColor
+        computedSkyColor.copy(this.spaceColor).lerp(this.skyColor, t);
+        return computedSkyColor;
+    }
+
+    updateAtmosphericGradient(altitude: number) {
+        if (altitude >= this.skyAltitude) {
+            this.horizonGradient.visible = false;
+            return;
+        }
+
+        this.horizonGradient.visible = true;
+        this.horizonGradient.update(
+            this.view,
+            this.computeFogSpread(altitude),
+        );
+    }
+
+    dispose() {
+        this.view.scene.fog = null;
+        this.view.scene.remove(this.horizonGradient.mesh);
+        this.horizonGradient.mesh.geometry.dispose();
+        this.horizonGradient.mesh.material.dispose();
+    }
+}
+
+export default SimpleSky;

--- a/packages/Main/src/Core/Prefab/Globe/SimpleSky.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SimpleSky.ts
@@ -78,6 +78,8 @@ class SimpleSky implements ISkyStrategy {
             this.update();
         } else {
             this.view.scene.fog = null;
+            const renderer = this.view.mainLoop.gfxEngine.renderer;
+            renderer.setClearColor(this.spaceColor, renderer.getClearAlpha());
         }
     }
 

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -4,6 +4,7 @@ import SimpleSky, { SimpleSkyParameters } from 'Core/Prefab/Globe/SimpleSky';
 import ISkyStrategy from 'Core/Prefab/Globe/ISkyStrategy';
 import GlobeView from 'Core/Prefab/GlobeView';
 import { AtmosphereParameters } from '@takram/three-atmosphere';
+import * as THREE from 'three';
 
 class SkyController {
     private readonly _view: GlobeView;
@@ -14,6 +15,7 @@ class SkyController {
     private _realisticLighting = false;
     private _realisticParams?: RealisticSkyParameters | undefined;
     private _simpleParams?: SimpleSkyParameters | undefined;
+    private _ambientLight: THREE.AmbientLight;
 
     constructor(view: GlobeView,
         options: {
@@ -24,6 +26,8 @@ class SkyController {
         this._view = view;
         this._realisticParams = options.realisticSky;
         this._simpleParams = options.simpleSky;
+        this._ambientLight = new THREE.AmbientLight(0xffffff, 3);
+        this._view.scene.add(this._ambientLight);
         this.realisticLighting = options.realisticLighting ?? false;
     }
 
@@ -33,21 +37,17 @@ class SkyController {
         if (this._activeSky && this._realisticLighting === value) { return; }
         this._realisticLighting = value;
 
-        // Disable the previous strategy
-        if (this._activeSky) {
-            this._activeSky.enabled = false;
-        }
+        const previousSkyEnabled = (this._activeSky === undefined || this._activeSky.enabled);
 
-        if (value) {
-            this.sunLightLayer.visible = true;
-            this._view.notifyChange(this._view.camera3D);
-        } else if (this._sunLightLayer) {
-            this._sunLightLayer.visible = false;
+        // Disable the previous strategy
+        if (this._activeSky !== undefined) {
+            this._activeSky.enabled = false;
         }
 
         // Activate the new strategy
         this._activeSky = value ? this.realisticSky : this.simpleSky;
-        this._activeSky.enabled = true;
+        this._activeSky.enabled = previousSkyEnabled;
+        this.setSunlightVisible(previousSkyEnabled && value);
 
         this._view.notifyChange(this._view.camera3D);
     }
@@ -78,9 +78,7 @@ class SkyController {
         if (this._activeSky) {
             this._activeSky.enabled = value;
         }
-        if (this._realisticLighting && this._sunLightLayer) {
-            this._sunLightLayer.visible = value;
-        }
+        this.setSunlightVisible(this._realisticLighting && value);
     }
 
     get enabled() {
@@ -116,6 +114,15 @@ class SkyController {
             });
         }
         return this._sunLightLayer;
+    }
+
+    private setSunlightVisible(value: boolean) {
+        this._ambientLight.visible = !value;
+        if (value) {
+            this.sunLightLayer.visible = true;
+        } else if (this._sunLightLayer) {
+            this.sunLightLayer.visible = false;
+        }
     }
 }
 

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -1,5 +1,5 @@
 import SunLightLayer from 'Layer/SunLightLayer';
-import RealisticSky from 'Core/Prefab/Globe/RealisticSky';
+import RealisticSky, {RealisticSkyParameters} from 'Core/Prefab/Globe/RealisticSky';
 import SimpleSky, { SimpleSkyParameters } from 'Core/Prefab/Globe/SimpleSky';
 import ISkyStrategy from 'Core/Prefab/Globe/ISkyStrategy';
 import GlobeView from 'Core/Prefab/GlobeView';
@@ -12,8 +12,8 @@ class SkyController {
     private _simpleSky: SimpleSky | undefined;
     private _sunLightLayer: SunLightLayer | undefined;
     private _realisticLighting = false;
-    private _realisticParams?: AtmosphereParameters;
-    private _simpleParams?: SimpleSkyParameters;
+    private _realisticParams?: RealisticSkyParameters | undefined;
+    private _simpleParams?: SimpleSkyParameters | undefined;
 
     constructor(view: GlobeView,
         options: {

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -49,7 +49,6 @@ class SkyController {
         this._activeSky = value ? this.realisticSky : this.simpleSky;
         this._activeSky.enabled = true;
 
-        this._view.updateAltitudeAndClipping();
         this._view.notifyChange(this._view.camera3D);
     }
 

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -1,5 +1,5 @@
 import SunLightLayer from 'Layer/SunLightLayer';
-import RealisticSky, {RealisticSkyParameters} from 'Core/Prefab/Globe/RealisticSky';
+import RealisticSky, { RealisticSkyParameters } from 'Core/Prefab/Globe/RealisticSky';
 import SimpleSky, { SimpleSkyParameters } from 'Core/Prefab/Globe/SimpleSky';
 import ISkyStrategy from 'Core/Prefab/Globe/ISkyStrategy';
 import GlobeView from 'Core/Prefab/GlobeView';

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -1,0 +1,123 @@
+import SunLightLayer from 'Layer/SunLightLayer';
+import RealisticSky from 'Core/Prefab/Globe/RealisticSky';
+import SimpleSky, { SimpleSkyParameters } from 'Core/Prefab/Globe/SimpleSky';
+import ISkyStrategy from 'Core/Prefab/Globe/ISkyStrategy';
+import GlobeView from 'Core/Prefab/GlobeView';
+import { AtmosphereParameters } from '@takram/three-atmosphere';
+
+class SkyController {
+    private readonly _view: GlobeView;
+    private _activeSky: ISkyStrategy | undefined;
+    private _realisticSky: RealisticSky | undefined;
+    private _simpleSky: SimpleSky | undefined;
+    private _sunLightLayer: SunLightLayer | undefined;
+    private _realisticLighting = false;
+    private _realisticParams?: AtmosphereParameters;
+    private _simpleParams?: SimpleSkyParameters;
+
+    constructor(view: GlobeView,
+        options: {
+            realisticLighting?: boolean;
+            realisticSky?: AtmosphereParameters;
+            simpleSky?: SimpleSkyParameters;
+        } = {}) {
+        this._view = view;
+        this._realisticParams = options.realisticSky;
+        this._simpleParams = options.simpleSky;
+        this.realisticLighting = options.realisticLighting ?? false;
+    }
+
+    get realisticLighting() { return this._realisticLighting; }
+
+    set realisticLighting(value: boolean) {
+        if (this._activeSky && this._realisticLighting === value) { return; }
+        this._realisticLighting = value;
+
+        // Disable the previous strategy
+        if (this._activeSky) {
+            this._activeSky.enabled = false;
+        }
+
+        if (value) {
+            this.sunLightLayer.visible = true;
+            this._view.notifyChange(this._view.camera3D);
+        } else if (this._sunLightLayer) {
+            this._sunLightLayer.visible = false;
+        }
+
+        // Activate the new strategy
+        this._activeSky = value ? this.realisticSky : this.simpleSky;
+        this._activeSky.enabled = true;
+
+        this._view.updateAltitudeAndClipping();
+        this._view.notifyChange(this._view.camera3D);
+    }
+
+    get castShadow() { return this._sunLightLayer ? this._sunLightLayer.castShadow : false; }
+    set castShadow(value: boolean) {
+        if (!this._sunLightLayer || this._sunLightLayer.castShadow === value) { return; }
+        this._sunLightLayer.castShadow = value;
+        this._view.notifyChange(this._view.camera3D);
+    }
+
+    get forceDaytime() {
+        return this._sunLightLayer?.forceDaytime ?? false;
+    }
+
+    set forceDaytime(value: boolean) {
+        const layer = this.sunLightLayer;
+        if (layer.forceDaytime === value) return;
+        layer.forceDaytime = value;
+        this._view.notifyChange(this._view.camera3D);
+    }
+
+    update() {
+        this._activeSky?.update();
+    }
+
+    set enabled(value: boolean) {
+        if (this._activeSky) {
+            this._activeSky.enabled = value;
+        }
+        if (this._realisticLighting && this._sunLightLayer) {
+            this._sunLightLayer.visible = value;
+        }
+    }
+
+    get enabled() {
+        return this._activeSky !== undefined && this._activeSky.enabled;
+    }
+
+    dispose() {
+        this._realisticSky?.dispose();
+        this._simpleSky?.dispose();
+    }
+
+    get realisticSky() {
+        this._realisticSky ??= new RealisticSky(
+            this._view,
+            this.sunLightLayer,
+            this._realisticParams);
+        return this._realisticSky;
+    }
+
+    get simpleSky() {
+        this._simpleSky ??= new SimpleSky(this._view, this._simpleParams ?? { skyAltitude: 200000 });
+        return this._simpleSky;
+    }
+
+    get sunLightLayer() {
+        if (!this._sunLightLayer) {
+            const sunLightLayer = new SunLightLayer();
+            this._sunLightLayer = sunLightLayer;
+            this._view.addLayer(sunLightLayer).then(() => {
+                this._view.notifyChange(this._view.camera3D);
+            }).catch((error: unknown) => {
+                console.error('Failed to add SunLightLayer:', error);
+            });
+        }
+        return this._sunLightLayer;
+    }
+}
+
+export default SkyController;

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -6,8 +6,8 @@ import { Coordinates, ellipsoidSizes } from '@itowns/geographic';
 import GlobeLayer from 'Core/Prefab/Globe/GlobeLayer';
 import CameraUtils from 'Utils/CameraUtils';
 import WebXR from 'Renderer/WebXR';
-import SkyManager from 'Core/Prefab/Globe/SkyManager';
-import SunLightLayer from 'Layer/SunLightLayer';
+import SkyController from 'Core/Prefab/Globe/SkyController';
+import { MAIN_LOOP_EVENTS } from 'Core/MainLoop';
 
 /**
  * Fires when the view is completely loaded. Controls and view's functions can be called then.
@@ -88,8 +88,7 @@ class GlobeView extends View {
      * @param {number} [options.maxFarAltitude=80000] - the altitude at which the horizon is fully visible (meters).
      * @param {number} [options.minFarDistance=10000] - the minimum horizon distance (meters).
      * @param {boolean} [options.realisticLighting=false] - Enable realistic lighting.
-     * If true, it can later be switched by setting this.skyManager.enabled to true/false.
-     * If false, it will be impossible to enable it later on.
+     * It can later be switched by setting this.realisticLighting to true/false.
      * @param {boolean} [options.shadows=false] - Enable shadow map rendering. Can be toggled
      * later via `this.shadows`.
      */
@@ -102,8 +101,11 @@ class GlobeView extends View {
         this.altitude = 10000000;
         this.DEFAULT_NEAR = Math.max(15.0, 0.000002352 * ellipsoidSizes.x);
         this.camera3D.near = this.DEFAULT_NEAR;
+        this.cameraNear = this.DEFAULT_NEAR;
+
         this.DEFAULT_FAR = ellipsoidSizes.x * 10;
         this.camera3D.far = this.DEFAULT_FAR;
+        this.cameraFar = this.DEFAULT_FAR;
 
         this.farFactor = options.farFactor ?? 0.3;
         this.maxFarAltitude = options.maxFarAltitude ?? 80000;
@@ -146,14 +148,10 @@ class GlobeView extends View {
         }
 
         this.date = new Date(); // now
-
-        // Sunlight and shadow layer
-        this.sunLightLayer = new SunLightLayer(this);
-        this.addLayer(this.sunLightLayer);
-
-        if (options.realisticLighting === true) {
-            this.skyManager = new SkyManager(this);
-        }
+        this.skyController = new SkyController(this, options);
+        this.addFrameRequester(MAIN_LOOP_EVENTS.BEFORE_RENDER, () => {
+            this.skyController.update();
+        });
 
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFShadowMap;
@@ -171,8 +169,10 @@ class GlobeView extends View {
 
         this.horizonScaleFactor = this.computeHorizonScaleFactor();
         this.horizonDistance = this.computeHorizonDistance();
-        this.camera3D.near = this.computeCameraNear();
-        this.camera3D.far = this.computeCameraFar();
+        this.cameraNear = this.computeCameraNear();
+        this.camera3D.near = this.cameraNear;
+        this.cameraFar = this.computeCameraFar();
+        this.camera3D.far = this.cameraFar;
 
         this.camera3D.updateProjectionMatrix();
     }
@@ -184,7 +184,7 @@ class GlobeView extends View {
      */
     computeHorizonScaleFactor() {
         if (!this.dynamicCameraNearFar
-            || this.skyManager?.enabled // Realistic lighting needs full horizon (no scale-down) for aerial perspective
+            || this.realisticLighting // Realistic lighting needs full horizon (no scale-down) for aerial perspective
             || this.farFactor === 1
             || this.altitude >= this.maxFarAltitude) {
             return 1;
@@ -230,7 +230,7 @@ class GlobeView extends View {
 
         // Three-geospatial aerial-perspective is not working well with a close camera far-plane.
         // Disabling dynamic camera far when realistic lighting is enabled
-        if (this.horizonScaleFactor >= 1 || this.skyManager?.enabled) {
+        if (this.horizonScaleFactor >= 1 || this.realisticLighting) {
             // Setting far plane behind the globe
             return this.camera3D.position.length() + this.globeRadiusMax;
         }
@@ -286,14 +286,15 @@ class GlobeView extends View {
      * Does not affect shadows cast by user-defined lights.
      * @type {boolean}
      */
-    get shadows() {
-        return this.sunLightLayer.castShadow;
+    get shadows() { return this.skyController.castShadow; }
+    set shadows(value) { this.skyController.castShadow = value; }
+
+    get realisticLighting() {
+        return this.skyController?.realisticLighting;
     }
 
-    set shadows(value) {
-        if (this.sunLightLayer.castShadow == value) { return; }
-        this.sunLightLayer.castShadow = value;
-        this.notifyChange(this.camera3D);
+    set realisticLighting(value) {
+        this.skyController.realisticLighting = value;
     }
 }
 

--- a/packages/Main/src/Core/Prefab/GlobeView.js
+++ b/packages/Main/src/Core/Prefab/GlobeView.js
@@ -295,6 +295,7 @@ class GlobeView extends View {
 
     set realisticLighting(value) {
         this.skyController.realisticLighting = value;
+        this.updateAltitudeAndClipping();
     }
 }
 

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -569,6 +569,11 @@ class OGC3DTilesLayer extends GeometryLayer {
             referPointsMaterialProperties(material, this);
         } else {
             referMaterialProperties(material, this);
+            // Force matte appearance for 3D tiles meshes
+            if (material.isMeshStandardMaterial) {
+                material.roughness = 1.0;
+                material.metalness = 0.0;
+            }
         }
 
         model.material = material;

--- a/packages/Main/src/Layer/SunLightLayer.ts
+++ b/packages/Main/src/Layer/SunLightLayer.ts
@@ -2,7 +2,6 @@ import * as THREE from 'three';
 import {
     getSunDirectionECEF,
 } from '@takram/three-atmosphere';
-import SkyManager from 'Core/Prefab/Globe/SkyManager';
 import GeometryLayer from './GeometryLayer';
 import { getRig } from '../Utils/CameraUtils';
 
@@ -69,9 +68,6 @@ class SunLightLayer extends GeometryLayer {
         const { view } = context;
 
         getSunDirectionECEF(view.date, this.sunDirection);
-
-        // actually only useful if Sun or Moon direction has changed
-        if (view.skyManager) { view.skyManager.update(); }
 
         // Center the shadow around the camera's target position
         const sunTargetPos = getRig(camera).targetWorldPosition || camera.position;

--- a/packages/Main/src/Layer/SunLightLayer.ts
+++ b/packages/Main/src/Layer/SunLightLayer.ts
@@ -99,11 +99,9 @@ class SunLightLayer extends GeometryLayer {
             .add(prevSunTargetPos);
         this.sunLight.updateMatrixWorld();
 
-        // Calculate shadow box half-side to render shadows on all screen
-        // in most cases. These values were determined empirically.
-        // Only update if the value has changed enough,
-        // to avoid flickering effect
-        const shadowHalfSide = 0.017 * camera.far + 200;
+        // Calculate an appropriate shadow box half-side by using camera distance to target
+        // Only update if the value has changed enough, to avoid flickering effect
+        const shadowHalfSide = camera.position.distanceTo(sunTargetPos);
         if (Math.abs(shadowHalfSide - prevShadowHalfSide) > prevShadowHalfSide * 0.1) {
             shadowCam.far = 2 * shadowHalfSide;
             shadowCam.left = -shadowHalfSide;

--- a/packages/Main/src/Layer/SunLightLayer.ts
+++ b/packages/Main/src/Layer/SunLightLayer.ts
@@ -13,7 +13,7 @@ interface UpdateContext {
         renderer: THREE.WebGLRenderer;
         scene: THREE.Scene;
         date: Date;
-        skyManager: SkyManager;
+        altitude: number;
     };
 }
 
@@ -26,10 +26,23 @@ class SunLightLayer extends GeometryLayer {
     sunLight: THREE.DirectionalLight;
     sunDirection: THREE.Vector3;
     isSunLightLayer: boolean;
+    forceDaytime: boolean;
+    shadowsMaxAltitude: number;
+    sunTiltAltitude: number;
 
     private _prevSunIntensity = 0;
+    private readonly _up = new THREE.Vector3();
+    private readonly _worldRef = new THREE.Vector3(0, 0, 1);
+    private readonly _tangent = new THREE.Vector3();
+    private readonly _newSunDirection = new THREE.Vector3();
 
-    constructor() {
+    /**
+     * @param [forceDaytime=false] - Indicates whether to force daytime lighting regardless of the scene's time.
+     * @param [shadowsMaxAltitude=30000] - Specifies the maximum altitude at which shadows are cast.
+     * @param [sunTiltAltitude=30000] - Specifies the maximum altitude at which the sun tilts when forceDaytime is true
+     * @returns
+     */
+    constructor(forceDaytime = false, shadowsMaxAltitude = 30000, sunTiltAltitude = 30000) {
         const object3d = new THREE.Group();
         const id = 'sunlight';
         object3d.name = id;
@@ -46,6 +59,14 @@ class SunLightLayer extends GeometryLayer {
         this.defineLayerProperty('castShadow', this.castShadow, () => {
             this.sunLight.castShadow = this.castShadow;
         });
+
+        this.forceDaytime = forceDaytime;
+        this.defineLayerProperty('forceDaytime', forceDaytime);
+
+        this.sunTiltAltitude = sunTiltAltitude;
+        this.defineLayerProperty('sunTiltAltitude', this.sunTiltAltitude);
+
+        this.shadowsMaxAltitude = shadowsMaxAltitude;
 
         this.object3d.add(
             this.sunLight,
@@ -67,19 +88,33 @@ class SunLightLayer extends GeometryLayer {
 
         const { view } = context;
 
-        getSunDirectionECEF(view.date, this.sunDirection);
+        if (this.forceDaytime) {
+            this._dayTimeSunDirection(
+                context.camera.camera3D.position,
+                context.view.altitude,
+                this.sunDirection,
+            );
+        } else {
+            getSunDirectionECEF(context.view.date, this.sunDirection);
+        }
 
         // Center the shadow around the camera's target position
         const sunTargetPos = getRig(camera).targetWorldPosition || camera.position;
 
-        // Turn sunlight on/off based on sun elevation above/below local horizon
+        // Turn sunlight on/off based on sun elevation above/below local horizon when close enough to ground
         const sunElevation = this.sunDirection.dot(sunTargetPos);
-        if (sunElevation < 0 && this.sunLight.intensity) {
+        const sunDisabled = sunElevation < 0 && view.altitude < this.shadowsMaxAltitude;
+
+        if (sunDisabled && this.sunLight.intensity) {
             this._prevSunIntensity = this.sunLight.intensity;
             this.sunLight.intensity = 0;
-        } else if (sunElevation >= 0 && !this.sunLight.intensity) {
+        } else if (!sunDisabled && !this.sunLight.intensity) {
             this.sunLight.intensity = this._prevSunIntensity;
         }
+
+        // Disable shadow casting above an altitude threshold
+        const aboveMaxAltitude = view.altitude > this.shadowsMaxAltitude;
+        this.sunLight.castShadow = aboveMaxAltitude ? false : this.castShadow;
 
         // Only update if the position has changed enough,
         // to avoid flickering effect
@@ -105,6 +140,44 @@ class SunLightLayer extends GeometryLayer {
             shadowCam.top = shadowHalfSide;
             shadowCam.bottom = -shadowHalfSide;
             shadowCam.updateProjectionMatrix();
+        }
+    }
+
+    /*
+     * Calculates the direction of the sun to ensure a sunny sky.
+     * Updates the provided sunDirection vector with a new calculated direction.
+     * The sun is aligned with the camera far away from the globe to show the whole planet.
+     * It tilts progressively below this.sunTiltAltitude to cast good-looking shadows.
+     */
+    _dayTimeSunDirection(cameraPosition: THREE.Vector3, altitude: number, sunDirection: THREE.Vector3) {
+        const up = this._up.copy(cameraPosition).normalize();
+
+        // Stable reference axis
+        const worldRef = this._worldRef.set(0, 0, 1);
+        if (Math.abs(up.dot(worldRef)) > 0.99) {
+            worldRef.set(1, 0, 0);
+        }
+
+        // tangent = worldRef projected on plane orthogonal to up
+        const tangent = this._tangent.copy(worldRef).projectOnPlane(up).normalize();
+
+        const groundTilt = 0.6;
+        const fadeStart = this.sunTiltAltitude / 2;
+        const fadeEnd = this.sunTiltAltitude;
+
+        // Apply a smoothstep to interpolate between groundTilt and 1.0 (aligned with camera)
+        const t = THREE.MathUtils.clamp((altitude - fadeStart) / (fadeEnd - fadeStart), 0, 1);
+        const k = t * t * (3 - 2 * t);
+        const effectiveTilt = THREE.MathUtils.lerp(groundTilt, 1.0, k);
+
+        const newSunDirection = this._newSunDirection
+            .copy(up).multiplyScalar(effectiveTilt)
+            .addScaledVector(tangent, 1 - effectiveTilt)
+            .normalize();
+
+        // Only change sunDirection if the new direction is significantly different
+        if (sunDirection.dot(newSunDirection) < 0.99995) {
+            sunDirection.copy(newSunDirection);
         }
     }
 }

--- a/test/functional/GlobeControls.js
+++ b/test/functional/GlobeControls.js
@@ -27,7 +27,7 @@ describe('GlobeControls with globe example', function _() {
                 };
 
             // Hide GUI :
-            debugMenu.gui.remove(cRL);
+            cRL.hide();
             minimap.hide();
             navigation.hide();
             searchbar.hide();


### PR DESCRIPTION
## Description
This PR has to be merged after #2699. It is its follow-up. It answers some of the issues pointed out by #2780.

### Major changes
It introduces a new architecture for sky management:
#### Sky strategies
- SkyManager code was mostly moved into `RealisticSky`. It implements the new interface `ISkyStrategy`.
- A new "simple" sky mode was introduced with `SimpleSky`. It also implements `ISkyStrategy`. It changes the sky color based on altitude, adds fog to the scene and renders an "atmospheric gradient" to blend the fog with the sky. A `skyAltitude` parameter defines when the sky changes color. Fog and horizon gradient are disabled above this value, and their spread is increased when getting closer to the ground.
- The `HorizonGradient` code and its shader hold responsability for the atmospheric gradient rendering. It's a full-screen quad rendered on a Mesh. **This part was mostly written with LLMs.**
- A new `SkyController` was created to handle sky-related logic away from the view. It was named so to avoid confusions with `SkyManager` that was also renamed. It lazy-loads sky strategies, preventing from initializing three-geospatial when not required.
- Providing an API to modify atmosphere parameters (see mars example)
- Actually removing RealisticSky effect passes from the composer when disabling it. The realisticLighting mode was still having effects on the view when disabled.

#### SunLight and shadow casting
- Adding a new `forceDaytime` option to the sunLightLayer to make the sun "follow" the camera instead of relying on a Date. The sun is aligned with the camera to display the full globe, and tilts when zooming in to cast shadows nicely.
- Computing the shadows box size based on distance to the sun target instead of using camera far.
- Turning off shadow casting above a `shadowsMaxAltitude` parameter
- Making the "sun intensity hack" that prevents from lighting buildings from below when the sun is behing horizon only apply when close to the ground, under `shadowsMaxAltitude` parameter
 
### Minor changes
- Making the 3DTiles meshes matte
- Disabling any sky effect during debug camera render for consistency
- Tweeking realistic lighting Aerial Perspective Blending to make it look better

### Notes
- For now, Realistic lighting is not compatible with dynamic far. Many more tiles are displayed when it is enabled.

## Screenshots
#### Globe appearance improvements (this branch versus master)
<img height="300" alt="image" src="https://github.com/user-attachments/assets/c218a277-18ee-4b7a-b2b4-03bd9ee2eee5" /> 
<img height="300" alt="image" src="https://github.com/user-attachments/assets/4664019a-64d3-4e50-8396-ab950a0acf31" />

#### Simple Sky
<img width="1920" height="948" alt="image" src="https://github.com/user-attachments/assets/285bc7a1-1fba-41e5-a719-9a83d4a221c9" />

### forceDayTime
<img width="1920" height="944" alt="image" src="https://github.com/user-attachments/assets/0811ce44-3824-47c7-9806-6752dceab916" />

#### Matte 3D tiles mesh
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/4199a699-93da-421e-b4c0-95a85c282989" />

#### Adjusting aerial perspective blending (this branch versus master)
<img height="300" alt="image" src="https://github.com/user-attachments/assets/865560b6-d16f-4713-9399-8a251b3fc088" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/9e9ff3e9-9cef-4742-b9ec-d7d15fe57bf5" />


#### Mars simple and realistic atmosphere
<img width="1920" height="949" alt="image" src="https://github.com/user-attachments/assets/fe50d6a8-9e0c-4374-983f-16ea96016498" />
<img width="1920" height="944" alt="image" src="https://github.com/user-attachments/assets/d34b22dd-46dd-4a65-b96f-341b668b0aa0" />

#### Debug camera render ignores the sky effects
<img height="945" alt="image" src="https://github.com/user-attachments/assets/8b1bb77d-11c3-4b52-8a27-2d9f17195dd2" />
<img height="945" alt="image" src="https://github.com/user-attachments/assets/8c9434e2-c069-44c6-ad7d-725705257c43" />

