### PR TITLE
feat(style): move style.point.model to its own category: 'model'

### DIFF
--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -91,7 +91,6 @@
                     trunkRadius,
                     trunkRadius,
                     trunkHeight,
-                    32
                 );
                 const material = new THREE.MeshPhongMaterial({
                     color: 0x8b4513,
@@ -104,9 +103,7 @@
 
                 // Canopy
                 const geometryCanop = new THREE.SphereGeometry(
-                    topHeight,
-                    topHeight,
-                    10
+                    topHeight
                 );
                 const materialCanop = new THREE.MeshPhongMaterial({
                     color: 0x00aa00,

--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -174,17 +174,15 @@
 
                 // called when the resource is loaded
                 (gltf) => {
-                    var model = gltf.scene;
+                    var object = gltf.scene;
+                    object.rotateX(Math.PI / 2.0);
 
-                    model.rotateX(Math.PI / 2.0);
                     gltf.scene.position.z = 2;
-                    model.scale.set(6, 6, 6);
 
                     var styleModel3D = {
-                        point: {
-                            model: {
-                                object: model,
-                            },
+                        model: {
+                            object,
+                            scale: 6,
                         },
                     };
 
@@ -216,10 +214,8 @@
 
             //Tree
             var styleModel3D = {
-                point: {
-                    model: {
-                        object: makeTree(),
-                    },
+                model: {
+                    object: makeTree(),
                 },
             };
 

--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -171,17 +171,15 @@
 
                 // called when the resource is loaded
                 (gltf) => {
-                    var model = gltf.scene;
+                    var object = gltf.scene;
+                    object.rotateX(Math.PI / 2.0);
 
-                    model.rotateX(Math.PI / 2.0);
                     gltf.scene.position.z = 2;
-                    model.scale.set(6, 6, 6);
 
                     var styleModel3D = {
-                        point: {
-                            model: {
-                                object: model,
-                            },
+                        model: {
+                            object,
+                            scale: 6,
                         },
                     };
 
@@ -213,10 +211,8 @@
 
             //Tree
             var styleModel3D = {
-                point: {
-                    model: {
-                        object: makeTree(),
-                    },
+                model: {
+                    object: makeTree(),
                 },
             };
 

--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -52,7 +52,13 @@
             var viewerDiv = document.getElementById("viewerDiv");
 
             // Instanciate iTowns GlobeView*
-            var view = new itowns.GlobeView(viewerDiv, placement);
+            var view = new itowns.GlobeView(
+                viewerDiv,
+                placement,
+                {
+                    realisticLighting: true,
+                }
+            );
 
             // Setup loading screen and debug menu
             setupLoadingScreen(viewerDiv, view);

--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -175,14 +175,13 @@
                 // called when the resource is loaded
                 (gltf) => {
                     var object = gltf.scene;
-                    object.rotateX(Math.PI / 2.0);
-
-                    gltf.scene.position.z = 2;
 
                     var styleModel3D = {
                         model: {
                             object,
                             scale: 6,
+                            up: new THREE.Vector3(0, 1, 0),
+                            north: new THREE.Vector3(0, 0, 1),
                         },
                     };
 

--- a/examples/misc_instancing.html
+++ b/examples/misc_instancing.html
@@ -172,14 +172,13 @@
                 // called when the resource is loaded
                 (gltf) => {
                     var object = gltf.scene;
-                    object.rotateX(Math.PI / 2.0);
-
-                    gltf.scene.position.z = 2;
 
                     var styleModel3D = {
                         model: {
                             object,
                             scale: 6,
+                            up: new THREE.Vector3(0, 1, 0),
+                            front: new THREE.Vector3(0, 0, 1),
                         },
                     };
 

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -18,6 +18,10 @@ const baseCoord = new THREE.Vector3();
 const topCoord = new THREE.Vector3();
 const inverseScale = new THREE.Vector3();
 const extent = new Extent('EPSG:4326', 0, 0, 0, 0);
+const scale = new THREE.Vector3();
+const mat = new THREE.Matrix4();
+const bbox = new THREE.Box3();
+const modelSize = new THREE.Vector3();
 
 const _color = new THREE.Color();
 const maxValueUint8 = 2 ** 8 - 1;
@@ -714,19 +718,37 @@ function updateExtrudedPolygonBuffers(featureMesh, buffers, id) {
 /**
  * Created Instanced object from mesh
  *
- * @param {THREE.MESH} mesh Model 3D to instanciate
- * @param {*} count number of instances to create (int)
+ * @param {THREE.Mesh} mesh Model 3D to instanciate
  * @param {*} ptsIn positions of instanced (array double)
+ * @param {*} geometries geometries to use for the instanced meshes
+ * @param {number} geometries.length number of instances to create (int)
+ * @param {THREE.Vector3} modelSize size of the object model
+ *
  * @returns {THREE.InstancedMesh} Instanced mesh
  */
-function createInstancedMesh(mesh, count, ptsIn) {
+function createInstancedMesh(mesh, ptsIn, geometries, modelSize) {
+    const styleModel = style.model;
+    const count = geometries.length;
     const instancedMesh = new THREE.InstancedMesh(mesh.geometry, mesh.material, count);
-    let index = 0;
-    for (let i = 0; i < count * 3; i += 3) {
-        const mat = new THREE.Matrix4();
-        mat.setPosition(ptsIn[i], ptsIn[i + 1], ptsIn[i + 2]);
-        instancedMesh.setMatrixAt(index, mat);
-        index++;
+
+    for (let j = 0; j < count; j += 1) {
+        context.setGeometry(geometries[j]);
+        if (styleModel.size) {
+            scale.copy(styleModel.size);
+            scale.divide(modelSize);
+        } else {
+            scale.setScalar(1);
+        }
+        scale.multiplyScalar(styleModel.scale);
+
+        let headingRad = 0;
+        if (styleModel.heading) {
+            headingRad = styleModel.heading * THREE.MathUtils.DEG2RAD;
+        }
+        mat.makeRotationZ(-headingRad);
+        mat.setPosition(ptsIn[j * 3], ptsIn[j * 3 + 1], ptsIn[j * 3 + 2]);
+        mat.scale(scale);
+        instancedMesh.setMatrixAt(j, mat);
     }
 
     instancedMesh.instanceMatrix.needsUpdate = true;
@@ -741,17 +763,24 @@ function createInstancedMesh(mesh, count, ptsIn) {
  * @returns {THREE.Mesh} mesh or GROUP of THREE.InstancedMesh
  */
 function pointsToInstancedMeshes(feature) {
+    context.setFeature(feature);
+    style.setContext(context);
+
     const ptsIn = feature.vertices;
-    const count = feature.geometries.length;
-    const modelObject = style.point.model.object;
+    const geometries = feature.geometries;
+    const modelObject = style.model.object;
+    bbox.setFromObject(modelObject);
+    bbox.getSize(modelSize);
 
     if (modelObject instanceof THREE.Mesh) {
-        return createInstancedMesh(modelObject, count, ptsIn);
+        return createInstancedMesh(modelObject, ptsIn, geometries,  modelSize);
     } else if (modelObject instanceof THREE.Object3D) {
         const group = new THREE.Group();
         // Get independent meshes from more complexe object
         const meshes = separateMeshes(modelObject);
-        meshes.forEach(mesh => group.add(createInstancedMesh(mesh, count, ptsIn)));
+        meshes.forEach((mesh) => {
+            group.add(createInstancedMesh(mesh, ptsIn, geometries, modelSize));
+        });
         return group;
     } else {
         throw new Error('The format of the model object provided in the style (layer.style.point.model.object) is not supported. Only THREE.Mesh or THREE.Object3D are supported.');
@@ -773,7 +802,7 @@ function featureToMesh(feature, options) {
     let mesh;
     switch (feature.type) {
         case FEATURE_TYPES.POINT:
-            if (style.point?.model?.object) {
+            if (style.model?.object) {
                 try {
                     mesh = pointsToInstancedMeshes(feature);
                     mesh.isInstancedMesh = true;
@@ -945,8 +974,7 @@ export function applyStyle(featureMesh, collection, styleIn, buffersToUpdate = [
         context.setGeometry(geometry);
         switch (feature.type) {
             case FEATURE_TYPES.POINT: {
-                const pointStyle = style.point;
-                if (pointStyle?.model?.object) { break; } // instanced mesh
+                if (style.model?.object) { break; } // instanced mesh
                 updatePointBuffers(featureMesh, buffers);
                 break;
             }

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -13,6 +13,8 @@ let style;
 
 const dim_ref = new THREE.Vector2();
 const dim = new THREE.Vector2();
+const zVect = new THREE.Vector3(0, 0, 1);
+const yVect = new THREE.Vector3(0, 1, 0);
 const up = new THREE.Vector3();
 const baseCoord = new THREE.Vector3();
 const topCoord = new THREE.Vector3();
@@ -28,6 +30,9 @@ const maxValueUint8 = 2 ** 8 - 1;
 const maxValueUint16 = 2 ** 16 - 1;
 const maxValueUint32 = 2 ** 32 - 1;
 const crsWGS84 = 'EPSG:4326';
+
+const quaternion = new THREE.Quaternion();
+const quaternionY = new THREE.Quaternion();
 
 class FeatureMesh extends THREE.Group {
     #currentCrs;
@@ -198,7 +203,7 @@ function featureToPoint(feature, options) {
     let featureId = 0;
     const vertices = new Float32Array(ptsIn);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
 
     const pointMaterialSize = [];
 
@@ -253,7 +258,7 @@ function updatePointBuffers(featureMesh, buffers, id) {
     // context setup
     context.setFeature(feature);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
     style.setContext(context);
 
@@ -323,7 +328,7 @@ function featureToLine(feature, options) {
         indexPtr: 0,
     };
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     // Multi line case
     for (const geometry of feature.geometries) {
         context.setGeometry(geometry);
@@ -374,7 +379,7 @@ function updateLineBuffers(featureMesh, buffers, id) {
     // context setup
     context.setFeature(feature);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
     style.setContext(context);
 
@@ -432,7 +437,7 @@ function featureToPolygon(feature, options) {
     const batchId = options.batchId || ((p, id) => id);
 
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     let featureId = 0;
 
     for (const geometry of feature.geometries) {
@@ -481,7 +486,7 @@ function updatePolygonBuffers(featureMesh, buffers, id) {
     // context setup
     context.setFeature(feature);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
     style.setContext(context);
 
@@ -562,7 +567,7 @@ function featureToExtrudedPolygon(feature, options) {
     let featureId = 0;
 
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
 
     for (const geometry of feature.geometries) {
@@ -605,7 +610,7 @@ function updateExtrudedPolygonBuffers(featureMesh, buffers, id) {
     // context setup
     context.setFeature(feature);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     coord.setCrs(context.collection.crs);
     style.setContext(context);
 
@@ -769,6 +774,18 @@ function pointsToInstancedMeshes(feature) {
     const ptsIn = feature.vertices;
     const geometries = feature.geometries;
     const modelObject = style.model.object;
+
+    // orientation of the model following up and north properties.
+    quaternion.setFromUnitVectors(style.model.up, zVect);
+
+    const northWithRotation = style.model.north.applyQuaternion(quaternion);
+    const angletoNorth =  northWithRotation.angleTo(yVect);
+    quaternionY.setFromAxisAngle(yVect, angletoNorth);
+    quaternion.multiply(quaternionY);
+
+    modelObject.setRotationFromQuaternion(quaternion);
+
+    // Size of the object model
     bbox.setFromObject(modelObject);
     bbox.getSize(modelSize);
 

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -18,6 +18,10 @@ const baseCoord = new THREE.Vector3();
 const topCoord = new THREE.Vector3();
 const inverseScale = new THREE.Vector3();
 const extent = new Extent('EPSG:4326', 0, 0, 0, 0);
+const scale = new THREE.Vector3();
+const mat = new THREE.Matrix4();
+const bbox = new THREE.Box3();
+const modelSize = new THREE.Vector3();
 
 // Scratch vectors for extruded-line geometry building
 let xAxis;
@@ -1068,19 +1072,37 @@ function updateExtrudedPolygonBuffers(featureMesh, buffers, id) {
 /**
  * Created Instanced object from mesh
  *
- * @param {THREE.MESH} mesh Model 3D to instanciate
- * @param {*} count number of instances to create (int)
+ * @param {THREE.Mesh} mesh Model 3D to instanciate
  * @param {*} ptsIn positions of instanced (array double)
+ * @param {*} geometries geometries to use for the instanced meshes
+ * @param {number} geometries.length number of instances to create (int)
+ * @param {THREE.Vector3} modelSize size of the object model
+ *
  * @returns {THREE.InstancedMesh} Instanced mesh
  */
-function createInstancedMesh(mesh, count, ptsIn) {
+function createInstancedMesh(mesh, ptsIn, geometries, modelSize) {
+    const styleModel = style.model;
+    const count = geometries.length;
     const instancedMesh = new THREE.InstancedMesh(mesh.geometry, mesh.material, count);
-    let index = 0;
-    for (let i = 0; i < count * 3; i += 3) {
-        const mat = new THREE.Matrix4();
-        mat.setPosition(ptsIn[i], ptsIn[i + 1], ptsIn[i + 2]);
-        instancedMesh.setMatrixAt(index, mat);
-        index++;
+
+    for (let j = 0; j < count; j += 1) {
+        context.setGeometry(geometries[j]);
+        if (styleModel.size) {
+            scale.copy(styleModel.size);
+            scale.divide(modelSize);
+        } else {
+            scale.setScalar(1);
+        }
+        scale.multiplyScalar(styleModel.scale);
+
+        let headingRad = 0;
+        if (styleModel.heading) {
+            headingRad = styleModel.heading * THREE.MathUtils.DEG2RAD;
+        }
+        mat.makeRotationZ(-headingRad);
+        mat.setPosition(ptsIn[j * 3], ptsIn[j * 3 + 1], ptsIn[j * 3 + 2]);
+        mat.scale(scale);
+        instancedMesh.setMatrixAt(j, mat);
     }
 
     instancedMesh.instanceMatrix.needsUpdate = true;
@@ -1095,17 +1117,24 @@ function createInstancedMesh(mesh, count, ptsIn) {
  * @returns {THREE.Mesh} mesh or GROUP of THREE.InstancedMesh
  */
 function pointsToInstancedMeshes(feature) {
+    context.setFeature(feature);
+    style.setContext(context);
+
     const ptsIn = feature.vertices;
-    const count = feature.geometries.length;
-    const modelObject = style.point.model.object;
+    const geometries = feature.geometries;
+    const modelObject = style.model.object;
+    bbox.setFromObject(modelObject);
+    bbox.getSize(modelSize);
 
     if (modelObject instanceof THREE.Mesh) {
-        return createInstancedMesh(modelObject, count, ptsIn);
+        return createInstancedMesh(modelObject, ptsIn, geometries,  modelSize);
     } else if (modelObject instanceof THREE.Object3D) {
         const group = new THREE.Group();
         // Get independent meshes from more complexe object
         const meshes = separateMeshes(modelObject);
-        meshes.forEach(mesh => group.add(createInstancedMesh(mesh, count, ptsIn)));
+        meshes.forEach((mesh) => {
+            group.add(createInstancedMesh(mesh, ptsIn, geometries, modelSize));
+        });
         return group;
     } else {
         throw new Error('The format of the model object provided in the style (layer.style.point.model.object) is not supported. Only THREE.Mesh or THREE.Object3D are supported.');
@@ -1127,7 +1156,7 @@ function featureToMesh(feature, options) {
     let mesh;
     switch (feature.type) {
         case FEATURE_TYPES.POINT:
-            if (style.point?.model?.object) {
+            if (style.model?.object) {
                 try {
                     mesh = pointsToInstancedMeshes(feature);
                     mesh.isInstancedMesh = true;
@@ -1332,8 +1361,7 @@ export function applyStyle(featureMesh, collection, styleIn, buffersToUpdate = [
         context.setGeometry(geometry);
         switch (feature.type) {
             case FEATURE_TYPES.POINT: {
-                const pointStyle = style.point;
-                if (pointStyle?.model?.object) { break; } // instanced mesh
+                if (style.model?.object) { break; } // instanced mesh
                 updatePointBuffers(featureMesh, buffers);
                 break;
             }

--- a/packages/Main/src/Converter/Feature2Mesh.js
+++ b/packages/Main/src/Converter/Feature2Mesh.js
@@ -13,7 +13,9 @@ let style;
 
 const dim_ref = new THREE.Vector2();
 const dim = new THREE.Vector2();
+const zVect = new THREE.Vector3(0, 0, 1);
 const up = new THREE.Vector3();
+const right = new THREE.Vector3();
 const baseCoord = new THREE.Vector3();
 const topCoord = new THREE.Vector3();
 const inverseScale = new THREE.Vector3();
@@ -225,7 +227,7 @@ function featureToPoint(feature, options) {
     let featureId = 0;
     const vertices = new Float32Array(ptsIn);
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
 
     const pointMaterialSize = [];
 
@@ -346,7 +348,7 @@ function featureToLine(feature, options) {
         indexPtr: 0,
     };
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     // Multi line case
     for (const geometry of feature.geometries) {
         context.setGeometry(geometry);
@@ -798,7 +800,7 @@ function featureToPolygon(feature, options) {
     const batchId = options.batchId || ((p, id) => id);
 
     inverseScale.setFromMatrixScale(context.collection.matrixWorldInverse);
-    up.set(0, 0, 1).multiply(inverseScale);
+    up.copy(zVect).multiply(inverseScale);
     let featureId = 0;
 
     for (const geometry of feature.geometries) {
@@ -1123,6 +1125,13 @@ function pointsToInstancedMeshes(feature) {
     const ptsIn = feature.vertices;
     const geometries = feature.geometries;
     const modelObject = style.model.object;
+
+    /* Orientation of the model following up and front properties. */
+    right.crossVectors(style.model.front, style.model.up);
+    mat.makeBasis(right, style.model.front, style.model.up).transpose();
+    modelObject.setRotationFromMatrix(mat);
+
+    /* Get the size of the object model once oriented. */
     bbox.setFromObject(modelObject);
     bbox.getSize(modelSize);
 
@@ -1137,7 +1146,7 @@ function pointsToInstancedMeshes(feature) {
         });
         return group;
     } else {
-        throw new Error('The format of the model object provided in the style (layer.style.point.model.object) is not supported. Only THREE.Mesh or THREE.Object3D are supported.');
+        throw new Error('The format of the model object provided in the style (layer.style.model.object) is not supported. Only THREE.Mesh or THREE.Object3D are supported.');
     }
 }
 

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -359,7 +359,13 @@ function _addIcon(icon, domElement, opt) {
  * for each coordinate.
  * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
  * then the altitude value is set to 0.
- * @property {object} point.model - 3D model to instantiate at each point position
+ *
+ * @property {object} model - To instanciate a unique 3D model at different point positions
+ * @property {THREE.Object3D} model.object - The 3D model object to instantiate at each position
+ * @property {object|Function} model.size - The wanted size of the instanced model in local dimension.
+ * Should be (or returning) an object containing 3 properties: x, y and z.
+ * @property {object|Function} model.heading - The heading (or azimuth) to orient the model in degree.
+ * @property {object|Function} model.scale - The value to scale the model. (default value is 1)
  *
  * @property {object} text - All things {@link Label} related.
  * @property {string|Function} text.field - A string representing a property key of
@@ -478,6 +484,7 @@ class Style extends EventDispatcher {
         params.fill = params.fill || {};
         params.stroke = params.stroke || {};
         params.point = params.point || {};
+        params.model = params.model || {};
         params.text = params.text || {};
         params.icon = params.icon || {};
 
@@ -485,6 +492,7 @@ class Style extends EventDispatcher {
         this._initFill(params.fill);
         this._initStroke(params.stroke);
         this._initPoint(params.point);
+        this._initModel(params.model);
         this._initText(params.text);
         this._initIcon(params.icon);
     }
@@ -603,9 +611,17 @@ class Style extends EventDispatcher {
         defineStyleProperty(this, 'point', 'radius', params.radius, 2.0);
         defineStyleProperty(this, 'point', 'width', params.width, 0.0);
         defineStyleProperty(this, 'point', 'base_altitude', params.base_altitude, baseAltitudeDefault);
-        if (params.model) {
-            defineStyleProperty(this, 'point', 'model', params.model);
-        }
+    }
+
+    /**
+     * @param {object} params - 3D model style parameters.
+       @private */
+    _initModel(params) {
+        this._defineCategoryProperty('model');
+        defineStyleProperty(this, 'model', 'object', params.object);
+        defineStyleProperty(this, 'model', 'size', params.size);
+        defineStyleProperty(this, 'model', 'heading', params.heading);
+        defineStyleProperty(this, 'model', 'scale', params.scale, 1.0);
     }
 
     /**

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -1,7 +1,7 @@
 import { Coordinates } from '@itowns/geographic';
 import { LRUCache } from 'lru-cache';
 import Fetcher from 'Provider/Fetcher';
-import { Color, EventDispatcher } from 'three';
+import { Color, EventDispatcher, Vector3 } from 'three';
 import { deltaE } from 'Renderer/Color';
 
 import itowns_stroke_single_before from './StyleChunk/itowns_stroke_single_before.css';
@@ -210,7 +210,7 @@ export class StyleContext {
     get featureStyle() {
         let featureStyle = this.#feature.style;
         if (featureStyle instanceof Function) {
-            featureStyle = featureStyle(this.properties, this);
+            featureStyle = this.properties ? featureStyle(this.properties, this) : undefined;
         }
         return featureStyle;
     }
@@ -365,7 +365,9 @@ function _addIcon(icon, domElement, opt) {
  * @property {object|Function} model.size - The wanted size of the instanced model in local dimension.
  * Should be (or returning) an object containing 3 properties: x, y and z.
  * @property {object|Function} model.heading - The heading (or azimuth) to orient the model in degree.
- * @property {object|Function} model.scale - The value to scale the model. (default value is 1)
+ * @property {object|Function} model.scale - The value to scale the model. (default value is 1).
+ * @property {object|Function} model.up - The vector pointing up. (default value is Vector3(0, 0, 1)).
+ * @property {object|Function} model.north - The vector pointing north. (default value is Vector3(0, 1, 0)).
  *
  * @property {object} text - All things {@link Label} related.
  * @property {string|Function} text.field - A string representing a property key of
@@ -622,6 +624,8 @@ class Style extends EventDispatcher {
         defineStyleProperty(this, 'model', 'size', params.size);
         defineStyleProperty(this, 'model', 'heading', params.heading);
         defineStyleProperty(this, 'model', 'scale', params.scale, 1.0);
+        defineStyleProperty(this, 'model', 'up', params.up, new Vector3(0, 0, 1));
+        defineStyleProperty(this, 'model', 'north', params.north, new Vector3(0, 1, 0));
     }
 
     /**

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -332,7 +332,13 @@ function _addIcon(icon, domElement, opt) {
  * for each coordinate.
  * If `base_altitude` is `undefined`, the original altitude is kept, and if it doesn't exist
  * then the altitude value is set to 0.
- * @property {object} point.model - 3D model to instantiate at each point position
+ *
+ * @property {object} model - To instanciate a unique 3D model at different point positions
+ * @property {THREE.Object3D} model.object - The 3D model object to instantiate at each position
+ * @property {object|Function} model.size - The wanted size of the instanced model in local dimension.
+ * Should be (or returning) an object containing 3 properties: x, y and z.
+ * @property {object|Function} model.heading - The heading (or azimuth) to orient the model in degree.
+ * @property {object|Function} model.scale - The value to scale the model. (default value is 1)
  *
  * @property {object} text - All things {@link Label} related.
  * @property {string|Function} text.field - A string representing a property key of
@@ -451,6 +457,7 @@ class Style extends EventDispatcher {
         params.fill = params.fill || {};
         params.stroke = params.stroke || {};
         params.point = params.point || {};
+        params.model = params.model || {};
         params.text = params.text || {};
         params.icon = params.icon || {};
 
@@ -458,6 +465,7 @@ class Style extends EventDispatcher {
         this._initFill(params.fill);
         this._initStroke(params.stroke);
         this._initPoint(params.point);
+        this._initModel(params.model);
         this._initText(params.text);
         this._initIcon(params.icon);
     }
@@ -608,9 +616,17 @@ class Style extends EventDispatcher {
         defineStyleProperty(this, 'point', 'radius', params.radius, 2.0);
         defineStyleProperty(this, 'point', 'width', params.width, 0.0);
         defineStyleProperty(this, 'point', 'base_altitude', params.base_altitude, baseAltitudeDefault);
-        if (params.model) {
-            defineStyleProperty(this, 'point', 'model', params.model);
-        }
+    }
+
+    /**
+     * @param {object} params - 3D model style parameters.
+       @private */
+    _initModel(params) {
+        this._defineCategoryProperty('model');
+        defineStyleProperty(this, 'model', 'object', params.object);
+        defineStyleProperty(this, 'model', 'size', params.size);
+        defineStyleProperty(this, 'model', 'heading', params.heading);
+        defineStyleProperty(this, 'model', 'scale', params.scale, 1.0);
     }
 
     /**

--- a/packages/Main/src/Core/Style.js
+++ b/packages/Main/src/Core/Style.js
@@ -1,8 +1,9 @@
-import { Coordinates } from '@itowns/geographic';
+import { EventDispatcher, Vector3 } from 'three';
 import { LRUCache } from 'lru-cache';
+import { Coordinates } from '@itowns/geographic';
 import Fetcher from 'Provider/Fetcher';
-import { EventDispatcher } from 'three';
 import { sharedContext2D, sharedReadContext2D } from 'Utils/CanvasUtils';
+
 
 import itowns_stroke_single_before from './StyleChunk/itowns_stroke_single_before.css';
 
@@ -179,7 +180,7 @@ export class StyleContext {
     get featureStyle() {
         let featureStyle = this.#feature.style;
         if (featureStyle instanceof Function) {
-            featureStyle = featureStyle(this.properties, this);
+            featureStyle = this.properties ? featureStyle(this.properties, this) : undefined;
         }
         return featureStyle;
     }
@@ -337,8 +338,11 @@ function _addIcon(icon, domElement, opt) {
  * @property {THREE.Object3D} model.object - The 3D model object to instantiate at each position
  * @property {object|Function} model.size - The wanted size of the instanced model in local dimension.
  * Should be (or returning) an object containing 3 properties: x, y and z.
- * @property {object|Function} model.heading - The heading (or azimuth) to orient the model in degree.
- * @property {object|Function} model.scale - The value to scale the model. (default value is 1)
+ * @property {number|Function} model.heading - The heading (or azimuth) to orient the model in degree.
+ * @property {number|Function} model.scale - The value to scale the model. (default value is 1).
+ * @property {THREE.Vector3|Function} model.up - The vector pointing up. (default value is Vector3(0, 0, 1)).
+ * @property {THREE.Vector3|Function} model.front - The vector pointing toward the front of the model. It
+ * should be orthogonal to the 'up' vector. (default value is Vector3(0, 1, 0)).
  *
  * @property {object} text - All things {@link Label} related.
  * @property {string|Function} text.field - A string representing a property key of
@@ -627,6 +631,8 @@ class Style extends EventDispatcher {
         defineStyleProperty(this, 'model', 'size', params.size);
         defineStyleProperty(this, 'model', 'heading', params.heading);
         defineStyleProperty(this, 'model', 'scale', params.scale, 1.0);
+        defineStyleProperty(this, 'model', 'up', params.up, new Vector3(0, 0, 1));
+        defineStyleProperty(this, 'model', 'front', params.front, new Vector3(0, 1, 0));
     }
 
     /**

--- a/packages/Main/test/unit/feature2mesh.js
+++ b/packages/Main/test/unit/feature2mesh.js
@@ -99,9 +99,7 @@ describe('Feature2Mesh', function () {
 
     it('convert to instanced meshes', function (done) {
         const styleModel3D = {
-            point: {
-                model: { object: makeTree() },
-            },
+            model: { object: makeTree() },
         };
         parsed3
             .then((collection) => {

--- a/packages/Main/test/unit/feature2mesh.js
+++ b/packages/Main/test/unit/feature2mesh.js
@@ -111,9 +111,7 @@ describe('Feature2Mesh', function () {
 
     it('convert to instanced meshes', function (done) {
         const styleModel3D = {
-            point: {
-                model: { object: makeTree() },
-            },
+            model: { object: makeTree() },
         };
         parsed3
             .then((collection) => {


### PR DESCRIPTION
Currently, to instanciate several object 3D at different position, the associated style is the style category 'point' with the parameter 'object'.
The use of extra parameter as 'orientation', 'size', 'scale' to cite a few is currently limited. That's the reason why I propose to add a new style category 'model' with it's own parameter. (As it's done for text and icon).


- Shift the model.scale.set() to style.model.scale (to keep the origin size of the model)
- add orientation of the model through 'up' and ~'north'~ 'front' properties (as Vector3)