### PR TITLE
fix(picking): fix pointcloud picking

### DIFF
--- a/packages/Main/src/Core/Picking.js
+++ b/packages/Main/src/Core/Picking.js
@@ -152,18 +152,14 @@ export default {
             const idx = (yi * (radius * 2 + 1) + xi) * 4;
             const data = buffer.slice(idx, idx + 4);
 
-            // see PotreeProvider and the construction of unique_id
-            const objId = (data[0] << 8) | data[1];
-            const index = (data[2] << 8) | data[3];
+            // see PointCloudProvider and the construction of unique_id
+            const id = ((data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3]) >>> 0;
 
-            const r = { objId, index };
-
-            for (let i = 0; i < candidates.length; i++) {
-                if (candidates[i].objId == r.objId && candidates[i].index == r.index) {
-                    return;
-                }
+            // 0 is the background of the picking buffer
+            if (id === 0 || candidates.includes(id)) {
+                return;
             }
-            candidates.push(r);
+            candidates.push(id);
         });
 
         layer.object3d.traverse((o) => {
@@ -175,12 +171,14 @@ export default {
                 if (!o.geometry || !o.geometry.attributes || !o.geometry.attributes.position) {
                     return;
                 }
-                // if baseId matches objId, the clicked point belongs to `o`
+                // if the id belongs to the range owned by `o`, the clicked
+                // point belongs to `o`
                 for (let i = 0; i < candidates.length; i++) {
-                    if (candidates[i].objId == o.baseId) {
+                    const index = candidates[i] - o.baseId;
+                    if (index >= 0 && index < o.geometry.attributes.position.count) {
                         // Get point position: get the picked point from the buffer geometry and apply local to world
                         // transform of the picked object
-                        pointPos.fromBufferAttribute(o.geometry.attributes.position, candidates[i].index);
+                        pointPos.fromBufferAttribute(o.geometry.attributes.position, index);
                         o.localToWorld(pointPos);
                         // Compute distance to the camera
                         pointPosCoord.setCrs(view.referenceCrs);
@@ -192,7 +190,7 @@ export default {
                         result.push({
                             object: o,
                             point: pointPos.clone(), // the position of the point in the 3D view. Same name and value than what's returned by pickObjectsAt
-                            index: candidates[i].index,
+                            index,
                             distance: dist,
                             layer,
                         });

--- a/packages/Main/src/Layer/PointCloudLayer.ts
+++ b/packages/Main/src/Layer/PointCloudLayer.ts
@@ -4,6 +4,7 @@ import GeometryLayer from 'Layer/GeometryLayer';
 import PointsMaterial, { PNTS_MODE, PNTS_SIZE_MODE } from 'Renderer/PointsMaterial';
 import Picking from 'Core/Picking';
 import { computeVisibilityTextureData } from 'Utils/PointCloudUtils';
+import { releaseObjectPickingIds } from 'Utils/PointCloudPickingUtils';
 
 import type PointCloudNode from 'Core/PointCloudNode';
 
@@ -534,6 +535,7 @@ abstract class PointCloudLayer<S extends PointCloudSource = PointCloudSource>
             if (node.notVisibleSince && (now - node.notVisibleSince > 10000)) {
                 this.group.remove(obj);
                 obj.geometry.dispose();
+                releaseObjectPickingIds(obj);
                 node.obj = undefined;
                 this.dispatchEvent({ type: 'dispose-model', scene: obj, tile: obj.userData.node });
             }

--- a/packages/Main/src/Provider/PointCloudProvider.js
+++ b/packages/Main/src/Provider/PointCloudProvider.js
@@ -1,19 +1,24 @@
 import * as THREE from 'three';
+import { allocatePickingIds } from 'Utils/PointCloudPickingUtils';
 
-let nextuuid = 1;
 function addPickingAttribute(points) {
     // generate unique id for picking
     const numPoints = points.geometry.attributes.position.count;
-    const ids = new Uint8Array(4 * numPoints);
-    const baseId = nextuuid++;
-    if (numPoints > 0xffff || baseId > 0xffff) {
-        // TODO: fixme
-        console.warn('Currently picking is limited to Points with less than 65535 elements and less than 65535 Points instances');
+    if (numPoints === 0) {
         return points;
     }
+
+    // Reserve a contiguous range of ids: the id of the point `i` is
+    // `baseId + i`, encoded as a big endian 32 bits integer.
+    const baseId = allocatePickingIds(numPoints);
+    if (baseId < 0) {
+        console.warn('Picking is disabled for this node: no more picking ids available (more than 2^32 points are loaded)');
+        return points;
+    }
+
+    const ids = new Uint8Array(4 * numPoints);
     for (let i = 0; i < numPoints; i++) {
-        // todo numpoints > 16bits
-        const v = (baseId << 16) | i;
+        const v = baseId + i;
         ids[4 * i + 0] = (v & 0xff000000) >> 24;
         ids[4 * i + 1] = (v & 0x00ff0000) >> 16;
         ids[4 * i + 2] = (v & 0x0000ff00) >> 8;

--- a/packages/Main/src/Utils/PointCloudPickingUtils.ts
+++ b/packages/Main/src/Utils/PointCloudPickingUtils.ts
@@ -1,0 +1,95 @@
+/**
+ * Picking ids allocator for point clouds.
+ *
+ * Picking is implemented by rendering a unique 32 bits id per point into an
+ * RGBA8 buffer. Instead of splitting those 32 bits into a fixed
+ * `16 bits object id | 16 bits point index` layout - which limits a node to
+ * 65535 points and a layer to 65535 nodes - each `THREE.Points` object is given
+ * a contiguous range of ids `[baseId, baseId + count)`. A point is then
+ * identified by `baseId + index`, and the owning object is the one whose range
+ * contains the decoded id.
+ *
+ * Ranges are released when a node is disposed and reused by later allocations,
+ * so the only limit is the number of points simultaneously loaded (2^32).
+ */
+
+import * as THREE from 'three';
+
+/** A half-open range of picking ids `[start, end)`. */
+interface PickingIdRange {
+    start: number;
+    end: number;
+}
+
+/** An object that may own a range of picking ids. */
+export interface PickablePointsObject extends THREE.Points {
+    baseId?: number;
+}
+
+// Number of distinct values encodable on 32 bits.
+const PICKING_ID_LIMIT = 2 ** 32;
+
+/** Allocated ranges, kept sorted by `start` and non-overlapping. */
+const allocatedRanges: PickingIdRange[] = [];
+
+/**
+ * Reserve a contiguous range of `count` picking ids.
+ *
+ * @param count - Number of ids to reserve.
+ * @returns The first id of the reserved range, or `-1` if there is no free
+ * range large enough.
+ */
+export function allocatePickingIds(count: number): number {
+    if (count <= 0) {
+        return -1;
+    }
+
+    let start = 1;
+    for (let i = 0; i < allocatedRanges.length; i++) {
+        const range = allocatedRanges[i];
+        if (range.start - start >= count) {
+            allocatedRanges.splice(i, 0, { start, end: start + count });
+            return start;
+        }
+        start = range.end;
+    }
+
+    const end = start + count;
+    if (end > PICKING_ID_LIMIT) {
+        return -1;
+    }
+
+    allocatedRanges.push({ start, end });
+    return start;
+}
+
+/**
+ * Give back a range previously reserved by {@link allocatePickingIds}, making
+ * its ids available again.
+ *
+ * @param baseId - The first id of the range to release.
+ */
+export function releasePickingIds(baseId: number): void {
+    for (let i = 0; i < allocatedRanges.length; i++) {
+        if (allocatedRanges[i].start === baseId) {
+            allocatedRanges.splice(i, 1);
+            return;
+        }
+        if (allocatedRanges[i].start > baseId) {
+            return;
+        }
+    }
+}
+
+/**
+ * Release the picking ids owned by a `THREE.Points` object, if any.
+ *
+ * @param pointsObj - The object being disposed.
+ */
+export function releaseObjectPickingIds(pointsObj: PickablePointsObject): void {
+    if (pointsObj.baseId === undefined) {
+        return;
+    }
+    releasePickingIds(pointsObj.baseId);
+    pointsObj.baseId = undefined;
+}

--- a/packages/Main/test/unit/pointcloudpickingutils.js
+++ b/packages/Main/test/unit/pointcloudpickingutils.js
@@ -1,0 +1,105 @@
+import assert from 'assert';
+import {
+    allocatePickingIds,
+    releasePickingIds,
+    releaseObjectPickingIds,
+} from 'Utils/PointCloudPickingUtils';
+
+describe('PointCloudPickingUtils', function () {
+    // The allocator holds module level state: release everything allocated by a
+    // test so the next one starts from a clean state.
+    let allocated = [];
+
+    function allocate(count) {
+        const baseId = allocatePickingIds(count);
+        if (baseId >= 0) {
+            allocated.push(baseId);
+        }
+        return baseId;
+    }
+
+    afterEach(function () {
+        allocated.forEach(baseId => releasePickingIds(baseId));
+        allocated = [];
+    });
+
+    it('allocates contiguous non-overlapping ranges', function () {
+        const a = allocate(10);
+        const b = allocate(5);
+        const c = allocate(1);
+
+        assert.ok(a > 0, 'ids must not start at 0, which is the "no pick" value');
+        assert.strictEqual(b, a + 10);
+        assert.strictEqual(c, b + 5);
+    });
+
+    it('returns -1 for a non positive count', function () {
+        assert.strictEqual(allocatePickingIds(0), -1);
+        assert.strictEqual(allocatePickingIds(-3), -1);
+    });
+
+    it('returns -1 when no range is large enough', function () {
+        assert.strictEqual(allocatePickingIds(2 ** 32), -1);
+    });
+
+    it('reuses a released range', function () {
+        const a = allocate(10);
+        const b = allocate(10);
+
+        releasePickingIds(a);
+        allocated = allocated.filter(id => id !== a);
+
+        const c = allocate(10);
+        assert.strictEqual(c, a, 'the freed range should be reused');
+
+        const d = allocate(10);
+        assert.strictEqual(d, b + 10, 'the next range is allocated after the last one');
+    });
+
+    it('only reuses a hole big enough to hold the request', function () {
+        const a = allocate(4);
+        const b = allocate(20);
+
+        releasePickingIds(a);
+        allocated = allocated.filter(id => id !== a);
+
+        // Too big for the 4 ids hole left by `a`, must go after `b`.
+        const c = allocate(5);
+        assert.strictEqual(c, b + 20);
+
+        // Fits exactly in the hole left by `a`.
+        const d = allocate(4);
+        assert.strictEqual(d, a);
+    });
+
+    it('ignores the release of an unknown base id', function () {
+        const a = allocate(10);
+
+        releasePickingIds(a + 3);
+        releasePickingIds(a + 1000);
+
+        // `a` is still allocated, so the next range comes after it.
+        assert.strictEqual(allocate(10), a + 10);
+    });
+
+    it('releases the ids owned by an object', function () {
+        const a = allocate(10);
+        const points = { baseId: a };
+
+        releaseObjectPickingIds(points);
+        allocated = allocated.filter(id => id !== a);
+
+        assert.strictEqual(points.baseId, undefined);
+        assert.strictEqual(allocate(10), a, 'the range owned by the object is free again');
+    });
+
+    it('does nothing when the object owns no ids', function () {
+        const a = allocate(10);
+        const points = {};
+
+        releaseObjectPickingIds(points);
+
+        assert.strictEqual(points.baseId, undefined);
+        assert.strictEqual(allocate(10), a + 10, 'no range was released');
+    });
+});


### PR DESCRIPTION
## Description

Picking is implemented by rendering a unique 32 bits id per point into an RGBA8 buffer.
Instead of splitting those 32 bits into a fixed `16 bits object id | 16 bits point index` layout - which limits a node to 65535 points and a layer to 65535 nodes - each `THREE.Points` object is given a contiguous range of ids `[baseId, baseId + count)`.
A point is then identified by `baseId + index`, and the owning object is the one whose range contains the decoded id.

Ranges are released when a node is disposed and reused by later allocations, so the only limit is the number of points simultaneously loaded (2^32).

## Motivation and Context

Fix for #2837 

## Screenshots (if appropriate)

Now we can click near the red car, we got points.

<img width="1916" height="874" alt="Capture d’écran 2026-09-04 à 08 06 14" src="https://github.com/user-attachments/assets/d946c384-edce-49f4-849c-033a3c0f05eb" />
