### PR TITLE
Line extrusion as cylinders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ potree
 .nyc_output/
 buildDocs/
 tsconfig.tsbuildinfo
-.github/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ potree
 .nyc_output/
 buildDocs/
 tsconfig.tsbuildinfo
+.github/

--- a/examples/source_stream_wfs_3d.html
+++ b/examples/source_stream_wfs_3d.html
@@ -176,6 +176,7 @@
 
             var useFixedHeight = true;
             var useFixedColor = true;
+            var extrudeLines = false;
 
             function acceptFeature(properties) {
                 return !!properties.hauteur;
@@ -243,7 +244,12 @@
                     useFixedColor = !useFixedColor;
                     wfsBuildingLayer.style.fill.color = useFixedColor ? '#00cc00' : colorBuildings;
                     view.notifyChange(wfsBuildingLayer);
-                }
+                },
+                toggleLineExtrusion: function () {
+                    extrudeLines = !extrudeLines;
+                    lyonTclBusLayer.style.stroke.extrusion_radius = extrudeLines ? 3 : undefined;
+                    view.notifyChange(lyonTclBusLayer);
+                },
             };
 
             // Listen for globe full initialisation event
@@ -287,6 +293,11 @@
                     layer.whenReady.then( function _(layer) {
                         var gui = debug.GeometryDebug.createGeometryDebugUI(debugGui, view, layer);
                         debug.GeometryDebug.addMaterialLineWidth(gui, view, layer, 1, 10);
+
+                        // Button to demonstrate line extrusion
+                        gui.add(extrusionToggle, 'toggleLineExtrusion').name('Toggle Extrusion');
+                        extrusionToggle.toggleLineExtrusion();
+
                         gui.close();
                     });
                 }

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -25,6 +25,8 @@ const maxValueUint16 = 2 ** 16 - 1;
 const maxValueUint32 = 2 ** 32 - 1;
 const crsWGS84 = 'EPSG:4326';
 const SEGMENTS = 8; // radial segments in a circle - used to model cylinders and spheres
+// Scratch vectors used while building spherical wedges for extruded lines.
+let wedgeScratch;
 
 class FeatureMesh extends THREE.Group {
     #currentCrs;
@@ -537,6 +539,16 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     const firstCoord = new THREE.Vector3();
     const lastCoord = new THREE.Vector3();
     const lastZAxis = new THREE.Vector3();
+    wedgeScratch = {
+        xAxis: new THREE.Vector3(),
+        tempAxis: new THREE.Vector3(),
+        normal: new THREE.Vector3(),
+        normalXComp: new THREE.Vector3(),
+        vertex: new THREE.Vector3(),
+        interpolatedYAxis: new THREE.Vector3(),
+        yAxisBase: new THREE.Vector3(),
+        yAxisTop: new THREE.Vector3(),
+    };
     let hasSegment = false;
 
     // For each consecutive pair of points, make a cylinder centered on the segment
@@ -550,13 +562,13 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
             up.fromArray(feature.normals, iVertIn).multiply(inverseScale);
         }
 
-        const p0Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn).clone();
+        const p0Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn);
         coord.copy(p0Local).applyMatrix4(context.collection.matrix);
         if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
         altitude = style.stroke.base_altitude;
         baseCoord.copy(up).multiplyScalar(altitude - coord.z).add(p0Local);
 
-        const p1Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn + 3).clone();
+        const p1Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn + 3);
         coord.copy(p1Local).applyMatrix4(context.collection.matrix);
         if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
         altitude = style.stroke.base_altitude;
@@ -638,30 +650,35 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
     if (Number.isNaN(prevZAxis.x)) { return; } // prevZAxis hasn't been set yet
 
     const { vertices, colors, batchIds, indices } = buffers;
+    const {
+        xAxis,
+        tempAxis,
+        normal,
+        normalXComp,
+        vertex,
+        interpolatedYAxis,
+        yAxisBase,
+        yAxisTop,
+    } = wedgeScratch;
 
     // Create orthonormal basis for the plane containing both normals
-    const xAxis = new THREE.Vector3().crossVectors(prevZAxis, zAxis);
+    xAxis.crossVectors(prevZAxis, zAxis);
     if (xAxis.lengthSq() < 0.001) {
-        const tempAxis = Math.abs(prevZAxis.x) < 0.9 ?
-            new THREE.Vector3(1, 0, 0) :
-            new THREE.Vector3(0, 1, 0);
+        const isIsNearX = Math.abs(prevZAxis.x) > 0.9;
+        tempAxis.set(isIsNearX ? 0 : 1, isIsNearX ? 1 : 0, 0);
         xAxis.crossVectors(tempAxis, prevZAxis).normalize();
     } else {
         xAxis.normalize();
     }
 
     const meshColor = toColor(style.stroke.color).multiplyScalar(255);
-    const normal = new THREE.Vector3();
-    const normalXComp = new THREE.Vector3();
-    const vertex = new THREE.Vector3();
-    const yAxisInterpolated = new THREE.Vector3();
 
     // Calculate number of intermediate steps based on angle between axes
     const angle = Math.acos(Math.max(-1, Math.min(1, prevZAxis.dot(zAxis))));
     const numSteps = Math.max(1, Math.round(angle * SEGMENTS / (2 * Math.PI)));
 
-    const yAxisBase = new THREE.Vector3().crossVectors(prevZAxis, xAxis);
-    const yAxisTop = new THREE.Vector3().crossVectors(zAxis, xAxis);
+    yAxisBase.crossVectors(prevZAxis, xAxis);
+    yAxisTop.crossVectors(zAxis, xAxis);
 
     // let theta be the angle between the y axes
     const cosTheta = Math.max(-1, Math.min(1, yAxisBase.dot(yAxisTop)));
