### PR TITLE
fix: zoom-dependent properties on vector rasterisation

### DIFF
--- a/packages/Main/src/Converter/Feature2Texture.js
+++ b/packages/Main/src/Converter/Feature2Texture.js
@@ -109,7 +109,7 @@ const featureExtent = new Extent('EPSG:4326', 0, 0, 0, 0);
 export default {
     // backgroundColor is a THREE.Color to specify a color to fill the texture
     // with, given there is no feature passed in parameter
-    createTextureFromFeature(collection, extent, sizeTexture, layerStyle, backgroundColor) {
+    createTextureFromFeature(collection, extent, zoom, sizeTexture, layerStyle, backgroundColor) {
         style = layerStyle || defaultStyle;
         style.setContext(context);
         let texture;
@@ -160,7 +160,7 @@ export default {
             // to scale line width and radius circle
             const invCtxScale = Math.abs(1 / scale.x);
 
-            context.setZoom(extent.zoom);
+            context.setZoom(zoom);
 
             // Draw the canvas
             for (const feature of collection.features) {

--- a/packages/Main/src/Converter/Feature2Texture.js
+++ b/packages/Main/src/Converter/Feature2Texture.js
@@ -110,7 +110,7 @@ const featureExtent = new Extent('EPSG:4326', 0, 0, 0, 0);
 export default {
     // backgroundColor is a THREE.Color to specify a color to fill the texture
     // with, given there is no feature passed in parameter
-    createTextureFromFeature(collection, extent, sizeTexture, layerStyle, backgroundColor) {
+    createTextureFromFeature(collection, extent, zoom, sizeTexture, layerStyle, backgroundColor) {
         style = layerStyle || defaultStyle;
         style.setContext(context);
         let texture;
@@ -157,7 +157,7 @@ export default {
             // to scale line width and radius circle
             const invCtxScale = Math.abs(1 / scale.x);
 
-            context.setZoom(extent.zoom);
+            context.setZoom(zoom);
 
             // Draw the canvas
             for (const feature of collection.features) {

--- a/packages/Main/src/Converter/textureConverter.js
+++ b/packages/Main/src/Converter/textureConverter.js
@@ -27,7 +27,14 @@ export default {
                 undefined;
 
             destinationTile.toExtent(layer.crs, extentTexture);
-            texture = Feature2Texture.createTextureFromFeature(data, extentTexture, layer.subdivisionThreshold, layer.style, backgroundColor);
+            texture = Feature2Texture.createTextureFromFeature(
+                data,
+                extentTexture,
+                destinationTile.zoom,
+                layer.subdivisionThreshold,
+                layer.style,
+                backgroundColor,
+            );
             texture.features = data;
             texture.extent = destinationTile;
         } else if (data.isTexture) {


### PR DESCRIPTION
## Description

This PR fixes zoom-dependent properties which where not correctly evaluated during vector rasterisation (Feature2Mesh). This was caused due to the fact that the zoom style context was initialised from the undefined property zoom of the extent (which does not exist). Instead, the signature of Feature2Mesh was modified to pass the zoom of the destination tile.

You could reproduce the zoom-related issue on the `vector_tile_mapbox_raster.html` example.
