### PR TITLE
fix: don't let feature's material opacity override style opacity

### DIFF
--- a/examples/vector_tile_3d_mesh_mapbox.html
+++ b/examples/vector_tile_3d_mesh_mapbox.html
@@ -87,7 +87,7 @@
                     return view.addLayer(layer);
                 });
 
-            // Add an elevation layer, whose properties are defined in a json 
+            // Add an elevation layer, whose properties are defined in a json
             // file.
             function addElevationLayerFromConfig(config) {
                 config.source = new itowns.WMTSSource(config.source);
@@ -96,7 +96,7 @@
             }
             itowns.Fetcher.json('./layers/JSONLayers/IGN_MNT_HIGHRES.json')
                 .then(addElevationLayerFromConfig);
-            
+
 
 
             // ---------- DISPLAY VECTOR TILED BUILDING DATA AS 3D MESHES : ----------
@@ -108,7 +108,12 @@
                 style: 'mapbox://styles/mapbox/streets-v8',
                 accessToken: 'pk.eyJ1IjoiZnRvcm9tYW5vZmYiLCJhIjoiY2xrc2Zpa2o3MDQxNTNxcG5sczJyaTlncyJ9.5KFKdMLIiy-b_fAjSVhjCQ',
                 filter: (layer) => {
-                    return layer.id === 'building';
+                    if (layer.id !== 'building') {
+                        return false;
+                    }
+                    // Force opaque: iTowns can't evaluate Mapbox's zoom-based fade.
+                    layer.paint['fill-opacity'] = 1;
+                    return true;
                 },
             });
 

--- a/packages/Main/src/Layer/ReferencingLayerProperties.js
+++ b/packages/Main/src/Layer/ReferencingLayerProperties.js
@@ -7,7 +7,7 @@ function ReferLayerProperties(material, layer) {
         const getOpacity = (opacity) => {
             const styleOpacity = material.layer.style?.fill?.opacity ?? 1;
             const layerOpacity = material.layer.opacity;
-            return layerOpacity * (opacity ?? styleOpacity);
+            return layerOpacity * (opacity ?? 1) * styleOpacity;
         };
 
         let opacity;


### PR DESCRIPTION
## Description

Fix `ReferLayerProperties.getOpacity` so intrinsic material opacity and style `fill.opacity` apply as independent multipliers instead of one masking the other. Also patch the `vector_tile_3d_mesh_mapbox.html` example to force `fill-opacity: 1` on Mapbox's `building` layer, since its zoom-stop fade can't be evaluated correctly here.

## Motivation and Context

Commit `49c69fce` froze the opacity getter at the material's default (1), so `style.fill.opacity` was never applied: extruded polygons and line-extruded cylinders always rendered fully opaque. This restores style-driven opacity without regressing the original 3D-Tiles/glTF fix.
Tested in Firefox/Ubuntu.