### PR TITLE
Fix extruded polygons not displayed

### DIFF
--- a/packages/Main/src/Layer/ReferencingLayerProperties.js
+++ b/packages/Main/src/Layer/ReferencingLayerProperties.js
@@ -17,6 +17,7 @@ function ReferLayerProperties(material, layer) {
                 get: () => getOpacity(opacity),
             });
         } else if (material.opacity != undefined) {
+            opacity = material.opacity;
             Object.defineProperty(material, 'opacity', {
                 get: () => getOpacity(opacity),
             });

--- a/packages/Main/src/Source/TMSSource.js
+++ b/packages/Main/src/Source/TMSSource.js
@@ -107,10 +107,10 @@ class TMSSource extends Source {
         return URLBuilder.xyz(tile, this);
     }
 
-    hasData(tile) {
-        return  tile.zoom >= this.zoom.min &&
-            tile.zoom <= this.zoom.max &&
-            this.tileMatrixSetLimits.isInside(tile);
+    hasData(extentOrTile) {
+        const inZoomRange = extentOrTile.isExtent ||
+            (extentOrTile.zoom >= this.zoom.min && extentOrTile.zoom <= this.zoom.max);
+        return inZoomRange && this.tileMatrixSetLimits.isInside(extentOrTile);
     }
 }
 


### PR DESCRIPTION
## Description
Fix 3D mesh rendering bugs in examples

## Motivation and Context
3D meshes were not showing in `vector_tile_3d_mesh*` examples.
This fixes https://github.com/iTowns/itowns/issues/2789 and https://github.com/iTowns/itowns/pull/2794.
There were actually 2 regressions:
* one introduced in 74811a1, dealing with opacity, only breaking the Mapbox example
* one introduced in 3c64961, dealing with extent testing, breaking both 3D mesh examples.
