### PR TITLE
fix(geographic): set default target CRS in Extent.as to the target CRS

### DIFF
--- a/packages/Geographic/src/Extent.ts
+++ b/packages/Geographic/src/Extent.ts
@@ -114,6 +114,11 @@ class Extent {
      */
     as(crs: string, target: Extent = new Extent(crs)) {
         CRS.isValid(crs);
+        if (CRS.isGeocentric(crs)) {
+            throw new Error(
+                `Non-compatible geocentric projection ${crs} to build a geographical extent`,
+            );
+        }
         if (this.crs != crs) {
             // Compute min/max in x/y by projecting 8 cardinal points,
             // and then taking the min/max of each coordinates.

--- a/packages/Geographic/src/Extent.ts
+++ b/packages/Geographic/src/Extent.ts
@@ -112,7 +112,7 @@ class Extent {
      * provided a new extent will be created.
      * @returns
      */
-    as(crs: string, target: Extent = new Extent('EPSG:4326')) {
+    as(crs: string, target: Extent = new Extent(crs)) {
         CRS.isValid(crs);
         if (this.crs != crs) {
             // Compute min/max in x/y by projecting 8 cardinal points,

--- a/packages/Geographic/test/unit/extent.js
+++ b/packages/Geographic/test/unit/extent.js
@@ -288,4 +288,11 @@ describe('Extent', function () {
     it('should throw error when instance with geocentric projection', () => {
         assert.throws(() => new Extent('EPSG:4978'));
     });
+
+    it('should use target CRS by default when converting with as()', function () {
+        const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
+        const converted = extent.as('EPSG:3857');
+        assert.strictEqual(converted.crs, 'EPSG:3857');
+    });
 });
+

--- a/packages/Geographic/test/unit/extent.js
+++ b/packages/Geographic/test/unit/extent.js
@@ -294,5 +294,10 @@ describe('Extent', function () {
         const converted = extent.as('EPSG:3857');
         assert.strictEqual(converted.crs, 'EPSG:3857');
     });
+
+    it('should throw an error when converting to a geocentric projection with as()', function () {
+        const extent = new Extent('EPSG:4326', 0, 10, 0, 10);
+        assert.throws(() => extent.as('EPSG:4978'));
+    });
 });
 


### PR DESCRIPTION
When using `Extent.as(crs)` without specifying a target Extent instance, it defaulted to creating an Extent in `'EPSG:4326'` instead of using the target `crs` projection. This changes the default `target` argument from `new Extent('EPSG:4326')` to `new Extent(crs)` so that the newly created Extent uses the correct destination coordinate reference system by default. A corresponding unit test is also added to check this behavior.