### PR TITLE
fix(example): Fix destroy gui when we change source dataset on pointc…

### DIFF
--- a/examples/pointcloud_loader.html
+++ b/examples/pointcloud_loader.html
@@ -60,12 +60,11 @@
         <div id="viewerDiv"></div>
 
         <script type="module">
-            import { Vector3 } from 'three';
             import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
             import Stats from 'stats-gl';
             import { getFormat, getPointCloudClass, getDefaultAttribute, zoomToLayer } from './jsm/PointCloudHelper.js';
 
-            import { CRS, MAIN_LOOP_EVENTS, PNTS_MODE, PlanarControls, View } from 'itowns';
+            import { CRS, MAIN_LOOP_EVENTS, PlanarControls, View } from 'itowns';
             import { PointCloudDebug } from 'debug';
 
             const viewerDiv = document.getElementById('viewerDiv');
@@ -87,6 +86,7 @@
             window.updateUrlParams = updateUrlParams;
 
             let currentView = null;
+            let gui = null;
 
             window.load = async function load(url, options = {}) {
                 // Cleanup previous view
@@ -94,6 +94,10 @@
                     currentView.dispose();
                     currentView = null;
                     viewerDiv.innerHTML = '';
+                }
+
+                if (gui) {
+                    gui.destroy();
                 }
 
                 const { format = 'auto', crs } = options;
@@ -131,7 +135,7 @@
                 const controls = new PlanarControls(view);
                 controls.groundLevel = layer.minElevationRange;
 
-                const gui = new GUI();
+                gui = new GUI();
                 PointCloudDebug.initTools(view, layer, gui);
             }
 

--- a/examples/pointcloud_loader.html
+++ b/examples/pointcloud_loader.html
@@ -60,12 +60,11 @@
         <div id="viewerDiv"></div>
 
         <script type="module">
-            import { Vector3 } from 'three';
             import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
             import Stats from 'stats-gl';
             import { getFormat, getPointCloudClass, getDefaultAttribute, zoomToLayer } from './jsm/PointCloudHelper.js';
 
-            import { CRS, MAIN_LOOP_EVENTS, PNTS_MODE, PlanarControls, View } from 'itowns';
+            import { CRS, MAIN_LOOP_EVENTS, PlanarControls, View } from 'itowns';
             import { PointCloudDebug } from 'debug';
 
             const viewerDiv = document.getElementById('viewerDiv');
@@ -87,6 +86,7 @@
             window.updateUrlParams = updateUrlParams;
 
             let currentView = null;
+            let gui;
 
             window.load = async function load(url, options = {}) {
                 // Cleanup previous view
@@ -131,7 +131,10 @@
                 const controls = new PlanarControls(view);
                 controls.groundLevel = layer.minElevationRange;
 
-                const gui = new GUI();
+                if (gui) {
+                    gui.destroy();
+                }
+                gui = new GUI();
                 PointCloudDebug.initTools(view, layer, gui);
             }
 

--- a/examples/pointcloud_loader_globe.html
+++ b/examples/pointcloud_loader_globe.html
@@ -60,14 +60,12 @@
         <div id="viewerDiv"></div>
 
         <script type="module">
-            import { Vector3 } from 'three';
             import Stats from 'stats-gl';
             import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
             import { getFormat, getPointCloudClass, getDefaultAttribute, zoomToLayerGlobe } from './jsm/PointCloudHelper.js';
 
             import {
-                CRS, MAIN_LOOP_EVENTS, PNTS_MODE,
-                Coordinates,
+                CRS, MAIN_LOOP_EVENTS,
                 View,
                 GlobeView,
                 Fetcher,
@@ -97,6 +95,7 @@
             window.updateUrlParams = updateUrlParams;
 
             let currentView = null;
+            let gui = null;
 
             window.load = async function load(url, options = {}) {
                 // Cleanup previous view
@@ -104,6 +103,10 @@
                     currentView.dispose();
                     currentView = null;
                     viewerDiv.innerHTML = '';
+                }
+
+                if (gui) {
+                    gui.destroy();
                 }
 
                 const { format = 'auto', crs } = options;
@@ -162,7 +165,7 @@
                     view.controls.lookAtCoordinate(options.placement, true);
                 }
 
-                const gui = new GUI();
+                gui = new GUI();
                 PointCloudDebug.initTools(view, layer, gui);
             }
 

--- a/examples/pointcloud_loader_globe.html
+++ b/examples/pointcloud_loader_globe.html
@@ -60,14 +60,12 @@
         <div id="viewerDiv"></div>
 
         <script type="module">
-            import { Vector3 } from 'three';
             import Stats from 'stats-gl';
             import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
             import { getFormat, getPointCloudClass, getDefaultAttribute, zoomToLayerGlobe } from './jsm/PointCloudHelper.js';
 
             import {
-                CRS, MAIN_LOOP_EVENTS, PNTS_MODE,
-                Coordinates,
+                CRS, MAIN_LOOP_EVENTS,
                 View,
                 GlobeView,
                 Fetcher,
@@ -97,6 +95,7 @@
             window.updateUrlParams = updateUrlParams;
 
             let currentView = null;
+            let gui;
 
             window.load = async function load(url, options = {}) {
                 // Cleanup previous view
@@ -155,14 +154,16 @@
                     stats.update()
                 });
 
-
                 await layer.whenReady;
                 zoomToLayerGlobe(view, layer);
                 if (options.placement) {
                     view.controls.lookAtCoordinate(options.placement, true);
                 }
 
-                const gui = new GUI();
+                if (gui) {
+                    gui.destroy();
+                }
+                gui = new GUI();
                 PointCloudDebug.initTools(view, layer, gui);
             }
 


### PR DESCRIPTION
## Description
They was a bug if we deploy pointcloud settings and if we load new dataset.
Old GUI wasn't destroy, It caused a display issue and settings wasn't working anymore.

## Screenshots (if appropriate)
<img width="769" height="808" alt="Capture d’écran 2026-06-18 à 15 03 03" src="https://github.com/user-attachments/assets/cfa1140e-bd26-4bbf-98dd-b71abace4f42" />
