### PR TITLE
fix: allow rendering shadows without realistic lighting

### DIFF
--- a/examples/3dtiles_loader.html
+++ b/examples/3dtiles_loader.html
@@ -96,7 +96,6 @@
 
             // Create a GlobeView
             const view = new GlobeView(viewerDiv, placement, {
-                shadows: true,
                 controls: {
                     minDistance: 100,
                 }

--- a/packages/Debug/src/RealisticLightingDebug.js
+++ b/packages/Debug/src/RealisticLightingDebug.js
@@ -13,7 +13,7 @@ export function createRealisticLightingDebugUI(gui, view) {
     const dateTimeFolder = createDateTimeUI(realisticLightingFolder, view);
 
     function toggleDateTimeFolder() {
-        if (!view.realisticLighting || view.skyController.forceDaytime) {
+        if (!(view.realisticLighting || view.shadows) || view.skyController.forceDaytime) {
             dateTimeFolder.hide();
         } else {
             dateTimeFolder.show();

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -54,8 +54,8 @@ class SkyController {
 
     get castShadow() { return this._sunLightLayer ? this._sunLightLayer.castShadow : false; }
     set castShadow(value: boolean) {
-        if (!this._sunLightLayer || this._sunLightLayer.castShadow === value) { return; }
-        this._sunLightLayer.castShadow = value;
+        if (this.castShadow === value) { return; }
+        this.sunLightLayer.castShadow = value;
         this.updateSunlightVisibility();
         this._view.notifyChange(this._view.camera3D);
     }

--- a/packages/Main/src/Core/Prefab/Globe/SkyController.ts
+++ b/packages/Main/src/Core/Prefab/Globe/SkyController.ts
@@ -47,7 +47,7 @@ class SkyController {
         // Activate the new strategy
         this._activeSky = value ? this.realisticSky : this.simpleSky;
         this._activeSky.enabled = previousSkyEnabled;
-        this.setSunlightVisible(previousSkyEnabled && value);
+        this.updateSunlightVisibility();
 
         this._view.notifyChange(this._view.camera3D);
     }
@@ -56,6 +56,7 @@ class SkyController {
     set castShadow(value: boolean) {
         if (!this._sunLightLayer || this._sunLightLayer.castShadow === value) { return; }
         this._sunLightLayer.castShadow = value;
+        this.updateSunlightVisibility();
         this._view.notifyChange(this._view.camera3D);
     }
 
@@ -78,7 +79,7 @@ class SkyController {
         if (this._activeSky) {
             this._activeSky.enabled = value;
         }
-        this.setSunlightVisible(this._realisticLighting && value);
+        this.updateSunlightVisibility();
     }
 
     get enabled() {
@@ -116,9 +117,13 @@ class SkyController {
         return this._sunLightLayer;
     }
 
-    private setSunlightVisible(value: boolean) {
-        this._ambientLight.visible = !value;
-        if (value) {
+    // Sunlight (and its ambient-light fallback) is needed whenever the sky is enabled and either realistic
+    // lighting or cast-shadows requires an actual directional light in the scene.
+    private updateSunlightVisibility() {
+        const skyEnabled = this._activeSky?.enabled;
+        const sunlightNeeded = skyEnabled && (this._realisticLighting || this.castShadow);
+        this._ambientLight.visible = !sunlightNeeded;
+        if (sunlightNeeded) {
             this.sunLightLayer.visible = true;
         } else if (this._sunLightLayer) {
             this.sunLightLayer.visible = false;


### PR DESCRIPTION
## Description
Fixed `SkyController` so enabling `castShadow` turns on the sun light even when `realisticLighting` is off.

## Motivation and Context
Consumers may want cast shadows independently of realistic lighting, but the sunlight visibility logic coupled the two, silently dropping shadows when realistic lighting was disabled.

Tested on Firefox, Ubuntu.