@@ -676,7 +693,7 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
         for (let step = 0; step <= numSteps; step++) {
             const t = step / numSteps;
 
-            yAxisInterpolated.copy(yAxisBase).applyAxisAngle(xAxis, t * theta);
+            interpolatedYAxis.copy(yAxisBase).applyAxisAngle(xAxis, t * theta);
 
             const ringStart = buffers.vertPtr;
             ringVertices.push(ringStart);
@@ -687,7 +704,7 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
                 if (vertices) {
                     const angle = (k / SEGMENTS) * Math.PI * 2;
                     normalXComp.copy(xAxis).multiplyScalar(Math.cos(angle));
-                    normal.copy(normalXComp).addScaledVector(yAxisInterpolated, Math.sin(angle));
+                    normal.copy(normalXComp).addScaledVector(interpolatedYAxis, Math.sin(angle));
                     vertex.copy(origin).addScaledVector(normal, radius).toArray(vertices, 3 * v);
                 }
                 if (batchIds) {

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -1228,9 +1228,12 @@ export default {
                 this._styleTopologyVersion ??= 0;
                 this._styleColorVersion ??= 0;
                 this._stylePositionVersion ??= 0;
+                const hasLineFeature = features.some(f => f.type === FEATURE_TYPES.LINE);
                 style.addEventListener('style-property-changed', (event) => {
                     if (event.parameter === 'topology' ||
-                        event.parameter === 'lineCap') {
+                        event.parameter === 'line_cap' ||
+                        // changing the altitude may change line topologies
+                        (event.parameter === 'base_altitude' && hasLineFeature)) {
                         this._styleTopologyVersion++;
                     } else if (event.parameter === 'color') {
                         this._styleColorVersion++;

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -46,6 +46,7 @@ class FeatureMesh extends THREE.Group {
         this.#collection.matrixWorldInverse = collection.matrixWorldInverse.clone();
 
         this.#collection.crs = collection.crs;
+        this.#collection.extent = collection.extent;
 
         this.#originalCrs = collection.crs;
         this.#currentCrs = this.#originalCrs;
@@ -511,6 +512,23 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     up.set(0, 0, 1).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
     style.setContext(context);
+
+    // Compute reprojection inverse scale (same logic as FeatureMesh.as())
+    dim_ref.set(1, 1);
+    dim.set(1, 1);
+    const collExtent = context.collection.extent;
+    if (collExtent) {
+        const crs = context.collection.crs;
+        if (collExtent.isExtent) {
+            extent.copy(collExtent).applyMatrix4(context.collection.matrix);
+            extent.as(crs, extent);
+        } else {
+            collExtent.toExtent(crs, extent);
+        }
+        extent.spatialEuclideanDimensions(dim_ref);
+        extent.planarDimensions(dim);
+    }
+
     const { vertices, colors, batchIds, indices } = buffers;
 
     // geometry range
@@ -602,6 +620,12 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
                 const theta = (k / SEGMENTS) * Math.PI * 2;
                 normal.copy(xAxis).multiplyScalar(Math.cos(theta))
                     .addScaledVector(yAxis, Math.sin(theta));
+                normal.multiply(inverseScale);
+                if (dim.x && dim.y && dim_ref.x && dim_ref.y) {
+                    normal.x *= dim.x / dim_ref.x;
+                    normal.y *= dim.y / dim_ref.y;
+                }
+
                 vertex.copy(baseCoord).addScaledVector(normal, radius).toArray(vertices, 3 * v);
                 vertex.copy(topCoord).addScaledVector(normal, radius).toArray(vertices, 3 * (v + 1));
             }
@@ -705,6 +729,11 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
                     const angle = (k / SEGMENTS) * Math.PI * 2;
                     normalXComp.copy(xAxis).multiplyScalar(Math.cos(angle));
                     normal.copy(normalXComp).addScaledVector(interpolatedYAxis, Math.sin(angle));
+                    normal.multiply(inverseScale);
+                    if (dim.x && dim.y && dim_ref.x && dim_ref.y) {
+                        normal.x *= dim.x / dim_ref.x;
+                        normal.y *= dim.y / dim_ref.y;
+                    }
                     vertex.copy(origin).addScaledVector(normal, radius).toArray(vertices, 3 * v);
                 }
                 if (batchIds) {

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -29,6 +29,7 @@ let normal;
 let vertex;
 let lastCoord;
 let lastZAxis;
+let wedgeScratch; // collection of vectors used while building spherical wedges
 
 const _color = new THREE.Color();
 const maxValueUint8 = 2 ** 8 - 1;
@@ -36,8 +37,6 @@ const maxValueUint16 = 2 ** 16 - 1;
 const maxValueUint32 = 2 ** 32 - 1;
 const crsWGS84 = 'EPSG:4326';
 const SEGMENTS = 8; // radial segments in a circle - used to model cylinders and spheres
-// Scratch vectors used while building spherical wedges for extruded lines.
-let wedgeScratch;
 
 // Populate the module-level dim_ref and dim vectors from a source extent.
 function computeExtentDimensions(sourceExtent, matrix, crs) {
@@ -574,6 +573,29 @@ function buildCylinderRing(buffers, id) {
     }
 }
 
+function initExtrudedLineVectors() {
+    if (xAxis) { return; } // already initialized
+    xAxis = new THREE.Vector3();
+    yAxis = new THREE.Vector3();
+    zAxis = new THREE.Vector3();
+    prevZAxis = new THREE.Vector3(NaN, NaN, NaN);
+    capAxis = new THREE.Vector3();
+    normal = new THREE.Vector3();
+    vertex = new THREE.Vector3();
+    lastCoord = new THREE.Vector3();
+    lastZAxis = new THREE.Vector3();
+    wedgeScratch = {
+        xAxis: new THREE.Vector3(),
+        tempAxis: new THREE.Vector3(),
+        normal: new THREE.Vector3(),
+        normalXComp: new THREE.Vector3(),
+        vertex: new THREE.Vector3(),
+        interpolatedYAxis: new THREE.Vector3(),
+        yAxisBase: new THREE.Vector3(),
+        yAxisTop: new THREE.Vector3(),
+    };
+}
+
 /**
  * Update vertex data for extruded LINE features (cylindrical tubes with spherical joints).
  * Creates cylindrical geometry around line segments with spherical wedges at joints and,
@@ -624,26 +646,7 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     const radius = style.stroke.extrusion_radius;
     const useRoundCaps = style.stroke.line_cap === 'round';
 
-    // pre-allocated vectors
-    xAxis = new THREE.Vector3();
-    yAxis = new THREE.Vector3();
-    zAxis = new THREE.Vector3();
-    prevZAxis = new THREE.Vector3(NaN, NaN, NaN);
-    capAxis = new THREE.Vector3();
-    normal = new THREE.Vector3();
-    vertex = new THREE.Vector3();
-    lastCoord = new THREE.Vector3();
-    lastZAxis = new THREE.Vector3();
-    wedgeScratch = {
-        xAxis: new THREE.Vector3(),
-        tempAxis: new THREE.Vector3(),
-        normal: new THREE.Vector3(),
-        normalXComp: new THREE.Vector3(),
-        vertex: new THREE.Vector3(),
-        interpolatedYAxis: new THREE.Vector3(),
-        yAxisBase: new THREE.Vector3(),
-        yAxisTop: new THREE.Vector3(),
-    };
+    initExtrudedLineVectors(); // initialize pre-allocated vectors
 
     // whether the line sequence is not degenerate, i.e. has at least 2 points
     let hasSegment = false;

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -24,6 +24,7 @@ const maxValueUint8 = 2 ** 8 - 1;
 const maxValueUint16 = 2 ** 16 - 1;
 const maxValueUint32 = 2 ** 32 - 1;
 const crsWGS84 = 'EPSG:4326';
+const SEGMENTS = 8; // radial segments in a circle - used to model cylinders and spheres
 
 class FeatureMesh extends THREE.Group {
     #currentCrs;
@@ -419,6 +420,267 @@ function updateLineBuffers(featureMesh, buffers, id) {
     }
 }
 
+function featureToExtrudedLine(feature, options) {
+    const maxVertsPerJoint = (SEGMENTS / 2 + 1) * SEGMENTS / 2;
+    const vertSize = (feature.vertices.length - 3 * feature.geometries.length) * 2 * SEGMENTS + // cylinders
+        (feature.vertices.length - 6 * feature.geometries.length) * maxVertsPerJoint; // joints
+    const vertices = new Float32Array(vertSize);
+    const colors = new Uint8Array(vertSize);
+    const batchIdFn = options.batchId || ((p, id) => id);
+    const batchIds = new Uint32Array(vertices.length / 3);
+
+    context.setFeature(feature);
+    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
+    up.set(0, 0, 1).multiply(inverseScale);
+    coord.setCrs(context.collection.crs);
+
+    let totalSegments = 0;
+    let totalJoints = 0;
+    for (const g of feature.geometries) {
+        totalSegments += Math.max(0, g.indices[0].count - 1);
+        totalJoints += Math.max(0, g.indices[0].count - 2);
+    }
+    const maxQuadsPerJoint = SEGMENTS / 2 * (SEGMENTS / 2 - 1);
+    const totalQuads = totalSegments * SEGMENTS + totalJoints * maxQuadsPerJoint;
+    const indices = getIntArrayFromSize(6 * totalQuads, vertices.length / 3);
+    const buffers = {
+        vertices,
+        colors,
+        batchIds,
+        vertPtr: 0,
+
+        indices,
+        indexPtr: 0,
+    };
+    let featureId = 0;
+
+    // Build one cylinder per line segment
+    for (const geometry of feature.geometries) {
+        context.setGeometry(geometry);
+        const id = batchIdFn(geometry.properties, featureId++);
+        updateExtrudedLineBuffers({ feature }, buffers, id);
+    }
+
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+    geom.setAttribute('color', new THREE.Uint8BufferAttribute(colors, 3, true));
+    geom.setAttribute('batchId', new THREE.Uint32BufferAttribute(batchIds, 1));
+    geom.setIndex(new THREE.BufferAttribute(indices, 1));
+
+    return new THREE.Mesh(geom, options.polygonMaterial);
+}
+
+/**
+ * Update vertex data for extruded LINE features (cylindrical tubes with spherical joints).
+ * Creates cylindrical geometry around line segments with spherical wedges at joints.
+ *
+ * @param {object} featureMesh - Object carrying the feature (expects { feature }).
+ * @param {object} buffers - Buffer management object.
+ * @param {Float32Array} [buffers.vertices] - Target positions buffer to write into.
+ * @param {Uint8Array} [buffers.colors] - Target color buffer (rgb Uint8, normalized).
+ * @param {Uint32Array} [buffers.batchIds] - Target per-vertex batch id buffer.
+ * @param {TypedArray} [buffers.indices] - Target index buffer to write triangle indices to.
+ * @param {number} buffers.vertPtr - Current write position in vertex buffers (incremented by function).
+ * @param {number} buffers.indexPtr - Current write position in index buffer (incremented by function).
+ * @param {number} [id] - Batch id value to assign to written vertices when batchIds is provided.
+ */
+function updateExtrudedLineBuffers(featureMesh, buffers, id) {
+    const feature = featureMesh.feature;
+    const ptsIn = feature.vertices;
+    if (!ptsIn?.length) {
+        console.error('Feature has no vertices');
+        return;
+    }
+
+    // context setup
+    context.setFeature(feature);
+    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
+    up.set(0, 0, 1).multiply(inverseScale);
+    coord.setCrs(context.collection.crs);
+    style.setContext(context);
+    const { vertices, colors, batchIds, indices } = buffers;
+
+    // geometry range
+    const geometry = context.geometry;
+    const start = geometry.indices[0].offset;
+    const count = geometry.indices[0].count;
+    const end = start + count;
+
+    // avoid integer overflow with 16-bit index buffers
+    if (buffers.indices instanceof Uint16Array && end - 1 > 0xffff) {
+        console.warn('Feature to Extruded Line: integer overflow, too many points in lines');
+        return;
+    }
+
+    const radius = style.stroke.extrusion_radius;
+
+    // pre-allocated vectors
+    const xAxis = new THREE.Vector3();
+    const yAxis = new THREE.Vector3();
+    const zAxis = new THREE.Vector3();
+    const prevZAxis = new THREE.Vector3(NaN, NaN, NaN);
+    const normal = new THREE.Vector3();
+    const vertex = new THREE.Vector3();
+
+    // For each consecutive pair of points, make a cylinder centered on the segment
+    for (let i = start; i < end - 1; i++) {
+        const iVertIn = i * 3;
+
+        let altitude;
+
+        // Base and top points in layer-local space with altitude shift
+        if (feature.normals) {
+            up.fromArray(feature.normals, iVertIn).multiply(inverseScale);
+        }
+
+        const p0Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn).clone();
+        coord.copy(p0Local).applyMatrix4(context.collection.matrix);
+        if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
+        altitude = style.stroke.base_altitude;
+        baseCoord.copy(up).multiplyScalar(altitude - coord.z).add(p0Local);
+
+        const p1Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn + 3).clone();
+        coord.copy(p1Local).applyMatrix4(context.collection.matrix);
+        if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
+        altitude = style.stroke.base_altitude;
+        topCoord.copy(up).multiplyScalar(altitude - coord.z).add(p1Local);
+
+        // Axis vector
+        zAxis.subVectors(topCoord, baseCoord);
+        const axisLen = zAxis.length();
+        if (axisLen === 0) { continue; } // start and end are the same
+        zAxis.divideScalar(axisLen);
+
+        // Build a local frame: choose an arbitrary vector not parallel to Z axis
+        if (Math.abs(zAxis.z) > 0.9) { xAxis.set(1, 0, 0); } else { xAxis.set(0, 0, 1); }
+        yAxis.crossVectors(zAxis, xAxis).normalize();
+        xAxis.crossVectors(yAxis, zAxis);
+
+        // Create ring vertices around both ends
+        const meshColor = toColor(style.stroke.color).multiplyScalar(255);
+        for (let k = 0; k < SEGMENTS; k++) {
+            const v = buffers.vertPtr;
+            if (vertices) {
+                const theta = (k / SEGMENTS) * Math.PI * 2;
+                normal.copy(xAxis).multiplyScalar(Math.cos(theta))
+                    .addScaledVector(yAxis, Math.sin(theta));
+                vertex.copy(baseCoord).addScaledVector(normal, radius).toArray(vertices, 3 * v);
+                vertex.copy(topCoord).addScaledVector(normal, radius).toArray(vertices, 3 * (v + 1));
+            }
+            if (batchIds) {
+                batchIds[v] = id;
+                batchIds[v + 1] = id;
+            }
+            if (colors) {
+                meshColor.toArray(colors, 3 * v);
+                meshColor.toArray(colors, 3 * (v + 1));
+            }
+            if (indices) {
+                const v0 = v;
+                const v1 = v + ((k + 1) % SEGMENTS - k) * 2;
+                indices.set([v0, v1, v0 + 1, v0 + 1, v1, v1 + 1], buffers.indexPtr);
+                buffers.indexPtr += 6;
+            }
+            buffers.vertPtr += 2;
+        }
+
+        if (i !== start) {
+            makeSphericalWedgeVertices(baseCoord, radius, prevZAxis, zAxis, buffers, id);
+        }
+
+        prevZAxis.copy(zAxis);
+    }
+}
+
+/**
+ * Generate vertices for a spherical wedge between two half-circles
+ * @param {THREE.Vector3} origin - Center of the spherical wedge
+ * @param {number} radius - Radius of the spherical wedge
+ * @param {THREE.Vector3} prevZAxis - Normal vector of the first half-circle (negated)
+ * @param {THREE.Vector3} zAxis - Normal vector of the second half-circle
+ * @param {object} buffers - Contains vertex, color, batch ID, and index buffers with current write offsets
+ * @param {number} id - Batch ID value to assign to written vertices if batchIds is provided
+ */
+function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, id) {
+    if (Number.isNaN(prevZAxis.x)) { return; } // prevZAxis hasn't been set yet
+
+    const { vertices, colors, batchIds, indices } = buffers;
+
+    // Create orthonormal basis for the plane containing both normals
+    const xAxis = new THREE.Vector3().crossVectors(prevZAxis, zAxis).normalize();
+    const yAxisBase = new THREE.Vector3().crossVectors(prevZAxis, xAxis);
+    const yAxisTop = new THREE.Vector3().crossVectors(zAxis, xAxis);
+
+    const meshColor = toColor(style.stroke.color).multiplyScalar(255);
+    const normal = new THREE.Vector3();
+    const normalXComp = new THREE.Vector3();
+    const vertex = new THREE.Vector3();
+    const yAxisInterpolated = new THREE.Vector3();
+
+    // Calculate number of intermediate steps based on angle between axes
+    const angle = Math.acos(Math.max(-1, Math.min(1, prevZAxis.dot(zAxis))));
+    const numSteps = Math.max(1, Math.round(angle * SEGMENTS / (2 * Math.PI)));
+
+    // let theta be the angle between the y axes
+    const cosTheta = Math.max(-1, Math.min(1, yAxisBase.dot(yAxisTop)));
+
+    // don't generate anything if axes are nearly aligned
+    if (Math.abs(cosTheta) >= 0.9995) { return; }
+
+    // Generate vertices for all intermediate rings
+    const ringVertices = [];
+    if (vertices || batchIds || colors) {
+        const theta = Math.acos(cosTheta);
+        const sinTheta = Math.sin(theta);
+        for (let step = 0; step <= numSteps; step++) {
+            const t = step / numSteps;
+
+            // Interpolate between yAxisBase and yAxisTop using slerp
+            const weight1 = Math.sin((1 - t) * theta) / sinTheta;
+            const weight2 = Math.sin(t * theta) / sinTheta;
+
+            yAxisInterpolated.copy(yAxisBase).multiplyScalar(weight1)
+                .addScaledVector(yAxisTop, weight2);
+
+            const ringStart = buffers.vertPtr;
+            ringVertices.push(ringStart);
+
+            // Create vertices for this ring
+            for (let k = 0; k <= SEGMENTS / 2; k++) {
+                const v = buffers.vertPtr;
+                if (vertices) {
+                    const angle = (k / SEGMENTS) * Math.PI * 2;
+                    normalXComp.copy(xAxis).multiplyScalar(Math.cos(angle));
+                    normal.copy(normalXComp).addScaledVector(yAxisInterpolated, Math.sin(angle));
+                    vertex.copy(baseCoord).addScaledVector(normal, radius).toArray(vertices, 3 * v);
+                }
+                if (batchIds) {
+                    batchIds[v] = id;
+                }
+                if (colors) {
+                    meshColor.toArray(colors, 3 * v);
+                }
+                buffers.vertPtr++;
+            }
+        }
+    }
+
+    // Generate faces between consecutive rings
+    if (indices) {
+        for (let step = 0; step < numSteps; step++) {
+            const currentRingStart = ringVertices[step];
+            const nextRingStart = ringVertices[step + 1];
+
+            for (let k = 0; k < SEGMENTS / 2; k++) {
+                const v0 = currentRingStart + k;
+                const v1 = nextRingStart + k;
+                indices.set([v0, v0 + 1, v1, v1, v0 + 1, v1 + 1], buffers.indexPtr);
+                buffers.indexPtr += 6;
+            }
+        }
+    }
+}
+
 function featureToPolygon(feature, options) {
     const vertices = new Float32Array(feature.vertices);
     const colors = new Uint8Array(feature.vertices.length);
@@ -785,7 +1047,11 @@ function featureToMesh(feature, options) {
             }
             break;
         case FEATURE_TYPES.LINE:
-            mesh = featureToLine(feature, options);
+            if (style.isExtruded()) {
+                mesh = featureToExtrudedLine(feature, options);
+            } else {
+                mesh = featureToLine(feature, options);
+            }
             break;
         case FEATURE_TYPES.POLYGON:
             if (style.isExtruded()) {
@@ -892,6 +1158,7 @@ export default {
                         this._styleColorVersion++;
                     } else if (
                         event.parameter === 'extrusion_height' ||
+                        event.parameter === 'extrusion_radius' ||
                         event.parameter === 'base_altitude' ||
                         event.parameter === 'levelled_roofs') {
                         this._stylePositionVersion++;
@@ -951,7 +1218,11 @@ export function applyStyle(featureMesh, collection, styleIn, buffersToUpdate = [
                 break;
             }
             case FEATURE_TYPES.LINE: {
-                updateLineBuffers(featureMesh, buffers);
+                if (style.isExtruded()) {
+                    updateExtrudedLineBuffers(featureMesh, buffers);
+                } else {
+                    updateLineBuffers(featureMesh, buffers);
+                }
                 break;
             }
             case FEATURE_TYPES.POLYGON: {

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -1074,6 +1074,25 @@ function featureToMesh(feature, options) {
 }
 
 /**
+ * Rebuild the geometry of each child mesh in a {@link FeatureMesh} using the
+ * current layer style. Disposes the old geometry before replacing the mesh.
+ * @param {FeatureMesh} featureMesh - the feature mesh whose children to rebuild
+ * @param {Style} layerStyle - the layer style to use for the rebuild
+ */
+export function rebuildMeshTopology(featureMesh, layerStyle) {
+    style = layerStyle;
+    context.setCollection(featureMesh.collection);
+    for (const oldMesh of [...featureMesh.meshes.children]) {
+        const newMesh = featureToMesh(oldMesh.feature, featureMesh.options);
+        if (newMesh) {
+            oldMesh.geometry.dispose();
+            featureMesh.meshes.remove(oldMesh);
+            featureMesh.meshes.add(newMesh);
+        }
+    }
+}
+
+/**
  * @module Feature2Mesh
  */
 export default {
@@ -1143,6 +1162,8 @@ export default {
                 return mesh;
             });
             const featureNode = new FeatureMesh(meshes, collection);
+            featureNode.options = options;
+            featureNode.styleTopologyVersion = this?._styleTopologyVersion ?? 0;
             featureNode.styleColorVersion = this?._styleColorVersion ?? 0;
             featureNode.stylePositionVersion = this?._stylePositionVersion ?? 0;
             if (this && style !== defaultStyle) {
@@ -1151,10 +1172,13 @@ export default {
                 // MVT feature meshes follow terrain tile subdivision. Track style
                 // changes at layer level so current tiles can be restyled safely
                 // from FeatureProcessing revisits.
-                this._styleColorVersion = this._styleColorVersion ?? 0;
-                this._stylePositionVersion = this._stylePositionVersion ?? 0;
+                this._styleTopologyVersion ??= 0;
+                this._styleColorVersion ??= 0;
+                this._stylePositionVersion ??= 0;
                 style.addEventListener('style-property-changed', (event) => {
-                    if (event.parameter === 'color') {
+                    if (event.parameter === 'topology') {
+                        this._styleTopologyVersion++;
+                    } else if (event.parameter === 'color') {
                         this._styleColorVersion++;
                     } else if (
                         event.parameter === 'extrusion_height' ||

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -28,6 +28,26 @@ const SEGMENTS = 8; // radial segments in a circle - used to model cylinders and
 // Scratch vectors used while building spherical wedges for extruded lines.
 let wedgeScratch;
 
+// Populate the module-level dim_ref and dim vectors from a source extent.
+function computeExtentDimensions(sourceExtent, matrix, crs) {
+    if (sourceExtent.isExtent) {
+        extent.copy(sourceExtent).applyMatrix4(matrix);
+        extent.as(crs, extent);
+    } else {
+        sourceExtent.toExtent(crs, extent);
+    }
+    extent.spatialEuclideanDimensions(dim_ref);
+    extent.planarDimensions(dim);
+}
+
+function refreshCollectionContext(feature) {
+    context.setFeature(feature);
+    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
+    up.set(0, 0, 1).multiply(inverseScale);
+    coord.setCrs(context.collection.crs);
+    style.setContext(context);
+}
+
 class FeatureMesh extends THREE.Group {
     #currentCrs;
     #originalCrs;
@@ -76,14 +96,7 @@ class FeatureMesh extends THREE.Group {
                 // TODO: An extent here could be either a geographic extent (for
                 // features from WFS) or a tiled extent (for features from MVT).
                 // Unify both behavior.
-                if (this.extent.isExtent) {
-                    extent.copy(this.extent).applyMatrix4(this.#collection.matrix);
-                    extent.as(coord.crs, extent);
-                } else {
-                    this.extent.toExtent(coord.crs, extent);
-                }
-                extent.spatialEuclideanDimensions(dim_ref);
-                extent.planarDimensions(dim);
+                computeExtentDimensions(this.extent, this.#collection.matrix, coord.crs);
                 if (dim.x && dim.y) {
                     this.scale.copy(dim_ref).divide(dim).setZ(1);
                 }
@@ -251,11 +264,7 @@ function updatePointBuffers(featureMesh, buffers, id) {
     }
 
     // context setup
-    context.setFeature(feature);
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
-    style.setContext(context);
+    refreshCollectionContext(feature);
 
     const { vertices, colors, batchIds } = buffers;
 
@@ -372,11 +381,7 @@ function updateLineBuffers(featureMesh, buffers, id) {
     }
 
     // context setup
-    context.setFeature(feature);
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
-    style.setContext(context);
+    refreshCollectionContext(feature);
 
     const { vertices, colors, batchIds, indices } = buffers;
 
@@ -430,8 +435,6 @@ function featureToExtrudedLine(feature, options) {
     let totalJoints = 0;
     let totalCaps = 0;
 
-    context.setFeature(feature);
-    style.setContext(context);
     for (const geometry of feature.geometries) {
         context.setGeometry(geometry);
         const pointCount = geometry.indices[0].count;
@@ -449,9 +452,6 @@ function featureToExtrudedLine(feature, options) {
     const batchIdFn = options.batchId || ((p, id) => id);
     const batchIds = new Uint32Array(vertices.length / 3);
 
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
 
     const totalQuads = totalSegments * SEGMENTS +
         (totalJoints + totalCaps) * maxQuadsPerWedge;
@@ -475,10 +475,10 @@ function featureToExtrudedLine(feature, options) {
     }
 
     const geom = new THREE.BufferGeometry();
-    geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
-    geom.setAttribute('color', new THREE.Uint8BufferAttribute(colors, 3, true));
-    geom.setAttribute('batchId', new THREE.Uint32BufferAttribute(batchIds, 1));
-    geom.setIndex(new THREE.BufferAttribute(indices, 1));
+    geom.setAttribute('position', new THREE.Float32BufferAttribute(vertices.subarray(0, buffers.vertPtr * 3), 3));
+    geom.setAttribute('color', new THREE.Uint8BufferAttribute(colors.subarray(0, buffers.vertPtr * 3), 3, true));
+    geom.setAttribute('batchId', new THREE.Uint32BufferAttribute(batchIds.subarray(0, buffers.vertPtr), 1));
+    geom.setIndex(new THREE.BufferAttribute(indices.subarray(0, buffers.indexPtr), 1));
 
     return new THREE.Mesh(geom, options.polygonMaterial);
 }
@@ -507,11 +507,7 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     }
 
     // context setup
-    context.setFeature(feature);
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
-    style.setContext(context);
+    refreshCollectionContext(feature);
 
     // Compute reprojection inverse scale (same logic as FeatureMesh.as())
     dim_ref.set(1, 1);
@@ -519,14 +515,7 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     const collExtent = context.collection.extent;
     if (collExtent) {
         const crs = context.collection.crs;
-        if (collExtent.isExtent) {
-            extent.copy(collExtent).applyMatrix4(context.collection.matrix);
-            extent.as(crs, extent);
-        } else {
-            collExtent.toExtent(crs, extent);
-        }
-        extent.spatialEuclideanDimensions(dim_ref);
-        extent.planarDimensions(dim);
+        computeExtentDimensions(collExtent, context.collection.matrix, crs);
     }
 
     const { vertices, colors, batchIds, indices } = buffers;
@@ -688,8 +677,8 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
     // Create orthonormal basis for the plane containing both normals
     xAxis.crossVectors(prevZAxis, zAxis);
     if (xAxis.lengthSq() < 0.001) {
-        const isIsNearX = Math.abs(prevZAxis.x) > 0.9;
-        tempAxis.set(isIsNearX ? 0 : 1, isIsNearX ? 1 : 0, 0);
+        const isNearX = Math.abs(prevZAxis.x) > 0.9;
+        tempAxis.set(isNearX ? 0 : 1, isNearX ? 1 : 0, 0);
         xAxis.crossVectors(tempAxis, prevZAxis).normalize();
     } else {
         xAxis.normalize();
@@ -698,8 +687,8 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
     const meshColor = toColor(style.stroke.color).multiplyScalar(255);
 
     // Calculate number of intermediate steps based on angle between axes
-    const angle = Math.acos(Math.max(-1, Math.min(1, prevZAxis.dot(zAxis))));
-    const numSteps = Math.max(1, Math.round(angle * SEGMENTS / (2 * Math.PI)));
+    const zPrevZAngle = Math.acos(Math.max(-1, Math.min(1, prevZAxis.dot(zAxis))));
+    const numSteps = Math.max(1, Math.round(zPrevZAngle * SEGMENTS / (2 * Math.PI)));
 
     yAxisBase.crossVectors(prevZAxis, xAxis);
     yAxisTop.crossVectors(zAxis, xAxis);
@@ -819,11 +808,7 @@ function updatePolygonBuffers(featureMesh, buffers, id) {
     }
 
     // context setup
-    context.setFeature(feature);
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
-    style.setContext(context);
+    refreshCollectionContext(feature);
 
     const { vertices, colors, batchIds, indices } = buffers;
 
@@ -901,10 +886,6 @@ function featureToExtrudedPolygon(feature, options) {
 
     let featureId = 0;
 
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
-
     for (const geometry of feature.geometries) {
         context.setGeometry(geometry);
 
@@ -943,11 +924,7 @@ function updateExtrudedPolygonBuffers(featureMesh, buffers, id) {
     }
 
     // context setup
-    context.setFeature(feature);
-    inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
-    coord.setCrs(context.collection.crs);
-    style.setContext(context);
+    refreshCollectionContext(feature);
 
     const { vertices, colors, batchIds, indices } = buffers;
     const { levelled_roofs } = style.fill;
@@ -1166,9 +1143,9 @@ export function rebuildMeshTopology(featureMesh, layerStyle) {
     context.setCollection(featureMesh.collection);
     for (const oldMesh of [...featureMesh.meshes.children]) {
         const newMesh = featureToMesh(oldMesh.feature, featureMesh.options);
+        oldMesh.geometry.dispose();
+        featureMesh.meshes.remove(oldMesh);
         if (newMesh) {
-            oldMesh.geometry.dispose();
-            featureMesh.meshes.remove(oldMesh);
             featureMesh.meshes.add(newMesh);
         }
     }

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -436,7 +436,7 @@ function featureToExtrudedLine(feature, options) {
         const pointCount = geometry.indices[0].count;
         totalSegments += Math.max(0, pointCount - 1);
         totalJoints += Math.max(0, pointCount - 2);
-        if (style.stroke.lineCap === 'round' && pointCount > 1) {
+        if (style.stroke.line_cap === 'round' && pointCount > 1) {
             totalCaps += 2;
         }
     }
@@ -485,7 +485,7 @@ function featureToExtrudedLine(feature, options) {
 /**
  * Update vertex data for extruded LINE features (cylindrical tubes with spherical joints).
  * Creates cylindrical geometry around line segments with spherical wedges at joints and,
- * when `stroke.lineCap === 'round'`, half-sphere caps at line endpoints.
+ * when `stroke.line_cap === 'round'`, half-sphere caps at line endpoints.
  *
  * @param {object} featureMesh - Object carrying the feature (expects { feature }).
  * @param {object} buffers - Buffer management object.
@@ -526,7 +526,7 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     }
 
     const radius = style.stroke.extrusion_radius;
-    const useRoundCaps = style.stroke.lineCap === 'round';
+    const useRoundCaps = style.stroke.line_cap === 'round';
 
     // pre-allocated vectors
     const xAxis = new THREE.Vector3();

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -19,6 +19,17 @@ const topCoord = new THREE.Vector3();
 const inverseScale = new THREE.Vector3();
 const extent = new Extent('EPSG:4326', 0, 0, 0, 0);
 
+// Scratch vectors for extruded-line geometry building
+let xAxis;
+let yAxis;
+let zAxis;
+let prevZAxis;
+let capAxis;
+let normal;
+let vertex;
+let lastCoord;
+let lastZAxis;
+
 const _color = new THREE.Color();
 const maxValueUint8 = 2 ** 8 - 1;
 const maxValueUint16 = 2 ** 16 - 1;
@@ -484,6 +495,86 @@ function featureToExtrudedLine(feature, options) {
 }
 
 /**
+ * Compute base/top endpoint positions and the local orientation frame for a line segment.
+ * Sets baseCoord, topCoord, zAxis, xAxis, yAxis.
+ *
+ * @param {Feature} feature
+ * @param {Float32Array} ptsIn - Flat vertex position array
+ * @param {number} iVertIn - Flat index into ptsIn for the first endpoint
+ * @returns {boolean} false if the segment is degenerate (zero length)
+ */
+function computeSegmentFrame(feature, ptsIn, iVertIn) {
+    if (feature.normals) {
+        up.fromArray(feature.normals, iVertIn).multiply(inverseScale);
+    }
+
+    const p0Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn);
+    coord.copy(p0Local).applyMatrix4(context.collection.matrix);
+    if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
+    baseCoord.copy(up).multiplyScalar(style.stroke.base_altitude - coord.z).add(p0Local);
+
+    const p1Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn + 3);
+    coord.copy(p1Local).applyMatrix4(context.collection.matrix);
+    if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
+    topCoord.copy(up).multiplyScalar(style.stroke.base_altitude - coord.z).add(p1Local);
+
+    // cylinder axis
+    zAxis.subVectors(topCoord, baseCoord);
+    const axisLen = zAxis.length();
+    if (axisLen === 0) { return false; }
+    zAxis.divideScalar(axisLen);
+
+    // Build a local frame: choose an arbitrary vector not parallel to Z axis
+    if (Math.abs(zAxis.z) > 0.9) { xAxis.set(1, 0, 0); } else { xAxis.set(0, 0, 1); }
+    yAxis.crossVectors(zAxis, xAxis).normalize();
+    xAxis.crossVectors(yAxis, zAxis);
+
+    return true;
+}
+
+/**
+ * Append one ring of SEGMENTS cylinder vertex pairs to the buffers.
+ *
+ * @param {object} buffers - Buffer management object with vertPtr / indexPtr write cursors.
+ * @param {number} id - Batch ID value to assign to written vertices when batchIds is provided.
+ */
+function buildCylinderRing(buffers, id) {
+    const { vertices, colors, batchIds, indices } = buffers;
+    const meshColor = toColor(style.stroke.color).multiplyScalar(255);
+    const radius = style.stroke.extrusion_radius;
+    for (let k = 0; k < SEGMENTS; k++) {
+        const v = buffers.vertPtr;
+        if (vertices) {
+            const theta = (k / SEGMENTS) * Math.PI * 2;
+            normal.copy(xAxis).multiplyScalar(Math.cos(theta))
+                .addScaledVector(yAxis, Math.sin(theta));
+            normal.multiply(inverseScale);
+            if (dim.x && dim.y && dim_ref.x && dim_ref.y) {
+                normal.x *= dim.x / dim_ref.x;
+                normal.y *= dim.y / dim_ref.y;
+            }
+            vertex.copy(baseCoord).addScaledVector(normal, radius).toArray(vertices, 3 * v);
+            vertex.copy(topCoord).addScaledVector(normal, radius).toArray(vertices, 3 * (v + 1));
+        }
+        if (batchIds) {
+            batchIds[v] = id;
+            batchIds[v + 1] = id;
+        }
+        if (colors) {
+            meshColor.toArray(colors, 3 * v);
+            meshColor.toArray(colors, 3 * (v + 1));
+        }
+        if (indices) {
+            const v0 = v;
+            const v1 = v + ((k + 1) % SEGMENTS - k) * 2;
+            indices.set([v0, v1, v0 + 1, v0 + 1, v1, v1 + 1], buffers.indexPtr);
+            buffers.indexPtr += 6;
+        }
+        buffers.vertPtr += 2;
+    }
+}
+
+/**
  * Update vertex data for extruded LINE features (cylindrical tubes with spherical joints).
  * Creates cylindrical geometry around line segments with spherical wedges at joints and,
  * when `stroke.line_cap === 'round'`, half-sphere caps at line endpoints.
@@ -518,8 +609,6 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
         computeExtentDimensions(collExtent, context.collection.matrix, crs);
     }
 
-    const { vertices, colors, batchIds, indices } = buffers;
-
     // geometry range
     const geometry = context.geometry;
     const start = geometry.indices[0].offset;
@@ -536,16 +625,15 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     const useRoundCaps = style.stroke.line_cap === 'round';
 
     // pre-allocated vectors
-    const xAxis = new THREE.Vector3();
-    const yAxis = new THREE.Vector3();
-    const zAxis = new THREE.Vector3();
-    const prevZAxis = new THREE.Vector3(NaN, NaN, NaN);
-    const capAxis = new THREE.Vector3();
-    const normal = new THREE.Vector3();
-    const vertex = new THREE.Vector3();
-    const firstCoord = new THREE.Vector3();
-    const lastCoord = new THREE.Vector3();
-    const lastZAxis = new THREE.Vector3();
+    xAxis = new THREE.Vector3();
+    yAxis = new THREE.Vector3();
+    zAxis = new THREE.Vector3();
+    prevZAxis = new THREE.Vector3(NaN, NaN, NaN);
+    capAxis = new THREE.Vector3();
+    normal = new THREE.Vector3();
+    vertex = new THREE.Vector3();
+    lastCoord = new THREE.Vector3();
+    lastZAxis = new THREE.Vector3();
     wedgeScratch = {
         xAxis: new THREE.Vector3(),
         tempAxis: new THREE.Vector3(),
@@ -556,84 +644,24 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
         yAxisBase: new THREE.Vector3(),
         yAxisTop: new THREE.Vector3(),
     };
+
+    // whether the line sequence is not degenerate, i.e. has at least 2 points
     let hasSegment = false;
 
     // For each consecutive pair of points, make a cylinder centered on the segment
     for (let i = start; i < end - 1; i++) {
-        const iVertIn = i * 3;
-
-        let altitude;
-
-        // Base and top points in layer-local space with altitude shift
-        if (feature.normals) {
-            up.fromArray(feature.normals, iVertIn).multiply(inverseScale);
-        }
-
-        const p0Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn);
-        coord.copy(p0Local).applyMatrix4(context.collection.matrix);
-        if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
-        altitude = style.stroke.base_altitude;
-        baseCoord.copy(up).multiplyScalar(altitude - coord.z).add(p0Local);
-
-        const p1Local = context.setLocalCoordinatesFromArray(ptsIn, iVertIn + 3);
-        coord.copy(p1Local).applyMatrix4(context.collection.matrix);
-        if (coord.crs === 'EPSG:4978') { coord.as('EPSG:4326', coord); }
-        altitude = style.stroke.base_altitude;
-        topCoord.copy(up).multiplyScalar(altitude - coord.z).add(p1Local);
-
-        // Axis vector
-        zAxis.subVectors(topCoord, baseCoord);
-        const axisLen = zAxis.length();
-        if (axisLen === 0) { continue; } // start and end are the same
-        zAxis.divideScalar(axisLen);
+        if (!computeSegmentFrame(feature, ptsIn, i * 3)) { continue; }
 
         if (!hasSegment) {
             hasSegment = true;
-            firstCoord.copy(baseCoord);
             if (useRoundCaps) {
                 capAxis.copy(zAxis).negate();
-                makeSphericalWedgeVertices(firstCoord, radius, capAxis, zAxis, buffers, id);
+                // baseCoord here is the first vertex of the input segment
+                makeSphericalWedgeVertices(baseCoord, radius, capAxis, zAxis, buffers, id);
             }
         }
 
-        // Build a local frame: choose an arbitrary vector not parallel to Z axis
-        if (Math.abs(zAxis.z) > 0.9) { xAxis.set(1, 0, 0); } else { xAxis.set(0, 0, 1); }
-        yAxis.crossVectors(zAxis, xAxis).normalize();
-        xAxis.crossVectors(yAxis, zAxis);
-
-        // Create ring vertices around both ends
-        const meshColor = toColor(style.stroke.color).multiplyScalar(255);
-        for (let k = 0; k < SEGMENTS; k++) {
-            const v = buffers.vertPtr;
-            if (vertices) {
-                const theta = (k / SEGMENTS) * Math.PI * 2;
-                normal.copy(xAxis).multiplyScalar(Math.cos(theta))
-                    .addScaledVector(yAxis, Math.sin(theta));
-                normal.multiply(inverseScale);
-                if (dim.x && dim.y && dim_ref.x && dim_ref.y) {
-                    normal.x *= dim.x / dim_ref.x;
-                    normal.y *= dim.y / dim_ref.y;
-                }
-
-                vertex.copy(baseCoord).addScaledVector(normal, radius).toArray(vertices, 3 * v);
-                vertex.copy(topCoord).addScaledVector(normal, radius).toArray(vertices, 3 * (v + 1));
-            }
-            if (batchIds) {
-                batchIds[v] = id;
-                batchIds[v + 1] = id;
-            }
-            if (colors) {
-                meshColor.toArray(colors, 3 * v);
-                meshColor.toArray(colors, 3 * (v + 1));
-            }
-            if (indices) {
-                const v0 = v;
-                const v1 = v + ((k + 1) % SEGMENTS - k) * 2;
-                indices.set([v0, v1, v0 + 1, v0 + 1, v1, v1 + 1], buffers.indexPtr);
-                buffers.indexPtr += 6;
-            }
-            buffers.vertPtr += 2;
-        }
+        buildCylinderRing(buffers, id);
 
         if (i !== start) {
             makeSphericalWedgeVertices(baseCoord, radius, prevZAxis, zAxis, buffers, id);
@@ -699,40 +727,42 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
     // don't generate anything if both half-circles are already aligned
     if (cosTheta >= 0.9995) { return; }
 
+    // early return because in practice, if we don't rebuild vertices,
+    // we never need to rebuild indices either
+    if (!vertices && !batchIds && !colors) { return; }
+
     // Generate vertices for all intermediate rings
     const ringVertices = [];
-    if (vertices || batchIds || colors) {
-        const theta = Math.acos(cosTheta);
-        for (let step = 0; step <= numSteps; step++) {
-            const t = step / numSteps;
+    const theta = Math.acos(cosTheta);
+    for (let step = 0; step <= numSteps; step++) {
+        const t = step / numSteps;
 
-            interpolatedYAxis.copy(yAxisBase).applyAxisAngle(xAxis, t * theta);
+        interpolatedYAxis.copy(yAxisBase).applyAxisAngle(xAxis, t * theta);
 
-            const ringStart = buffers.vertPtr;
-            ringVertices.push(ringStart);
+        const ringStart = buffers.vertPtr;
+        ringVertices.push(ringStart);
 
-            // Create vertices for this ring
-            for (let k = 0; k <= SEGMENTS / 2; k++) {
-                const v = buffers.vertPtr;
-                if (vertices) {
-                    const angle = (k / SEGMENTS) * Math.PI * 2;
-                    normalXComp.copy(xAxis).multiplyScalar(Math.cos(angle));
-                    normal.copy(normalXComp).addScaledVector(interpolatedYAxis, Math.sin(angle));
-                    normal.multiply(inverseScale);
-                    if (dim.x && dim.y && dim_ref.x && dim_ref.y) {
-                        normal.x *= dim.x / dim_ref.x;
-                        normal.y *= dim.y / dim_ref.y;
-                    }
-                    vertex.copy(origin).addScaledVector(normal, radius).toArray(vertices, 3 * v);
+        // Create vertices for this ring
+        for (let k = 0; k <= SEGMENTS / 2; k++) {
+            const v = buffers.vertPtr;
+            if (vertices) {
+                const angle = (k / SEGMENTS) * Math.PI * 2;
+                normalXComp.copy(xAxis).multiplyScalar(Math.cos(angle));
+                normal.copy(normalXComp).addScaledVector(interpolatedYAxis, Math.sin(angle));
+                normal.multiply(inverseScale);
+                if (dim.x && dim.y && dim_ref.x && dim_ref.y) {
+                    normal.x *= dim.x / dim_ref.x;
+                    normal.y *= dim.y / dim_ref.y;
                 }
-                if (batchIds) {
-                    batchIds[v] = id;
-                }
-                if (colors) {
-                    meshColor.toArray(colors, 3 * v);
-                }
-                buffers.vertPtr++;
+                vertex.copy(origin).addScaledVector(normal, radius).toArray(vertices, 3 * v);
             }
+            if (batchIds) {
+                batchIds[v] = id;
+            }
+            if (colors) {
+                meshColor.toArray(colors, 3 * v);
+            }
+            buffers.vertPtr++;
         }
     }
 

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -421,27 +421,37 @@ function updateLineBuffers(featureMesh, buffers, id) {
 }
 
 function featureToExtrudedLine(feature, options) {
-    const maxVertsPerJoint = (SEGMENTS / 2 + 1) * SEGMENTS / 2;
-    const vertSize = (feature.vertices.length - 3 * feature.geometries.length) * 2 * SEGMENTS + // cylinders
-        (feature.vertices.length - 6 * feature.geometries.length) * maxVertsPerJoint; // joints
+    const maxVertsPerWedge = (SEGMENTS / 2 + 1) * (SEGMENTS / 2 + 1);
+    const maxQuadsPerWedge = SEGMENTS / 2 * SEGMENTS / 2;
+    let totalSegments = 0;
+    let totalJoints = 0;
+    let totalCaps = 0;
+
+    context.setFeature(feature);
+    style.setContext(context);
+    for (const geometry of feature.geometries) {
+        context.setGeometry(geometry);
+        const pointCount = geometry.indices[0].count;
+        totalSegments += Math.max(0, pointCount - 1);
+        totalJoints += Math.max(0, pointCount - 2);
+        if (style.stroke.lineCap === 'round' && pointCount > 1) {
+            totalCaps += 2;
+        }
+    }
+
+    const vertSize = (totalSegments * 2 * SEGMENTS + // cylinders
+        (totalJoints + totalCaps) * maxVertsPerWedge) * 3;
     const vertices = new Float32Array(vertSize);
     const colors = new Uint8Array(vertSize);
     const batchIdFn = options.batchId || ((p, id) => id);
     const batchIds = new Uint32Array(vertices.length / 3);
 
-    context.setFeature(feature);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
     up.set(0, 0, 1).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
 
-    let totalSegments = 0;
-    let totalJoints = 0;
-    for (const g of feature.geometries) {
-        totalSegments += Math.max(0, g.indices[0].count - 1);
-        totalJoints += Math.max(0, g.indices[0].count - 2);
-    }
-    const maxQuadsPerJoint = SEGMENTS / 2 * (SEGMENTS / 2 - 1);
-    const totalQuads = totalSegments * SEGMENTS + totalJoints * maxQuadsPerJoint;
+    const totalQuads = totalSegments * SEGMENTS +
+        (totalJoints + totalCaps) * maxQuadsPerWedge;
     const indices = getIntArrayFromSize(6 * totalQuads, vertices.length / 3);
     const buffers = {
         vertices,
@@ -472,7 +482,8 @@ function featureToExtrudedLine(feature, options) {
 
 /**
  * Update vertex data for extruded LINE features (cylindrical tubes with spherical joints).
- * Creates cylindrical geometry around line segments with spherical wedges at joints.
+ * Creates cylindrical geometry around line segments with spherical wedges at joints and,
+ * when `stroke.lineCap === 'round'`, half-sphere caps at line endpoints.
  *
  * @param {object} featureMesh - Object carrying the feature (expects { feature }).
  * @param {object} buffers - Buffer management object.
@@ -513,14 +524,20 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
     }
 
     const radius = style.stroke.extrusion_radius;
+    const useRoundCaps = style.stroke.lineCap === 'round';
 
     // pre-allocated vectors
     const xAxis = new THREE.Vector3();
     const yAxis = new THREE.Vector3();
     const zAxis = new THREE.Vector3();
     const prevZAxis = new THREE.Vector3(NaN, NaN, NaN);
+    const capAxis = new THREE.Vector3();
     const normal = new THREE.Vector3();
     const vertex = new THREE.Vector3();
+    const firstCoord = new THREE.Vector3();
+    const lastCoord = new THREE.Vector3();
+    const lastZAxis = new THREE.Vector3();
+    let hasSegment = false;
 
     // For each consecutive pair of points, make a cylinder centered on the segment
     for (let i = start; i < end - 1; i++) {
@@ -550,6 +567,15 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
         const axisLen = zAxis.length();
         if (axisLen === 0) { continue; } // start and end are the same
         zAxis.divideScalar(axisLen);
+
+        if (!hasSegment) {
+            hasSegment = true;
+            firstCoord.copy(baseCoord);
+            if (useRoundCaps) {
+                capAxis.copy(zAxis).negate();
+                makeSphericalWedgeVertices(firstCoord, radius, capAxis, zAxis, buffers, id);
+            }
+        }
 
         // Build a local frame: choose an arbitrary vector not parallel to Z axis
         if (Math.abs(zAxis.z) > 0.9) { xAxis.set(1, 0, 0); } else { xAxis.set(0, 0, 1); }
@@ -589,6 +615,13 @@ function updateExtrudedLineBuffers(featureMesh, buffers, id) {
         }
 
         prevZAxis.copy(zAxis);
+        lastCoord.copy(topCoord);
+        lastZAxis.copy(zAxis);
+    }
+
+    if (useRoundCaps && hasSegment) {
+        capAxis.copy(lastZAxis).negate();
+        makeSphericalWedgeVertices(lastCoord, radius, lastZAxis, capAxis, buffers, id);
     }
 }
 
@@ -607,9 +640,15 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
     const { vertices, colors, batchIds, indices } = buffers;
 
     // Create orthonormal basis for the plane containing both normals
-    const xAxis = new THREE.Vector3().crossVectors(prevZAxis, zAxis).normalize();
-    const yAxisBase = new THREE.Vector3().crossVectors(prevZAxis, xAxis);
-    const yAxisTop = new THREE.Vector3().crossVectors(zAxis, xAxis);
+    const xAxis = new THREE.Vector3().crossVectors(prevZAxis, zAxis);
+    if (xAxis.lengthSq() < 0.001) {
+        const tempAxis = Math.abs(prevZAxis.x) < 0.9 ?
+            new THREE.Vector3(1, 0, 0) :
+            new THREE.Vector3(0, 1, 0);
+        xAxis.crossVectors(tempAxis, prevZAxis).normalize();
+    } else {
+        xAxis.normalize();
+    }
 
     const meshColor = toColor(style.stroke.color).multiplyScalar(255);
     const normal = new THREE.Vector3();
@@ -621,26 +660,23 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
     const angle = Math.acos(Math.max(-1, Math.min(1, prevZAxis.dot(zAxis))));
     const numSteps = Math.max(1, Math.round(angle * SEGMENTS / (2 * Math.PI)));
 
+    const yAxisBase = new THREE.Vector3().crossVectors(prevZAxis, xAxis);
+    const yAxisTop = new THREE.Vector3().crossVectors(zAxis, xAxis);
+
     // let theta be the angle between the y axes
     const cosTheta = Math.max(-1, Math.min(1, yAxisBase.dot(yAxisTop)));
 
-    // don't generate anything if axes are nearly aligned
-    if (Math.abs(cosTheta) >= 0.9995) { return; }
+    // don't generate anything if both half-circles are already aligned
+    if (cosTheta >= 0.9995) { return; }
 
     // Generate vertices for all intermediate rings
     const ringVertices = [];
     if (vertices || batchIds || colors) {
         const theta = Math.acos(cosTheta);
-        const sinTheta = Math.sin(theta);
         for (let step = 0; step <= numSteps; step++) {
             const t = step / numSteps;
 
-            // Interpolate between yAxisBase and yAxisTop using slerp
-            const weight1 = Math.sin((1 - t) * theta) / sinTheta;
-            const weight2 = Math.sin(t * theta) / sinTheta;
-
-            yAxisInterpolated.copy(yAxisBase).multiplyScalar(weight1)
-                .addScaledVector(yAxisTop, weight2);
+            yAxisInterpolated.copy(yAxisBase).applyAxisAngle(xAxis, t * theta);
 
             const ringStart = buffers.vertPtr;
             ringVertices.push(ringStart);
@@ -652,7 +688,7 @@ function makeSphericalWedgeVertices(origin, radius, prevZAxis, zAxis, buffers, i
                     const angle = (k / SEGMENTS) * Math.PI * 2;
                     normalXComp.copy(xAxis).multiplyScalar(Math.cos(angle));
                     normal.copy(normalXComp).addScaledVector(yAxisInterpolated, Math.sin(angle));
-                    vertex.copy(baseCoord).addScaledVector(normal, radius).toArray(vertices, 3 * v);
+                    vertex.copy(origin).addScaledVector(normal, radius).toArray(vertices, 3 * v);
                 }
                 if (batchIds) {
                     batchIds[v] = id;
@@ -1176,7 +1212,8 @@ export default {
                 this._styleColorVersion ??= 0;
                 this._stylePositionVersion ??= 0;
                 style.addEventListener('style-property-changed', (event) => {
-                    if (event.parameter === 'topology') {
+                    if (event.parameter === 'topology' ||
+                        event.parameter === 'lineCap') {
                         this._styleTopologyVersion++;
                     } else if (event.parameter === 'color') {
                         this._styleColorVersion++;

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -334,7 +334,7 @@ function _addIcon(icon, domElement, opt) {
  * @property {number|Function} stroke.opacity - The opacity of the line. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
  * For a `GeometryLayer`, this opacity property isn't used.
- * @property {String|Function} [stroke.lineCap] - The shape used at the ends of lines.
+ * @property {string|Function} [stroke.line_cap] - The shape used at the ends of lines.
  * For extruded `GeometryLayer` lines, setting it to `round` adds half-sphere caps.
  * @property {number|Function} stroke.width - The width of the line. Default is `1.0`.
  * @property {number|Function} stroke.base_altitude - Only for {@link GeometryLayer}, defines altitude
@@ -574,7 +574,7 @@ class Style extends EventDispatcher {
                 },
                 set: (v) => {
                     if (this._extrusionHeight === undefined && v === undefined) { return; }
-                    let extrudedStateChanged = this._extrusionHeight === undefined || v === undefined;
+                    const extrudedStateChanged = this._extrusionHeight === undefined || v === undefined;
                     this._extrusionHeight = v;
                     this.dispatchEvent({
                         type: 'style-property-changed',
@@ -593,7 +593,7 @@ class Style extends EventDispatcher {
         this._defineCategoryProperty('stroke');
         defineStyleProperty(this, 'stroke', 'color', params.color);
         defineStyleProperty(this, 'stroke', 'opacity', params.opacity, 1.0);
-        defineStyleProperty(this, 'stroke', 'lineCap', params.lineCap, 'butt');
+        defineStyleProperty(this, 'stroke', 'line_cap', params.line_cap, 'butt');
         defineStyleProperty(this, 'stroke', 'width', params.width, 1.0);
         defineStyleProperty(this, 'stroke', 'dasharray', params.dasharray, []);
         defineStyleProperty(this, 'stroke', 'base_altitude', params.base_altitude, baseAltitudeDefault);
@@ -616,7 +616,7 @@ class Style extends EventDispatcher {
                 },
                 set: (v) => {
                     if (this._extrusionRadius === undefined && v === undefined) { return; }
-                    let extrudedStateChanged = this._extrusionRadius === undefined || v === undefined;
+                    const extrudedStateChanged = this._extrusionRadius === undefined || v === undefined;
                     this._extrusionRadius = v;
                     this.dispatchEvent({
                         type: 'style-property-changed',
@@ -724,8 +724,8 @@ class Style extends EventDispatcher {
         if (alpha !== txtrCtx.globalAlpha && typeof alpha == 'number') {
             txtrCtx.globalAlpha = alpha;
         }
-        if (txtrCtx.lineCap !== this.stroke.lineCap) {
-            txtrCtx.lineCap = this.stroke.lineCap;
+        if (txtrCtx.lineCap !== this.stroke.line_cap) {
+            txtrCtx.lineCap = this.stroke.line_cap;
         }
         txtrCtx.setLineDash(this.stroke.dasharray.map(a => a * invCtxScale * 2));
         txtrCtx.stroke(polygon);

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -341,7 +341,7 @@ function _addIcon(icon, domElement, opt) {
  * for each coordinate.
  * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
  * then the altitude value is set to 0.
- * @property {Number|Function} [stroke.extrusion_radius] - Only for {@link GeometryLayer} and if user sets it.
+ * @property {number|Function} [stroke.extrusion_radius] - Only for {@link GeometryLayer} and if user sets it.
  * If defined, lines will be extruded as cylinders with the specified amount as a radius.
  *
  * @property {object} point - Point style.

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -571,11 +571,13 @@ class Style extends EventDispatcher {
                     return undefined;
                 },
                 set: (v) => {
+                    if (this._extrusionHeight === undefined && v === undefined) { return; }
+                    let extrudedStateChanged = this._extrusionHeight === undefined || v === undefined;
                     this._extrusionHeight = v;
                     this.dispatchEvent({
                         type: 'style-property-changed',
                         style: this,
-                        parameter: 'extrusion_height',
+                        parameter: extrudedStateChanged ? 'topology' : 'extrusion_height',
                     });
                 },
             },
@@ -610,11 +612,13 @@ class Style extends EventDispatcher {
                     return undefined;
                 },
                 set: (v) => {
+                    if (this._extrusionRadius === undefined && v === undefined) { return; }
+                    let extrudedStateChanged = this._extrusionRadius === undefined || v === undefined;
                     this._extrusionRadius = v;
                     this.dispatchEvent({
                         type: 'style-property-changed',
                         style: this,
-                        parameter: 'extrusion_radius',
+                        parameter: extrudedStateChanged ? 'topology' : 'extrusion_radius',
                     });
                 },
             },

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -339,6 +339,8 @@ function _addIcon(icon, domElement, opt) {
  * for each coordinate.
  * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
  * then the altitude value is set to 0.
+ * @property {Number|Function} [stroke.extrusion_radius] - Only for {@link GeometryLayer} and if user sets it.
+ * If defined, lines will be extruded as cylinders with the specified amount as a radius.
  *
  * @property {object} point - Point style.
  * @property {string|Function} point.color - The color of the point. Can be any [valid
@@ -590,6 +592,33 @@ class Style extends EventDispatcher {
         defineStyleProperty(this, 'stroke', 'width', params.width, 1.0);
         defineStyleProperty(this, 'stroke', 'dasharray', params.dasharray, []);
         defineStyleProperty(this, 'stroke', 'base_altitude', params.base_altitude, baseAltitudeDefault);
+
+        // define a special case for extrusion_radius
+        // to be able to know if user set it or not without calling the getter
+        this._extrusionRadius = params.extrusion_radius;
+        Object.defineProperty(
+            this.stroke,
+            'extrusion_radius',
+            {
+                enumerable: true,
+                get: () => {
+                    if (this._extrusionRadius != undefined) {
+                        return readExpression(this._extrusionRadius, this.context);
+                    }
+                    const dataValue = this.context.featureStyle?.stroke?.extrusion_radius;
+                    if (dataValue != undefined) { return readExpression(dataValue, this.context); }
+                    return undefined;
+                },
+                set: (v) => {
+                    this._extrusionRadius = v;
+                    this.dispatchEvent({
+                        type: 'style-property-changed',
+                        style: this,
+                        parameter: 'extrusion_radius',
+                    });
+                },
+            },
+        );
     }
 
     /**
@@ -815,7 +844,7 @@ class Style extends EventDispatcher {
      * @returns {boolean} True if extrusion is enabled, false otherwise.
      */
     isExtruded() {
-        return this._extrusionHeight != undefined;
+        return this._extrusionHeight != undefined || this._extrusionRadius != undefined;
     }
 }
 

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -334,6 +334,8 @@ function _addIcon(icon, domElement, opt) {
  * @property {number|Function} stroke.opacity - The opacity of the line. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
  * For a `GeometryLayer`, this opacity property isn't used.
+ * @property {String|Function} [stroke.lineCap] - The shape used at the ends of lines.
+ * For extruded `GeometryLayer` lines, setting it to `round` adds half-sphere caps.
  * @property {number|Function} stroke.width - The width of the line. Default is `1.0`.
  * @property {number|Function} stroke.base_altitude - Only for {@link GeometryLayer}, defines altitude
  * for each coordinate.
@@ -591,6 +593,7 @@ class Style extends EventDispatcher {
         this._defineCategoryProperty('stroke');
         defineStyleProperty(this, 'stroke', 'color', params.color);
         defineStyleProperty(this, 'stroke', 'opacity', params.opacity, 1.0);
+        defineStyleProperty(this, 'stroke', 'lineCap', params.lineCap, 'butt');
         defineStyleProperty(this, 'stroke', 'width', params.width, 1.0);
         defineStyleProperty(this, 'stroke', 'dasharray', params.dasharray, []);
         defineStyleProperty(this, 'stroke', 'base_altitude', params.base_altitude, baseAltitudeDefault);

--- a/packages/Main/src/Core/StyleOptions.js
+++ b/packages/Main/src/Core/StyleOptions.js
@@ -45,6 +45,8 @@ import * as maplibre from '@maplibre/maplibre-gl-style-spec';
  * @property {number|Function} [stroke.opacity] - The opacity of the line. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
  * For a `GeometryLayer`, this opacity property isn't used.
+ * @property {String|Function} [stroke.lineCap] - The shape used at the ends of lines.
+ * For extruded `GeometryLayer` lines, setting it to `round` adds half-sphere caps.
  * @property {number|Function} [stroke.width] - The width of the line. Default is `1.0`.
  * @property {number|Function} [stroke.base_altitude] - `GeometryLayer` style option, defines altitude
  * for each coordinate.

--- a/packages/Main/src/Core/StyleOptions.js
+++ b/packages/Main/src/Core/StyleOptions.js
@@ -45,7 +45,7 @@ import * as maplibre from '@maplibre/maplibre-gl-style-spec';
  * @property {number|Function} [stroke.opacity] - The opacity of the line. Can be between
  * `0.0` and `1.0`. Default is `1.0`.
  * For a `GeometryLayer`, this opacity property isn't used.
- * @property {String|Function} [stroke.lineCap] - The shape used at the ends of lines.
+ * @property {string|Function} [stroke.line_cap] - The shape used at the ends of lines.
  * For extruded `GeometryLayer` lines, setting it to `round` adds half-sphere caps.
  * @property {number|Function} [stroke.width] - The width of the line. Default is `1.0`.
  * @property {number|Function} [stroke.base_altitude] - `GeometryLayer` style option, defines altitude
@@ -289,7 +289,7 @@ function setFromVectorTileLayer(layer, sprites, symbolToCircle = false) {
         const { color, opacity } = rgba2rgb(prepare);
         style.stroke.dasharray = readVectorProperty(layer.paint['line-dasharray']);
         style.stroke.color = color;
-        style.stroke.lineCap = layer.layout['line-cap'];
+        style.stroke.line_cap = layer.layout['line-cap'];
         style.stroke.width = readVectorProperty(layer.paint['line-width']);
         style.stroke.opacity = readVectorProperty(layer.paint['line-opacity']) || opacity;
     } else if (layer.type === 'circle' || symbolToCircle) {

--- a/packages/Main/src/Process/FeatureProcessing.js
+++ b/packages/Main/src/Process/FeatureProcessing.js
@@ -3,7 +3,7 @@ import ObjectRemovalHelper from 'Process/ObjectRemovalHelper';
 import handlingError from 'Process/handlerNodeError';
 import { Coordinates } from '@itowns/geographic';
 import { geoidLayerIsVisible } from 'Layer/GeoidLayer';
-import { applyStyle } from 'Converter/Feature2Mesh';
+import { applyStyle, rebuildMeshTopology } from 'Converter/Feature2Mesh';
 
 const coord = new Coordinates('EPSG:4326', 0, 0, 0);
 
@@ -26,6 +26,12 @@ export default {
                 f.layer.object3d.add(f);
                 f.meshes.position.z = geoidLayerIsVisible(layer.parent) ? node.geoidHeight : 0;
                 f.meshes.updateMatrixWorld();
+                const updateTopology = f.styleTopologyVersion !== (layer._styleTopologyVersion ?? 0);
+                if (updateTopology) {
+                    rebuildMeshTopology(f, layer.style);
+                    f.styleTopologyVersion = layer._styleTopologyVersion ?? 0;
+                    return;
+                }
                 const updateColor = f.styleColorVersion !== (layer._styleColorVersion ?? 0);
                 const updatePosition = f.stylePositionVersion !== (layer._stylePositionVersion ?? 0);
                 if (updateColor || updatePosition) {

--- a/packages/Main/src/Process/FeatureProcessing.js
+++ b/packages/Main/src/Process/FeatureProcessing.js
@@ -22,6 +22,7 @@ export default {
             node.layerUpdateState[layer.id] = new LayerUpdateState();
         } else if (!node.layerUpdateState[layer.id].canTryUpdate()) {
             // toggle visibility features
+            let topologyUpdated = false;
             node.link[layer.id]?.forEach((f) => {
                 f.layer.object3d.add(f);
                 f.meshes.position.z = geoidLayerIsVisible(layer.parent) ? node.geoidHeight : 0;
@@ -30,6 +31,7 @@ export default {
                 if (updateTopology) {
                     rebuildMeshTopology(f, layer.style);
                     f.styleTopologyVersion = layer._styleTopologyVersion ?? 0;
+                    topologyUpdated = true;
                     return;
                 }
                 const updateColor = f.styleColorVersion !== (layer._styleColorVersion ?? 0);
@@ -50,6 +52,9 @@ export default {
                     f.stylePositionVersion = layer._stylePositionVersion ?? 0;
                 }
             });
+            if (topologyUpdated) {
+                context.view.notifyChange(layer, true);
+            }
             return;
         }
 

--- a/packages/Main/test/unit/feature2mesh.js
+++ b/packages/Main/test/unit/feature2mesh.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { CRS } from '@itowns/geographic';
 import assert from 'assert';
 import GeoJsonParser from 'Parser/GeoJsonParser';
-import Feature2Mesh, { applyStyle } from 'Converter/Feature2Mesh';
+import Feature2Mesh, { applyStyle, rebuildMeshTopology } from 'Converter/Feature2Mesh';
 import Style from 'Core/Style';
 
 import geojson from '../data/geojson/holes.geojson';
@@ -56,6 +56,18 @@ describe('Feature2Mesh', function () {
     const parsed = GeoJsonParser.parse(geojson, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false, structure: '3d' } });
     const parsed2 = GeoJsonParser.parse(geojson2, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false, structure: '3d' } });
     const parsed3 = GeoJsonParser.parse(geojson3, { in: { crs: 'EPSG:3946' }, out: { crs: 'EPSG:3946', buildExtent: true, mergeFeatures: false, structure: '3d' } });
+    // Line-only collection in EPSG:4326 for extruded line tests
+    const parsedLine = GeoJsonParser.parse(
+        {
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                geometry: { type: 'LineString', coordinates: [[0, 0], [1, 0], [2, 0]] },
+                properties: {},
+            }],
+        },
+        { in: { crs: 'EPSG:4326' }, out: { crs: 'EPSG:4326', buildExtent: true, mergeFeatures: false, structure: '3d' } },
+    );
 
     it('rect mesh area should match geometry extent', function (done) {
         parsed
@@ -225,6 +237,57 @@ describe('Feature2Mesh', function () {
                 assert.equal(linePosAttr.array[2], 75);
                 assert.ok(lineColorAttr.version > initialLineColorVersion);
                 assert.ok(linePosAttr.version > initialLinePosVersion);
+                done();
+            }).catch(done);
+    });
+
+    it('line with extrusion_radius produces an indexed Mesh', function (done) {
+        parsedLine
+            .then((collection) => {
+                const layer = {
+                    style: new Style({ stroke: { extrusion_radius: 5, color: 'red' } }),
+                    convert: Feature2Mesh.convert(),
+                };
+                const featureNode = layer.convert.call(layer, collection);
+                const mesh = featureNode.meshes.children[0];
+                assert.equal(mesh.type, 'Mesh');
+                assert.ok(mesh.geometry.index !== null);
+                assert.ok(mesh.geometry.attributes.position.count > 0);
+                done();
+            }).catch(done);
+    });
+
+    it('round line caps produce more vertices than butt caps', function (done) {
+        parsedLine
+            .then((collection) => {
+                const layerButt = {
+                    style: new Style({ stroke: { extrusion_radius: 5, color: 'red', line_cap: 'butt' } }),
+                    convert: Feature2Mesh.convert(),
+                };
+                const layerRound = {
+                    style: new Style({ stroke: { extrusion_radius: 5, color: 'red', line_cap: 'round' } }),
+                    convert: Feature2Mesh.convert(),
+                };
+                const buttCount = layerButt.convert.call(layerButt, collection).meshes.children[0].geometry.attributes.position.count;
+                const roundCount = layerRound.convert.call(layerRound, collection).meshes.children[0].geometry.attributes.position.count;
+                assert.ok(roundCount > buttCount, `expected round (${roundCount}) > butt (${buttCount})`);
+                done();
+            }).catch(done);
+    });
+
+    it('rebuildMeshTopology replaces flat line with extruded mesh', function (done) {
+        parsedLine
+            .then((collection) => {
+                const layer = {
+                    style: new Style({ stroke: { color: 'red' } }),
+                    convert: Feature2Mesh.convert(),
+                };
+                const featureNode = layer.convert.call(layer, collection);
+                assert.equal(featureNode.meshes.children[0].type, 'LineSegments');
+
+                const extrudedStyle = new Style({ stroke: { extrusion_radius: 5, color: 'red' } });
+                rebuildMeshTopology(featureNode, extrudedStyle);
+                assert.equal(featureNode.meshes.children[0].type, 'Mesh');
                 done();
             }).catch(done);
     });

--- a/packages/Main/test/unit/featureProcessing.js
+++ b/packages/Main/test/unit/featureProcessing.js
@@ -35,11 +35,8 @@ describe('FeatureProcessing', function () {
             };
             node.layerUpdateState[layer.id] = new LayerUpdateState();
             node.layerUpdateState[layer.id].canTryUpdate = () => false;
-            node.link[layer.id] = [{
-                collection: featureNode.collection,
-                meshes: featureNode.meshes,
-                layer: { object3d: { add: () => {} } },
-            }];
+            featureNode.layer = layer;
+            node.link[layer.id] = [featureNode];
 
             const context = { view: {} };
 

--- a/packages/Main/test/unit/featureProcessing.js
+++ b/packages/Main/test/unit/featureProcessing.js
@@ -7,6 +7,15 @@ import GeoJsonParser from 'Parser/GeoJsonParser';
 
 import geojson from '../data/geojson/map.geojson';
 
+const lineOnlyGeoJSON = {
+    type: 'FeatureCollection',
+    features: [{
+        type: 'Feature',
+        geometry: { type: 'LineString', coordinates: [[0, 0], [1, 0]] },
+        properties: {},
+    }],
+};
+
 describe('FeatureProcessing', function () {
     const parsed = GeoJsonParser.parse(geojson, {
         in: { crs: 'EPSG:4326' },
@@ -54,6 +63,47 @@ describe('FeatureProcessing', function () {
             assert.strictEqual(colorAttr1.array[0], 0);
             assert.strictEqual(colorAttr1.array[1], 0);
             assert.strictEqual(colorAttr1.array[2], 255);
+            done();
+        }).catch(done);
+    });
+
+    it('topology version mismatch triggers rebuildMeshTopology and notifyChange', function (done) {
+        GeoJsonParser.parse(lineOnlyGeoJSON, {
+            in: { crs: 'EPSG:4326' },
+            out: { crs: 'EPSG:4326', buildExtent: true, mergeFeatures: false, structure: '3d' },
+        }).then((collection) => {
+            const style = new Style({ stroke: { color: 'red' } });
+            const layer = {
+                id: 'topo-layer',
+                object3d: { add: () => {} },
+                style,
+                convert: Feature2Mesh.convert(),
+            };
+            const featureNode = layer.convert.call(layer, collection);
+
+            const node = {
+                parent: { id: 'parent' },
+                visible: true,
+                layerUpdateState: {},
+                link: {},
+            };
+            node.layerUpdateState[layer.id] = new LayerUpdateState();
+            node.layerUpdateState[layer.id].canTryUpdate = () => false;
+            featureNode.layer = layer;
+            node.link[layer.id] = [featureNode];
+
+            // Setting extrusion_radius from undefined dispatches 'topology' → increments _styleTopologyVersion
+            layer.style.stroke.extrusion_radius = 5;
+
+            let notifyChangeCalled = false;
+            const context = {
+                view: { notifyChange: () => { notifyChangeCalled = true; } },
+            };
+
+            FeatureProcessing.update(context, layer, node);
+
+            assert.ok(notifyChangeCalled);
+            assert.strictEqual(featureNode.styleTopologyVersion, layer._styleTopologyVersion);
             done();
         }).catch(done);
     });

--- a/packages/Main/test/unit/style.js
+++ b/packages/Main/test/unit/style.js
@@ -333,7 +333,7 @@ describe('Style', function () {
         it('first assignment dispatches topology event', () => {
             const s = new Style();
             let param;
-            s.addEventListener('style-property-changed', e => { param = e.parameter; });
+            s.addEventListener('style-property-changed', (e) => { param = e.parameter; });
             s.stroke.extrusion_radius = 10;
             assert.strictEqual(param, 'topology');
         });
@@ -341,7 +341,7 @@ describe('Style', function () {
         it('subsequent change dispatches extrusion_radius event, not topology', () => {
             const s = new Style({ stroke: { extrusion_radius: 5 } });
             let param;
-            s.addEventListener('style-property-changed', e => { param = e.parameter; });
+            s.addEventListener('style-property-changed', (e) => { param = e.parameter; });
             s.stroke.extrusion_radius = 20;
             assert.strictEqual(param, 'extrusion_radius');
         });

--- a/packages/Main/test/unit/style.js
+++ b/packages/Main/test/unit/style.js
@@ -328,4 +328,22 @@ describe('Style', function () {
             });
         });
     });
+
+    describe('stroke.extrusion_radius', () => {
+        it('first assignment dispatches topology event', () => {
+            const s = new Style();
+            let param;
+            s.addEventListener('style-property-changed', e => { param = e.parameter; });
+            s.stroke.extrusion_radius = 10;
+            assert.strictEqual(param, 'topology');
+        });
+
+        it('subsequent change dispatches extrusion_radius event, not topology', () => {
+            const s = new Style({ stroke: { extrusion_radius: 5 } });
+            let param;
+            s.addEventListener('style-property-changed', e => { param = e.parameter; });
+            s.stroke.extrusion_radius = 20;
+            assert.strictEqual(param, 'extrusion_radius');
+        });
+    });
 });

--- a/packages/Main/test/unit/style.js
+++ b/packages/Main/test/unit/style.js
@@ -103,7 +103,7 @@ describe('Style', function () {
                 style._applyStrokeToPolygon(txtrCtx, invCtxScale);
                 assert.equal(txtrCtx.strokeStyle, style.stroke.color);
                 assert.equal(txtrCtx.lineWidth, style.stroke.width * invCtxScale);
-                assert.equal(txtrCtx.lineCap, style.stroke.lineCap);
+                assert.equal(txtrCtx.lineCap, style.stroke.line_cap);
                 assert.equal(txtrCtx.globalAlpha, style.stroke.opacity);
             });
         });


### PR DESCRIPTION
## Description
Extrude line GIS data in 3D using a diameter value to generate cylindrical geometry. Intended for utilities and linear infrastructures where physical thickness matters.

## Motivation and Context
Add support for defining a diameter for lines in the 3D view, useful to model pipes for example.
Implements [#2627](https://github.com/iTowns/itowns/issues/2627)
Tested on Ubuntu, Firefox.

## Screenshots
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/bf5ff770-1975-4dee-8ac6-a0bd38b0d207" />
