### PR TITLE
fix(example): use original open street map source

### DIFF
--- a/examples/layers/JSONLayers/OPENSM.json
+++ b/examples/layers/JSONLayers/OPENSM.json
@@ -4,7 +4,7 @@
         "crs": "EPSG:3857",
         "isInverted": true,
         "format": "image/png",
-        "url": "https://maps.pole-emploi.fr/styles/klokantech-basic/{z}/{x}/{y}.png",
+        "url": "https://tile.openstreetmap.org/${z}/${x}/${y}.png",
         "attribution": {
             "name":"OpenStreetMap",
             "url": "http://www.openstreetmap.org/"


### PR DESCRIPTION
## Description
Fixes  #2812 
Using the usual https://www.openstreetmap.org by default for reliability for examples.
It misses the openstreetmap attributions, but I believe this is outside of the scope of this fix.

### Before / after (3d tiles loader example)

<img width="1920" height="731" alt="image" src="https://github.com/user-attachments/assets/425e293b-0270-47fd-b41f-6a75500b372b" />

<img width="1920" height="839" alt="image" src="https://github.com/user-attachments/assets/b06422a9-0df4-4570-9d6f-6a351bf043e3" />
