### PR TITLE
fix(OGC3DTilesLayer): accept 'classification' with lowercase c

### DIFF
--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -584,7 +584,9 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         // Setup classification bufferAttribute
         if (model.isPoints) {
-            const classificationData = batchTable?.getPropertyArray('Classification');
+            const classificationData = batchTable?.getPropertyArray('Classification') 
+                || batchTable?.getPropertyArray('classification');
+                
             if (classificationData) {
                 geometry.setAttribute('classification',
                     new THREE.BufferAttribute(classificationData, 1),

--- a/packages/Main/src/Layer/OGC3DTilesLayer.js
+++ b/packages/Main/src/Layer/OGC3DTilesLayer.js
@@ -584,9 +584,8 @@ class OGC3DTilesLayer extends GeometryLayer {
 
         // Setup classification bufferAttribute
         if (model.isPoints) {
-            const classificationData = batchTable?.getPropertyArray('Classification') 
+            const classificationData = batchTable?.getPropertyArray('Classification')
                 || batchTable?.getPropertyArray('classification');
-                
             if (classificationData) {
                 geometry.setAttribute('classification',
                     new THREE.BufferAttribute(classificationData, 1),


### PR DESCRIPTION
## Description
For .pnts 3DTiles, classification data was supported only if it was stored as 'Classification' with an uppercase C. This MR aims at also supporting 'classification' with a lowercase c, as its use is becoming more widespread.